### PR TITLE
fix(lockfile): detect npm package-lock root drift

### DIFF
--- a/crates/aube-lockfile/src/drift.rs
+++ b/crates/aube-lockfile/src/drift.rs
@@ -37,8 +37,8 @@ impl LockfileGraph {
     /// `"lodash": "catalog:"` override reads as stale against a
     /// lockfile that recorded the resolved `"lodash": "4.17.21"`.
     ///
-    /// Lockfile formats that don't record specifiers (npm, yarn, bun) always
-    /// return `Fresh` since we have no way to detect drift without re-resolving.
+    /// Importers that don't record specifiers return `Fresh` since we have no
+    /// way to detect manifest drift without re-resolving.
     ///
     /// [`check_drift_workspace`]: Self::check_drift_workspace
     pub fn check_drift(
@@ -1085,8 +1085,8 @@ mod drift_tests {
 
     #[test]
     fn fresh_when_no_specifiers_recorded() {
-        // Non-pnpm formats (npm/yarn/bun) don't store specifiers, so we can't
-        // detect drift — we treat them as fresh and let the resolver decide.
+        // Some lockfile importers don't store specifiers, so we can't detect
+        // drift — we treat them as fresh and let the resolver decide.
         let manifest = make_manifest(&[("lodash", "^4.17.0")]);
         let graph = LockfileGraph {
             importers: {

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -279,8 +279,8 @@ pub struct DirectDep {
     pub dep_type: DepType,
     /// The specifier as written in package.json at the time the lockfile was
     /// generated (e.g., `"^4.17.0"`). Used by drift detection to compare against
-    /// the current manifest. Only populated by formats that record it
-    /// (pnpm-lock.yaml v9). `None` for npm/yarn/bun lockfiles.
+    /// the current manifest. Populated by formats that record it
+    /// (pnpm importers and npm root/workspace package entries).
     pub specifier: Option<String>,
 }
 

--- a/crates/aube-lockfile/src/npm/read.rs
+++ b/crates/aube-lockfile/src/npm/read.rs
@@ -305,25 +305,26 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
     let root = raw.packages.get("").cloned().unwrap_or_default();
 
     let mut direct: Vec<DirectDep> = Vec::new();
-    let push_direct = |dep_name: &str, dep_type: DepType, direct: &mut Vec<DirectDep>| {
-        let root_path = format!("node_modules/{dep_name}");
-        if let Some(info) = install_path_info.get(&root_path) {
-            direct.push(DirectDep {
-                name: info.name.clone(),
-                dep_path: info.dep_path.clone(),
-                dep_type,
-                specifier: None,
-            });
-        }
-    };
-    for dep_name in root.dependencies.keys() {
-        push_direct(dep_name, DepType::Production, &mut direct);
+    let push_direct =
+        |dep_name: &str, specifier: &str, dep_type: DepType, direct: &mut Vec<DirectDep>| {
+            let root_path = format!("node_modules/{dep_name}");
+            if let Some(info) = install_path_info.get(&root_path) {
+                direct.push(DirectDep {
+                    name: info.name.clone(),
+                    dep_path: info.dep_path.clone(),
+                    dep_type,
+                    specifier: Some(specifier.to_string()),
+                });
+            }
+        };
+    for (dep_name, specifier) in &root.dependencies {
+        push_direct(dep_name, specifier, DepType::Production, &mut direct);
     }
-    for dep_name in root.dev_dependencies.keys() {
-        push_direct(dep_name, DepType::Dev, &mut direct);
+    for (dep_name, specifier) in &root.dev_dependencies {
+        push_direct(dep_name, specifier, DepType::Dev, &mut direct);
     }
-    for dep_name in root.optional_dependencies.keys() {
-        push_direct(dep_name, DepType::Optional, &mut direct);
+    for (dep_name, specifier) in &root.optional_dependencies {
+        push_direct(dep_name, specifier, DepType::Optional, &mut direct);
     }
 
     // npm symlinks every workspace member (and any other top-level

--- a/crates/aube-lockfile/src/npm/tests.rs
+++ b/crates/aube-lockfile/src/npm/tests.rs
@@ -1,7 +1,10 @@
 use super::layout::package_name_from_install_path;
 use super::source::local_git_source_from_resolved;
 use super::*;
-use crate::{DepType, DirectDep, Error, GitSource, LocalSource, LockedPackage, LockfileGraph};
+use crate::{
+    DepType, DirectDep, DriftStatus, Error, GitSource, LocalSource, LockedPackage, LockfileGraph,
+    LockfileKind,
+};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
@@ -76,13 +79,57 @@ fn test_parse_simple() {
 
     let root = graph.importers.get(".").unwrap();
     assert_eq!(root.len(), 2);
-    assert!(
-        root.iter()
-            .any(|d| d.name == "foo" && d.dep_type == DepType::Production)
-    );
-    assert!(
-        root.iter()
-            .any(|d| d.name == "bar" && d.dep_type == DepType::Dev)
+    let foo_direct = root.iter().find(|d| d.name == "foo").unwrap();
+    assert_eq!(foo_direct.dep_type, DepType::Production);
+    assert_eq!(foo_direct.specifier.as_deref(), Some("^1.0.0"));
+    let bar_direct = root.iter().find(|d| d.name == "bar").unwrap();
+    assert_eq!(bar_direct.dep_type, DepType::Dev);
+    assert_eq!(bar_direct.specifier.as_deref(), Some("^2.0.0"));
+}
+
+#[test]
+fn test_parse_root_specifiers_drive_drift() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let content = r#"{
+            "name": "test",
+            "version": "1.0.0",
+            "lockfileVersion": 3,
+            "packages": {
+                "": {
+                    "name": "test",
+                    "version": "1.0.0",
+                    "dependencies": { "@raycast/api": "^1.104.13" }
+                },
+                "node_modules/@raycast/api": {
+                    "version": "1.104.20",
+                    "integrity": "sha512-aaa"
+                }
+            }
+        }"#;
+    std::fs::write(tmp.path(), content).unwrap();
+
+    let graph = parse(tmp.path()).unwrap();
+    let root = &graph.importers["."];
+    let raycast = root.iter().find(|d| d.name == "@raycast/api").unwrap();
+    assert_eq!(raycast.specifier.as_deref(), Some("^1.104.13"));
+
+    let manifest = aube_manifest::PackageJson {
+        dependencies: [("@vicinae/api".to_string(), "^0.21.5".to_string())]
+            .into_iter()
+            .collect(),
+        ..Default::default()
+    };
+    assert_eq!(
+        graph.check_drift_for_kind(
+            &manifest,
+            &BTreeMap::new(),
+            &[],
+            &BTreeMap::new(),
+            LockfileKind::Npm,
+        ),
+        DriftStatus::Stale {
+            reason: "manifest adds @vicinae/api@^0.21.5".to_string()
+        }
     );
 }
 
@@ -1671,7 +1718,7 @@ fn test_parse_workspace_links() {
     assert_eq!(importer[0].name, "@scope/app");
     assert_eq!(importer[0].dep_path, dep_path);
     assert!(matches!(importer[0].dep_type, DepType::Production));
-    assert!(importer[0].specifier.is_none());
+    assert_eq!(importer[0].specifier.as_deref(), Some("file:packages/app"));
 
     let app = &graph.packages[&importer[0].dep_path];
     assert_eq!(app.version, "0.68.1");


### PR DESCRIPTION
## Summary
- preserve npm root dependency specifiers when parsing package-lock.json
- let existing drift checks detect stale npm root dependency snapshots
- add regression coverage for the @raycast/api -> @vicinae/api mismatch from Discussion #964

## Tests
- cargo test -p aube-lockfile
- cargo fmt --check
- cargo clippy -p aube-lockfile --all-targets -- -D warnings

Refs #964

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes frozen-lockfile and warm-path behavior for npm projects when root dependencies diverge from the lockfile; limited to lockfile parsing and drift detection in aube-lockfile.
> 
> **Overview**
> **npm `package-lock.json` parsing now keeps root dependency specifiers** on each root `DirectDep`, so frozen-install drift checks can compare `package.json` against what the lockfile recorded instead of always treating npm roots as fresh.
> 
> The npm reader copies specifiers from the lockfile `""` entry for production, dev, and optional dependencies (workspace `file:` links still omit specifiers when synthesized). Docs now describe specifier-backed drift generically rather than as pnpm-only.
> 
> Regression tests assert parsed specifiers on simple locks, `file:` workspace deps, and the Discussion #964 case where the manifest swaps `@raycast/api` for `@vicinae/api` and `check_drift_for_kind(LockfileKind::Npm)` reports stale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7aa448f09718b5f758f2dbeec87de354b98c620c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->