### PR TITLE
fix(linker): make aube dir materialization atomic

### DIFF
--- a/crates/aube-linker/src/link.rs
+++ b/crates/aube-linker/src/link.rs
@@ -188,6 +188,7 @@ impl Linker {
             if !aube_entry.exists() {
                 self.materialize_into(
                     &aube_dir,
+                    &aube_dir,
                     dep_path,
                     pkg,
                     index,
@@ -379,6 +380,7 @@ impl Linker {
                                 }
                             };
                             self.materialize_into(
+                                &aube_dir,
                                 &aube_dir,
                                 dep_path,
                                 pkg,
@@ -737,6 +739,7 @@ impl Linker {
             }
             self.materialize_into(
                 &aube_dir,
+                &aube_dir,
                 dep_path,
                 pkg,
                 index,
@@ -890,6 +893,7 @@ impl Linker {
                                 }
                             };
                             self.materialize_into(
+                                &aube_dir,
                                 &aube_dir,
                                 dep_path,
                                 pkg,

--- a/crates/aube-linker/src/materialize.rs
+++ b/crates/aube-linker/src/materialize.rs
@@ -29,7 +29,7 @@ fn place_materialized_entry(src: &Path, dst: &Path) -> io::Result<MaterializePla
     for attempt in 0..MAX_ATTEMPTS {
         match std::fs::rename(src, dst) {
             Ok(()) => return Ok(MaterializePlacement::Placed),
-            Err(err) if dst.exists() => return Ok(MaterializePlacement::LostRace),
+            Err(_) if dst.exists() => return Ok(MaterializePlacement::LostRace),
             Err(err) if is_transient_rename_error(&err) && attempt < MAX_ATTEMPTS - 1 => {
                 thread::sleep(Duration::from_millis(backoff_ms));
                 backoff_ms = backoff_ms.saturating_mul(2);

--- a/crates/aube-linker/src/materialize.rs
+++ b/crates/aube-linker/src/materialize.rs
@@ -185,6 +185,7 @@ impl Linker {
 
         let result = self.materialize_into(
             &tmp_base,
+            &self.virtual_store,
             dep_path,
             pkg,
             index,
@@ -338,6 +339,7 @@ impl Linker {
         let tmp_base = aube_dir.join(&tmp_name);
         let result = self.materialize_into(
             &tmp_base,
+            aube_dir,
             dep_path,
             pkg,
             index,
@@ -386,6 +388,12 @@ impl Linker {
 
     /// Materialize a package's files and transitive dep symlinks into a base directory.
     ///
+    /// `base_dir` is where files are written during materialization.
+    /// `final_base_dir` is where those files will live after any
+    /// wrapper rename. These differ for `.tmp-*` staging dirs; Windows
+    /// junctions need the final root because they persist absolute
+    /// targets at creation time.
+    ///
     /// `apply_hashes` controls whether per-dep subdir names are run
     /// through `vstore_key` (the content-addressed name) or used as
     /// raw `dep_path` strings. Global-store callers pass `true` so
@@ -397,6 +405,7 @@ impl Linker {
     pub(crate) fn materialize_into(
         &self,
         base_dir: &Path,
+        final_base_dir: &Path,
         dep_path: &str,
         pkg: &LockedPackage,
         index: &PackageIndex,
@@ -413,6 +422,9 @@ impl Linker {
         // this graph", which is the common case.
         nested_link_targets: Option<&BTreeMap<String, PathBuf>>,
     ) -> Result<(), Error> {
+        #[cfg(not(windows))]
+        let _ = final_base_dir;
+
         validate_package_link_name(&pkg.name)?;
         for dep_name in pkg.dependencies.keys() {
             validate_package_link_name(dep_name)?;
@@ -610,27 +622,20 @@ impl Linker {
             let target = pathdiff::diff_paths(&sibling_abs, link_parent)
                 .unwrap_or_else(|| sibling_abs.clone());
 
-            // GVS materialize writes into `.tmp-<pid>-<id>/`, then
-            // atomic-renames into `self.virtual_store/<subdir>/`. POSIX
-            // symlinks store the relative offset verbatim. Offset stays
-            // invariant under the wrapper rename, so the link resolves
-            // correctly after the move. Windows junctions resolve the
-            // target against `link.parent()` at create time and persist
-            // an absolute path, which binds the junction to the tmp
-            // wrapper. After rename every sibling link dangles into a
-            // gone `.tmp-<pid>-...` path. Fix: on Windows GVS path
-            // (`apply_hashes = true`) rewrite the target to point at
-            // the final virtual store root so the stored absolute path
-            // survives the rename.
+            // Staged materialization writes into `.tmp-<pid>-<id>/`,
+            // then atomic-renames into `final_base_dir/<subdir>/`.
+            // POSIX symlinks store the relative offset verbatim.
+            // Offset stays invariant under the wrapper rename, so the
+            // link resolves correctly after the move. Windows junctions
+            // resolve the target against `link.parent()` at create time
+            // and persist an absolute path, which binds the junction to
+            // the tmp wrapper. Point Windows at the final root up front
+            // so the stored absolute path survives the rename.
             #[cfg(windows)]
-            let target = if apply_hashes {
-                self.virtual_store
-                    .join(&sibling_subdir)
-                    .join("node_modules")
-                    .join(dep_name)
-            } else {
-                target
-            };
+            let target = final_base_dir
+                .join(&sibling_subdir)
+                .join("node_modules")
+                .join(dep_name);
 
             sys::create_dir_link(&target, &symlink_path)
                 .map_err(|e| Error::Io(symlink_path.clone(), e))?;

--- a/crates/aube-linker/src/materialize.rs
+++ b/crates/aube-linker/src/materialize.rs
@@ -184,7 +184,7 @@ impl Linker {
         // `subdir` already comes from `dep_path_to_filename`, which
         // flattens `/` to `+` as part of its escape pass, so it's
         // already safe to splice into a single path component.
-        let tmp_name = materialize_tmp_name(&subdir);
+        let tmp_name = materialize_tmp_name(subdir.as_str());
         let tmp_base = self.virtual_store.join(&tmp_name);
 
         let result = self.materialize_into(
@@ -335,7 +335,7 @@ impl Linker {
             return Ok(());
         }
 
-        let tmp_name = materialize_tmp_name(&subdir);
+        let tmp_name = materialize_tmp_name(subdir.as_str());
         let tmp_base = aube_dir.join(&tmp_name);
         let result = self.materialize_into(
             &tmp_base,

--- a/crates/aube-linker/src/materialize.rs
+++ b/crates/aube-linker/src/materialize.rs
@@ -6,7 +6,51 @@ use crate::{Error, LinkStats, LinkStrategy, Linker, sys};
 use aube_lockfile::{LockedPackage, shared_local_dep_path};
 use aube_store::{PackageIndex, StoredFile};
 use std::collections::BTreeMap;
+use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread;
+use std::time::Duration;
+
+enum MaterializePlacement {
+    Placed,
+    LostRace,
+}
+
+fn materialize_tmp_name(subdir: &str) -> String {
+    static NEXT_TMP_ID: AtomicU64 = AtomicU64::new(0);
+    let id = NEXT_TMP_ID.fetch_add(1, Ordering::Relaxed);
+    format!(".tmp-{}-{id}-{subdir}", std::process::id())
+}
+
+fn place_materialized_entry(src: &Path, dst: &Path) -> io::Result<MaterializePlacement> {
+    const MAX_ATTEMPTS: u32 = 5;
+    let mut backoff_ms = 20u64;
+    for attempt in 0..MAX_ATTEMPTS {
+        match std::fs::rename(src, dst) {
+            Ok(()) => return Ok(MaterializePlacement::Placed),
+            Err(err) if dst.exists() => return Ok(MaterializePlacement::LostRace),
+            Err(err) if is_transient_rename_error(&err) && attempt < MAX_ATTEMPTS - 1 => {
+                thread::sleep(Duration::from_millis(backoff_ms));
+                backoff_ms = backoff_ms.saturating_mul(2);
+            }
+            Err(err) => return Err(err),
+        }
+    }
+    Err(io::Error::other(
+        "materialized entry rename exhausted attempts",
+    ))
+}
+
+fn is_transient_rename_error(err: &io::Error) -> bool {
+    matches!(
+        err.kind(),
+        io::ErrorKind::AlreadyExists
+            | io::ErrorKind::PermissionDenied
+            | io::ErrorKind::Interrupted
+            | io::ErrorKind::WouldBlock
+    )
+}
 
 impl Linker {
     /// Detect the best linking strategy for the filesystem at the given path.
@@ -140,7 +184,7 @@ impl Linker {
         // `subdir` already comes from `dep_path_to_filename`, which
         // flattens `/` to `+` as part of its escape pass, so it's
         // already safe to splice into a single path component.
-        let tmp_name = format!(".tmp-{}-{subdir}", std::process::id());
+        let tmp_name = materialize_tmp_name(&subdir);
         let tmp_base = self.virtual_store.join(&tmp_name);
 
         let result = self.materialize_into(
@@ -167,13 +211,13 @@ impl Linker {
             mkdirp(parent)?;
         }
 
-        match aube_util::fs_atomic::rename_with_retry(&tmp_entry, &final_entry) {
-            Ok(()) => {
+        match place_materialized_entry(&tmp_entry, &final_entry) {
+            Ok(MaterializePlacement::Placed) => {
                 trace!("atomically placed {subdir} in virtual store");
             }
-            Err(e) if final_entry.exists() => {
+            Ok(MaterializePlacement::LostRace) => {
                 // Another process won the race — that's fine, use theirs.
-                trace!("lost rename race for {dep_path}, using existing: {e}");
+                trace!("lost rename race for {dep_path}, using existing");
                 // Undo the stats from our materialization since we're discarding it
                 stats.packages_linked = stats.packages_linked.saturating_sub(1);
                 stats.files_linked = stats.files_linked.saturating_sub(index.len());
@@ -268,10 +312,13 @@ impl Linker {
     /// virtual store at `aube_dir/<dep_path>/node_modules/<name>/`.
     ///
     /// Idempotent: if the entry already exists, counts as cached and
-    /// returns. Used by the install-time materializer to pipeline the
-    /// link work into the fetch phase under non-GVS mode, so the
-    /// dedicated link phase only has to create top-level
-    /// `node_modules/<name>` symlinks.
+    /// returns. Otherwise materializes into a unique temp directory
+    /// and atomically renames that entry into place so duplicate
+    /// in-process fetch events for the same dep-path cannot race while
+    /// writing `node_modules/.aube/<dep_path>/`. Used by the
+    /// install-time materializer to pipeline the link work into the
+    /// fetch phase under non-GVS mode, so the dedicated link phase only
+    /// has to create top-level `node_modules/<name>` symlinks.
     pub fn ensure_in_aube_dir(
         &self,
         aube_dir: &Path,
@@ -281,24 +328,58 @@ impl Linker {
         stats: &mut LinkStats,
         nested_link_targets: Option<&BTreeMap<String, PathBuf>>,
     ) -> Result<(), Error> {
-        // `materialize_into` batches `create_dir_all` for every parent
-        // it needs, so callers don't have to mkdirp the entry's parent
-        // (which is just `aube_dir` itself, already created by the
-        // materializer driver).
-        let entry = aube_dir.join(self.aube_dir_entry_name(dep_path));
-        if entry.exists() {
+        let subdir = self.aube_dir_entry_name(dep_path);
+        let final_entry = aube_dir.join(&subdir);
+        if final_entry.exists() {
             stats.packages_cached += 1;
             return Ok(());
         }
-        self.materialize_into(
-            aube_dir,
+
+        let tmp_name = materialize_tmp_name(&subdir);
+        let tmp_base = aube_dir.join(&tmp_name);
+        let result = self.materialize_into(
+            &tmp_base,
             dep_path,
             pkg,
             index,
             stats,
             false,
             nested_link_targets,
-        )
+        );
+
+        if result.is_err() {
+            let _ = std::fs::remove_dir_all(&tmp_base);
+            return result;
+        }
+
+        let tmp_entry = tmp_base.join(&subdir);
+        if let Some(parent) = final_entry.parent() {
+            mkdirp(parent)?;
+        }
+
+        match place_materialized_entry(&tmp_entry, &final_entry) {
+            Ok(MaterializePlacement::Placed) => {}
+            Ok(MaterializePlacement::LostRace) => {
+                stats.packages_linked = stats.packages_linked.saturating_sub(1);
+                stats.files_linked = stats.files_linked.saturating_sub(index.len());
+                stats.packages_cached += 1;
+                let _ = std::fs::remove_dir_all(&tmp_base);
+                return Ok(());
+            }
+            Err(e) => {
+                let _ = std::fs::remove_dir_all(&tmp_base);
+                return Err(Error::Io(final_entry, e));
+            }
+        }
+
+        if let Err(e) = std::fs::remove_dir(&tmp_base) {
+            debug!(
+                "remove_dir({}) failed, leaving tmp in place: {e}",
+                tmp_base.display()
+            );
+        }
+
+        Ok(())
     }
 
     /// Materialize a package's files and transitive dep symlinks into a base directory.

--- a/crates/aube-linker/src/materialize.rs
+++ b/crates/aube-linker/src/materialize.rs
@@ -17,29 +17,28 @@ enum MaterializePlacement {
     LostRace,
 }
 
-fn materialize_tmp_name(subdir: &str) -> String {
+fn materialize_tmp_name() -> String {
     static NEXT_TMP_ID: AtomicU64 = AtomicU64::new(0);
     let id = NEXT_TMP_ID.fetch_add(1, Ordering::Relaxed);
-    format!(".tmp-{}-{id}-{subdir}", std::process::id())
+    format!(".tmp-{}-{id}", std::process::id())
 }
 
 fn place_materialized_entry(src: &Path, dst: &Path) -> io::Result<MaterializePlacement> {
     const MAX_ATTEMPTS: u32 = 5;
     let mut backoff_ms = 20u64;
-    for attempt in 0..MAX_ATTEMPTS {
+    let mut attempt = 0;
+    loop {
         match std::fs::rename(src, dst) {
             Ok(()) => return Ok(MaterializePlacement::Placed),
             Err(_) if dst.exists() => return Ok(MaterializePlacement::LostRace),
             Err(err) if is_transient_rename_error(&err) && attempt < MAX_ATTEMPTS - 1 => {
                 thread::sleep(Duration::from_millis(backoff_ms));
                 backoff_ms = backoff_ms.saturating_mul(2);
+                attempt += 1;
             }
             Err(err) => return Err(err),
         }
     }
-    Err(io::Error::other(
-        "materialized entry rename exhausted attempts",
-    ))
 }
 
 fn is_transient_rename_error(err: &io::Error) -> bool {
@@ -181,10 +180,7 @@ impl Linker {
 
         // Materialize into a temp directory, then atomically rename into place
         // to avoid TOCTOU races between concurrent `aube install` processes.
-        // `subdir` already comes from `dep_path_to_filename`, which
-        // flattens `/` to `+` as part of its escape pass, so it's
-        // already safe to splice into a single path component.
-        let tmp_name = materialize_tmp_name(subdir.as_str());
+        let tmp_name = materialize_tmp_name();
         let tmp_base = self.virtual_store.join(&tmp_name);
 
         let result = self.materialize_into(
@@ -207,8 +203,11 @@ impl Linker {
         let final_entry = self.virtual_store.join(&subdir);
 
         // Ensure the parent of the final entry exists (e.g. for scoped packages).
-        if let Some(parent) = final_entry.parent() {
-            mkdirp(parent)?;
+        if let Some(parent) = final_entry.parent()
+            && let Err(e) = mkdirp(parent)
+        {
+            let _ = std::fs::remove_dir_all(&tmp_base);
+            return Err(e);
         }
 
         match place_materialized_entry(&tmp_entry, &final_entry) {
@@ -335,7 +334,7 @@ impl Linker {
             return Ok(());
         }
 
-        let tmp_name = materialize_tmp_name(subdir.as_str());
+        let tmp_name = materialize_tmp_name();
         let tmp_base = aube_dir.join(&tmp_name);
         let result = self.materialize_into(
             &tmp_base,
@@ -353,8 +352,11 @@ impl Linker {
         }
 
         let tmp_entry = tmp_base.join(&subdir);
-        if let Some(parent) = final_entry.parent() {
-            mkdirp(parent)?;
+        if let Some(parent) = final_entry.parent()
+            && let Err(e) = mkdirp(parent)
+        {
+            let _ = std::fs::remove_dir_all(&tmp_base);
+            return Err(e);
         }
 
         match place_materialized_entry(&tmp_entry, &final_entry) {
@@ -608,7 +610,7 @@ impl Linker {
             let target = pathdiff::diff_paths(&sibling_abs, link_parent)
                 .unwrap_or_else(|| sibling_abs.clone());
 
-            // GVS materialize writes into `.tmp-<pid>-<subdir>/`, then
+            // GVS materialize writes into `.tmp-<pid>-<id>/`, then
             // atomic-renames into `self.virtual_store/<subdir>/`. POSIX
             // symlinks store the relative offset verbatim. Offset stays
             // invariant under the wrapper rename, so the link resolves

--- a/crates/aube-linker/src/sweep.rs
+++ b/crates/aube-linker/src/sweep.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 /// Sweep orphan `.tmp-<pid>-*` directories in the virtual store.
 ///
-/// Linker materializes each package into `.tmp-<pid>-<subdir>/`
+/// Linker materializes each package into `.tmp-<pid>-<id>/`
 /// then atomic-renames into `.aube/<subdir>/`. Crash or Ctrl-C
 /// between materialize and rename leaves the tmp dir behind.
 /// Nothing else cleans these up so they accumulate on every aborted
@@ -20,7 +20,7 @@ pub fn sweep_stale_tmp_dirs(virtual_store: &Path) {
     for entry in entries.flatten() {
         let name = entry.file_name();
         let name = name.to_string_lossy();
-        // Match our exact prefix. Format: `.tmp-<pid>-<subdir>`
+        // Match our exact prefix. Format: `.tmp-<pid>-<id>`
         // where pid is numeric.
         if !name.starts_with(".tmp-") {
             continue;

--- a/crates/aube-linker/src/tests.rs
+++ b/crates/aube-linker/src/tests.rs
@@ -165,6 +165,92 @@ fn test_link_all_handles_self_referential_dep_at_different_version() {
 }
 
 #[test]
+fn test_ensure_in_aube_dir_handles_concurrent_same_dep_path() {
+    const THREADS: usize = 16;
+
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = dir.path().join("project");
+    let aube_dir = project_dir.join("node_modules/.aube");
+    std::fs::create_dir_all(&aube_dir).unwrap();
+
+    let store = Store::at(dir.path().join("store/files"));
+    let mut index = PackageIndex::default();
+    let pkg_json = store
+        .import_bytes(b"{\"name\":\"debug\",\"version\":\"4.4.0\"}", false)
+        .unwrap();
+    index.insert("package.json".to_string(), pkg_json);
+    for i in 0..128 {
+        let stored = store
+            .import_bytes(format!("module.exports = {i};").as_bytes(), false)
+            .unwrap();
+        index.insert(format!("files/{i}.js"), stored);
+    }
+
+    let pkg = LockedPackage {
+        name: "debug".to_string(),
+        version: "4.4.0".to_string(),
+        integrity: None,
+        dependencies: BTreeMap::new(),
+        dep_path: "debug@4.4.0".to_string(),
+        ..Default::default()
+    };
+
+    let linker = std::sync::Arc::new(Linker::new_with_gvs(&store, LinkStrategy::Copy, false));
+    let index = std::sync::Arc::new(index);
+    let pkg = std::sync::Arc::new(pkg);
+    let aube_dir = std::sync::Arc::new(aube_dir);
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(THREADS));
+
+    let handles: Vec<_> = (0..THREADS)
+        .map(|_| {
+            let linker = linker.clone();
+            let index = index.clone();
+            let pkg = pkg.clone();
+            let aube_dir = aube_dir.clone();
+            let barrier = barrier.clone();
+            std::thread::spawn(move || {
+                barrier.wait();
+                let mut stats = LinkStats::default();
+                linker
+                    .ensure_in_aube_dir(&aube_dir, "debug@4.4.0", &pkg, &index, &mut stats, None)
+                    .expect("duplicate materialization should be idempotent");
+                stats
+            })
+        })
+        .collect();
+
+    let stats = handles.into_iter().map(|h| h.join().unwrap()).fold(
+        LinkStats::default(),
+        |mut total, stats| {
+            total.packages_linked += stats.packages_linked;
+            total.packages_cached += stats.packages_cached;
+            total.files_linked += stats.files_linked;
+            total
+        },
+    );
+
+    assert_eq!(stats.packages_linked, 1);
+    assert_eq!(stats.packages_cached, THREADS - 1);
+    assert_eq!(stats.files_linked, index.len());
+    assert!(
+        aube_dir
+            .join("debug@4.4.0/node_modules/debug/files/127.js")
+            .exists(),
+        "winning materialization must be usable"
+    );
+    assert!(
+        std::fs::read_dir(aube_dir.as_ref())
+            .unwrap()
+            .all(|entry| !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".tmp-")),
+        "losing staging directories must be cleaned up"
+    );
+}
+
+#[test]
 fn test_link_all_creates_pnpm_virtual_store() {
     let dir = tempfile::tempdir().unwrap();
     let project_dir = dir.path().join("project");


### PR DESCRIPTION
Summary:
- stage per-project `.aube/<dep_path>` materialization in unique temp dirs
- atomically place the completed entry and treat duplicate work as a cache hit
- add a concurrent regression test for duplicate same-dep-path materialization

Tests:
- `mise x cmake -- cargo test -p aube-linker test_ensure_in_aube_dir_handles_concurrent_same_dep_path`
- `mise x cmake -- cargo test -p aube-linker`
- `mise x cmake -- cargo clippy -p aube-linker --all-targets -- -D warnings`
- `cargo fmt --check`

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core install/link filesystem paths and concurrent materialization; behavior change is intentional but errors or partial cleanup on rename races could affect `node_modules/.aube` integrity.
> 
> **Overview**
> **Per-project `.aube` materialization is now atomic**, matching the global virtual store: `ensure_in_aube_dir` writes into a unique `.tmp-<pid>-<id>/` staging directory, then renames the finished entry into `node_modules/.aube/<dep_path>/`. Concurrent fetch/link work for the same dep-path treats a lost rename as a cache hit, rolls back link stats, and cleans up the loser’s staging dir.
> 
> **Shared placement helpers** replace the prior GVS-only rename helper: `materialize_tmp_name()` (pid + in-process counter), `place_materialized_entry()` with backoff on transient rename errors, and updated stale-tmp sweep comments.
> 
> **`materialize_into`** takes a new `final_base_dir` argument so staged writes can target the post-rename root—**Windows transitive junctions** now point at `final_base_dir` siblings up front so links stay valid after the wrapper rename. Call sites in `link.rs` pass staging vs final roots where needed.
> 
> **Tests:** `test_ensure_in_aube_dir_handles_concurrent_same_dep_path` (16 threads) asserts one winner, correct stats, and no leftover `.tmp-*` dirs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2b26bf8b058db7f2af021bcbd7788ec672d411a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple processes or threads materialize the same package path concurrently.
  * Added retry-aware, atomic placement during staging-to-final transitions to reduce transient failures.
  * Temp staging directories now use process-unique names and are cleaned up more consistently, avoiding duplicates and leftover artifacts.
* **Tests**
  * Added a concurrency regression test covering simultaneous materialization with the same dependency path, asserting idempotency, correct winner behavior, and staging cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->