### PR TITLE
perf(install): overlap cold-install lockfile write with the link tail

### DIFF
--- a/crates/aube-lockfile/Cargo.toml
+++ b/crates/aube-lockfile/Cargo.toml
@@ -49,3 +49,8 @@ harness = false
 name = "pnpm_lock_parse"
 harness = false
 required-features = ["bench"]
+
+[[bench]]
+name = "pnpm_lock_write"
+harness = false
+required-features = ["bench"]

--- a/crates/aube-lockfile/benches/pnpm_lock_write.rs
+++ b/crates/aube-lockfile/benches/pnpm_lock_write.rs
@@ -1,0 +1,48 @@
+//! Lockfile write-overlap economics benchmark.
+//!
+//! The lockfile-write-overlap optimization moves the serialize, reformat,
+//! and atomic-write work off the install's critical path onto a background
+//! `spawn_blocking` task, overlapping it with the link tail. The spawned
+//! task operates on a clone of the graph, so the net win is the recovered
+//! write time minus the clone cost.
+//!
+//! This bench measures both sides on a large real `pnpm-lock.yaml` so the
+//! decision to ship is grounded in numbers, not intuition. Point it at a
+//! big lockfile with `AUBE_BENCH_LOCKFILE=/path/to/pnpm-lock.yaml`.
+
+use aube_lockfile::pnpm;
+use aube_manifest::PackageJson;
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+
+fn load_path() -> String {
+    std::env::var("AUBE_BENCH_LOCKFILE").expect("set AUBE_BENCH_LOCKFILE to a large pnpm-lock.yaml")
+}
+
+fn bench(c: &mut Criterion) {
+    let path = load_path();
+    let graph = pnpm::parse(std::path::Path::new(&path)).expect("parse bench lockfile");
+    let manifest = PackageJson::default();
+    eprintln!(
+        "benchmarking write/clone on {}: {} packages, {} importers",
+        path,
+        graph.packages.len(),
+        graph.importers.len()
+    );
+
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    // Use the pnpm-lock.yaml name so the writer takes the native-alias path.
+    let out = tmp.path().join("pnpm-lock.yaml");
+
+    let mut g = c.benchmark_group("pnpm-lock-write");
+    // The overlappable work: serialize + reformat + atomic fs write.
+    g.bench_function("write_full", |b| {
+        b.iter(|| pnpm::__bench_write_to(black_box(&out), black_box(&graph), black_box(&manifest)))
+    });
+    // The offsetting cost the spawned task pays (a deep clone of the graph).
+    g.bench_function("graph_clone", |b| b.iter(|| black_box(graph.clone())));
+    g.finish();
+}
+
+criterion_group!(benches, bench);
+criterion_main!(benches);

--- a/crates/aube-lockfile/src/pnpm/mod.rs
+++ b/crates/aube-lockfile/src/pnpm/mod.rs
@@ -33,6 +33,21 @@ pub fn __bench_parse_serde(content: &str) -> Option<(usize, usize, usize)> {
         .map(|r| raw::__bench_counts(&r))
 }
 
