### PR TITLE
docs: fix security docs inaccuracies and add missing advisoryBloomCheck coverage

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,11 +18,13 @@ several more available as one-line opt-ins. Full reference:
 | Setting | Default | What it protects against |
 | --- | --- | --- |
 | `blockExoticSubdeps` | `true` | Transitive deps from `git+`, `file:`, or raw tarball URLs |
-| `allowBuilds` (deny-by-default) | `true` | Lifecycle scripts running without explicit approval |
+| `allowBuilds` | deny all dep scripts | Lifecycle scripts running without explicit approval |
 | `trustPolicy` | `"no-downgrade"` | Versions that lost provenance or trusted-publisher evidence |
 | `minimumReleaseAge` | `1440` (24h) | Newly published versions before they have aged in the registry |
-| `jailBuilds` | `false` (planned `true` in v2) | Approved scripts with full filesystem / network / env |
-| `paranoid` | `false` | Master switch — forces `jailBuilds`, `trustPolicy=no-downgrade`, `minimumReleaseAgeStrict`, `strictStoreIntegrity`, `strictDepBuilds` |
+| `advisoryCheck` | `"on"` | Known-malicious packages (OSV `MAL-*` advisories) on `aube add` and fresh-resolution installs |
+| `lowDownloadThreshold` | `1000` | Typosquats — `aube add` prompts on packages with near-zero weekly downloads |
+| `jailBuilds` | `false` (planned `true` in the next major) | Approved scripts getting full filesystem / network / env |
+| `paranoid` | `false` | Master switch — forces `jailBuilds`, `trustPolicy=no-downgrade`, `minimumReleaseAgeStrict`, `strictStoreIntegrity`, `strictDepBuilds`, `advisoryCheck=required` |
 | Tarball integrity (SHA-512) | always on | Tampered tarballs in the registry or proxy cache |
 | Content-addressed store (BLAKE3) | always on | Drift between the store and the linked `node_modules` |
 | `aube audit` | n/a | Known CVEs against the resolved dependency tree |

