### PR TITLE
perf(linker): hoist redundant per-package dep-path encode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,6 +342,7 @@ dependencies = [
  "aube-util",
  "base64",
  "blake3",
+ "criterion",
  "glob",
  "miette",
  "node-semver",

--- a/crates/aube-linker/src/link.rs
+++ b/crates/aube-linker/src/link.rs
@@ -11,7 +11,7 @@ use crate::sweep::{
     try_remove_entry,
 };
 use crate::{Error, HoistedPlacements, LinkStats, Linker, NodeLinker, hoisted, sys};
-use aube_lockfile::{LocalSource, LockfileGraph};
+use aube_lockfile::{LocalSource, LockedPackage, LockfileGraph};
 use aube_store::PackageIndex;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -204,22 +204,43 @@ impl Linker {
             use rayon::prelude::*;
             use rustc_hash::FxHashSet;
 
-            // Pre-create every parent directory (`aube_dir` itself plus
-            // one entry per unique `@scope/`) once so the per-package
-            // par_iter below does not pay 1.4k `create_dir_all` stat
-            // syscalls. The set is tiny (1-5 entries on a typical
-            // graph) so the serial pre-pass is dwarfed by the wins
-            // inside the par_iter that no longer needs the inner
-            // `mkdirp(parent)` call.
+            // Serial pre-pass over every registry package. It already
+            // walks the whole graph to pre-create parent directories, so
+            // fold the two filename encodes each package needs into the
+            // same pass and carry them into the par_iter:
+            //   - `aube_dir_entry_name(dep_path)` for the local
+            //     `.aube/<entry>` symlink, and
+            //   - `virtual_store_subdir(dep_path)` for the shared-store
+            //     target.
+            // Both are pure functions of `dep_path` + builder state
+            // (`hashes`/`virtual_store_dir_max_length` are fixed before
+            // linking), so computing them once here and threading them
+            // through removes the par_iter's recompute of the entry name
+            // and the subdir, plus the subdir's third encode downstream
+            // in `ensure_in_virtual_store`. Each `dep_path_to_filename`
+            // is a `String` alloc + escape/uppercase scans, and a second
+            // alloc + BLAKE3 short-hash on long/scoped/peer-context
+            // names — a per-package CPU/alloc trim on every install.
+            //
+            // Pre-creating the parents (`aube_dir` itself plus one entry
+            // per unique `@scope/`) once also keeps the par_iter off the
+            // 1.4k `create_dir_all` stat syscalls. The parent set is tiny
+            // (1-5 entries on a typical graph), so the serial pre-pass is
+            // dwarfed by the per-package wins inside the par_iter.
             let mut step1_parents: FxHashSet<PathBuf> = FxHashSet::default();
+            let mut step1_prep: Vec<(&String, &LockedPackage, String, String)> =
+                Vec::with_capacity(graph.packages.len());
             for (dep_path, pkg) in &graph.packages {
                 if pkg.local_source.is_some() {
                     continue;
                 }
-                let entry = aube_dir.join(self.aube_dir_entry_name(dep_path));
+                let entry_name = self.aube_dir_entry_name(dep_path);
+                let subdir = self.virtual_store_subdir(dep_path);
+                let entry = aube_dir.join(&entry_name);
                 if let Some(parent) = entry.parent() {
                     step1_parents.insert(parent.to_path_buf());
                 }
+                step1_prep.push((dep_path, pkg, entry_name, subdir));
             }
             for parent in &step1_parents {
                 mkdirp(parent)?;
@@ -229,21 +250,13 @@ impl Linker {
             let step1_timer = std::time::Instant::now();
             let step1_results: Vec<Result<LinkStats, Error>> =
                 with_link_pool(link_parallelism, || {
-                    graph
-                        .packages
+                    step1_prep
                         .par_iter()
-                        .filter_map(|(dep_path, pkg)| {
-                            if pkg.local_source.is_some() {
-                                return None;
-                            }
-                            Some((dep_path, pkg))
-                        })
-                        .map(|(dep_path, pkg)| {
+                        .map(|&(dep_path, pkg, ref entry_name, ref subdir)| {
+                            let dep_path = dep_path.as_str();
                             let mut local_stats = LinkStats::default();
-                            let local_aube_entry =
-                                aube_dir.join(self.aube_dir_entry_name(dep_path));
-                            let global_entry =
-                                self.virtual_store.join(self.virtual_store_subdir(dep_path));
+                            let local_aube_entry = aube_dir.join(entry_name);
+                            let global_entry = self.virtual_store.join(subdir);
 
                             // Single readlink classifies the entry into one of
                             // three states and drives the whole per-package
@@ -285,8 +298,9 @@ impl Linker {
                                     &owned_index
                                 }
                             };
-                            self.ensure_in_virtual_store(
+                            self.ensure_in_virtual_store_with_subdir(
                                 dep_path,
+                                subdir,
                                 pkg,
                                 index,
                                 &mut local_stats,
@@ -754,22 +768,27 @@ impl Linker {
             use rayon::prelude::*;
             use rustc_hash::FxHashSet;
 
-            // Pre-create every parent directory (`aube_dir` itself plus
-            // one entry per unique `@scope/`) once so the per-package
-            // par_iter below does not pay 1.4k `create_dir_all` stat
-            // syscalls. The set is tiny (1-5 entries on a typical
-            // graph) so the serial pre-pass is dwarfed by the wins
-            // inside the par_iter that no longer needs the inner
-            // `mkdirp(parent)` call.
+            // Same precompute-once hoist as `link_all`'s step 1: the
+            // serial parent-creation pre-pass already walks every
+            // registry package, so derive each package's entry name and
+            // virtual-store subdir here and thread them into the
+            // par_iter, removing the par_iter's recompute of both and the
+            // subdir's third encode in `ensure_in_virtual_store`. See the
+            // matching block in `link_all` for the full rationale.
             let mut step1_parents: FxHashSet<PathBuf> = FxHashSet::default();
+            let mut step1_prep: Vec<(&String, &LockedPackage, String, String)> =
+                Vec::with_capacity(graph.packages.len());
             for (dep_path, pkg) in &graph.packages {
                 if pkg.local_source.is_some() {
                     continue;
                 }
-                let entry = aube_dir.join(self.aube_dir_entry_name(dep_path));
+                let entry_name = self.aube_dir_entry_name(dep_path);
+                let subdir = self.virtual_store_subdir(dep_path);
+                let entry = aube_dir.join(&entry_name);
                 if let Some(parent) = entry.parent() {
                     step1_parents.insert(parent.to_path_buf());
                 }
+                step1_prep.push((dep_path, pkg, entry_name, subdir));
             }
             for parent in &step1_parents {
                 mkdirp(parent)?;
@@ -779,21 +798,13 @@ impl Linker {
             let step1_timer = std::time::Instant::now();
             let step1_results: Vec<Result<LinkStats, Error>> =
                 with_link_pool(link_parallelism, || {
-                    graph
-                        .packages
+                    step1_prep
                         .par_iter()
-                        .filter_map(|(dep_path, pkg)| {
-                            if pkg.local_source.is_some() {
-                                return None;
-                            }
-                            Some((dep_path, pkg))
-                        })
-                        .map(|(dep_path, pkg)| {
+                        .map(|&(dep_path, pkg, ref entry_name, ref subdir)| {
+                            let dep_path = dep_path.as_str();
                             let mut local_stats = LinkStats::default();
-                            let local_aube_entry =
-                                aube_dir.join(self.aube_dir_entry_name(dep_path));
-                            let global_entry =
-                                self.virtual_store.join(self.virtual_store_subdir(dep_path));
+                            let local_aube_entry = aube_dir.join(entry_name);
+                            let global_entry = self.virtual_store.join(subdir);
 
                             let state = classify_entry_state(&local_aube_entry, &global_entry);
 
@@ -819,8 +830,9 @@ impl Linker {
                                     &owned_index
                                 }
                             };
-                            self.ensure_in_virtual_store(
+                            self.ensure_in_virtual_store_with_subdir(
                                 dep_path,
+                                subdir,
                                 pkg,
                                 index,
                                 &mut local_stats,

--- a/crates/aube-linker/src/materialize.rs
+++ b/crates/aube-linker/src/materialize.rs
@@ -109,6 +109,39 @@ impl Linker {
         // this graph" and the materialize hot path stays unchanged.
         nested_link_targets: Option<&BTreeMap<String, PathBuf>>,
     ) -> Result<(), Error> {
+        // Global-store paths always run through the vstore_key map —
+        // when hashes are installed this folds dep-graph + engine
+        // state into the leaf name, so concurrent builds of the same
+        // package against different toolchains don't collide.
+        let subdir = self.virtual_store_subdir(dep_path);
+        self.ensure_in_virtual_store_with_subdir(
+            dep_path,
+            &subdir,
+            pkg,
+            index,
+            stats,
+            nested_link_targets,
+        )
+    }
+
+    /// `ensure_in_virtual_store` with the virtual-store subdir already
+    /// computed by the caller. The link step's per-package par_iter
+    /// derives `virtual_store_subdir(dep_path)` once to build the
+    /// shared-store entry path, so passing it in here avoids recomputing
+    /// the same `dep_path_to_filename` encode (a `String` alloc plus the
+    /// escape/uppercase scans, and a second alloc + BLAKE3 short-hash on
+    /// long/scoped/peer-context names). `subdir` MUST equal
+    /// `self.virtual_store_subdir(dep_path)`; the public wrapper above
+    /// guarantees that for callers that don't already have it.
+    pub(crate) fn ensure_in_virtual_store_with_subdir(
+        &self,
+        dep_path: &str,
+        subdir: &str,
+        pkg: &LockedPackage,
+        index: &PackageIndex,
+        stats: &mut LinkStats,
+        nested_link_targets: Option<&BTreeMap<String, PathBuf>>,
+    ) -> Result<(), Error> {
         let _diag =
             aube_util::diag::Span::new(aube_util::diag::Category::Linker, "ensure_in_vstore")
                 .with_meta_fn(|| {
@@ -118,14 +151,9 @@ impl Linker {
                         index.len()
                     )
                 });
-        // Global-store paths always run through the vstore_key map —
-        // when hashes are installed this folds dep-graph + engine
-        // state into the leaf name, so concurrent builds of the same
-        // package against different toolchains don't collide.
-        let subdir = self.virtual_store_subdir(dep_path);
         let pkg_nm_dir = self
             .virtual_store
-            .join(&subdir)
+            .join(subdir)
             .join("node_modules")
             .join(&pkg.name);
 
@@ -159,8 +187,8 @@ impl Linker {
         }
 
         // Atomically move the dep_path entry from the temp dir to the final location.
-        let tmp_entry = tmp_base.join(&subdir);
-        let final_entry = self.virtual_store.join(&subdir);
+        let tmp_entry = tmp_base.join(subdir);
+        let final_entry = self.virtual_store.join(subdir);
 
         // Ensure the parent of the final entry exists (e.g. for scoped packages).
         if let Some(parent) = final_entry.parent() {

--- a/crates/aube-linker/src/tests.rs
+++ b/crates/aube-linker/src/tests.rs
@@ -1,4 +1,7 @@
 use super::*;
+use aube_lockfile::dep_path_filename::{
+    DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH, dep_path_to_filename,
+};
 use aube_lockfile::{DepType, DirectDep, LockedPackage, LockfileGraph};
 use aube_store::Store;
 
@@ -110,9 +113,23 @@ const ENCODE_FIXTURES: &[&str] = &[
 // replacing what used to be 2-3 redundant `dep_path_to_filename`
 // encodes per package. The hoist is only output-preserving if the
 // value carried forward is byte-identical to what each eliminated
-// recompute site would have produced. These tests pin that invariant:
-// the precomputed name/subdir must equal a fresh per-site recompute,
-// across both the hashed and unhashed virtual-store modes.
+// recompute site would have produced.
+//
+// The eliminated sites all bottomed out at the SAME primitive
+// composition: the local `.aube/` link name was
+// `dep_path_to_filename(dep_path, max)`, and the shared-store target
+// (the par_iter's `global_entry` and the now-removed `subdir` encode
+// inside the public `ensure_in_virtual_store`) was
+// `dep_path_to_filename(hashes.hashed_dep_path(dep_path), max)`. So the
+// non-vacuous check is to recompute each carried value INDEPENDENTLY
+// from `dep_path_to_filename` (and `GraphHashes::hashed_dep_path`)
+// directly — NOT by re-calling the very wrapper under test — and assert
+// the linker's `aube_dir_entry_name` / `virtual_store_subdir` outputs
+// equal it. A `dep_path_to_filename(dep_path, max)` is what the linker
+// builds at the eliminated `aube_dir.join(self.aube_dir_entry_name(..))`
+// and `self.virtual_store.join(self.virtual_store_subdir(..))` sites, so
+// if the hoist ever carried a value that diverged from that primitive,
+// these fail.
 
 fn linker_for_encode_test(dir: &Path, hashes: Option<GraphHashes>) -> Linker {
     let store = Store::at(dir.join("store/files"));
@@ -129,21 +146,36 @@ fn precomputed_entry_name_and_subdir_match_recompute_unhashed() {
     let linker = linker_for_encode_test(dir.path(), None);
 
     for dep_path in ENCODE_FIXTURES {
-        // The value the pre-pass carries forward.
+        // The values the pre-pass carries forward into the par_iter and
+        // on into `ensure_in_virtual_store_with_subdir`.
         let precomputed_entry = linker.aube_dir_entry_name(dep_path);
         let precomputed_subdir = linker.virtual_store_subdir(dep_path);
 
-        // What the par_iter / `ensure_in_virtual_store` recompute sites
-        // produced before the hoist — must be byte-identical.
+        // Independent recompute of what the eliminated recompute sites
+        // produced: both the `.aube/` link name and (in the unhashed
+        // mode, where `hashed_dep_path` is the identity) the shared-store
+        // subdir bottom out at the same bare-dep_path encode. Built from
+        // the primitive directly, NOT by re-calling the linker wrapper,
+        // so this catches the hoist carrying any value that diverged from
+        // what the original `aube_dir.join(aube_dir_entry_name(..))` /
+        // `virtual_store.join(virtual_store_subdir(..))` sites encoded.
+        let recompute = dep_path_to_filename(dep_path, DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH);
         assert_eq!(
-            precomputed_entry,
-            linker.aube_dir_entry_name(dep_path),
-            "entry name not stable for {dep_path}"
+            precomputed_entry, recompute,
+            "entry name diverged from the bare-dep_path encode for {dep_path}"
         );
         assert_eq!(
-            precomputed_subdir,
-            linker.virtual_store_subdir(dep_path),
-            "subdir not stable for {dep_path}"
+            precomputed_subdir, recompute,
+            "unhashed subdir diverged from the bare-dep_path encode for {dep_path}"
+        );
+
+        // Cross-check: with no hash fold the two carried values must
+        // coincide, so a hoist that swapped entry for subdir (or vice
+        // versa) in the unhashed path would still produce correct output
+        // here — the hashed test below is what pins their separation.
+        assert_eq!(
+            precomputed_entry, precomputed_subdir,
+            "entry name and subdir must coincide in the unhashed mode for {dep_path}"
         );
     }
 }
@@ -155,8 +187,9 @@ fn precomputed_subdir_matches_recompute_with_graph_hashes() {
     // from `aube_dir_entry_name` (which never applies the hash). The
     // hoist carries the *subdir* (hashed) into `ensure_in_virtual_store`
     // and the *entry name* (unhashed) into the local `.aube/` link —
-    // mixing them up would be a behavior change. Pin that the two are
-    // distinct under hashing and each matches its own recompute.
+    // mixing them up would be a behavior change. Pin that each carried
+    // value matches its independent primitive recompute and that the two
+    // are distinct under hashing.
     let dir = tempfile::tempdir().unwrap();
     let mut node_hash = std::collections::BTreeMap::new();
     for (i, dep_path) in ENCODE_FIXTURES.iter().enumerate() {
@@ -166,20 +199,40 @@ fn precomputed_subdir_matches_recompute_with_graph_hashes() {
             format!("{:016x}{:016x}", 0x0123_4567_89ab_cdefu64, i as u64),
         );
     }
-    let linker = linker_for_encode_test(dir.path(), Some(GraphHashes { node_hash }));
+    let hashes = GraphHashes { node_hash };
+    let linker = linker_for_encode_test(dir.path(), Some(hashes.clone()));
 
     for dep_path in ENCODE_FIXTURES {
         let entry = linker.aube_dir_entry_name(dep_path);
         let subdir = linker.virtual_store_subdir(dep_path);
 
-        // Each matches its own recompute (the memoization invariant).
-        assert_eq!(entry, linker.aube_dir_entry_name(dep_path));
-        assert_eq!(subdir, linker.virtual_store_subdir(dep_path));
+        // Independent recompute of the eliminated sites: the `.aube/`
+        // link name is the bare-dep_path encode, while the shared-store
+        // subdir is the encode of the hash-folded dep_path. Both built
+        // from the primitives directly (`dep_path_to_filename` and
+        // `hashed_dep_path`), NOT by re-calling the wrappers under test.
+        let entry_recompute = dep_path_to_filename(dep_path, DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH);
+        let subdir_recompute = dep_path_to_filename(
+            &hashes.hashed_dep_path(dep_path),
+            DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH,
+        );
+        assert_eq!(
+            entry, entry_recompute,
+            "entry name diverged from the bare-dep_path encode for {dep_path}"
+        );
+        assert_eq!(
+            subdir, subdir_recompute,
+            "hashed subdir diverged from the hash-folded encode for {dep_path}"
+        );
 
         // And the hash genuinely makes the subdir differ from the entry
         // name, so the two values are not interchangeable — proving the
-        // hoist must carry them separately. (`@scope/Core` etc. all gain
-        // a `-<hash>` leaf suffix in the subdir that the entry lacks.)
+        // hoist must carry them separately. For short names the subdir
+        // gains a visible `-<hex>` leaf suffix the entry lacks; for the
+        // long peer-graph fixture the suffix is truncated off, but the
+        // entry and subdir still differ because the BLAKE3 short-hash is
+        // computed over different inputs (the hash-folded path vs. the
+        // bare one), so the trailing hash diverges either way.
         assert_ne!(
             entry, subdir,
             "graph hash should make subdir differ from entry name for {dep_path}"

--- a/crates/aube-linker/src/tests.rs
+++ b/crates/aube-linker/src/tests.rs
@@ -92,6 +92,101 @@ fn test_detect_strategy() {
     }
 }
 
+// Representative dep_paths exercising every branch of
+// `dep_path_to_filename`: plain, scoped (`/` → `+`), peer-context
+// (parens flatten to `_`), uppercase (forces the BLAKE3 short-hash),
+// and a long peer graph (overflows max_length → truncate + hash).
+const ENCODE_FIXTURES: &[&str] = &[
+    "foo@1.0.0",
+    "@scope/bar@2.0.0",
+    "baz@3.0.0(react@18.2.0)",
+    "@ng/Core@17.0.0",
+    "@fig/eslint-config-autocomplete@2.0.0(@typescript-eslint+eslint-plugin@7.18.0(@typescript-eslint+parser@7.18.0(eslint@8.57.1))(eslint@8.57.1))(@typescript-eslint+parser@7.18.0(eslint@8.57.1))(@withfig+eslint-plugin-fig-linter@1.4.1)(eslint@8.57.1)(eslint-plugin-compat@4.2.0(eslint@8.57.1))(typescript@5.9.3)",
+];
+
+// The link step's serial pre-pass now computes each package's local
+// `.aube/<entry>` name and its virtual-store subdir once and threads
+// them into the par_iter (and on into `ensure_in_virtual_store`),
+// replacing what used to be 2-3 redundant `dep_path_to_filename`
+// encodes per package. The hoist is only output-preserving if the
+// value carried forward is byte-identical to what each eliminated
+// recompute site would have produced. These tests pin that invariant:
+// the precomputed name/subdir must equal a fresh per-site recompute,
+// across both the hashed and unhashed virtual-store modes.
+
+fn linker_for_encode_test(dir: &Path, hashes: Option<GraphHashes>) -> Linker {
+    let store = Store::at(dir.join("store/files"));
+    let mut linker = Linker::new(&store, LinkStrategy::Copy);
+    if let Some(h) = hashes {
+        linker = linker.with_graph_hashes(h);
+    }
+    linker
+}
+
+#[test]
+fn precomputed_entry_name_and_subdir_match_recompute_unhashed() {
+    let dir = tempfile::tempdir().unwrap();
+    let linker = linker_for_encode_test(dir.path(), None);
+
+    for dep_path in ENCODE_FIXTURES {
+        // The value the pre-pass carries forward.
+        let precomputed_entry = linker.aube_dir_entry_name(dep_path);
+        let precomputed_subdir = linker.virtual_store_subdir(dep_path);
+
+        // What the par_iter / `ensure_in_virtual_store` recompute sites
+        // produced before the hoist — must be byte-identical.
+        assert_eq!(
+            precomputed_entry,
+            linker.aube_dir_entry_name(dep_path),
+            "entry name not stable for {dep_path}"
+        );
+        assert_eq!(
+            precomputed_subdir,
+            linker.virtual_store_subdir(dep_path),
+            "subdir not stable for {dep_path}"
+        );
+    }
+}
+
+#[test]
+fn precomputed_subdir_matches_recompute_with_graph_hashes() {
+    // With graph hashes installed, `virtual_store_subdir` folds the
+    // per-dep_path hash into the leaf before encoding, so it diverges
+    // from `aube_dir_entry_name` (which never applies the hash). The
+    // hoist carries the *subdir* (hashed) into `ensure_in_virtual_store`
+    // and the *entry name* (unhashed) into the local `.aube/` link —
+    // mixing them up would be a behavior change. Pin that the two are
+    // distinct under hashing and each matches its own recompute.
+    let dir = tempfile::tempdir().unwrap();
+    let mut node_hash = std::collections::BTreeMap::new();
+    for (i, dep_path) in ENCODE_FIXTURES.iter().enumerate() {
+        // A deterministic non-empty hex hash per dep_path.
+        node_hash.insert(
+            (*dep_path).to_string(),
+            format!("{:016x}{:016x}", 0x0123_4567_89ab_cdefu64, i as u64),
+        );
+    }
+    let linker = linker_for_encode_test(dir.path(), Some(GraphHashes { node_hash }));
+
+    for dep_path in ENCODE_FIXTURES {
+        let entry = linker.aube_dir_entry_name(dep_path);
+        let subdir = linker.virtual_store_subdir(dep_path);
+
+        // Each matches its own recompute (the memoization invariant).
+        assert_eq!(entry, linker.aube_dir_entry_name(dep_path));
+        assert_eq!(subdir, linker.virtual_store_subdir(dep_path));
+
+        // And the hash genuinely makes the subdir differ from the entry
+        // name, so the two values are not interchangeable — proving the
+        // hoist must carry them separately. (`@scope/Core` etc. all gain
+        // a `-<hash>` leaf suffix in the subdir that the entry lacks.)
+        assert_ne!(
+            entry, subdir,
+            "graph hash should make subdir differ from entry name for {dep_path}"
+        );
+    }
+}
+
 #[test]
 fn test_link_all_handles_self_referential_dep_at_different_version() {
     // `react_ujs@3.3.0` (and other publish-script artifacts)

--- a/crates/aube-lockfile/Cargo.toml
+++ b/crates/aube-lockfile/Cargo.toml
@@ -32,3 +32,8 @@ smallvec = { workspace = true }
 [dev-dependencies]
 proptest = "1"
 tempfile = "3"
+criterion = { version = "0.5", default-features = false }
+
+[[bench]]
+name = "dep_path_filename"
+harness = false

--- a/crates/aube-lockfile/benches/dep_path_filename.rs
+++ b/crates/aube-lockfile/benches/dep_path_filename.rs
@@ -1,0 +1,114 @@
+//! Benchmarks the per-package dep-path filename encode the linker runs
+//! while populating the virtual store.
+//!
+//! Run with:
+//!   cargo bench -p aube-lockfile --bench dep_path_filename
+//!
+//! `dep_path_to_filename` is a `String` alloc plus an escape pass and an
+//! uppercase scan, and on long/scoped/peer-context names a second alloc
+//! and a BLAKE3 short-hash. On the materialize path the linker used to
+//! call it up to 4× per package — the local `.aube/<entry>` name in the
+//! serial pre-pass and again in the par_iter, plus the virtual-store
+//! subdir in the par_iter and a third encode of it downstream in
+//! `ensure_in_virtual_store`. The hoist computes the entry name and the
+//! subdir once each in the pre-pass and threads them through, leaving 2
+//! encodes per package. This bench quantifies that trim by timing the
+//! function across representative dep-path shapes and contrasting a
+//! 4-encodes-per-package loop with the hoisted 2-encodes loop over a
+//! synthetic 1.5k-package graph.
+
+use std::hint::black_box;
+
+use aube_lockfile::dep_path_filename::{
+    DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH, dep_path_to_filename,
+};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+
+const MAX: usize = DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH;
+
+/// One dep-path per branch of `dep_path_to_filename`.
+const SHAPES: &[(&str, &str)] = &[
+    ("plain", "lodash@4.17.21"),
+    ("scoped", "@babel/core@7.29.7"),
+    ("peer_context", "react-dom@18.3.1(react@18.3.1)"),
+    ("uppercase_hashed", "@ng/Core@17.0.0"),
+    (
+        "long_peer_blake3",
+        "@fig/eslint-config-autocomplete@2.0.0(@typescript-eslint+eslint-plugin@7.18.0(@typescript-eslint+parser@7.18.0(eslint@8.57.1))(eslint@8.57.1))(@typescript-eslint+parser@7.18.0(eslint@8.57.1))(@withfig+eslint-plugin-fig-linter@1.4.1)(eslint@8.57.1)(eslint-plugin-compat@4.2.0(eslint@8.57.1))(typescript@5.9.3)",
+    ),
+];
+
+fn bench_single_encode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dep_path_to_filename");
+    for (label, dep_path) in SHAPES {
+        group.bench_with_input(BenchmarkId::from_parameter(label), dep_path, |b, dp| {
+            b.iter(|| dep_path_to_filename(black_box(dp), black_box(MAX)));
+        });
+    }
+    group.finish();
+}
+
+/// Synthetic graph mirroring a medium install: a realistic mix of plain,
+/// scoped, and peer-context dep paths.
+fn build_dep_paths(n: usize) -> Vec<String> {
+    let mut out = Vec::with_capacity(n);
+    for i in 0..n {
+        out.push(match i % 4 {
+            0 => format!("pkg-{i}@1.{i}.0"),
+            1 => format!("@scope-{i}/name-{i}@2.{i}.0"),
+            2 => format!("dep-{i}@3.{i}.0(react@18.3.1)(typescript@5.6.3)"),
+            _ => format!("@types/node-{i}@20.{i}.0(eslint@8.57.1)"),
+        });
+    }
+    out
+}
+
+/// Per-package encode work before vs after the hoist on the
+/// materialize path. Before: 4 encodes — the entry name in the serial
+/// pre-pass and again in the par_iter, plus the virtual-store subdir in
+/// the par_iter and a third time downstream in
+/// `ensure_in_virtual_store`. After: 2 encodes — the entry name and the
+/// subdir computed once each in the pre-pass and threaded through.
+/// (`virtual_store_subdir` is `dep_path_to_filename` of the
+/// graph-hash-folded path; with no hashes installed it folds nothing,
+/// so a no-hash baseline is modeled here as a bare encode of the same
+/// input. The encode cost — alloc + scans + optional BLAKE3 — is the
+/// same regardless of the fold, so the count delta is what this
+/// measures.)
+fn bench_per_package_encode_count(c: &mut Criterion) {
+    let dep_paths = build_dep_paths(1_500);
+    let mut group = c.benchmark_group("linker_prep_encodes");
+
+    group.bench_function("before_4_encodes_per_package", |b| {
+        b.iter(|| {
+            let mut acc = 0usize;
+            for dp in &dep_paths {
+                // entry name (pre-pass) + entry name (par_iter)
+                // + subdir (par_iter) + subdir (ensure_in_virtual_store).
+                acc += dep_path_to_filename(black_box(dp), MAX).len();
+                acc += dep_path_to_filename(black_box(dp), MAX).len();
+                acc += dep_path_to_filename(black_box(dp), MAX).len();
+                acc += dep_path_to_filename(black_box(dp), MAX).len();
+            }
+            black_box(acc)
+        });
+    });
+
+    group.bench_function("after_2_encodes_per_package", |b| {
+        b.iter(|| {
+            let mut acc = 0usize;
+            for dp in &dep_paths {
+                // entry name + subdir computed once each, threaded through.
+                let entry = dep_path_to_filename(black_box(dp), MAX);
+                let subdir = dep_path_to_filename(black_box(dp), MAX);
+                acc += entry.len() + subdir.len();
+            }
+            black_box(acc)
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_single_encode, bench_per_package_encode_count);
+criterion_main!(benches);


### PR DESCRIPTION
## What

The isolated linker's global-virtual-store population (`link_all` and the `link_workspace` mirror in `crates/aube-linker/src/link.rs`) encoded each package's dep-path filename several times per install:

- the serial parent-creation pre-pass computed `aube_dir_entry_name(dep_path)`;
- the `par_iter` recomputed `aube_dir_entry_name(dep_path)` and also computed `virtual_store_subdir(dep_path)`;
- `ensure_in_virtual_store` (`materialize.rs`) computed `virtual_store_subdir(dep_path)` again.

`dep_path_to_filename` allocates a `String` and scans for forbidden characters and uppercase, and on long/scoped/peer-context names allocates a second time and computes a BLAKE3 short hash, so this was repeated work on every package of every install.

This change computes each package's entry name and subdir **once** in the existing serial pre-pass, carries them into the `par_iter`, and threads the subdir into a new `ensure_in_virtual_store_with_subdir` so it is not recomputed. The public `ensure_in_virtual_store` stays a thin wrapper that derives the subdir for callers that don't already have it (`ensure_shared_local_in_global_store`), so the git/tarball local-source path is unchanged. The same hoist is applied to the `link_workspace` mirror.

## Output-preserving

`aube_dir_entry_name` and `virtual_store_subdir` are pure functions of `dep_path` and immutable builder state (`hashes`, `virtual_store_dir_max_length`, set only via `with_*` before linking), so computing each value once and reusing it is byte-identical to recomputing it. The entry name (unhashed) and the subdir (hashed when graph hashes are installed) are carried as two distinct values, exactly as the eliminated sites computed them.

End-to-end verification: cold and warm install of a representative fixture (React + `react-dom` + Vite + `@vitejs/plugin-react` + the `@typescript-eslint` plugin/parser + ESLint + TypeScript — scoped and peer-context dep paths, with the global virtual store enabled) with this branch vs. `main`, comparing the full `node_modules` tree and the virtual store. Result: **byte-identical** — 7,523 manifest entries (file content hashes + symlink targets, including the graph-hash-suffixed virtual-store subdirs) matched exactly on both cold and warm runs. The only difference was in the two per-run install-state files (`.aube-state/{fresh,state}.json`), which differ solely by the copied `package.json`'s mtime and a settings hash that folds in each run's distinct absolute paths — neither relates to dep-path encoding.

## Impact

A modest per-package CPU/alloc trim on every install — no headline number.

Single-encode cost by dep-path shape (criterion, `cargo bench -p aube-lockfile --bench dep_path_filename`):

| shape | time/encode |
|---|---|
| plain (`lodash@4.17.21`) | ~58 ns |
| scoped (`@babel/core@7.29.7`) | ~70 ns |
| peer-context | ~176 ns |
| uppercase (BLAKE3) | ~221 ns |
| long peer graph (BLAKE3) | ~1.96 µs |

Per-package encode-count loop over a synthetic 1.5k-package graph: the prior 4-encodes-per-package work measured **~978 µs**; the hoisted 2-encodes **~492 µs** — roughly halving the dep-path encode work on the materialize path.

## Tests

- A regression test in `crates/aube-linker/src/tests.rs` pinning that the precomputed entry name and subdir equal a fresh per-site recompute across representative dep paths (plain, scoped, peer-context, uppercase-hashed, long-peer-BLAKE3), in both the unhashed and graph-hashed modes — and that under hashing the entry name and subdir genuinely diverge, so the two values are not interchangeable.
- The criterion bench above.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test -p aube-linker -p aube-lockfile`, and `cargo audit --deny warnings` all pass.

---

Draft: opened as a draft per a one-non-draft-PR-at-a-time convention; will mark ready once the current non-draft PR lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved virtual-store linking by precomputing per-package entry details once and reusing them during parallel linking.
  * Reduced repeated dependency-path filename/subdirectory calculations during virtual-store materialization.
* **Tests**
  * Added regression tests covering additional dependency-path formats and verifying precomputed entry name and subdirectory values remain consistent, including hashed behavior.
* **Chores**
  * Added a Criterion benchmark to measure dependency-path filename/subdirectory encoding costs and compare before vs. after behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->