### PR TITLE
fix(store): tolerate tarball build metadata

### DIFF
--- a/crates/aube-store/src/integrity.rs
+++ b/crates/aube-store/src/integrity.rs
@@ -306,6 +306,15 @@ pub fn validate_pkg_content(
         .strip_prefix('v')
         .filter(|rest| rest.starts_with(|c: char| c.is_ascii_digit()))
         .unwrap_or(actual_version);
+    // npm registry metadata may omit semver build metadata that is
+    // still present in the tarball's own package.json. Treat that as
+    // the same version for the tarball-side normalization path: build
+    // metadata does not affect semver precedence, and pnpm accepts
+    // packages such as @trpc/react-query@11.0.0-rc.747 whose manifest
+    // declares 11.0.0-rc.747+64714681c.
+    let actual_version_without_build = actual_version_normalized
+        .split_once('+')
+        .map(|(base, _)| base);
     // pnpm v9 lockfiles key git-hosted deps by the codeload tarball URL
     // (or a `git+<url>#<commit>` form) in the `version` slot of the
     // dep_path — that URL is what the resolver hands us as
@@ -317,7 +326,9 @@ pub fn validate_pkg_content(
     let expected_is_url_or_ref = expected_version.contains("://")
         || expected_version.starts_with("git+")
         || expected_version.starts_with("file:");
-    let version_matches = expected_is_url_or_ref || actual_version_normalized == expected_version;
+    let version_matches = expected_is_url_or_ref
+        || actual_version_normalized == expected_version
+        || actual_version_without_build == Some(expected_version);
     if actual_name != expected_name || !version_matches {
         // Only carry the *actual* coordinate the tarball declared.
         // Every caller wraps the error with the expected

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -1128,6 +1128,23 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_pkg_content_tolerates_tarball_build_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("files"));
+        let index = index_with_manifest(&store, "@trpc/react-query", "11.0.0-rc.747+64714681c");
+        assert!(validate_pkg_content(&index, "@trpc/react-query", "11.0.0-rc.747").is_ok());
+    }
+
+    #[test]
+    fn test_validate_pkg_content_build_metadata_keeps_base_version_strict() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("files"));
+        let index = index_with_manifest(&store, "@trpc/react-query", "11.0.0-rc.748+64714681c");
+        let err = validate_pkg_content(&index, "@trpc/react-query", "11.0.0-rc.747").unwrap_err();
+        assert!(err.to_string().contains("content mismatch"), "{err}");
+    }
+
+    #[test]
     fn test_validate_pkg_content_skips_version_for_url_shaped_expected() {
         // pnpm v9 lockfiles key github-hosted deps by the codeload
         // tarball URL in the version slot; the tarball's real semver


### PR DESCRIPTION
Summary:
- allow strict package-content validation when a tarball manifest carries extra semver build metadata
- keep base-version mismatches strict
- add regression tests for the `@trpc/react-query@11.0.0-rc.747+...` shape

Tests:
- `mise x cmake -- cargo test -p aube-store test_validate_pkg_content_tolerates_tarball_build_metadata`
- `mise x cmake -- cargo test -p aube-store validate_pkg_content_build_metadata`
- `mise x cmake -- cargo test -p aube-store`
- `mise x cmake -- cargo clippy -p aube-store --all-targets -- -D warnings`
- `cargo fmt --check`

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to version string normalization in an integrity guard, with tests; does not relax name checks or URL-shaped expected versions.
> 
> **Overview**
> **Strict package-content validation** now treats a tarball `package.json` version with extra **semver build metadata** (`+…`) as matching the registry-resolved base version, after existing leading-`v` normalization.
> 
> `validate_pkg_content` strips the `+build` suffix on the tarball side only when comparing to `expected_version`, so installs like `@trpc/react-query@11.0.0-rc.747` succeed when the manifest declares `11.0.0-rc.747+64714681c`. **Different base versions** (e.g. `11.0.0-rc.748+…` vs expected `11.0.0-rc.747`) still fail.
> 
> Regression tests cover the tolerant match and the strict base-version rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13c2f76d76367c5f2277f916710e63f2235aba0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package content validation to accept version strings that differ only by semver build metadata.
  * Continued to reject true version mismatches with the same error reporting as before.

* **Tests**
  * Added coverage for version validation with build metadata.
  * Added a mismatch test to ensure incorrect base versions still fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->