+/// Benchmark-only: the full serialize + reformat + atomic-write path —
+/// exactly the work the lockfile-write-overlap optimization moves onto a
+/// background thread. Measured against `LockfileGraph::clone()` (the
+/// offsetting cost the spawned task pays) to decide whether overlapping
+/// the write with the link tail is a net win.
+#[cfg(feature = "bench")]
+#[doc(hidden)]
+pub fn __bench_write_to(
+    path: &std::path::Path,
+    graph: &crate::LockfileGraph,
+    manifest: &aube_manifest::PackageJson,
+) {
+    write::write(path, graph, manifest).expect("bench write");
+}
+
 pub(super) fn tarball_url_is_hosted_git(url: &str) -> bool {
     let Some((host, path)) = http_url_host_and_path(url) else {
         return false;

--- a/crates/aube/src/commands/install/lockfile_write_overlap.rs
+++ b/crates/aube/src/commands/install/lockfile_write_overlap.rs
@@ -59,11 +59,12 @@ pub(super) fn overlap_enabled() -> bool {
 
 /// The serialize + reformat + atomic write, with the lockfile graph and
 /// every parameter borrowed. Both the overlapped path (via the owned
-/// `LockfileWriteInputs`) and the killswitch-disabled inline path call
-/// this with the SAME values, so the two produce byte-identical output.
-/// This is the exact body the pre-overlap inline write ran.
+/// `LockfileWriteInputs`) and the killswitch-disabled inline call site in
+/// `mod.rs` call this with the SAME values, so the two produce
+/// byte-identical output. This is the exact body the pre-overlap inline
+/// write ran.
 #[allow(clippy::too_many_arguments)]
-fn write_one(
+pub(super) fn write_one(
     graph: &aube_lockfile::LockfileGraph,
     manifest: &aube_manifest::PackageJson,
     manifests: &[(String, aube_manifest::PackageJson)],
@@ -131,36 +132,6 @@ pub(super) fn spawn(inputs: LockfileWriteInputs) -> LockfileWriteHandle {
     })
 }
 
-/// Write inline on the calling thread — the killswitch-disabled path.
-/// Borrows the call-site values directly (no graph clone — the inline
-/// path pays exactly the pre-overlap cost), with identical error ordering.
-#[allow(clippy::too_many_arguments)]
-pub(super) fn write_inline(
-    graph: &aube_lockfile::LockfileGraph,
-    manifest: &aube_manifest::PackageJson,
-    manifests: &[(String, aube_manifest::PackageJson)],
-    lockfile_dir: &std::path::Path,
-    lockfile_importer_key: &str,
-    cwd: &std::path::Path,
-    write_kind: aube_lockfile::LockfileKind,
-    shared_workspace_lockfile: bool,
-    has_workspace: bool,
-    per_project_write_selection: Option<&BTreeSet<String>>,
-) -> miette::Result<()> {
-    write_one(
-        graph,
-        manifest,
-        manifests,
-        lockfile_dir,
-        lockfile_importer_key,
-        cwd,
-        write_kind,
-        shared_workspace_lockfile,
-        has_workspace,
-        per_project_write_selection,
-    )
-}
-
 /// Join a spawned write handle, mapping a task panic to a diagnostic. A
 /// write error surfaces here (at the join point, before finalize) rather
 /// than being dropped. Returns the write's own `Result` unchanged so the
@@ -169,9 +140,11 @@ pub(super) fn write_inline(
 pub(super) async fn join(handle: LockfileWriteHandle) -> miette::Result<()> {
     match handle.await {
         Ok(write_result) => write_result,
-        Err(join_err) => Err(Err::<(), _>(join_err)
+        // `JoinError` is a plain `std::error::Error` (not a miette
+        // `Diagnostic`), so the bridge to a `Report` is `into_diagnostic()`
+        // on the `Result`.
+        Err(join_err) => Result::<(), _>::Err(join_err)
             .into_diagnostic()
-            .unwrap_err()
-            .wrap_err("lockfile write task panicked")),
+            .wrap_err("lockfile write task panicked"),
     }
 }

--- a/crates/aube/src/commands/install/lockfile_write_overlap.rs
+++ b/crates/aube/src/commands/install/lockfile_write_overlap.rs
@@ -1,0 +1,177 @@
+//! Overlap the cold-install lockfile write (serialize + reformat +
+//! atomic fs write) with the post-write link tail.
+//!
+//! On a fresh-resolve cold install the lockfile-write block runs as a
+//! serial blocking span *before* `filter_graph` + the link phase. On a
+//! large tree the serialize + pnpm-parity reformat + atomic write costs
+//! 10-55 ms (measured: ~11 ms at 1.5k packages, ~54 ms at 4.2k), all of
+//! it on the critical path while the linker sits idle.
+//!
+//! This moves that work onto a `spawn_blocking` task that runs concurrently
+//! with `filter_graph`, the progress reconcile, and `run_link_phase`, then
+//! joins before `run_finalize_phase` reads the graph again. The spawned
+//! task operates on a clone of the graph (taken after the write-prep
+//! mutations, before `filter_graph` mutates the original), so the cold
+//! path now clones the graph twice — once here and once for the catch-up
+//! integrity-rewrite holder. The extra clone is cheap relative to the
+//! work it overlaps: a full graph clone measures ~0.6-3 ms, ~12-18x less
+//! than the 11-55 ms write it hides, so the net win is the recovered write
+//! time minus one clone (~10 ms at 1.5k packages, ~51 ms at 4.2k).
+//!
+//! On by default. `AUBE_DISABLE_LOCKFILE_WRITE_OVERLAP=1` reverts to the
+//! old inline serial write (used for byte-identity comparison runs and as
+//! a fork-discipline killswitch); under that env the caller writes inline
+//! at the original point and never spawns a task, so the on-disk result is
+//! byte-identical to the pre-overlap code (verified by an `install.bats`
+//! cold-install diff).
+
+use super::lockfile_dir::write_lockfile_dir_remapped;
+use super::workspace::write_per_project_lockfiles;
+use miette::{Context, IntoDiagnostic};
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+/// Owned inputs the spawned write task needs. All captures are owned so
+/// the closure is `'static`. The graph is the only non-trivial capture (a
+/// clone taken at the spawn site); the rest are cheap path/flag copies.
+pub(super) struct LockfileWriteInputs {
+    pub graph: aube_lockfile::LockfileGraph,
+    pub manifest: aube_manifest::PackageJson,
+    pub manifests: Vec<(String, aube_manifest::PackageJson)>,
+    pub lockfile_dir: PathBuf,
+    pub lockfile_importer_key: String,
+    pub cwd: PathBuf,
+    pub write_kind: aube_lockfile::LockfileKind,
+    pub shared_workspace_lockfile: bool,
+    pub has_workspace: bool,
+    pub per_project_write_selection: Option<BTreeSet<String>>,
+}
+
+pub(super) type LockfileWriteHandle = tokio::task::JoinHandle<miette::Result<()>>;
+
+/// Returns whether the write-overlap optimization is enabled (the
+/// default). `AUBE_DISABLE_LOCKFILE_WRITE_OVERLAP` (under the active
+/// embedder's env prefix) disables it. Reads through `embedder_env` so a
+/// host with no `env_prefix` exposes no branded toggle.
+pub(super) fn overlap_enabled() -> bool {
+    aube_util::env::embedder_env("DISABLE_LOCKFILE_WRITE_OVERLAP").is_none()
+}
+
+/// The serialize + reformat + atomic write, with the lockfile graph and
+/// every parameter borrowed. Both the overlapped path (via the owned
+/// `LockfileWriteInputs`) and the killswitch-disabled inline path call
+/// this with the SAME values, so the two produce byte-identical output.
+/// This is the exact body the pre-overlap inline write ran.
+#[allow(clippy::too_many_arguments)]
+fn write_one(
+    graph: &aube_lockfile::LockfileGraph,
+    manifest: &aube_manifest::PackageJson,
+    manifests: &[(String, aube_manifest::PackageJson)],
+    lockfile_dir: &std::path::Path,
+    lockfile_importer_key: &str,
+    cwd: &std::path::Path,
+    write_kind: aube_lockfile::LockfileKind,
+    shared_workspace_lockfile: bool,
+    has_workspace: bool,
+    per_project_write_selection: Option<&BTreeSet<String>>,
+) -> miette::Result<()> {
+    if shared_workspace_lockfile || !has_workspace {
+        let written_path = write_lockfile_dir_remapped(
+            lockfile_dir,
+            lockfile_importer_key,
+            graph,
+            manifest,
+            write_kind,
+        )
+        .into_diagnostic()
+        .wrap_err("failed to write lockfile")?;
+        // Matches the format resolve.bats and similar tests assert against
+        // (e.g. "Wrote aube-lock.yaml").
+        tracing::debug!(
+            "Wrote {}",
+            written_path
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| written_path.display().to_string())
+        );
+    } else {
+        write_per_project_lockfiles(
+            cwd,
+            graph,
+            manifests,
+            write_kind,
+            per_project_write_selection,
+        )?;
+    }
+    Ok(())
+}
+
+/// Spawn the lockfile write on a blocking thread so it overlaps the link
+/// tail. Takes the owned clone of the graph + the other captures so the
+/// closure is `'static`. The returned handle MUST be joined (via [`join`])
+/// before the install completes so a write error still surfaces.
+pub(super) fn spawn(inputs: LockfileWriteInputs) -> LockfileWriteHandle {
+    tokio::task::spawn_blocking(move || {
+        let _diag = aube_util::diag::Span::new(
+            aube_util::diag::Category::Install,
+            "lockfile_write_overlapped",
+        );
+        write_one(
+            &inputs.graph,
+            &inputs.manifest,
+            &inputs.manifests,
+            &inputs.lockfile_dir,
+            &inputs.lockfile_importer_key,
+            &inputs.cwd,
+            inputs.write_kind,
+            inputs.shared_workspace_lockfile,
+            inputs.has_workspace,
+            inputs.per_project_write_selection.as_ref(),
+        )
+    })
+}
+
+/// Write inline on the calling thread — the killswitch-disabled path.
+/// Borrows the call-site values directly (no graph clone — the inline
+/// path pays exactly the pre-overlap cost), with identical error ordering.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn write_inline(
+    graph: &aube_lockfile::LockfileGraph,
+    manifest: &aube_manifest::PackageJson,
+    manifests: &[(String, aube_manifest::PackageJson)],
+    lockfile_dir: &std::path::Path,
+    lockfile_importer_key: &str,
+    cwd: &std::path::Path,
+    write_kind: aube_lockfile::LockfileKind,
+    shared_workspace_lockfile: bool,
+    has_workspace: bool,
+    per_project_write_selection: Option<&BTreeSet<String>>,
+) -> miette::Result<()> {
+    write_one(
+        graph,
+        manifest,
+        manifests,
+        lockfile_dir,
+        lockfile_importer_key,
+        cwd,
+        write_kind,
+        shared_workspace_lockfile,
+        has_workspace,
+        per_project_write_selection,
+    )
+}
+
+/// Join a spawned write handle, mapping a task panic to a diagnostic. A
+/// write error surfaces here (at the join point, before finalize) rather
+/// than being dropped. Returns the write's own `Result` unchanged so the
+/// error chain is exactly what the inline path would have produced, with a
+/// panic wrapped distinctly.
+pub(super) async fn join(handle: LockfileWriteHandle) -> miette::Result<()> {
+    match handle.await {
+        Ok(write_result) => write_result,
+        Err(join_err) => Err(Err::<(), _>(join_err)
+            .into_diagnostic()
+            .unwrap_err()
+            .wrap_err("lockfile write task panicked")),
+    }
+}

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -19,6 +19,7 @@ mod layout;
 mod lifecycle;
 mod link;
 mod lockfile_dir;
+mod lockfile_write_overlap;
 mod materialize;
 pub(crate) mod node_gyp_bootstrap;
 mod resolve;
@@ -889,6 +890,14 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     // frozen-lockfile path or when the prewarm short-circuits.
     let mut prewarm_graph_hashes: Option<std::sync::Arc<aube_lockfile::graph_hash::GraphHashes>> =
         None;
+    // The cold-install lockfile write runs on a `spawn_blocking` task so it
+    // overlaps `filter_graph` + the link phase (see
+    // `lockfile_write_overlap`). The handle escapes the resolve match arm
+    // and is joined before `run_finalize_phase` re-reads the graph, so a
+    // write error still surfaces. `None` on every path that wrote inline
+    // (lockfile-matched fast path, killswitch disabled, `lockfile=false`,
+    // or after the rare catch-up integrity rewrite joined it early).
+    let mut lockfile_write_handle: Option<lockfile_write_overlap::LockfileWriteHandle> = None;
     let (graph, package_indices, cached_count, fetch_count) = match lockfile_result {
         Ok((mut graph, kind)) => {
             // Under `sharedWorkspaceLockfile=false` the project's own
@@ -1887,31 +1896,40 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 // snapshot metadata (`optional: true`, `transitivePeerDependencies`)
                 // before the write and before the host-only `filter_graph` below.
                 crate::commands::prepare_resolved_graph_for_lockfile_write(&mut graph);
-                if shared_workspace_lockfile || !has_workspace {
-                    let written_path = write_lockfile_dir_remapped(
-                        &lockfile_dir,
-                        &lockfile_importer_key,
+                // The serialize + reformat + atomic write is the slowest
+                // serial span before the linker (10-55 ms on large trees).
+                // When the overlap is on, hand it a clone of the prepared
+                // graph and run it on a blocking thread so it overlaps
+                // `filter_graph` + the link phase; the handle is joined
+                // before `run_finalize_phase`.
+                // `AUBE_DISABLE_LOCKFILE_WRITE_OVERLAP=1` reverts to the
+                // inline serial write — byte-identical output, same error
+                // point, and no graph clone (exactly the pre-overlap cost).
+                if lockfile_write_overlap::overlap_enabled() {
+                    let write_inputs = lockfile_write_overlap::LockfileWriteInputs {
+                        graph: graph.clone(),
+                        manifest: manifest.clone(),
+                        manifests: manifests.clone(),
+                        lockfile_dir: lockfile_dir.clone(),
+                        lockfile_importer_key: lockfile_importer_key.clone(),
+                        cwd: cwd.clone(),
+                        write_kind,
+                        shared_workspace_lockfile,
+                        has_workspace,
+                        per_project_write_selection: per_project_write_selection.clone(),
+                    };
+                    lockfile_write_handle = Some(lockfile_write_overlap::spawn(write_inputs));
+                } else {
+                    lockfile_write_overlap::write_inline(
                         &graph,
                         &manifest,
-                        write_kind,
-                    )
-                    .into_diagnostic()
-                    .wrap_err("failed to write lockfile")?;
-                    // Log the basename (matches the format resolve.bats and
-                    // similar tests assert against — e.g. "Wrote aube-lock.yaml").
-                    tracing::debug!(
-                        "Wrote {}",
-                        written_path
-                            .file_name()
-                            .map(|n| n.to_string_lossy().into_owned())
-                            .unwrap_or_else(|| written_path.display().to_string())
-                    );
-                } else {
-                    write_per_project_lockfiles(
-                        &cwd,
-                        &graph,
                         &manifests,
+                        &lockfile_dir,
+                        &lockfile_importer_key,
+                        &cwd,
                         write_kind,
+                        shared_workspace_lockfile,
+                        has_workspace,
                         per_project_write_selection.as_ref(),
                     )?;
                 }
@@ -2028,6 +2046,16 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                     apply_computed_integrities(&mut graph, &catchup_integrities);
                     if let Some(lock_graph) = lockfile_graph_for_integrity_rewrite.as_mut() {
                         apply_computed_integrities(lock_graph, &catchup_integrities);
+                        // The integrity rewrite overwrites the lockfile the
+                        // overlapped write produced. Join the in-flight write
+                        // first so the two never race the same atomic-write
+                        // rename and the on-disk result is the rewrite (the
+                        // serial ordering the inline path had: write, then
+                        // catch-up rewrite). Consumes the handle so the
+                        // post-match join is a no-op.
+                        if let Some(handle) = lockfile_write_handle.take() {
+                            lockfile_write_overlap::join(handle).await?;
+                        }
                         if shared_workspace_lockfile || !has_workspace {
                             write_lockfile_dir_remapped(
                                 &lockfile_dir,
@@ -2226,6 +2254,13 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         prog_ref,
         phase_timings: &mut phase_timings,
     })?;
+    // Join the overlapped lockfile write before finalize re-reads the
+    // graph. The write ran concurrently with the link phase above; a write
+    // error surfaces here (it is not dropped). `None` on every inline-write
+    // path, so this is a no-op there.
+    if let Some(handle) = lockfile_write_handle.take() {
+        lockfile_write_overlap::join(handle).await?;
+    }
     finalize::run_finalize_phase(finalize::FinalizePhaseInput {
         cwd: &cwd,
         settings_ctx: &settings_ctx,

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1920,7 +1920,10 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                     };
                     lockfile_write_handle = Some(lockfile_write_overlap::spawn(write_inputs));
                 } else {
-                    lockfile_write_overlap::write_inline(
+                    // Killswitch-disabled inline write: borrow the call-site
+                    // values directly (no graph clone — exactly the pre-overlap
+                    // cost), same error point.
+                    lockfile_write_overlap::write_one(
                         &graph,
                         &manifest,
                         &manifests,

--- a/test/install.bats
+++ b/test/install.bats
@@ -83,6 +83,29 @@ YAML
 	assert_failure
 }
 
+@test "cold-install lockfile is byte-identical with the write-overlap on vs off" {
+	# The cold-install lockfile write runs overlapped with the link phase
+	# on a background thread by default; AUBE_DISABLE_LOCKFILE_WRITE_OVERLAP
+	# reverts to the inline serial write. The two paths must produce the
+	# exact same bytes on disk — the overlap changes *when* the write runs,
+	# never *what* it writes. Drive a fresh resolve (no lockfile) both ways
+	# and diff the result.
+	cp "$PROJECT_ROOT/fixtures/basic/package.json" .
+
+	run aube install
+	assert_success
+	assert_file_exists aube-lock.yaml
+	cp aube-lock.yaml overlapped.yaml
+
+	rm -rf node_modules aube-lock.yaml
+	AUBE_DISABLE_LOCKFILE_WRITE_OVERLAP=1 run aube install
+	assert_success
+	assert_file_exists aube-lock.yaml
+
+	run diff overlapped.yaml aube-lock.yaml
+	assert_success
+}
+
 @test "aube install warm path works in CI frozen mode" {
 	_setup_basic_fixture
 	export CI=1


### PR DESCRIPTION
## Measured

Overlapping the cold-install lockfile write with the link tail recovers the full serialize+write span minus a graph clone. Measured with a criterion bench (`pnpm_lock_write`) on real `pnpm-lock.yaml` files, release profile, on macOS/arm64:

| lockfile | packages | write_full (recovered) | graph_clone (offset) | **net win** |
|----------|---------:|-----------------------:|---------------------:|------------:|
| rolldown | 1504 | 11.01 ms ± 0.56 | 0.64 ms ± 0.03 | **~10.4 ms** |
| many-deps (@teambit/bit) | 4199 | 55.82 ms ± 1.73 | 4.71 ms ± 1.96 | **~51 ms** |

`write_full` is the serialize + pnpm-parity reformat + atomic fs write — exactly the work that moves off the critical path. `graph_clone` is the offsetting cost the spawned task pays. The write is ~12-18x the clone, so the net is the recovered write time minus one clone, well outside noise.

## Mechanism

On the fresh-resolve cold install the lockfile write ran as a serial blocking span *before* `filter_graph` + `run_link_phase`, with the linker idle. This moves it onto a `tokio::task::spawn_blocking` task that runs concurrently with `filter_graph`, the progress reconcile, and the link phase, joining before `run_finalize_phase` re-reads the graph.

The task operates on a clone of the *prepared* graph, taken after the write-prep mutations (`refresh_lockfile_pin`, `stamp_pnpm_config_checksums`, `prepare_resolved_graph_for_lockfile_write`) and before `filter_graph` mutates the original in place — so it serializes the exact same state the inline write did.

## Killswitch

On by default. `AUBE_DISABLE_LOCKFILE_WRITE_OVERLAP` reverts to the inline serial write — byte-identical output, same error point, and no graph clone (exactly the pre-overlap cost). Matches the existing `AUBE_DISABLE_*` overlap-opt convention (`DISABLE_CRITICAL_PATH`, `DISABLE_TARBALL_STREAM`, …) and reads through `embedder_env`, so a host with no `env_prefix` exposes no branded toggle.

## Error ordering

The rare catch-up integrity-rewrite (when a platform-mismatched survivor needs a computed-integrity refresh) overwrites the same lockfile. It joins the in-flight write first, so the two never race the same atomic-write rename and the on-disk result is the rewrite — preserving the old serial "write, then catch-up rewrite" order. The post-link join surfaces a write error (including a task panic, wrapped distinctly) rather than dropping it.

## Tests

- `install.bats`: a byte-identical cold-install test that drives a fresh resolve with the overlap on (default) and off (`AUBE_DISABLE_LOCKFILE_WRITE_OVERLAP=1`) and diffs the resulting `aube-lock.yaml` — they must be byte-for-byte identical (the overlap changes *when* the write runs, never *what*).
- `pnpm_lock_write` criterion bench measuring `write_full` vs `graph_clone` (feature-gated behind `bench`).

`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, the `aube-lockfile` unit tests, the hermetic `e2e.rs`, and the install / lockfile / workspace / resolve bats files all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cold installs can now write lockfiles in parallel with other install phases, reducing overall latency.
  * Added a benchmark to measure lockfile write performance.
* **Bug Fixes**
  * Ensures any overlapped lockfile write is properly completed before integrity rewrite and finalization, preventing update races.
  * Allows write overlap to be disabled via `DISABLE_LOCKFILE_WRITE_OVERLAP`.
* **Tests**
  * Added coverage verifying lockfile output is byte-identical whether write overlap is enabled or disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->