### PR TITLE
fix(release): avoid stale publishing targets

### DIFF
--- a/.github/workflows/copr-publish.yml
+++ b/.github/workflows/copr-publish.yml
@@ -10,9 +10,9 @@ on:
         required: true
         type: string
       chroots:
-        description: "COPR chroots to target (space-separated)"
+        description: "COPR chroots to target (space-separated; empty uses project defaults)"
         required: false
-        default: "fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64"
+        default: ""
         type: string
 
 permissions: {}
@@ -97,9 +97,8 @@ jobs:
         run: |
           VERSION="${TAG#v}"
 
-          if [ "$EVENT_NAME" = "release" ]; then
-            CHROOTS="fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64"
-          else
+          CHROOTS=""
+          if [ "$EVENT_NAME" != "release" ]; then
             CHROOTS="$INPUT_CHROOTS"
           fi
 

--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -79,6 +79,21 @@ jobs:
           mkdir -p dist
           ./packaging/homebrew/render-formula.sh > dist/aube.rb
 
+      - name: Check tap token access
+        env:
+          GH_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::AUBE_GH_TOKEN is required to push ${TAP_REPO}"
+            exit 1
+          fi
+
+          CAN_PUSH=$(gh api "repos/${TAP_REPO}" --jq '.permissions.push // false' 2>/dev/null || echo "api-error")
+          if [ "$CAN_PUSH" != "true" ]; then
+            echo "::error::AUBE_GH_TOKEN must have Contents write access to ${TAP_REPO}; GitHub reported push permission: ${CAN_PUSH}"
+            exit 1
+          fi
+
       - name: Publish to tap
         env:
           GITHUB_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -90,8 +90,8 @@ sudo apt update && sudo apt install --only-upgrade aube
 
 ## Fedora / RHEL (COPR)
 
-**Supported:** Fedora 42, Fedora 43, Fedora Rawhide, EPEL 9, EPEL 10
-(RHEL / Rocky / Alma 9 and 10), both `x86_64` and `aarch64`.
+**Supported:** Fedora 43, Fedora 44, Fedora Rawhide, EPEL 10
+(RHEL / Rocky / Alma 10), both `x86_64` and `aarch64`.
 
 Aube publishes RPMs to the COPR project
 [`jdxcode/aube`](https://copr.fedorainfracloud.org/coprs/jdxcode/aube/):

--- a/packaging/copr/build-copr.sh
+++ b/packaging/copr/build-copr.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 PACKAGE_NAME="${PACKAGE_NAME:-aube}"
-CHROOTS="${CHROOTS:-fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64}"
+CHROOTS="${CHROOTS:-}"
 BUILD_PROFILE="${BUILD_PROFILE:-release}"
 MAINTAINER_NAME="${MAINTAINER_NAME:-aube Release Bot}"
 MAINTAINER_EMAIL="${MAINTAINER_EMAIL:-noreply@aube.jdx.dev}"
@@ -19,7 +19,7 @@ usage() {
 	echo "Options:"
 	echo "  -v, --version VERSION        Package version (required)"
 	echo "  -p, --profile PROFILE        Build profile (default: release)"
-	echo "  -c, --chroots CHROOTS        COPR chroots (default: fedora-rawhide-aarch64 fedora-rawhide-x86_64 fedora-44-aarch64 fedora-44-x86_64 fedora-43-aarch64 fedora-43-x86_64 fedora-42-aarch64 fedora-42-x86_64 epel-10-aarch64 epel-10-x86_64)"
+	echo "  -c, --chroots CHROOTS        COPR chroots (default: project defaults)"
 	echo "  -o, --owner OWNER            COPR owner (default: jdxcode)"
 	echo "  -j, --project PROJECT        COPR project (default: aube)"
 	echo "  -n, --name NAME              Package name (default: aube)"
@@ -107,7 +107,7 @@ echo "=== COPR Build Configuration ==="
 echo "Package Name: $PACKAGE_NAME"
 echo "Version: $VERSION (rpm: $RPM_VERSION)"
 echo "Build Profile: $BUILD_PROFILE"
-echo "Chroots: $CHROOTS"
+echo "Chroots: ${CHROOTS:-project defaults}"
 echo "COPR Owner: $COPR_OWNER"
 echo "COPR Project: $COPR_PROJECT"
 echo "Maintainer: $MAINTAINER_NAME <$MAINTAINER_EMAIL>"
@@ -280,10 +280,12 @@ if [ "$DRY_RUN" != "true" ]; then
 	# paths that ever grow spaces or shell metacharacters don't get
 	# re-split by `eval`.
 	copr_cmd=(copr-cli build)
-	IFS=' ' read -ra chroot_array <<<"$CHROOTS"
-	for chroot in "${chroot_array[@]}"; do
-		copr_cmd+=(--chroot "$chroot")
-	done
+	if [ -n "$CHROOTS" ]; then
+		IFS=' ' read -ra chroot_array <<<"$CHROOTS"
+		for chroot in "${chroot_array[@]}"; do
+			copr_cmd+=(--chroot "$chroot")
+		done
+	fi
 	copr_cmd+=("$COPR_OWNER/$COPR_PROJECT" "$SRPM_FILE")
 
 	"${copr_cmd[@]}"


### PR DESCRIPTION
## Summary
- submit COPR release builds to the project default chroots instead of hardcoding stale Fedora targets
- add a Homebrew tap token preflight so missing cross-repo write access fails early with a clear error
- update COPR install docs to match the currently enabled project chroots

## Verification
- bash -n packaging/copr/build-copr.sh packaging/homebrew/render-formula.sh
- mise x actionlint@latest -- actionlint .github/workflows/copr-publish.yml .github/workflows/publish-homebrew.yml
- mise x shellcheck@latest -- shellcheck packaging/copr/build-copr.sh packaging/homebrew/render-formula.sh
- git diff --check

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to release workflows, packaging scripts, and docs; no runtime or auth logic in the application itself.
> 
> **Overview**
> **COPR releases** no longer pass a hardcoded `--chroot` list. On `release` events, `CHROOTS` stays empty so `copr-cli build` uses the COPR project’s configured chroots; manual `workflow_dispatch` can still override via the `chroots` input (default empty). `build-copr.sh` matches this: default chroots are empty and `--chroot` flags are only added when `CHROOTS` is set.
> 
> **Homebrew publishing** adds a **Check tap token access** step that verifies `AUBE_GH_TOKEN` exists and has `push` on `jdx/homebrew-tap` before clone/push, with explicit `::error::` messages.
> 
> **Installation docs** update the Fedora/RHEL COPR support line to Fedora 43/44/Rawhide and EPEL 10 (drops Fedora 42 and EPEL 9 from the documented list).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55cc05153b8c79b332a7359bf0e6d273b8bd0ed5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * COPR builds now use the project’s default chroot settings unless you explicitly provide a custom list.
  * Homebrew publishing now checks that the publish token and repository access are valid before starting.

* **Documentation**
  * Updated installation guidance to reflect the currently supported Fedora, EPEL, and RHEL-compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->