--- a/docs/security.md
+++ b/docs/security.md
@@ -18,15 +18,17 @@ configured individually:
 
 - [`jailBuilds = true`](#jailed-lifecycle-scripts)
 - [`trustPolicy = no-downgrade`](#trust-policy) (overrides explicit `off`)
-- `minimumReleaseAgeStrict = true` — turns the age gate into a hard fail
-  instead of "fall back to the lowest satisfying version"
-- `strictStoreIntegrity = true` — fail when a tarball ships without
-  `dist.integrity` instead of warning
-- `strictDepBuilds = true` — fail the install when a dep has unreviewed
-  build scripts instead of silently skipping
+- [`minimumReleaseAgeStrict = true`](#minimum-release-age) — turns the age
+  gate into a hard fail instead of "fall back to the lowest satisfying
+  version"
+- [`strictStoreIntegrity = true`](/settings/#setting-strictstoreintegrity) —
+  fail when a tarball ships without `dist.integrity` instead of warning
+- [`strictDepBuilds = true`](/settings/#setting-strictdepbuilds) — fail the
+  install when a dep has unreviewed build scripts instead of silently
+  skipping them
 - [`advisoryCheck = required`](#typosquat-and-impersonation-protection) —
-  fail `aube add` if OSV can't be reached instead of falling back to
-  download-count signal alone
+  fail any live-API OSV check when OSV can't be reached, instead of warning
+  and continuing
 
 Use it when you want maximum protection without listing each setting.
 
@@ -59,37 +61,35 @@ if one already exists) as `false`; approving them flips the entry to `true`.
 
 ### Suspicious-script content sniff
 
-Before the warm-up nudge to run `aube approve-builds`, aube runs a
-small pattern matcher against each unreviewed dep's `preinstall` /
-`install` / `postinstall` script bodies and surfaces a
-`WARN_AUBE_SUSPICIOUS_LIFECYCLE_SCRIPT` for any that match a
-known-dangerous shape:
+Before nudging you to run `aube approve-builds`, aube runs a small pattern
+matcher against each unreviewed dep's `preinstall` / `install` /
+`postinstall` script bodies and surfaces a
+`WARN_AUBE_SUSPICIOUS_LIFECYCLE_SCRIPT` for any that match a known-dangerous
+shape:
 
 - `curl … | sh` / `wget … | bash` — fetch-and-pipe-to-shell.
 - `eval(atob(…))` / `Function(atob(…))` / `eval(Buffer.from(…))` —
-  base64-decode-then-evaluate. Common dropper shape.
-- Reads of `~/.ssh`, `~/.aws`, `~/.npmrc`, `~/.config/gh` —
-  credential files a lifecycle script has no business touching.
-- `process.env.*TOKEN`, `*SECRET`, `*API_KEY`, etc. — secret-shaped
-  env vars exfilled from CI.
-- Discord webhooks, Telegram bot API, OAST collaborator hosts —
-  known exfil channels.
+  base64-decode-then-evaluate, a common dropper shape.
+- Reads of `~/.ssh`, `~/.aws`, `~/.npmrc`, `~/.config/gh` — credential files
+  a lifecycle script has no business touching.
+- `process.env.*TOKEN`, `*SECRET`, `*API_KEY`, etc. — secret-shaped env vars
+  exfiltrated from CI.
+- Discord webhooks, Telegram bot API, OAST collaborator hosts — known exfil
+  channels.
 - `http://1.2.3.4/…` bare-IP HTTP targets.
 
-The sniff is **advisory** — it never blocks an install or write.
-The `allowBuilds` allowlist remains the only gate on whether
-scripts actually execute. The signal is intended to give the user
-something more than `name@version` to judge by when deciding
-whether to approve a build. `aube approve-builds` repeats the same
-warnings inline next to each picker entry, and `aube
-ignored-builds` lists them under each `name@version` line.
+The sniff is **advisory** — it never blocks an install or write. The
+`allowBuilds` allowlist remains the only gate on whether scripts actually
+execute; the sniff just gives you more than `name@version` to judge by when
+deciding whether to approve a build. `aube approve-builds` repeats the same
+warnings inline next to each picker entry, and `aube ignored-builds` lists
+them under each `name@version` line.
 
-False positives are possible (an SDK that legitimately hits a
-Discord webhook from a `postinstall` would flag), but lifecycle
-script bodies are short and almost never contain bare
-`curl … | sh` legitimately. To bypass for a known-good package,
-add it to `allowBuilds: true` once you've inspected the script —
-the warning has done its job.
+False positives are possible (an SDK that legitimately hits a Discord
+webhook from a `postinstall` would flag), but lifecycle script bodies are
+short and almost never contain a bare `curl … | sh` legitimately. Once
+you've inspected a flagged script and decided it's fine, add the package to
+`allowBuilds: true` — the warning has done its job.
 
 ## Jailed lifecycle scripts
 
@@ -123,7 +123,8 @@ Full reference: [Jailed builds](/package-manager/jailed-builds).
 
 `trustPolicy = no-downgrade` blocks installs of a version that carries weaker
 trust evidence than any earlier-published version of the same package. aube
-only counts the structured metadata shape npm emits after registry-side checks:
+recognizes three tiers of evidence, strongest first, and only counts the
+structured metadata shapes npm emits after registry-side checks:
 
 1. **npm staged publish approval** — package metadata carries an `approver`
    field from the registry-side approval flow.
@@ -144,16 +145,17 @@ without the original CI flow.
 trustPolicy: no-downgrade
 ```
 
-Exempt specific packages or versions when needed (only exact versions, no
-ranges):
+Exempt specific packages or versions when needed:
 
 ```yaml
 trustPolicyExclude:
-  - "@vendor/legacy-pkg"            # all versions
-  - "old-thing@1.0.0"                # one version
-  - "things@1.0.0 || 1.0.1"          # version union
-  - "is-*"                           # name glob (no version)
+  - "@vendor/legacy-pkg"       # every version of one package
+  - "old-thing@1.0.0"          # one exact version
+  - "things@1.0.0 || 1.0.1"    # union of exact versions
+  - "is-*"                     # name glob (globs take no version)
 ```
+
+Versions must be exact — `^`/`~`/`>=` ranges are not accepted.
 
 Default: `no-downgrade`. Set `trustPolicy: off` to disable, or use
 `trustPolicyExclude` for per-package opt-outs.
@@ -183,14 +185,13 @@ Settings: [`minimumReleaseAge`](/settings/#setting-minimumreleaseage),
 
 ## Typosquat and impersonation protection
 
-`aube add` checks every package you name on the command line *and* the
-full post-resolve transitive closure against [OSV](https://osv.dev) for
-`MAL-*` malicious-package advisories — same check `aube update` and any
-other install path runs where the resolver picks a version that wasn't
-already pinned by the lockfile. Plain reinstalls (the lockfile was
-authoritative) skip the live API for latency; an opt-in local mirror
-(see [Install-time OSV check](#install-time-osv-check) below) covers
-that path.
+`aube add` checks every package you name on the command line — and, after
+resolution, the full transitive closure — against [OSV](https://osv.dev) for
+`MAL-*` malicious-package advisories. The same check runs on `aube update`
+and on any install where the resolver picks a version the lockfile didn't
+already pin. Plain reinstalls (where the lockfile was authoritative) skip
+the live API for latency; two opt-in local backends cover that path — see
+[Install-time OSV check](#install-time-osv-check) below.
 
 Two signals, with different response levels:
 
@@ -248,34 +249,47 @@ Settings: [`advisoryCheck`](/settings/#setting-advisorycheck),
 
 ## Install-time OSV check
 
-OSV `MAL-*` checks are routed three ways post-resolve so the freshest
-signal lands when it matters most without paying for a per-install
+After resolution, every install picks exactly one OSV `MAL-*` backend, so
+the freshest signal lands when it matters most without paying a per-install
 network round-trip when it doesn't:
 
-| Install path                                      | Backend       | Setting                       |
-| ------------------------------------------------- | ------------- | ----------------------------- |
-| `aube add`, `aube update`                         | Live API      | `advisoryCheck` (default `on`)|
-| Missing lockfile / resolver picked new version    | Live API      | `advisoryCheck` (default `on`)|
-| `advisoryCheckEveryInstall = true`                | Live API      | `advisoryCheck` (default `on`)|
-| Plain reinstall (lockfile authoritative)          | Local mirror  | `advisoryCheckOnInstall` (default `off`) |
-| Anything else                                     | No check      | —                             |
+| Install path                                   | Backend         | Setting                                   |
+| ---------------------------------------------- | --------------- | ----------------------------------------- |
+| `aube add`, `aube update`                      | Live API        | `advisoryCheck` (default `on`)            |
+| Missing lockfile / resolver picked new version | Live API        | `advisoryCheck` (default `on`)            |
+| `advisoryCheckEveryInstall = true`             | Live API        | `advisoryCheck` (default `on`)            |
+| Plain reinstall (lockfile authoritative)       | Bloom prefilter | `advisoryBloomCheck` (default `off`)      |
+| Plain reinstall, bloom disabled                | Local mirror    | `advisoryCheckOnInstall` (default `off`)  |
+| Plain reinstall, both disabled                 | No check        | —                                         |
 
-The mirror lives at `$XDG_CACHE_HOME/aube/osv/npm/` (the bulk zip from
-`osv-vulnerabilities.storage.googleapis.com/npm/all.zip`, roughly tens
-of MB) and lazily refreshes with an ETag-conditional GET every 24
-hours. Hits map to the same `ERR_AUBE_MALICIOUS_PACKAGE` exit as the
-live-API gate.
+The two local backends cover plain reinstalls without a live round-trip:
 
-Trade-off: the mirror lags reality by up to ~24h. An advisory published
-in the last day won't be in your local index unless a refresh happens to
-fall after it. Fresh-resolution installs always go through the live API
-so that lag doesn't matter for new picks; plain reinstalls trade
-sub-day staleness for sub-millisecond lookups.
+**Bloom prefilter** (`advisoryBloomCheck`) downloads a ~380 KB bloom filter
+built from OSV's malicious-package archive (regenerated upstream every 10
+minutes), probes the resolved graph against it, and escalates only the hits
+(~0.1% false-positive rate) to the live API for exact `(name, version)`
+confirmation. A typical lockfile costs zero or one extra live-API round
+trip per install. When both local backends are enabled, the bloom wins —
+it's far cheaper on the wire and its confirmed hits go through the same
+live-API oracle.
+
+**Local mirror** (`advisoryCheckOnInstall`) keeps the bulk zip from
+`osv-vulnerabilities.storage.googleapis.com/npm/all.zip` (roughly tens of
+MB) at `$XDG_CACHE_HOME/aube/osv/npm/`, lazily refreshed with an
+ETag-conditional GET every 24 hours. Lookups are sub-millisecond, but the
+index lags reality by up to ~24h — an advisory published in the last day
+won't be in it unless a refresh happens to fall after it. Fresh-resolution
+installs always go through the live API, so that lag never affects new
+picks.
+
+Confirmed hits from any backend fail the install with the same
+`ERR_AUBE_MALICIOUS_PACKAGE` exit.
 
 ```yaml
-# Default: live API on aube add / update / fresh-resolution. Mirror
-# disabled — plain reinstalls skip OSV entirely.
+# Default: live API on aube add / update / fresh-resolution.
+# Plain reinstalls skip OSV entirely.
 advisoryCheck: on
+advisoryBloomCheck: off
 advisoryCheckOnInstall: off
 advisoryCheckEveryInstall: false
 ```
@@ -287,23 +301,23 @@ advisoryCheckEveryInstall: true
 ```
 
 ```yaml
-# Cheap fallback: live API on fresh-resolution, local mirror covers
-# plain reinstalls so even CI re-runs see SOME OSV coverage.
+# Cheap always-on coverage: bloom prefilter covers plain reinstalls
+# with a ~380 KB download; hits escalate to the live API.
 advisoryCheck: on
-advisoryCheckOnInstall: on
+advisoryBloomCheck: on
 ```
 
-Refresh-failure semantics for the mirror:
+Both local backends share the same refresh-failure semantics:
 
-- `advisoryCheckOnInstall = on`: `WARN_AUBE_OSV_MIRROR_REFRESH_FAILED`,
-  install continues against the prior on-disk index (or empty on first
-  sync).
-- `advisoryCheckOnInstall = required`: mirror refresh failures map to
-  `ERR_AUBE_ADVISORY_CHECK_FAILED`. Use when a stale or unreachable
-  mirror should block.
+- `on`: warn (`WARN_AUBE_OSV_BLOOM_REFRESH_FAILED` /
+  `WARN_AUBE_OSV_MIRROR_REFRESH_FAILED`) and continue against the prior
+  on-disk copy (or empty on first sync).
+- `required`: refresh failures map to `ERR_AUBE_ADVISORY_CHECK_FAILED`. Use
+  in hardened CI where a stale or unreachable index should block.
 
 Settings:
 [`advisoryCheck`](/settings/#setting-advisorycheck),
+[`advisoryBloomCheck`](/settings/#setting-advisorybloomcheck),
 [`advisoryCheckOnInstall`](/settings/#setting-advisorycheckoninstall),
 [`advisoryCheckEveryInstall`](/settings/#setting-advisorycheckeveryinstall).
 
@@ -345,10 +359,11 @@ scrubbed from the script environment unless explicitly granted via
 
 ## Pluggable security scanner
 
-`securityScanner` runs a [Bun-compatible security scanner](https://bun.sh/docs/pm/security-scanner-api)
-against the resolved install graph. Point the setting at the same
-npm package you'd put in Bun's `bunfig.toml#install.security.scanner`
-and aube loads it through a `node` bridge — the
+`securityScanner` runs a
+[Bun-compatible security scanner](https://bun.sh/docs/pm/security-scanner-api)
+against the resolved install graph. Point the setting at the same npm
+package you'd put in Bun's `bunfig.toml#install.security.scanner` and aube
+loads it through a `node` bridge — the
 [oven-sh template](https://github.com/oven-sh/security-scanner-template)
 and [`@socketsecurity/bun-security-scanner`](https://github.com/SocketDev/bun-security-scanner)
 both run unchanged.
@@ -358,11 +373,10 @@ both run unchanged.
 securityScanner: "@acme/bun-security-scanner"
 ```
 
-The scanner fires post-resolve, sees the full transitive graph
-with resolved versions, and **fails closed** on any scanner
-failure (missing `node`, unresolvable module, timeout, etc.).
-Requires Node 22.6+. Set `securityScanner: ""` to disable when
-bootstrapping.
+The scanner fires post-resolve, sees the full transitive graph with
+resolved versions, and **fails closed** on any scanner failure (missing
+`node`, unresolvable module, timeout, etc.). Requires Node 22.6+. Set
+`securityScanner: ""` to disable when bootstrapping.
 
 Full reference: [Security scanner](/package-manager/security-scanner).
 


### PR DESCRIPTION
Cross-checked both security docs against the implementation (`crates/aube-settings/settings.toml`, the OSV routing in `crates/aube/src/commands/add_supply_chain.rs`, and `aube-codes`) and fixed the places where they had drifted or contradicted themselves.

## docs/security.md

- **Install-time OSV check**: the routing table claimed checks were "routed three ways" and never mentioned `advisoryBloomCheck` — but `run_post_resolve_osv_routing` routes plain reinstalls to the bloom prefilter *first*, with the local mirror as fallback. The table now covers all six routes, and the section documents both local backends (bloom: ~380 KB filter, hits escalate to the live API; mirror: bulk zip, up to ~24h stale) plus their shared refresh-failure semantics (`WARN_AUBE_OSV_BLOOM_REFRESH_FAILED` / `WARN_AUBE_OSV_MIRROR_REFRESH_FAILED`).
- **`trustPolicyExclude`**: the example contradicted its own intro ("only exact versions, no ranges" followed by a union and a glob). Each example line now says what it is, with the actual rule stated once.
- **Trust policy**: the evidence list is now explicitly a ranking (strongest first), matching how the code compares tiers.
- **Paranoid bundle**: the `advisoryCheck = required` bullet said it only affects `aube add`; it applies to every live-API OSV check. Also linked the previously unlinked bullets to their settings anchors.
- Rewrapped two sections that were wrapped at ~55 columns to match the rest of the file, and tightened the typosquat section's run-on opening paragraph.

## SECURITY.md

- The paranoid row omitted `advisoryCheck=required` from the bundle, out of sync with `resolve_osv_routing_settings`.
- The `allowBuilds` row listed a default of `true`, which isn't a value that setting takes — now reads "deny all dep scripts".
- Added the two default-on protections the table skipped: `advisoryCheck` (OSV `MAL-*` gate) and `lowDownloadThreshold` (typosquat prompt).
- Aligned "planned `true` in v2" with the docs-site phrasing "next major".

*This PR description was generated by Claude.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation changes with no runtime or configuration behavior changes.
> 
> **Overview**
> Documentation-only PR that brings **`SECURITY.md`** and **`docs/security.md`** in line with current settings and `run_post_resolve_osv_routing` behavior.
> 
> **`docs/security.md`** now documents **`advisoryBloomCheck`** as the preferred plain-reinstall OSV path (bloom before mirror), expands the install-time routing table to six paths, and explains bloom vs mirror trade-offs plus shared refresh warnings. It also fixes **`paranoid`** / **`advisoryCheck=required`** scope (all live-API OSV checks, not just `aube add`), clarifies **`trustPolicyExclude`** examples vs exact-version rules, ranks trust evidence tiers, and adds setting links in the paranoid bundle.
> 
> **`SECURITY.md`** corrects the feature table: **`allowBuilds`** default wording, adds **`advisoryCheck`** and **`lowDownloadThreshold`**, includes **`advisoryCheck=required`** in the **`paranoid`** row, and matches **`jailBuilds`** “next major” phrasing with the docs site.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b067c18c02050a264f53a03b8c2816612ddc40a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->