### PR TITLE
perf(linker): OS-gate packageImportMethod=auto (reflink on macOS), with the auto-only hardlink fallback scoped to auto

### DIFF
--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -232,9 +232,9 @@ pub struct Linker {
 #[derive(Debug, Clone, Copy)]
 pub enum LinkStrategy {
     /// Copy-on-write (APFS clonefile, btrfs reflink). Selected by
-    /// explicit `packageImportMethod = clone` / `clone-or-copy`;
-    /// `auto` picks [`Hardlink`] because hardlink is measurably
-    /// faster on every benchmarked target.
+    /// explicit `packageImportMethod = clone` / `clone-or-copy`, and by
+    /// `auto` on macOS where APFS clonefile is measurably faster than
+    /// hardlink. (On Linux and other targets `auto` picks [`Hardlink`].)
     Reflink,
     /// Hard link (ext4, NTFS)
     Hardlink,

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -238,13 +238,16 @@ pub enum LinkStrategy {
     /// Copy-on-write chosen by `auto` on a same-filesystem macOS target,
     /// where APFS clonefile benchmarks faster than hardlink. (On Linux
     /// and other targets `auto` picks [`Hardlink`].) Distinct from
-    /// [`Reflink`] because `auto` owns a stronger fallback: the same-FS
-    /// probe already proved the target shares a mount, so on a non-APFS
-    /// same-FS volume (HFS+) — where `clonefile` is unsupported but
-    /// hardlinks are not — `auto` degrades to a hardlink before copy, so
-    /// a same-FS target always keeps a zero-cost link. Explicit
-    /// `clone` / `clone-or-copy` keep their documented copy fallback and
-    /// never take this hardlink step.
+    /// [`Reflink`] because `auto` owns a stronger reflink-failure fallback:
+    /// the same-FS probe already proved the target shares a mount, so on a
+    /// non-APFS same-FS volume (HFS+) — where `clonefile` is unsupported but
+    /// hardlinks are not — `auto` degrades to a hardlink before copy,
+    /// keeping the link zero-cost where explicit `clone` / `clone-or-copy`
+    /// would copy. (Small macOS files copy outright before any reflink or
+    /// hardlink attempt; the hardlink step is the reflink-*failure* fallback,
+    /// not an unconditional same-FS guarantee.) Explicit `clone` /
+    /// `clone-or-copy` keep their documented copy fallback and never take
+    /// this hardlink step.
     ///
     /// [`Reflink`]: LinkStrategy::Reflink
     /// [`Hardlink`]: LinkStrategy::Hardlink

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -231,11 +231,24 @@ pub struct Linker {
 /// Strategy for linking files from the store to node_modules.
 #[derive(Debug, Clone, Copy)]
 pub enum LinkStrategy {
-    /// Copy-on-write (APFS clonefile, btrfs reflink). Selected by
-    /// explicit `packageImportMethod = clone` / `clone-or-copy`, and by
-    /// `auto` on macOS where APFS clonefile is measurably faster than
-    /// hardlink. (On Linux and other targets `auto` picks [`Hardlink`].)
+    /// Copy-on-write (APFS clonefile, btrfs reflink). Selected only by
+    /// explicit `packageImportMethod = clone` / `clone-or-copy`, whose
+    /// documented contract is reflink with a plain **copy** fallback.
     Reflink,
+    /// Copy-on-write chosen by `auto` on a same-filesystem macOS target,
+    /// where APFS clonefile benchmarks faster than hardlink. (On Linux
+    /// and other targets `auto` picks [`Hardlink`].) Distinct from
+    /// [`Reflink`] because `auto` owns a stronger fallback: the same-FS
+    /// probe already proved the target shares a mount, so on a non-APFS
+    /// same-FS volume (HFS+) — where `clonefile` is unsupported but
+    /// hardlinks are not — `auto` degrades to a hardlink before copy, so
+    /// a same-FS target always keeps a zero-cost link. Explicit
+    /// `clone` / `clone-or-copy` keep their documented copy fallback and
+    /// never take this hardlink step.
+    ///
+    /// [`Reflink`]: LinkStrategy::Reflink
+    /// [`Hardlink`]: LinkStrategy::Hardlink
+    ReflinkAuto,
     /// Hard link (ext4, NTFS)
     Hardlink,
     /// Full copy (fallback)

--- a/crates/aube-linker/src/materialize.rs
+++ b/crates/aube-linker/src/materialize.rs
@@ -686,11 +686,35 @@ impl Linker {
                     // silently regresses to a byte transfer per file.
                     // Explicit `clone` / `clone-or-copy` (Reflink) keep
                     // their documented copy fallback and skip this step.
-                    if auto && std::fs::hard_link(&stored.store_path, dst).is_ok() {
-                        trace!("reflink failed, fell back to hardlink: {e}");
+                    //
+                    // Surface the hardlink attempt's OWN error in the copy
+                    // trace: if the auto hardlink itself fails (a cross-mount
+                    // edge the probe missed, a transient permission error), it
+                    // — not the original reflink error — is the proximate
+                    // cause of the copy, so reporting only `e` would point at
+                    // the wrong failure.
+                    let hardlinked = if auto {
+                        match std::fs::hard_link(&stored.store_path, dst) {
+                            Ok(()) => {
+                                trace!("reflink failed, fell back to hardlink: {e}");
+                                true
+                            }
+                            Err(he) => {
+                                trace!(
+                                    "reflink failed ({e}); hardlink fallback also failed ({he}); falling back to copy"
+                                );
+                                false
+                            }
+                        }
+                    } else {
+                        false
+                    };
+                    if hardlinked {
                         realized = "reflink_fallback_hardlink";
                     } else {
-                        trace!("reflink failed, falling back to copy: {e}");
+                        if !auto {
+                            trace!("reflink failed, falling back to copy: {e}");
+                        }
                         std::fs::copy(&stored.store_path, dst).map_err(map_io)?;
                         realized = "reflink_fallback_copy";
                     }

--- a/crates/aube-linker/src/materialize.rs
+++ b/crates/aube-linker/src/materialize.rs
@@ -21,11 +21,13 @@ impl Linker {
     /// falls back to `fs::copy` per file silently, thousands of
     /// wasted syscalls, user thinks they got hardlinks.
     ///
-    /// Returns `Hardlink` when the probe succeeds, `Copy` otherwise.
-    /// Reflink is reachable only through explicit
-    /// `packageImportMethod = clone` / `clone-or-copy`; `auto` resolves
-    /// to `Hardlink` because hardlink benchmarks faster across every
-    /// target reflink supports (APFS clonefile, btrfs/xfs FICLONE).
+    /// Returns the same-filesystem strategy when the probe succeeds,
+    /// `Copy` otherwise. The same-FS strategy is OS-specific: on macOS
+    /// `auto` resolves to `Reflink` (APFS clonefile benchmarks ~1.91x
+    /// faster than hardlink), on Linux and other targets it resolves to
+    /// `Hardlink` (btrfs/xfs hardlink benchmarks ~2.4-2.6x faster than
+    /// FICLONE reflink). `Reflink` is otherwise reachable only through
+    /// explicit `packageImportMethod = clone` / `clone-or-copy`.
     pub fn detect_strategy(path: &Path) -> LinkStrategy {
         Self::detect_strategy_cross(path, path)
     }
@@ -34,8 +36,20 @@ impl Linker {
     /// store FS), dst is the project modules dir (or any dir on the
     /// destination FS). Probe creates a real cross-mount src file
     /// and tries to hardlink into dst, which catches EXDEV up front.
-    /// Returns `Hardlink` when the probe succeeds, `Copy` otherwise.
+    /// A successful hardlink proves src and dst share a mount, so it
+    /// doubles as the same-FS probe for reflink too (APFS clonefile /
+    /// btrfs FICLONE require the same FS). Returns the OS-specific
+    /// same-FS strategy when the probe succeeds (`Reflink` on macOS,
+    /// `Hardlink` elsewhere), `Copy` otherwise.
     pub fn detect_strategy_cross(src_dir: &Path, dst_dir: &Path) -> LinkStrategy {
+        // Same-FS strategy `auto` resolves to once the probe succeeds.
+        // macOS/APFS clonefile is measurably faster than hardlink there;
+        // Linux btrfs/xfs hardlink is measurably faster than FICLONE.
+        #[cfg(target_os = "macos")]
+        const SAME_FS_STRATEGY: LinkStrategy = LinkStrategy::Reflink;
+        #[cfg(not(target_os = "macos"))]
+        const SAME_FS_STRATEGY: LinkStrategy = LinkStrategy::Hardlink;
+
         // Memoize per (src_dir, dst_dir) for the process lifetime.
         // The probe writes a real test file and tries hardlink,
         // ~2 syscalls + 2 unlinks. Multiple Linker instances within
@@ -56,7 +70,7 @@ impl Linker {
 
         let strategy = if std::fs::write(&test_src, b"test").is_ok() {
             let result = if std::fs::hard_link(&test_src, &test_dst).is_ok() {
-                LinkStrategy::Hardlink
+                SAME_FS_STRATEGY
             } else {
                 LinkStrategy::Copy
             };
@@ -73,7 +87,9 @@ impl Linker {
         // hardlink-ok, the other sees the first writer's leftover and
         // falls back to Copy. `.insert()` would let the wrong Copy
         // result clobber the correct Hardlink for the rest of the
-        // process; `or_insert` keeps whichever value landed first.
+        // process; `or_insert` keeps whichever value landed first. (The
+        // value at stake is the same-FS strategy above, not literally
+        // Hardlink — Reflink on macOS.)
         *cache
             .write()
             .expect("probe cache poisoned")

--- a/crates/aube-linker/src/materialize.rs
+++ b/crates/aube-linker/src/materialize.rs
@@ -8,6 +8,15 @@ use aube_store::{PackageIndex, StoredFile};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+/// Test-only switch that forces the reflink attempt in
+/// [`Linker::link_file_fresh`] to be treated as failed, so the
+/// clonefile-failure fallback path can be exercised deterministically on
+/// any filesystem (CI runs on reflink-capable APFS/btrfs where a real
+/// `clonefile` would otherwise succeed). Compiled out of release builds.
+#[cfg(test)]
+pub(crate) static FORCE_REFLINK_FAILURE: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
 impl Linker {
     /// Detect the best linking strategy for the filesystem at the given path.
     ///
@@ -21,21 +30,23 @@ impl Linker {
     /// falls back to `fs::copy` per file silently, thousands of
     /// wasted syscalls, user thinks they got hardlinks.
     ///
-    /// Returns the same-filesystem strategy when the probe succeeds,
-    /// `Copy` otherwise. The same-FS strategy is OS-specific: on macOS
-    /// `auto` resolves to `Reflink` (APFS clonefile benchmarks ~1.91x
-    /// faster than hardlink), on Linux and other targets it resolves to
-    /// `Hardlink` (btrfs/xfs hardlink benchmarks ~2.4-2.6x faster than
-    /// FICLONE reflink). `Reflink` is otherwise reachable only through
-    /// explicit `packageImportMethod = clone` / `clone-or-copy`.
+    /// Returns the same-filesystem strategy `auto` resolves to when the
+    /// probe succeeds, `Copy` otherwise. The same-FS strategy is
+    /// OS-specific: on macOS `auto` resolves to `ReflinkAuto` (APFS
+    /// clonefile benchmarks ~1.91x faster than hardlink), on Linux and
+    /// other targets it resolves to `Hardlink` (btrfs/xfs hardlink
+    /// benchmarks ~2.4-2.6x faster than FICLONE reflink).
     ///
-    /// The macOS `Reflink` resolution is conservative on non-APFS
-    /// volumes: `clonefile` is APFS-only, so on an HFS+ volume (external
-    /// drives, Fusion/older disks) the same-FS hardlink probe succeeds
-    /// and resolves `Reflink`, but the real `clonefile` then fails.
+    /// The macOS `auto` resolution is conservative on non-APFS volumes:
+    /// `clonefile` is APFS-only, so on an HFS+ volume (external drives,
+    /// Fusion/older disks) the same-FS hardlink probe succeeds and
+    /// resolves `ReflinkAuto`, but the real `clonefile` then fails.
     /// `link_file_fresh` handles this by falling the reflink back to a
     /// hardlink (which HFS+ supports) before copy, so a non-APFS same-FS
     /// target still gets zero-cost links rather than a per-file copy.
+    /// This probe never yields the plain `Reflink` strategy — that is
+    /// reachable only through explicit `packageImportMethod = clone` /
+    /// `clone-or-copy`, which keep a plain copy fallback.
     pub fn detect_strategy(path: &Path) -> LinkStrategy {
         Self::detect_strategy_cross(path, path)
     }
@@ -47,14 +58,16 @@ impl Linker {
     /// A successful hardlink proves src and dst share a mount, so it
     /// doubles as the same-FS probe for reflink too (APFS clonefile /
     /// btrfs FICLONE require the same FS). Returns the OS-specific
-    /// same-FS strategy when the probe succeeds (`Reflink` on macOS,
+    /// same-FS strategy when the probe succeeds (`ReflinkAuto` on macOS,
     /// `Hardlink` elsewhere), `Copy` otherwise.
     pub fn detect_strategy_cross(src_dir: &Path, dst_dir: &Path) -> LinkStrategy {
         // Same-FS strategy `auto` resolves to once the probe succeeds.
         // macOS/APFS clonefile is measurably faster than hardlink there;
         // Linux btrfs/xfs hardlink is measurably faster than FICLONE.
+        // `ReflinkAuto` (not the plain `Reflink` explicit selections use)
+        // carries the non-APFS hardlink-before-copy fallback.
         #[cfg(target_os = "macos")]
-        const SAME_FS_STRATEGY: LinkStrategy = LinkStrategy::Reflink;
+        const SAME_FS_STRATEGY: LinkStrategy = LinkStrategy::ReflinkAuto;
         #[cfg(not(target_os = "macos"))]
         const SAME_FS_STRATEGY: LinkStrategy = LinkStrategy::Hardlink;
 
@@ -97,7 +110,7 @@ impl Linker {
         // result clobber the correct Hardlink for the rest of the
         // process; `or_insert` keeps whichever value landed first. (The
         // value at stake is the same-FS strategy above, not literally
-        // Hardlink — Reflink on macOS.)
+        // Hardlink — ReflinkAuto on macOS.)
         *cache
             .write()
             .expect("probe cache poisoned")
@@ -612,7 +625,19 @@ impl Linker {
         let diag_t0 = aube_util::diag::enabled().then(std::time::Instant::now);
         let realized: &'static str;
         match self.strategy {
-            LinkStrategy::Reflink => {
+            // Two reflink strategies share the clonefile attempt and the
+            // macOS small-file copy shortcut, but differ in fallback:
+            //   * `Reflink` (explicit `clone` / `clone-or-copy`) — the
+            //     documented contract is reflink with a plain copy
+            //     fallback, so a clonefile failure degrades straight to
+            //     copy.
+            //   * `ReflinkAuto` (`auto` on a same-FS macOS target) — the
+            //     probe already proved the target shares a mount, so on a
+            //     non-APFS same-FS volume (HFS+, where `clonefile` is
+            //     unsupported but hardlinks are not) it tries a zero-cost
+            //     hardlink before copy.
+            LinkStrategy::Reflink | LinkStrategy::ReflinkAuto => {
+                let auto = matches!(self.strategy, LinkStrategy::ReflinkAuto);
                 #[cfg(target_os = "macos")]
                 if matches!(stored.size, Some(size) if size <= SMALL_FILE_COPY_MAX) {
                     std::fs::copy(&stored.store_path, dst).map_err(map_io)?;
@@ -626,27 +651,46 @@ impl Linker {
                     }
                     return Ok(());
                 }
-                if let Err(e) = reflink_copy::reflink(&stored.store_path, dst) {
+                let reflink_result = {
+                    #[cfg(test)]
+                    {
+                        if FORCE_REFLINK_FAILURE.load(std::sync::atomic::Ordering::Relaxed) {
+                            Err(std::io::Error::new(
+                                std::io::ErrorKind::Unsupported,
+                                "forced reflink failure (test)",
+                            ))
+                        } else {
+                            reflink_copy::reflink(&stored.store_path, dst)
+                        }
+                    }
+                    #[cfg(not(test))]
+                    {
+                        reflink_copy::reflink(&stored.store_path, dst)
+                    }
+                };
+                if let Err(e) = reflink_result {
                     // Source-missing short-circuit avoids the misleading
                     // "fell back to copy" trace and the redundant copy
                     // attempt that would just ENOENT for the same reason.
                     if !stored.store_path.exists() {
                         return Err(missing_source());
                     }
-                    // Reflink is only the resolved strategy when the same-FS
-                    // probe succeeded, so the target is known same-filesystem.
-                    // `reflink_copy::reflink` uses `clonefile`, which is
-                    // APFS-only: on an HFS+ volume it fails even though the
-                    // volume is same-FS and supports hardlinks. Try a
-                    // hardlink before degrading to a full per-file copy — a
-                    // hardlink is zero-cost and preserves the dedupe the
-                    // probe promised, where copy silently regresses to a byte
-                    // transfer per file.
-                    if std::fs::hard_link(&stored.store_path, dst).is_ok() {
+                    // `auto` (ReflinkAuto) is the resolved strategy only
+                    // when the same-FS probe succeeded, so the target is
+                    // known same-filesystem. `reflink_copy::reflink` uses
+                    // `clonefile`, which is APFS-only: on an HFS+ volume it
+                    // fails even though the volume is same-FS and supports
+                    // hardlinks. There, try a hardlink before degrading to
+                    // a full per-file copy — a hardlink is zero-cost and
+                    // preserves the dedupe the probe promised, where copy
+                    // silently regresses to a byte transfer per file.
+                    // Explicit `clone` / `clone-or-copy` (Reflink) keep
+                    // their documented copy fallback and skip this step.
+                    if auto && std::fs::hard_link(&stored.store_path, dst).is_ok() {
                         trace!("reflink failed, fell back to hardlink: {e}");
                         realized = "reflink_fallback_hardlink";
                     } else {
-                        trace!("reflink and hardlink failed, falling back to copy: {e}");
+                        trace!("reflink failed, falling back to copy: {e}");
                         std::fs::copy(&stored.store_path, dst).map_err(map_io)?;
                         realized = "reflink_fallback_copy";
                     }

--- a/crates/aube-linker/src/materialize.rs
+++ b/crates/aube-linker/src/materialize.rs
@@ -28,6 +28,14 @@ impl Linker {
     /// `Hardlink` (btrfs/xfs hardlink benchmarks ~2.4-2.6x faster than
     /// FICLONE reflink). `Reflink` is otherwise reachable only through
     /// explicit `packageImportMethod = clone` / `clone-or-copy`.
+    ///
+    /// The macOS `Reflink` resolution is conservative on non-APFS
+    /// volumes: `clonefile` is APFS-only, so on an HFS+ volume (external
+    /// drives, Fusion/older disks) the same-FS hardlink probe succeeds
+    /// and resolves `Reflink`, but the real `clonefile` then fails.
+    /// `link_file_fresh` handles this by falling the reflink back to a
+    /// hardlink (which HFS+ supports) before copy, so a non-APFS same-FS
+    /// target still gets zero-cost links rather than a per-file copy.
     pub fn detect_strategy(path: &Path) -> LinkStrategy {
         Self::detect_strategy_cross(path, path)
     }
@@ -625,10 +633,23 @@ impl Linker {
                     if !stored.store_path.exists() {
                         return Err(missing_source());
                     }
-                    // Fall back to copy on cross-filesystem errors
-                    trace!("reflink failed, falling back to copy: {e}");
-                    std::fs::copy(&stored.store_path, dst).map_err(map_io)?;
-                    realized = "reflink_fallback_copy";
+                    // Reflink is only the resolved strategy when the same-FS
+                    // probe succeeded, so the target is known same-filesystem.
+                    // `reflink_copy::reflink` uses `clonefile`, which is
+                    // APFS-only: on an HFS+ volume it fails even though the
+                    // volume is same-FS and supports hardlinks. Try a
+                    // hardlink before degrading to a full per-file copy — a
+                    // hardlink is zero-cost and preserves the dedupe the
+                    // probe promised, where copy silently regresses to a byte
+                    // transfer per file.
+                    if std::fs::hard_link(&stored.store_path, dst).is_ok() {
+                        trace!("reflink failed, fell back to hardlink: {e}");
+                        realized = "reflink_fallback_hardlink";
+                    } else {
+                        trace!("reflink and hardlink failed, falling back to copy: {e}");
+                        std::fs::copy(&stored.store_path, dst).map_err(map_io)?;
+                        realized = "reflink_fallback_copy";
+                    }
                 } else {
                     realized = "reflink";
                 }
@@ -657,6 +678,7 @@ impl Linker {
             // O(1) and the static `&str` keeps the JSONL category compact.
             let name = match realized {
                 "reflink" => "link_reflink",
+                "reflink_fallback_hardlink" => "link_reflink_fallback_hardlink",
                 "reflink_fallback_copy" => "link_reflink_fallback",
                 "hardlink" => "link_hardlink",
                 "hardlink_fallback_copy" => "link_hardlink_fallback",

--- a/crates/aube-linker/src/tests.rs
+++ b/crates/aube-linker/src/tests.rs
@@ -292,15 +292,15 @@ fn test_link_file_fresh_hardlink_short_circuits_when_source_missing() {
 #[test]
 #[cfg(unix)]
 fn test_link_file_fresh_reflink_falls_back_to_hardlink_not_copy() {
-    // jdx/aube#914 review (Greptile P2): macOS resolves same-FS `auto`
-    // to `Reflink`, but `clonefile` is APFS-only. On a non-APFS same-FS
-    // target (HFS+, or any non-reflink FS) the reflink fails and used to
-    // degrade straight to a per-file copy — a silent regression from the
-    // zero-cost hardlink the same FS supports. The fallback must try a
-    // hardlink before copy. We can only assert the hardlink outcome on a
-    // filesystem that actually lacks reflink (where the fallback fires);
-    // on a reflink-capable FS the reflink succeeds and there is nothing
-    // to fall back from, so the inode check is gated on a probe.
+    // macOS resolves same-FS `auto` to `Reflink`, but `clonefile` is
+    // APFS-only. On a non-APFS same-FS target (HFS+, or any non-reflink
+    // FS) the reflink fails, and degrading straight to a per-file copy
+    // would forfeit the zero-cost hardlink the same FS supports. The
+    // fallback must try a hardlink before copy. We can only assert the
+    // hardlink outcome on a filesystem that actually lacks reflink
+    // (where the fallback fires); on a reflink-capable FS the reflink
+    // succeeds and there is nothing to fall back from, so the inode
+    // check is gated on a probe.
     use std::os::unix::fs::MetadataExt;
 
     let dir = tempfile::tempdir().unwrap();

--- a/crates/aube-linker/src/tests.rs
+++ b/crates/aube-linker/src/tests.rs
@@ -290,6 +290,53 @@ fn test_link_file_fresh_hardlink_short_circuits_when_source_missing() {
 }
 
 #[test]
+#[cfg(unix)]
+fn test_link_file_fresh_reflink_falls_back_to_hardlink_not_copy() {
+    // jdx/aube#914 review (Greptile P2): macOS resolves same-FS `auto`
+    // to `Reflink`, but `clonefile` is APFS-only. On a non-APFS same-FS
+    // target (HFS+, or any non-reflink FS) the reflink fails and used to
+    // degrade straight to a per-file copy — a silent regression from the
+    // zero-cost hardlink the same FS supports. The fallback must try a
+    // hardlink before copy. We can only assert the hardlink outcome on a
+    // filesystem that actually lacks reflink (where the fallback fires);
+    // on a reflink-capable FS the reflink succeeds and there is nothing
+    // to fall back from, so the inode check is gated on a probe.
+    use std::os::unix::fs::MetadataExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = Store::at(dir.path().join("store/files"));
+    let stored = store.import_bytes(b"hello reflink", false).unwrap();
+    let store_path = stored.store_path.clone();
+
+    let dst_dir = dir.path().join("dst");
+    std::fs::create_dir_all(&dst_dir).unwrap();
+    let dst = dst_dir.join("hello.txt");
+
+    let linker = Linker::new_with_gvs(&store, LinkStrategy::Reflink, true);
+    linker
+        .link_file_fresh(&stored, "hello.txt", &dst)
+        .expect("reflink strategy must materialize the file");
+
+    // Data integrity holds regardless of which realized path was taken.
+    assert_eq!(std::fs::read_to_string(&dst).unwrap(), "hello reflink");
+
+    // Probe whether this FS supports reflink at all. If not, the fallback
+    // fired and the result must be a hardlink (same inode as the source),
+    // never a copy (distinct inode).
+    let reflink_probe = dst_dir.join(".reflink-probe");
+    let reflink_supported = reflink_copy::reflink(&store_path, &reflink_probe).is_ok();
+    let _ = std::fs::remove_file(&reflink_probe);
+    if !reflink_supported {
+        let src_ino = std::fs::metadata(&store_path).unwrap().ino();
+        let dst_ino = std::fs::metadata(&dst).unwrap().ino();
+        assert_eq!(
+            src_ino, dst_ino,
+            "reflink-unsupported FS must fall back to a hardlink (same inode), not a copy"
+        );
+    }
+}
+
+#[test]
 fn test_link_all_creates_top_level_entries() {
     let dir = tempfile::tempdir().unwrap();
     let project_dir = dir.path().join("project");

--- a/crates/aube-linker/src/tests.rs
+++ b/crates/aube-linker/src/tests.rs
@@ -83,12 +83,23 @@ fn make_graph() -> LockfileGraph {
 fn test_detect_strategy() {
     let dir = tempfile::tempdir().unwrap();
     let strategy = Linker::detect_strategy(dir.path());
-    // Probe returns `Hardlink` or `Copy`; `Reflink` is only
-    // reachable through explicit `packageImportMethod =
-    // clone`/`clone-or-copy`, so the match guards that contract.
+    // The probe resolves a same-FS success to the OS-specific `auto`
+    // strategy and a cross-FS failure to `Copy`. On macOS the same-FS
+    // strategy is `Reflink` (APFS clonefile), elsewhere `Hardlink`.
+    // Whether the tempdir's FS supports the same-mount link depends on
+    // the runner, so accept the same-FS strategy or `Copy`, but reject
+    // the *other* OS's same-FS strategy — that would mean the cfg gate
+    // resolved on the wrong target.
     match strategy {
-        LinkStrategy::Hardlink | LinkStrategy::Copy => {}
-        LinkStrategy::Reflink => panic!("detect_strategy must not return Reflink"),
+        LinkStrategy::Copy => {}
+        #[cfg(target_os = "macos")]
+        LinkStrategy::Reflink => {}
+        #[cfg(target_os = "macos")]
+        LinkStrategy::Hardlink => panic!("macOS `auto` must resolve same-FS to Reflink"),
+        #[cfg(not(target_os = "macos"))]
+        LinkStrategy::Hardlink => {}
+        #[cfg(not(target_os = "macos"))]
+        LinkStrategy::Reflink => panic!("non-macOS `auto` must resolve same-FS to Hardlink"),
     }
 }
 

--- a/crates/aube-linker/src/tests.rs
+++ b/crates/aube-linker/src/tests.rs
@@ -85,21 +85,26 @@ fn test_detect_strategy() {
     let strategy = Linker::detect_strategy(dir.path());
     // The probe resolves a same-FS success to the OS-specific `auto`
     // strategy and a cross-FS failure to `Copy`. On macOS the same-FS
-    // strategy is `Reflink` (APFS clonefile), elsewhere `Hardlink`.
-    // Whether the tempdir's FS supports the same-mount link depends on
-    // the runner, so accept the same-FS strategy or `Copy`, but reject
-    // the *other* OS's same-FS strategy — that would mean the cfg gate
-    // resolved on the wrong target.
+    // strategy is `ReflinkAuto` (APFS clonefile, with the auto-only
+    // hardlink-before-copy fallback), elsewhere `Hardlink`. Whether the
+    // tempdir's FS supports the same-mount link depends on the runner, so
+    // accept the same-FS strategy or `Copy`, but reject the *other* OS's
+    // same-FS strategy — that would mean the cfg gate resolved on the
+    // wrong target. The probe must never yield the plain `Reflink`
+    // explicit selections use.
     match strategy {
         LinkStrategy::Copy => {}
+        LinkStrategy::Reflink => {
+            panic!("`auto` probe must resolve same-FS to ReflinkAuto, never plain Reflink")
+        }
         #[cfg(target_os = "macos")]
-        LinkStrategy::Reflink => {}
+        LinkStrategy::ReflinkAuto => {}
         #[cfg(target_os = "macos")]
-        LinkStrategy::Hardlink => panic!("macOS `auto` must resolve same-FS to Reflink"),
+        LinkStrategy::Hardlink => panic!("macOS `auto` must resolve same-FS to ReflinkAuto"),
         #[cfg(not(target_os = "macos"))]
         LinkStrategy::Hardlink => {}
         #[cfg(not(target_os = "macos"))]
-        LinkStrategy::Reflink => panic!("non-macOS `auto` must resolve same-FS to Hardlink"),
+        LinkStrategy::ReflinkAuto => panic!("non-macOS `auto` must resolve same-FS to Hardlink"),
     }
 }
 
@@ -289,51 +294,64 @@ fn test_link_file_fresh_hardlink_short_circuits_when_source_missing() {
     );
 }
 
-#[test]
+/// Materialize one file under `strategy` with the reflink attempt forced
+/// to fail, then report whether the result is a hardlink (same inode as
+/// the source) or a copy (distinct inode). Isolates the clonefile-failure
+/// fallback so the split between `ReflinkAuto` and explicit `Reflink` is
+/// observable on any filesystem, including reflink-capable APFS/btrfs CI.
 #[cfg(unix)]
-fn test_link_file_fresh_reflink_falls_back_to_hardlink_not_copy() {
-    // macOS resolves same-FS `auto` to `Reflink`, but `clonefile` is
-    // APFS-only. On a non-APFS same-FS target (HFS+, or any non-reflink
-    // FS) the reflink fails, and degrading straight to a per-file copy
-    // would forfeit the zero-cost hardlink the same FS supports. The
-    // fallback must try a hardlink before copy. We can only assert the
-    // hardlink outcome on a filesystem that actually lacks reflink
-    // (where the fallback fires); on a reflink-capable FS the reflink
-    // succeeds and there is nothing to fall back from, so the inode
-    // check is gated on a probe.
+fn realized_inode_matches_source_on_reflink_failure(strategy: LinkStrategy) -> bool {
     use std::os::unix::fs::MetadataExt;
+    use std::sync::atomic::Ordering;
 
     let dir = tempfile::tempdir().unwrap();
     let store = Store::at(dir.path().join("store/files"));
-    let stored = store.import_bytes(b"hello reflink", false).unwrap();
+    // >16 KiB so the macOS small-file copy shortcut does not pre-empt the
+    // reflink path under test.
+    let content = vec![b'x'; 32 * 1024];
+    let stored = store.import_bytes(&content, false).unwrap();
     let store_path = stored.store_path.clone();
 
     let dst_dir = dir.path().join("dst");
     std::fs::create_dir_all(&dst_dir).unwrap();
-    let dst = dst_dir.join("hello.txt");
+    let dst = dst_dir.join("payload.bin");
 
-    let linker = Linker::new_with_gvs(&store, LinkStrategy::Reflink, true);
-    linker
-        .link_file_fresh(&stored, "hello.txt", &dst)
-        .expect("reflink strategy must materialize the file");
+    let linker = Linker::new_with_gvs(&store, strategy, true);
+    crate::materialize::FORCE_REFLINK_FAILURE.store(true, Ordering::Relaxed);
+    let result = linker.link_file_fresh(&stored, "payload.bin", &dst);
+    crate::materialize::FORCE_REFLINK_FAILURE.store(false, Ordering::Relaxed);
+    result.expect("a reflink strategy must still materialize the file via its fallback");
 
-    // Data integrity holds regardless of which realized path was taken.
-    assert_eq!(std::fs::read_to_string(&dst).unwrap(), "hello reflink");
+    // Data integrity holds whichever fallback fired.
+    assert_eq!(std::fs::read(&dst).unwrap(), content);
 
-    // Probe whether this FS supports reflink at all. If not, the fallback
-    // fired and the result must be a hardlink (same inode as the source),
-    // never a copy (distinct inode).
-    let reflink_probe = dst_dir.join(".reflink-probe");
-    let reflink_supported = reflink_copy::reflink(&store_path, &reflink_probe).is_ok();
-    let _ = std::fs::remove_file(&reflink_probe);
-    if !reflink_supported {
-        let src_ino = std::fs::metadata(&store_path).unwrap().ino();
-        let dst_ino = std::fs::metadata(&dst).unwrap().ino();
-        assert_eq!(
-            src_ino, dst_ino,
-            "reflink-unsupported FS must fall back to a hardlink (same inode), not a copy"
-        );
-    }
+    std::fs::metadata(&store_path).unwrap().ino() == std::fs::metadata(&dst).unwrap().ino()
+}
+
+#[test]
+#[cfg(unix)]
+fn test_reflink_auto_falls_back_to_hardlink_not_copy() {
+    // `auto` on a same-FS macOS target resolves to `ReflinkAuto`; the
+    // probe already proved the target shares a mount, so a clonefile
+    // failure (non-APFS same-FS volume, e.g. HFS+) must degrade to a
+    // zero-cost hardlink before a per-file copy.
+    assert!(
+        realized_inode_matches_source_on_reflink_failure(LinkStrategy::ReflinkAuto),
+        "ReflinkAuto must fall back to a hardlink (same inode), not a copy, on reflink failure"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn test_explicit_reflink_falls_back_to_copy_not_hardlink() {
+    // Explicit `clone` / `clone-or-copy` map to `Reflink`, whose
+    // documented contract is reflink with a plain *copy* fallback. They
+    // must NOT take the auto-only hardlink step on a clonefile failure —
+    // the result is a distinct inode (copy), never the source's inode.
+    assert!(
+        !realized_inode_matches_source_on_reflink_failure(LinkStrategy::Reflink),
+        "explicit Reflink must fall back to a copy (distinct inode), not a hardlink"
+    );
 }
 
 #[test]

--- a/crates/aube-linker/src/tests.rs
+++ b/crates/aube-linker/src/tests.rs
@@ -294,6 +294,42 @@ fn test_link_file_fresh_hardlink_short_circuits_when_source_missing() {
     );
 }
 
+/// RAII guard that serializes `FORCE_REFLINK_FAILURE` across the parallel
+/// test runner and always restores the flag — even if the body panics.
+///
+/// `FORCE_REFLINK_FAILURE` is a process-wide `AtomicBool`, so two reflink
+/// fallback tests running concurrently could otherwise observe each other's
+/// `store(false)` mid-`link_file_fresh` (a reflink-capable FS would then take
+/// the real clonefile path and skew the inode assertion), and a bare manual
+/// reset would leak the `true` state to the next test on a panic. Holding the
+/// `Mutex` for the whole forced-failure window mutually excludes the tests; the
+/// `Drop` impl makes the reset panic-safe.
+#[cfg(unix)]
+struct ForcedReflinkFailure {
+    _guard: std::sync::MutexGuard<'static, ()>,
+}
+
+#[cfg(unix)]
+impl ForcedReflinkFailure {
+    fn engage() -> Self {
+        use std::sync::atomic::Ordering;
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        // Recover from a poisoned lock: a prior test panicking inside the guard
+        // is exactly the case this exists for, and the `Drop` reset still ran.
+        let guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        crate::materialize::FORCE_REFLINK_FAILURE.store(true, Ordering::Relaxed);
+        Self { _guard: guard }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for ForcedReflinkFailure {
+    fn drop(&mut self) {
+        use std::sync::atomic::Ordering;
+        crate::materialize::FORCE_REFLINK_FAILURE.store(false, Ordering::Relaxed);
+    }
+}
+
 /// Materialize one file under `strategy` with the reflink attempt forced
 /// to fail, then report whether the result is a hardlink (same inode as
 /// the source) or a copy (distinct inode). Isolates the clonefile-failure
@@ -302,7 +338,6 @@ fn test_link_file_fresh_hardlink_short_circuits_when_source_missing() {
 #[cfg(unix)]
 fn realized_inode_matches_source_on_reflink_failure(strategy: LinkStrategy) -> bool {
     use std::os::unix::fs::MetadataExt;
-    use std::sync::atomic::Ordering;
 
     let dir = tempfile::tempdir().unwrap();
     let store = Store::at(dir.path().join("store/files"));
@@ -317,9 +352,12 @@ fn realized_inode_matches_source_on_reflink_failure(strategy: LinkStrategy) -> b
     let dst = dst_dir.join("payload.bin");
 
     let linker = Linker::new_with_gvs(&store, strategy, true);
-    crate::materialize::FORCE_REFLINK_FAILURE.store(true, Ordering::Relaxed);
-    let result = linker.link_file_fresh(&stored, "payload.bin", &dst);
-    crate::materialize::FORCE_REFLINK_FAILURE.store(false, Ordering::Relaxed);
+    let result = {
+        // Hold the guard across the materialize so a sibling test can't flip
+        // the global flag mid-call; the flag is restored on drop, panic-safe.
+        let _forced = ForcedReflinkFailure::engage();
+        linker.link_file_fresh(&stored, "payload.bin", &dst)
+    };
     result.expect("a reflink strategy must still materialize the file via its fallback");
 
     // Data integrity holds whichever fallback fired.

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -954,11 +954,15 @@ Controls how aube materializes files from the global content-addressable
 store into the virtual store.
 
 - `auto` (default) probes the destination filesystem and picks a
-  same-filesystem strategy with a `copy` fallback on cross-filesystem
-  boundaries. The same-filesystem strategy is OS-specific: `clone`
-  (reflink) on macOS, where APFS clonefile benchmarks ~1.91x faster
-  than hardlink, and `hardlink` on Linux and other targets, where
-  btrfs/xfs hardlink benchmarks ~2.4-2.6x faster than FICLONE reflink.
+  same-filesystem strategy, with a `copy` fallback when no link
+  primitive applies (cross-filesystem boundaries). The
+  same-filesystem strategy is OS-specific: `clone` (reflink) on macOS,
+  where APFS clonefile benchmarks ~1.91x faster than hardlink, and
+  `hardlink` on Linux and other targets, where btrfs/xfs hardlink
+  benchmarks ~2.4-2.6x faster than FICLONE reflink. On a macOS
+  same-filesystem target that is not APFS (HFS+), reflink is
+  unsupported, so `auto` falls back to a hardlink before copy —
+  same-filesystem volumes always get zero-cost links.
 - `hardlink` hard-links from the store, with a copy fallback on
   cross-filesystem errors.
 - `copy` always writes a full copy.

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -953,11 +953,12 @@ docs = """
 Controls how aube materializes files from the global content-addressable
 store into the virtual store.
 
-- `auto` (default) probes the destination filesystem and picks
-  `hardlink` with a `copy` fallback on cross-filesystem boundaries.
-  Hardlink benchmarks faster than reflink across every target reflink
-  supports (APFS clonefile, btrfs/xfs FICLONE), so `auto` skips the
-  reflink probe.
+- `auto` (default) probes the destination filesystem and picks a
+  same-filesystem strategy with a `copy` fallback on cross-filesystem
+  boundaries. The same-filesystem strategy is OS-specific: `clone`
+  (reflink) on macOS, where APFS clonefile benchmarks ~1.91x faster
+  than hardlink, and `hardlink` on Linux and other targets, where
+  btrfs/xfs hardlink benchmarks ~2.4-2.6x faster than FICLONE reflink.
 - `hardlink` hard-links from the store, with a copy fallback on
   cross-filesystem errors.
 - `copy` always writes a full copy.

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -956,13 +956,18 @@ store into the virtual store.
 - `auto` (default) probes the destination filesystem and picks a
   same-filesystem strategy, with a `copy` fallback when no link
   primitive applies (cross-filesystem boundaries). The
-  same-filesystem strategy is OS-specific: `clone` (reflink) on macOS,
-  where APFS clonefile benchmarks ~1.91x faster than hardlink, and
-  `hardlink` on Linux and other targets, where btrfs/xfs hardlink
+  same-filesystem strategy is OS-specific: reflink (clonefile) on
+  macOS, where APFS clonefile benchmarks ~1.91x faster than hardlink,
+  and `hardlink` on Linux and other targets, where btrfs/xfs hardlink
   benchmarks ~2.4-2.6x faster than FICLONE reflink. On a macOS
   same-filesystem target that is not APFS (HFS+), reflink is
-  unsupported, so `auto` falls back to a hardlink before copy —
-  same-filesystem volumes always get zero-cost links.
+  unsupported, so `auto` falls back to a hardlink before copy, so a
+  same-filesystem volume keeps a zero-cost link rather than degrading
+  to a per-file copy. (One exception on macOS: files of 16 KiB or
+  less are copied directly, since the clonefile syscall costs more
+  than copying so few bytes.) This auto-only hardlink fallback does
+  not apply to the explicit `clone` / `clone-or-copy` selections
+  below, which keep their documented copy fallback.
 - `hardlink` hard-links from the store, with a copy fallback on
   cross-filesystem errors.
 - `copy` always writes a full copy.

--- a/docs/package-manager/configuration.md
+++ b/docs/package-manager/configuration.md
@@ -9,7 +9,7 @@ CLI flags. Existing `pnpm-workspace.yaml` files are migration inputs.
 | Area | Default | Why it matters |
 | --- | --- | --- |
 | Linker | `nodeLinker=isolated` | Keeps transitive dependencies scoped to the packages that declared them. |
-| Package imports | `packageImportMethod=auto` | Hardlinks files from the store, falling back to copy on cross-filesystem boundaries. Opt into reflink with `clone` or `clone-or-copy`. |
+| Package imports | `packageImportMethod=auto` | Links files from the store with the faster same-filesystem primitive per platform — reflink (clonefile) on macOS, hardlink on Linux and elsewhere — falling back to copy on cross-filesystem boundaries. Force reflink everywhere with `clone` or `clone-or-copy`. |
 | New releases | `minimumReleaseAge=1440` | Avoids installing versions published in the last 24 hours by default. |
 | Exotic transitive deps | `blockExoticSubdeps=true` | Blocks transitive git and tarball dependencies unless you opt out. |
 | Dependency scripts | approval required | Build scripts in dependencies stay skipped until approved. |

--- a/docs/package-manager/configuration.md
+++ b/docs/package-manager/configuration.md
@@ -9,7 +9,7 @@ CLI flags. Existing `pnpm-workspace.yaml` files are migration inputs.
 | Area | Default | Why it matters |
 | --- | --- | --- |
 | Linker | `nodeLinker=isolated` | Keeps transitive dependencies scoped to the packages that declared them. |
-| Package imports | `packageImportMethod=auto` | Links files from the store with the faster same-filesystem primitive per platform — reflink (clonefile) on macOS, hardlink on Linux and elsewhere — falling back to copy on cross-filesystem boundaries. Force reflink everywhere with `clone` or `clone-or-copy`. |
+| Package imports | `packageImportMethod=auto` | Links files from the store with the faster same-filesystem primitive per platform — reflink (clonefile) on macOS, hardlink on Linux and elsewhere — falling back to copy on cross-filesystem boundaries. Set `clone` or `clone-or-copy` to attempt reflink first, still falling back to copy when reflink is unavailable. |
 | New releases | `minimumReleaseAge=1440` | Avoids installing versions published in the last 24 hours by default. |
 | Exotic transitive deps | `blockExoticSubdeps=true` | Blocks transitive git and tarball dependencies unless you opt out. |
 | Dependency scripts | approval required | Build scripts in dependencies stay skipped until approved. |

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -1018,13 +1018,18 @@ store into the virtual store.
 - `auto` (default) probes the destination filesystem and picks a
   same-filesystem strategy, with a `copy` fallback when no link
   primitive applies (cross-filesystem boundaries). The
-  same-filesystem strategy is OS-specific: `clone` (reflink) on macOS,
-  where APFS clonefile benchmarks ~1.91x faster than hardlink, and
-  `hardlink` on Linux and other targets, where btrfs/xfs hardlink
+  same-filesystem strategy is OS-specific: reflink (clonefile) on
+  macOS, where APFS clonefile benchmarks ~1.91x faster than hardlink,
+  and `hardlink` on Linux and other targets, where btrfs/xfs hardlink
   benchmarks ~2.4-2.6x faster than FICLONE reflink. On a macOS
   same-filesystem target that is not APFS (HFS+), reflink is
-  unsupported, so `auto` falls back to a hardlink before copy —
-  same-filesystem volumes always get zero-cost links.
+  unsupported, so `auto` falls back to a hardlink before copy, so a
+  same-filesystem volume keeps a zero-cost link rather than degrading
+  to a per-file copy. (One exception on macOS: files of 16 KiB or
+  less are copied directly, since the clonefile syscall costs more
+  than copying so few bytes.) This auto-only hardlink fallback does
+  not apply to the explicit `clone` / `clone-or-copy` selections
+  below, which keep their documented copy fallback.
 - `hardlink` hard-links from the store, with a copy fallback on
   cross-filesystem errors.
 - `copy` always writes a full copy.

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -1015,11 +1015,16 @@ Method for importing packages from the store into node_modules.
 Controls how aube materializes files from the global content-addressable
 store into the virtual store.
 
-- `auto` (default) probes the destination filesystem and picks
-  `hardlink` with a `copy` fallback on cross-filesystem boundaries.
-  Hardlink benchmarks faster than reflink across every target reflink
-  supports (APFS clonefile, btrfs/xfs FICLONE), so `auto` skips the
-  reflink probe.
+- `auto` (default) probes the destination filesystem and picks a
+  same-filesystem strategy, with a `copy` fallback when no link
+  primitive applies (cross-filesystem boundaries). The
+  same-filesystem strategy is OS-specific: `clone` (reflink) on macOS,
+  where APFS clonefile benchmarks ~1.91x faster than hardlink, and
+  `hardlink` on Linux and other targets, where btrfs/xfs hardlink
+  benchmarks ~2.4-2.6x faster than FICLONE reflink. On a macOS
+  same-filesystem target that is not APFS (HFS+), reflink is
+  unsupported, so `auto` falls back to a hardlink before copy —
+  same-filesystem volumes always get zero-cost links.
 - `hardlink` hard-links from the store, with a copy fallback on
   cross-filesystem errors.
 - `copy` always writes a full copy.


### PR DESCRIPTION
## What

Relands #914 (`auto` packageImportMethod OS-gating) with the split the review on #914 asked for, and supersedes it.

#914 added the non-APFS reflink→hardlink→copy fallback in the shared `LinkStrategy::Reflink` arm of `link_file_fresh`. Explicit `packageImportMethod = clone` / `clone-or-copy` also map to that strategy, so they inherited the hardlink-before-copy step — contradicting their documented contract (reflink with a plain **copy** fallback).

This PR scopes that fallback to the `auto`-on-macOS path only:

- A distinct `LinkStrategy::ReflinkAuto` variant carries the hardlink-before-copy fallback. `detect_strategy_cross` resolves `auto` to `ReflinkAuto` on macOS (`Hardlink` elsewhere); it is `#[cfg(target_os = "macos")]`-gated and never constructed on other targets.
- Explicit `clone` / `clone-or-copy` keep mapping to plain `LinkStrategy::Reflink`, whose `link_file_fresh` path is byte-for-byte the pre-#914 behavior: reflink with a plain copy fallback, no hardlink step. The macOS small-file (≤16 KiB) copy shortcut still applies to both reflink variants, unchanged.

The OS-gating itself (reflink on macOS where APFS clonefile is faster, hardlink on Linux/btrfs/xfs where it is faster) is the same as #914.

## Docs

`docs/package-manager/configuration.md` no longer says `auto` hardlinks and users opt into reflink; it now describes the per-platform same-filesystem primitive. The generated settings reference (`docs/settings/index.md`, regenerated from `crates/aube-settings/settings.toml`) describes the OS-specific `auto` behavior, acknowledges the macOS small-file copy shortcut (the "same-filesystem volumes always get zero-cost links" wording dropped that), and states the auto-only hardlink fallback does not apply to explicit `clone` / `clone-or-copy`.

## Tests

Two regression tests prove the split via a `#[cfg(test)]`-only forced-reflink-failure seam (deterministic on reflink-capable CI filesystems; zero release surface, no new dependency):

- `test_reflink_auto_falls_back_to_hardlink_not_copy` — `ReflinkAuto` on a reflink failure resolves to a hardlink (same inode as source).
- `test_explicit_reflink_falls_back_to_copy_not_hardlink` — explicit `Reflink` on a reflink failure resolves to a copy (distinct inode), never a hardlink. This test fails against #914's shared-path behavior and passes after the split.

`test_detect_strategy` is updated for the `ReflinkAuto` resolution.

Local checks (macOS arm64): `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p aube-linker` (86 passed), `cargo audit --deny warnings`, and `generate-settings-docs` (docs regenerated, no diff).

Supersedes #914.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `packageImportMethod=auto` now selects an OS/file-system-appropriate same-filesystem strategy: reflink/clone on macOS (APFS-preferred) and hardlink on Linux/other platforms, with copy fallback across filesystems.
  * macOS `auto` is conservative on non-APFS (HFS+), and very small files may be copied directly.

* **Bug Fixes**
  * If reflink fails under `auto`, it now tries a hardlink fallback before copying; explicit `clone`/`clone-or-copy` still fall back directly to copy.

* **Documentation**
  * Updated settings and configuration docs to reflect the revised `auto` behavior and fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
