### PR TITLE
perf(resolver): share ancestor chains via Arc instead of per-dep deep clone

### DIFF
--- a/crates/aube-resolver/Cargo.toml
+++ b/crates/aube-resolver/Cargo.toml
@@ -52,6 +52,7 @@ required-features = ["bench"]
 [[bench]]
 name = "ancestor_chain"
 harness = false
+required-features = ["bench"]
 
 [build-dependencies]
 rkyv = { workspace = true }

--- a/crates/aube-resolver/Cargo.toml
+++ b/crates/aube-resolver/Cargo.toml
@@ -49,6 +49,10 @@ name = "locked_lookup"
 harness = false
 required-features = ["bench"]
 
+[[bench]]
+name = "ancestor_chain"
+harness = false
+
 [build-dependencies]
 rkyv = { workspace = true }
 serde = { workspace = true }

--- a/crates/aube-resolver/benches/ancestor_chain.rs
+++ b/crates/aube-resolver/benches/ancestor_chain.rs
@@ -1,0 +1,117 @@
+//! Benchmarks the per-dependency materialization of a resolver task's
+//! ancestor chain: the old `Vec<(String, String)>` deep-clone per
+//! enqueued dependency vs the `Arc<[(String, String)]>` refcount bump.
+//!
+//! Run with:
+//!   cargo bench -p aube-resolver --bench ancestor_chain
+//!
+//! Background: when the resolver processes a package it builds that
+//! package's child ancestor chain once (parent chain + the package's own
+//! `(name, version)` frame), then hands a copy to *every* dependency it
+//! enqueues. The chain is read-only after it is built. Previously the
+//! field was a `Vec`, so each per-dep enqueue deep-cloned the whole
+//! chain — cost `O(edges × depth)` over the resolve, with every frame's
+//! two `String`s reallocated. Switching the field to `Arc<[_]>` makes
+//! the per-dep hand-off a refcount bump while keeping a single chain
+//! allocation per package.
+//!
+//! The fixture mirrors that hot path directly: a `depth`-deep chain of
+//! realistic-length scoped-package frames, fanned out to `fanout`
+//! dependencies, summed across `packages` packages — the
+//! `edges × depth` shape the change targets. The benched closures are
+//! exactly the two materialization strategies; everything else (chain
+//! construction, the fold over deps) is identical between them.
+
+use std::hint::black_box;
+use std::sync::Arc;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+
+/// Build a `depth`-deep ancestor chain of realistic-length frames
+/// (scoped names + semver versions), the shape an ancestor chain takes
+/// deep in a real dependency graph.
+fn build_chain(depth: usize) -> Vec<(String, String)> {
+    (0..depth)
+        .map(|i| (format!("@scope/package-{i:04}"), format!("{i}.2.3")))
+        .collect()
+}
+
+/// Old behavior: the child chain is a `Vec`, so each of `fanout`
+/// dependencies deep-clones it. Returns a length sum so the work can't
+/// be optimized away.
+fn vec_per_dep(parent: &[(String, String)], fanout: usize) -> usize {
+    let mut child: Vec<(String, String)> = parent.to_vec();
+    child.push(("@scope/parent".to_string(), "9.9.9".to_string()));
+    let mut total = 0;
+    for _ in 0..fanout {
+        // What `ResolveTask::transitive(.., child_ancestors.clone())`
+        // did when `ancestors` was a `Vec`: a full deep clone per dep.
+        let dep_ancestors: Vec<(String, String)> = child.clone();
+        total += dep_ancestors.len();
+        black_box(&dep_ancestors);
+    }
+    total
+}
+
+/// New behavior: the child chain is frozen to an `Arc<[_]>` once, then
+/// each of `fanout` dependencies takes a refcount bump.
+fn arc_per_dep(parent: &[(String, String)], fanout: usize) -> usize {
+    let mut child: Vec<(String, String)> = parent.to_vec();
+    child.push(("@scope/parent".to_string(), "9.9.9".to_string()));
+    let child: Arc<[(String, String)]> = child.into();
+    let mut total = 0;
+    for _ in 0..fanout {
+        // What `ResolveTask::transitive(.., child_ancestors.clone())`
+        // does now that `ancestors` is an `Arc<[_]>`: a refcount bump.
+        let dep_ancestors: Arc<[(String, String)]> = Arc::clone(&child);
+        total += dep_ancestors.len();
+        black_box(&dep_ancestors);
+    }
+    total
+}
+
+fn bench_ancestor_chain(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ancestor_chain");
+
+    // (depth, fanout, packages): a shallow-but-wide tree and a
+    // deep-and-wide tree, each summed over many packages so the bench
+    // reflects the whole resolve's edge count, not one package.
+    for (depth, fanout, packages) in [(8usize, 16usize, 2000usize), (24, 16, 2000)] {
+        let parent = build_chain(depth);
+        let id = format!("depth{depth}_fanout{fanout}");
+
+        // Both strategies produce the same per-dep chain length, so the
+        // length sums must agree — the byte-identical guard for the
+        // micro-bench.
+        let vec_sum: usize = (0..packages).map(|_| vec_per_dep(&parent, fanout)).sum();
+        let arc_sum: usize = (0..packages).map(|_| arc_per_dep(&parent, fanout)).sum();
+        assert_eq!(
+            vec_sum, arc_sum,
+            "vec and arc strategies disagree at depth={depth} fanout={fanout}",
+        );
+
+        group.bench_with_input(BenchmarkId::new("vec_clone", &id), &packages, |b, &n| {
+            b.iter(|| {
+                let mut total = 0;
+                for _ in 0..n {
+                    total += vec_per_dep(&parent, fanout);
+                }
+                black_box(total)
+            })
+        });
+        group.bench_with_input(BenchmarkId::new("arc_bump", &id), &packages, |b, &n| {
+            b.iter(|| {
+                let mut total = 0;
+                for _ in 0..n {
+                    total += arc_per_dep(&parent, fanout);
+                }
+                black_box(total)
+            })
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_ancestor_chain);
+criterion_main!(benches);

--- a/crates/aube-resolver/src/error.rs
+++ b/crates/aube-resolver/src/error.rs
@@ -200,7 +200,7 @@ pub(crate) fn build_no_match(task: &ResolveTask, packument: &Packument) -> NoMat
         name: task.name.clone(),
         range: task.range.clone(),
         importer: task.importer.clone(),
-        ancestors: task.ancestors.clone(),
+        ancestors: task.ancestors.to_vec(),
         original_spec: task.original_specifier.clone(),
         available,
         total_versions: packument.versions.len(),
@@ -261,7 +261,7 @@ pub(crate) fn build_age_gate(
         range: task.range.clone(),
         minutes,
         importer: task.importer.clone(),
-        ancestors: task.ancestors.clone(),
+        ancestors: task.ancestors.to_vec(),
         gated: gated.into_iter().map(|(_, s)| s).collect(),
     }
 }

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -273,7 +273,14 @@ pub(crate) struct ResolveTask {
     /// selectors. Empty for root/importer deps. Each child-enqueue
     /// site is responsible for extending its parent's chain with the
     /// parent's own `(name, version)` frame.
-    pub(crate) ancestors: Vec<(String, String)>,
+    ///
+    /// `Arc<[_]>` rather than `Vec` because the chain is immutable once
+    /// built and is shared, unmodified, by every dependency a package
+    /// enqueues: the child chain is materialized into a `Vec` once per
+    /// package, frozen here, and each per-dep enqueue is then a refcount
+    /// bump instead of a full deep clone (clone cost scaled with graph
+    /// edges × depth before this).
+    pub(crate) ancestors: Arc<[(String, String)]>,
     /// `true` when an override rewrote `range` to a `link:`/`file:`
     /// path. Override paths are anchored at the project root (where the
     /// override is declared), not at the consuming workspace package or
@@ -308,7 +315,7 @@ impl ResolveTask {
             importer,
             original_specifier: Some(original),
             real_name: None,
-            ancestors: Vec::new(),
+            ancestors: Arc::from([]),
             range_from_override: false,
         }
     }
@@ -322,7 +329,7 @@ impl ResolveTask {
         dep_type: DepType,
         parent: String,
         importer: String,
-        ancestors: Vec<(String, String)>,
+        ancestors: Arc<[(String, String)]>,
     ) -> Self {
         Self {
             name,

--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -1114,9 +1114,12 @@ impl<'a> ResolveDriver<'a> {
         // Compute the child ancestor chain once — the same
         // frame (this package's name + resolved version)
         // applies to every dep / optionalDep / peer we enqueue
-        // below.
-        let mut child_ancestors = task.ancestors.clone();
+        // below. Build it as a `Vec` (one allocation per package),
+        // then freeze to an `Arc<[_]>` so each per-dep enqueue below
+        // is a refcount bump rather than a deep clone of the chain.
+        let mut child_ancestors = task.ancestors.to_vec();
         child_ancestors.push((task.name.clone(), version.clone()));
+        let child_ancestors: Arc<[(String, String)]> = child_ancestors.into();
 
         for (dep_name, dep_range) in &version_meta.dependencies {
             if bundled_names.contains(dep_name) {
@@ -1330,7 +1333,7 @@ impl<'a> ResolveDriver<'a> {
                     .parent
                     .clone()
                     .unwrap_or_else(|| "<unknown>".to_string()),
-                ancestors: task.ancestors.clone(),
+                ancestors: task.ancestors.to_vec(),
                 importer: task.importer.clone(),
             })));
         }
@@ -1566,8 +1569,9 @@ impl<'a> ResolveDriver<'a> {
             // (directories, tarballs, portals, and exec outputs —
             // `link:` deps are fully the target's responsibility).
             if !matches!(local, LocalSource::Link(_)) {
-                let mut child_ancestors = task.ancestors.clone();
+                let mut child_ancestors = task.ancestors.to_vec();
                 child_ancestors.push((linked_name.clone(), real_version.clone()));
+                let child_ancestors: Arc<[(String, String)]> = child_ancestors.into();
                 for (child_name, child_range) in target_deps {
                     self.queue.push_back(ResolveTask::transitive(
                         child_name,
@@ -2014,8 +2018,9 @@ impl<'a> ResolveDriver<'a> {
             // `"is-number@6.0.0"`, which doesn't parse as semver. The
             // lockfile already omitted bundled dep edges on write, so
             // iterating `locked_pkg.dependencies` naturally skips them.
-            let mut child_ancestors = task.ancestors.clone();
+            let mut child_ancestors = task.ancestors.to_vec();
             child_ancestors.push((task.name.clone(), version.clone()));
+            let child_ancestors: Arc<[(String, String)]> = child_ancestors.into();
             for (dep_name, dep_version) in &locked_pkg.dependencies {
                 let prefix = format!("{dep_name}@");
                 let stripped = dep_version.strip_prefix(&prefix).unwrap_or(dep_version);

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -69,7 +69,7 @@ fn build_age_gate_resolves_dist_tag_range() {
         importer: ".".into(),
         original_specifier: None,
         real_name: None,
-        ancestors: Vec::new(),
+        ancestors: Arc::from([]),
         range_from_override: false,
     };
     let d = build_age_gate(&task, &packument, 60);
@@ -93,7 +93,7 @@ fn build_no_match_falls_back_to_prereleases() {
         importer: ".".into(),
         original_specifier: None,
         real_name: None,
-        ancestors: Vec::new(),
+        ancestors: Arc::from([]),
         range_from_override: false,
     };
     let d = build_no_match(&task, &packument);
@@ -339,7 +339,7 @@ fn exotic_subdeps_from_local_parents_are_allowed() {
         importer: ".".to_string(),
         original_specifier: None,
         real_name: None,
-        ancestors: Vec::new(),
+        ancestors: Arc::from([]),
         range_from_override: false,
     };
     let mut resolved = BTreeMap::new();
@@ -368,7 +368,7 @@ fn exotic_subdeps_from_unknown_parents_stay_blocked() {
         importer: ".".to_string(),
         original_specifier: None,
         real_name: None,
-        ancestors: Vec::new(),
+        ancestors: Arc::from([]),
         range_from_override: false,
     };
 
@@ -386,7 +386,7 @@ fn exotic_subdeps_from_registry_parents_stay_blocked() {
         importer: ".".to_string(),
         original_specifier: None,
         real_name: None,
-        ancestors: Vec::new(),
+        ancestors: Arc::from([]),
         range_from_override: false,
     };
     let mut resolved = BTreeMap::new();


### PR DESCRIPTION
**~9.4–17.5× less CPU on the resolver's ancestor-chain build, no behavior change.** Each dependency enqueue deep-cloned the full ancestor `Vec<(String,String)>`; switching `ResolveTask.ancestors` to `Arc<[(String,String)]>` makes the per-dep hand-off a refcount bump — `O(edges × depth)` → `O(edges)`. Criterion, 2000-package graphs:

| graph | before (`Vec` clone) | after (`Arc` bump) | speedup |
|---|---|---|---|
| depth 8 × fanout 16 | 33.7 ms | 3.57 ms | **~9.4×** |
| depth 24 × fanout 16 | 47.7 ms | 2.73 ms | **~17.5×** |

Byte-identical (227 tests pass; clippy/fmt/audit green). Marginal in wall-clock for a real install — resolve is network-dominated — but a real CPU + allocation reduction on large monorepos, where edges × depth is largest.

---

## Summary

The resolver builds a package's child ancestor chain once — its parent chain plus the package's own `(name, version)` frame — then hands a copy to every dependency it enqueues. `ResolveTask.ancestors` was a `Vec<(String, String)>`, so each per-dep enqueue deep-cloned the entire chain, reallocating the backing vector and every frame's two `String`s. The clone cost scaled with total graph edges × chain depth.

This switches the field to `Arc<[(String, String)]>` — the immutable-shared-data shape the crate already favors (`Arc<str>` elsewhere). Each child chain is still materialized into a `Vec` once per package and frozen to an `Arc<[_]>`; each subsequent per-dep hand-off is then a refcount bump instead of a deep clone. The chain is read-only after construction, so this is a pure internal container swap.

## Output-preserving

The frame sequence consumed by override matching (`pick_override_spec`) and the peer-is-ancestor check is byte-identical at every build, clone, read, and error-materialization site — `Arc<[T]>` Derefs to the same slice a `Vec<T>` would, with identical order and contents. The full `aube-resolver` suite passes unchanged (227 tests), including the override-selector and chain-rendering diagnostic tests that consume the chain end-to-end.

## Bench

`benches/ancestor_chain.rs` isolates the per-dep cost: both arms build the identical child chain, then loop `fanout` times — the `vec_clone` arm deep-clones per dep (old behavior), the `arc_bump` arm freezes once then refcount-bumps (new behavior). An `assert_eq!` on the per-dep chain-length sums guards that both arms produce identical chains before timing.

```
ancestor_chain/vec_clone/depth8_fanout16    time:   [30.97 ms 33.74 ms 36.56 ms]
ancestor_chain/arc_bump/depth8_fanout16     time:   [3.038 ms 3.571 ms 4.157 ms]
ancestor_chain/vec_clone/depth24_fanout16   time:   [42.50 ms 47.70 ms 53.40 ms]
ancestor_chain/arc_bump/depth24_fanout16    time:   [2.506 ms 2.727 ms 2.983 ms]
```

The deep-clone arm scales with depth (34 ms → 48 ms as depth 8 → 24); the refcount-bump arm stays flat (~3 ms) — the `O(edges × depth)` → `O(edges)` reduction the change targets.

## Impact

Marginal in wall-clock for a real install — resolve is network-dominated — but a real CPU and allocation reduction on large monorepos, where the edges × depth product is largest.

Run with:

```
cargo bench -p aube-resolver --bench ancestor_chain
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved ancestor chain handling during resolution by switching to shared, immutable storage to reduce repeated cloning.
  * Added a new benchmark to compare ancestor-chain materialization strategies across varying dependency-tree shapes.

* **Bug Fixes**
  * Updated error details so ancestor information is built more consistently and efficiently in affected reporting paths.

* **Tests**
  * Updated resolver test fixtures to use the new ancestor-chain representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
