### PR TITLE
ci: remove dtolnay rust-toolchain action

### DIFF
--- a/.github/workflows/ppa-publish.yml
+++ b/.github/workflows/ppa-publish.yml
@@ -153,11 +153,6 @@ jobs:
             pkg-config \
             jq
 
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          toolchain: stable
-
       - name: Vendor Rust dependencies
         run: |
           mkdir -p .cargo


### PR DESCRIPTION
Summary:
- Remove the dtolnay/rust-toolchain setup step from the PPA publishing workflow.
- Rely on the GitHub runner default Rust toolchain for cargo vendor.

Validation:
- rg -n "dtolnay/rust-toolchain|dtolnay" .github/workflows (no matches)
- git diff --check

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Packaging jobs depend on an unpinned runner Rust version while Debian metadata still expects `rustc (>= 1.93)`; a too-old default toolchain could break vendoring or diverge from other CI Rust setup.
> 
> **Overview**
> Removes the **Set up Rust** step that pinned **stable** via `dtolnay/rust-toolchain` from the PPA publishing workflow.
> 
> The **Vendor Rust dependencies** step now uses whatever `cargo`/`rustc` the `ubuntu-latest` runner provides, with no explicit toolchain install before `cargo vendor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5372ff9ab5e4bf7e46046da10edc7e3f09782e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->