### PR TITLE
perf(linker): OS-gate packageImportMethod=auto (reflink on macOS, hardlink elsewhere)

### DIFF
--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -232,9 +232,9 @@ pub struct Linker {
 #[derive(Debug, Clone, Copy)]
 pub enum LinkStrategy {
     /// Copy-on-write (APFS clonefile, btrfs reflink). Selected by
-    /// explicit `packageImportMethod = clone` / `clone-or-copy`;
-    /// `auto` picks [`Hardlink`] because hardlink is measurably
-    /// faster on every benchmarked target.
+    /// explicit `packageImportMethod = clone` / `clone-or-copy`, and by
+    /// `auto` on macOS where APFS clonefile is measurably faster than
+    /// hardlink. (On Linux and other targets `auto` picks [`Hardlink`].)
     Reflink,
     /// Hard link (ext4, NTFS)
     Hardlink,

--- a/crates/aube-linker/src/materialize.rs
+++ b/crates/aube-linker/src/materialize.rs
@@ -21,11 +21,13 @@ impl Linker {
     /// falls back to `fs::copy` per file silently, thousands of
     /// wasted syscalls, user thinks they got hardlinks.
     ///
-    /// Returns `Hardlink` when the probe succeeds, `Copy` otherwise.
-    /// Reflink is reachable only through explicit
-    /// `packageImportMethod = clone` / `clone-or-copy`; `auto` resolves
-    /// to `Hardlink` because hardlink benchmarks faster across every
-    /// target reflink supports (APFS clonefile, btrfs/xfs FICLONE).
+    /// Returns the same-filesystem strategy when the probe succeeds,
+    /// `Copy` otherwise. The same-FS strategy is OS-specific: on macOS
+    /// `auto` resolves to `Reflink` (APFS clonefile benchmarks ~1.91x
+    /// faster than hardlink), on Linux and other targets it resolves to
+    /// `Hardlink` (btrfs/xfs hardlink benchmarks ~2.4-2.6x faster than
+    /// FICLONE reflink). `Reflink` is otherwise reachable only through
+    /// explicit `packageImportMethod = clone` / `clone-or-copy`.
     pub fn detect_strategy(path: &Path) -> LinkStrategy {
         Self::detect_strategy_cross(path, path)
     }
@@ -34,8 +36,20 @@ impl Linker {
     /// store FS), dst is the project modules dir (or any dir on the
     /// destination FS). Probe creates a real cross-mount src file
     /// and tries to hardlink into dst, which catches EXDEV up front.
-    /// Returns `Hardlink` when the probe succeeds, `Copy` otherwise.
+    /// A successful hardlink proves src and dst share a mount, so it
+    /// doubles as the same-FS probe for reflink too (APFS clonefile /
+    /// btrfs FICLONE require the same FS). Returns the OS-specific
+    /// same-FS strategy when the probe succeeds (`Reflink` on macOS,
+    /// `Hardlink` elsewhere), `Copy` otherwise.
     pub fn detect_strategy_cross(src_dir: &Path, dst_dir: &Path) -> LinkStrategy {
+        // Same-FS strategy `auto` resolves to once the probe succeeds.
+        // macOS/APFS clonefile is measurably faster than hardlink there;
+        // Linux btrfs/xfs hardlink is measurably faster than FICLONE.
+        #[cfg(target_os = "macos")]
+        const SAME_FS_STRATEGY: LinkStrategy = LinkStrategy::Reflink;
+        #[cfg(not(target_os = "macos"))]
+        const SAME_FS_STRATEGY: LinkStrategy = LinkStrategy::Hardlink;
+
         // Memoize per (src_dir, dst_dir) for the process lifetime.
         // The probe writes a real test file and tries hardlink,
         // ~2 syscalls + 2 unlinks. Multiple Linker instances within
@@ -56,7 +70,7 @@ impl Linker {
 
         let strategy = if std::fs::write(&test_src, b"test").is_ok() {
             let result = if std::fs::hard_link(&test_src, &test_dst).is_ok() {
-                LinkStrategy::Hardlink
+                SAME_FS_STRATEGY
             } else {
                 LinkStrategy::Copy
             };
@@ -73,7 +87,9 @@ impl Linker {
         // hardlink-ok, the other sees the first writer's leftover and
         // falls back to Copy. `.insert()` would let the wrong Copy
         // result clobber the correct Hardlink for the rest of the
-        // process; `or_insert` keeps whichever value landed first.
+        // process; `or_insert` keeps whichever value landed first. (The
+        // value at stake is the same-FS strategy above, not literally
+        // Hardlink — Reflink on macOS.)
         *cache
             .write()
             .expect("probe cache poisoned")

--- a/crates/aube-linker/src/materialize.rs
+++ b/crates/aube-linker/src/materialize.rs
@@ -28,6 +28,14 @@ impl Linker {
     /// `Hardlink` (btrfs/xfs hardlink benchmarks ~2.4-2.6x faster than
     /// FICLONE reflink). `Reflink` is otherwise reachable only through
     /// explicit `packageImportMethod = clone` / `clone-or-copy`.
+    ///
+    /// The macOS `Reflink` resolution is conservative on non-APFS
+    /// volumes: `clonefile` is APFS-only, so on an HFS+ volume (external
+    /// drives, Fusion/older disks) the same-FS hardlink probe succeeds
+    /// and resolves `Reflink`, but the real `clonefile` then fails.
+    /// `link_file_fresh` handles this by falling the reflink back to a
+    /// hardlink (which HFS+ supports) before copy, so a non-APFS same-FS
+    /// target still gets zero-cost links rather than a per-file copy.
     pub fn detect_strategy(path: &Path) -> LinkStrategy {
         Self::detect_strategy_cross(path, path)
     }
@@ -625,10 +633,23 @@ impl Linker {
                     if !stored.store_path.exists() {
                         return Err(missing_source());
                     }
-                    // Fall back to copy on cross-filesystem errors
-                    trace!("reflink failed, falling back to copy: {e}");
-                    std::fs::copy(&stored.store_path, dst).map_err(map_io)?;
-                    realized = "reflink_fallback_copy";
+                    // Reflink is only the resolved strategy when the same-FS
+                    // probe succeeded, so the target is known same-filesystem.
+                    // `reflink_copy::reflink` uses `clonefile`, which is
+                    // APFS-only: on an HFS+ volume it fails even though the
+                    // volume is same-FS and supports hardlinks. Try a
+                    // hardlink before degrading to a full per-file copy — a
+                    // hardlink is zero-cost and preserves the dedupe the
+                    // probe promised, where copy silently regresses to a byte
+                    // transfer per file.
+                    if std::fs::hard_link(&stored.store_path, dst).is_ok() {
+                        trace!("reflink failed, fell back to hardlink: {e}");
+                        realized = "reflink_fallback_hardlink";
+                    } else {
+                        trace!("reflink and hardlink failed, falling back to copy: {e}");
+                        std::fs::copy(&stored.store_path, dst).map_err(map_io)?;
+                        realized = "reflink_fallback_copy";
+                    }
                 } else {
                     realized = "reflink";
                 }
@@ -657,6 +678,7 @@ impl Linker {
             // O(1) and the static `&str` keeps the JSONL category compact.
             let name = match realized {
                 "reflink" => "link_reflink",
+                "reflink_fallback_hardlink" => "link_reflink_fallback_hardlink",
                 "reflink_fallback_copy" => "link_reflink_fallback",
                 "hardlink" => "link_hardlink",
                 "hardlink_fallback_copy" => "link_hardlink_fallback",

--- a/crates/aube-linker/src/tests.rs
+++ b/crates/aube-linker/src/tests.rs
@@ -292,15 +292,15 @@ fn test_link_file_fresh_hardlink_short_circuits_when_source_missing() {
 #[test]
 #[cfg(unix)]
 fn test_link_file_fresh_reflink_falls_back_to_hardlink_not_copy() {
-    // jdx/aube#914 review (Greptile P2): macOS resolves same-FS `auto`
-    // to `Reflink`, but `clonefile` is APFS-only. On a non-APFS same-FS
-    // target (HFS+, or any non-reflink FS) the reflink fails and used to
-    // degrade straight to a per-file copy — a silent regression from the
-    // zero-cost hardlink the same FS supports. The fallback must try a
-    // hardlink before copy. We can only assert the hardlink outcome on a
-    // filesystem that actually lacks reflink (where the fallback fires);
-    // on a reflink-capable FS the reflink succeeds and there is nothing
-    // to fall back from, so the inode check is gated on a probe.
+    // macOS resolves same-FS `auto` to `Reflink`, but `clonefile` is
+    // APFS-only. On a non-APFS same-FS target (HFS+, or any non-reflink
+    // FS) the reflink fails, and degrading straight to a per-file copy
+    // would forfeit the zero-cost hardlink the same FS supports. The
+    // fallback must try a hardlink before copy. We can only assert the
+    // hardlink outcome on a filesystem that actually lacks reflink
+    // (where the fallback fires); on a reflink-capable FS the reflink
+    // succeeds and there is nothing to fall back from, so the inode
+    // check is gated on a probe.
     use std::os::unix::fs::MetadataExt;
 
     let dir = tempfile::tempdir().unwrap();

--- a/crates/aube-linker/src/tests.rs
+++ b/crates/aube-linker/src/tests.rs
@@ -290,6 +290,53 @@ fn test_link_file_fresh_hardlink_short_circuits_when_source_missing() {
 }
 
 #[test]
+#[cfg(unix)]
+fn test_link_file_fresh_reflink_falls_back_to_hardlink_not_copy() {
+    // jdx/aube#914 review (Greptile P2): macOS resolves same-FS `auto`
+    // to `Reflink`, but `clonefile` is APFS-only. On a non-APFS same-FS
+    // target (HFS+, or any non-reflink FS) the reflink fails and used to
+    // degrade straight to a per-file copy — a silent regression from the
+    // zero-cost hardlink the same FS supports. The fallback must try a
+    // hardlink before copy. We can only assert the hardlink outcome on a
+    // filesystem that actually lacks reflink (where the fallback fires);
+    // on a reflink-capable FS the reflink succeeds and there is nothing
+    // to fall back from, so the inode check is gated on a probe.
+    use std::os::unix::fs::MetadataExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = Store::at(dir.path().join("store/files"));
+    let stored = store.import_bytes(b"hello reflink", false).unwrap();
+    let store_path = stored.store_path.clone();
+
+    let dst_dir = dir.path().join("dst");
+    std::fs::create_dir_all(&dst_dir).unwrap();
+    let dst = dst_dir.join("hello.txt");
+
+    let linker = Linker::new_with_gvs(&store, LinkStrategy::Reflink, true);
+    linker
+        .link_file_fresh(&stored, "hello.txt", &dst)
+        .expect("reflink strategy must materialize the file");
+
+    // Data integrity holds regardless of which realized path was taken.
+    assert_eq!(std::fs::read_to_string(&dst).unwrap(), "hello reflink");
+
+    // Probe whether this FS supports reflink at all. If not, the fallback
+    // fired and the result must be a hardlink (same inode as the source),
+    // never a copy (distinct inode).
+    let reflink_probe = dst_dir.join(".reflink-probe");
+    let reflink_supported = reflink_copy::reflink(&store_path, &reflink_probe).is_ok();
+    let _ = std::fs::remove_file(&reflink_probe);
+    if !reflink_supported {
+        let src_ino = std::fs::metadata(&store_path).unwrap().ino();
+        let dst_ino = std::fs::metadata(&dst).unwrap().ino();
+        assert_eq!(
+            src_ino, dst_ino,
+            "reflink-unsupported FS must fall back to a hardlink (same inode), not a copy"
+        );
+    }
+}
+
+#[test]
 fn test_link_all_creates_top_level_entries() {
     let dir = tempfile::tempdir().unwrap();
     let project_dir = dir.path().join("project");

--- a/crates/aube-linker/src/tests.rs
+++ b/crates/aube-linker/src/tests.rs
@@ -83,12 +83,23 @@ fn make_graph() -> LockfileGraph {
 fn test_detect_strategy() {
     let dir = tempfile::tempdir().unwrap();
     let strategy = Linker::detect_strategy(dir.path());
-    // Probe returns `Hardlink` or `Copy`; `Reflink` is only
-    // reachable through explicit `packageImportMethod =
-    // clone`/`clone-or-copy`, so the match guards that contract.
+    // The probe resolves a same-FS success to the OS-specific `auto`
+    // strategy and a cross-FS failure to `Copy`. On macOS the same-FS
+    // strategy is `Reflink` (APFS clonefile), elsewhere `Hardlink`.
+    // Whether the tempdir's FS supports the same-mount link depends on
+    // the runner, so accept the same-FS strategy or `Copy`, but reject
+    // the *other* OS's same-FS strategy — that would mean the cfg gate
+    // resolved on the wrong target.
     match strategy {
-        LinkStrategy::Hardlink | LinkStrategy::Copy => {}
-        LinkStrategy::Reflink => panic!("detect_strategy must not return Reflink"),
+        LinkStrategy::Copy => {}
+        #[cfg(target_os = "macos")]
+        LinkStrategy::Reflink => {}
+        #[cfg(target_os = "macos")]
+        LinkStrategy::Hardlink => panic!("macOS `auto` must resolve same-FS to Reflink"),
+        #[cfg(not(target_os = "macos"))]
+        LinkStrategy::Hardlink => {}
+        #[cfg(not(target_os = "macos"))]
+        LinkStrategy::Reflink => panic!("non-macOS `auto` must resolve same-FS to Hardlink"),
     }
 }
 

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -937,11 +937,12 @@ docs = """
 Controls how aube materializes files from the global content-addressable
 store into the virtual store.
 
-- `auto` (default) probes the destination filesystem and picks
-  `hardlink` with a `copy` fallback on cross-filesystem boundaries.
-  Hardlink benchmarks faster than reflink across every target reflink
-  supports (APFS clonefile, btrfs/xfs FICLONE), so `auto` skips the
-  reflink probe.
+- `auto` (default) probes the destination filesystem and picks a
+  same-filesystem strategy with a `copy` fallback on cross-filesystem
+  boundaries. The same-filesystem strategy is OS-specific: `clone`
+  (reflink) on macOS, where APFS clonefile benchmarks ~1.91x faster
+  than hardlink, and `hardlink` on Linux and other targets, where
+  btrfs/xfs hardlink benchmarks ~2.4-2.6x faster than FICLONE reflink.
 - `hardlink` hard-links from the store, with a copy fallback on
   cross-filesystem errors.
 - `copy` always writes a full copy.

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -938,11 +938,15 @@ Controls how aube materializes files from the global content-addressable
 store into the virtual store.
 
 - `auto` (default) probes the destination filesystem and picks a
-  same-filesystem strategy with a `copy` fallback on cross-filesystem
-  boundaries. The same-filesystem strategy is OS-specific: `clone`
-  (reflink) on macOS, where APFS clonefile benchmarks ~1.91x faster
-  than hardlink, and `hardlink` on Linux and other targets, where
-  btrfs/xfs hardlink benchmarks ~2.4-2.6x faster than FICLONE reflink.
+  same-filesystem strategy, with a `copy` fallback when no link
+  primitive applies (cross-filesystem boundaries). The
+  same-filesystem strategy is OS-specific: `clone` (reflink) on macOS,
+  where APFS clonefile benchmarks ~1.91x faster than hardlink, and
+  `hardlink` on Linux and other targets, where btrfs/xfs hardlink
+  benchmarks ~2.4-2.6x faster than FICLONE reflink. On a macOS
+  same-filesystem target that is not APFS (HFS+), reflink is
+  unsupported, so `auto` falls back to a hardlink before copy —
+  same-filesystem volumes always get zero-cost links.
 - `hardlink` hard-links from the store, with a copy fallback on
   cross-filesystem errors.
 - `copy` always writes a full copy.

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -999,11 +999,16 @@ Method for importing packages from the store into node_modules.
 Controls how aube materializes files from the global content-addressable
 store into the virtual store.
 
-- `auto` (default) probes the destination filesystem and picks
-  `hardlink` with a `copy` fallback on cross-filesystem boundaries.
-  Hardlink benchmarks faster than reflink across every target reflink
-  supports (APFS clonefile, btrfs/xfs FICLONE), so `auto` skips the
-  reflink probe.
+- `auto` (default) probes the destination filesystem and picks a
+  same-filesystem strategy, with a `copy` fallback when no link
+  primitive applies (cross-filesystem boundaries). The
+  same-filesystem strategy is OS-specific: `clone` (reflink) on macOS,
+  where APFS clonefile benchmarks ~1.91x faster than hardlink, and
+  `hardlink` on Linux and other targets, where btrfs/xfs hardlink
+  benchmarks ~2.4-2.6x faster than FICLONE reflink. On a macOS
+  same-filesystem target that is not APFS (HFS+), reflink is
+  unsupported, so `auto` falls back to a hardlink before copy —
+  same-filesystem volumes always get zero-cost links.
 - `hardlink` hard-links from the store, with a copy fallback on
   cross-filesystem errors.
 - `copy` always writes a full copy.


### PR DESCRIPTION
## What

OS-gate the `packageImportMethod=auto` same-filesystem strategy: resolve to **reflink (clonefile)** on macOS/APFS and **hardlink** on Linux and other platforms. Today `auto` resolves to hardlink everywhere on a same-FS target.

The hardlink probe is kept purely as the same-mount detector; only the strategy it resolves to on success is OS-gated. Explicit `--package-import-method` selections and the reflink→copy graceful degradation are unchanged.

## Why — the cost flips by OS

Warm-install link phase, median of interleaved runs (disk usage equivalent between methods; FICLONE confirmed real via `strace`):

| filesystem | reflink | hardlink | faster |
|---|---|---|---|
| macOS APFS | 2.06 s | 3.93 s | **reflink ~1.91×** |
| Linux btrfs | 0.36 s | 0.14 s | **hardlink ~2.57×** |
| Linux xfs (reflink=1) | 0.12 s | 0.05 s | **hardlink ~2.40×** |

The difference is kernel (sys) time: APFS `clonefile()` is cheaper than an APFS hardlink, while Linux `FICLONE`'s per-file copy-on-write bookkeeping costs ~2–3× the sys time of a metadata-only `link()`. So `auto → hardlink` is correct on Linux and leaves ~1.9× on the table on macOS.

## Implementation

`SAME_FS_STRATEGY` const, `#[cfg(target_os = "macos")]` → `Reflink`, else `Hardlink`, used at the single same-FS decision point in `detect_strategy_cross`. The cfg-aware `test_detect_strategy` panics if the gate ever resolves the wrong-OS strategy.

**Non-APFS macOS volumes (review fix).** `clonefile` is APFS-only, but the same-FS probe is a hardlink, which also succeeds on HFS+ (external drives, Fusion/older disks). So on an HFS+ same-FS target `auto` resolves to `Reflink` and the real `clonefile` then fails. `link_file_fresh` now falls that failure back to a **hardlink before copy** — the probe already proved the target is same-filesystem, so a hardlink succeeds (HFS+ supports hardlinks) where reflink does not. This eliminates the silent per-file-copy regression a non-APFS same-FS volume would otherwise hit, with no filesystem sniffing. Emitted as a `reflink_fallback_hardlink` diag attribution; covered by `test_link_file_fresh_reflink_falls_back_to_hardlink_not_copy`.

## Caveats

- Linux numbers are arm64; x86_64 timing is unconfirmed (the mechanism — FICLONE extent bookkeeping vs metadata link — is architecture-independent, so a reversal is unlikely, but a native amd64 run would close it).
- Background discussion: #913.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refined the “auto” link strategy to select the most efficient same-filesystem import by platform (clone/reflink on macOS, hardlink on Linux/other platforms) and use copy as a cross-filesystem fallback.
  * On macOS, if reflink fails, “auto” now attempts a hardlink before falling back to copy.
* **Documentation**
  * Updated `packageImportMethod = "auto"` docs with OS/filesystem-specific behavior, including the non-APFS reflink fallback sequence.
* **Tests**
  * Updated strategy-detection assertions and added a Unix test covering reflink→hardlink fallback when reflink isn’t supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
