### PR TITLE
Update sponsor references for jdx.dev

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -197,9 +197,9 @@ jobs:
 
           ## 💚 Sponsor aube
 
-          aube is part of [**jdx.dev**](https://jdx.dev) — an independent developer-tooling studio run by [@jdx](https://github.com/jdx), also behind [mise](https://mise.jdx.dev/). Work on aube is funded entirely by sponsors.
+          aube is maintained by [@jdx](https://github.com/jdx), an open source developer for [**entire.io**](https://entire.io), the title sponsor of the [jdx.dev](https://jdx.dev) open source tools including [mise](https://mise.jdx.dev/). Work on aube is funded by sponsors.
 
-          If aube is saving your team install time or CI minutes, please consider [sponsoring at jdx.dev](https://jdx.dev). Individual and company sponsorships are what keep the project fast, free, and independent.
+          If aube is saving your team install time or CI minutes, please consider [sponsoring at jdx.dev](https://jdx.dev/sponsors.html). Individual and company sponsorships are what keep the project fast, free, and independent.
           EOF
           } > /tmp/release-notes.md
           gh release edit "$TAG" --notes-file /tmp/release-notes.md

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 </p>
 
 <p align="center">
-  Sponsored by <a href="https://entire.io">entire.io</a>, <a href="https://37signals.com">37signals</a>, and <a href="https://coderabbit.link/mise">CodeRabbit</a>.<br>
+  Sponsored by <a href="https://entire.io">entire.io</a> and <a href="https://37signals.com">37signals</a>.<br>
   <a href="https://jdx.dev/sponsors.html">View all sponsors</a>.
 </p>
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 </p>
 
 <p align="center">
-  Sponsored by <a href="https://entire.io">entire.io</a>, <a href="https://37signals.com">37signals</a>, <a href="https://coderabbit.link/mise">CodeRabbit</a>, and <a href="https://supabase.com">Supabase</a>.<br>
+  Sponsored by <a href="https://entire.io">entire.io</a>, <a href="https://37signals.com">37signals</a>, and <a href="https://coderabbit.link/mise">CodeRabbit</a>.<br>
   <a href="https://jdx.dev/sponsors.html">View all sponsors</a>.
 </p>
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@
 </p>
 
 <p align="center">
-  Sponsored by <a href="https://37signals.com">37signals</a>.<br>
-  <a href="https://en.dev/sponsors.html">View all sponsors</a>.
+  Sponsored by <a href="https://entire.io">entire.io</a>, <a href="https://37signals.com">37signals</a>, <a href="https://coderabbit.link/mise">CodeRabbit</a>, and <a href="https://supabase.com">Supabase</a>.<br>
+  <a href="https://jdx.dev/sponsors.html">View all sponsors</a>.
 </p>
 
 ## Why Try It

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1684,7 +1684,7 @@ cmd set-script hide=#true help="Set a `package.json` script (not implemented —
     }
     arg "[ARGS]…" help="Unused; captured so `aube <cmd> foo bar` parses instead of erroring on unexpected args before the fallback message prints" required=#false double_dash=automatic var=#true hide=#true
 }
-cmd sponsors help="Show the companies sponsoring aube and the jdx.dev project family"
+cmd sponsors help="Show the companies sponsoring aube and the jdx.dev open source tools"
 cmd stage help="Stage packages for publishing (not implemented — use `npm stage`)" {
     flag --fetch-retries help="Number of retry attempts for failed registry fetches" {
         long_help "Number of retry attempts for failed registry fetches.\n\nOverrides `fetchRetries` / `fetch-retries` from `.npmrc` / `aube-workspace.yaml` when set. Pair with `--fetch-timeout` to fail fast in scripted test runs."

--- a/crates/aube/src/commands/sponsors.rs
+++ b/crates/aube/src/commands/sponsors.rs
@@ -5,7 +5,7 @@ pub struct SponsorsArgs {}
 
 pub async fn run(_args: SponsorsArgs) -> miette::Result<()> {
     println!(
-        "aube and the jdx.dev project family are sponsored by:\n\n  37signals - https://37signals.com\n\nView all sponsors: https://jdx.dev/sponsors.html"
+        "aube and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n  CodeRabbit - https://coderabbit.link/mise\n  Supabase - https://supabase.com\n\nView all sponsors: https://jdx.dev/sponsors.html"
     );
     Ok(())
 }

--- a/crates/aube/src/commands/sponsors.rs
+++ b/crates/aube/src/commands/sponsors.rs
@@ -5,7 +5,7 @@ pub struct SponsorsArgs {}
 
 pub async fn run(_args: SponsorsArgs) -> miette::Result<()> {
     println!(
-        "aube and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n  CodeRabbit - https://coderabbit.link/mise\n\nView all sponsors: https://jdx.dev/sponsors.html"
+        "aube and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n\nView all sponsors: https://jdx.dev/sponsors.html"
     );
     Ok(())
 }

--- a/crates/aube/src/commands/sponsors.rs
+++ b/crates/aube/src/commands/sponsors.rs
@@ -5,7 +5,7 @@ pub struct SponsorsArgs {}
 
 pub async fn run(_args: SponsorsArgs) -> miette::Result<()> {
     println!(
-        "aube and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n  CodeRabbit - https://coderabbit.link/mise\n  Supabase - https://supabase.com\n\nView all sponsors: https://jdx.dev/sponsors.html"
+        "aube and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n  CodeRabbit - https://coderabbit.link/mise\n\nView all sponsors: https://jdx.dev/sponsors.html"
     );
     Ok(())
 }

--- a/crates/aube/src/lib.rs
+++ b/crates/aube/src/lib.rs
@@ -482,7 +482,7 @@ enum Commands {
     /// Set a `package.json` script (not implemented — use `npm set-script`)
     #[command(hide = true, name = "set-script")]
     SetScript(commands::npm_fallback::FallbackArgs),
-    /// Show the companies sponsoring aube and the jdx.dev project family
+    /// Show the companies sponsoring aube and the jdx.dev open source tools
     Sponsors(commands::sponsors::SponsorsArgs),
     /// Stage packages for publishing (not implemented — use `npm stage`)
     Stage(commands::npm_fallback::FallbackArgs),

--- a/docs/.vitepress/theme/EndevSponsors.vue
+++ b/docs/.vitepress/theme/EndevSponsors.vue
@@ -35,7 +35,7 @@ import { onMounted, ref } from "vue";
 
 const sponsors = ref([]);
 const error = ref(false);
-const footerTiers = new Set(["anchor", "premier", "partner"]);
+const footerTiers = new Set(["title", "premier", "partner"]);
 const sponsorFeedTimeoutMs = 5000;
 
 const sponsorItems = (items) => (Array.isArray(items) ? items : []);

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -9715,7 +9715,7 @@
         "flags": [],
         "mounts": [],
         "hide": false,
-        "help": "Show the companies sponsoring aube and the jdx.dev project family",
+        "help": "Show the companies sponsoring aube and the jdx.dev open source tools",
         "name": "sponsors",
         "aliases": [],
         "hidden_aliases": [],

--- a/docs/cli/sponsors.md
+++ b/docs/cli/sponsors.md
@@ -3,4 +3,4 @@
 
 - **Usage**: `aube sponsors`
 
-Show the companies sponsoring aube and the jdx.dev project family
+Show the companies sponsoring aube and the jdx.dev open source tools


### PR DESCRIPTION
## Summary
- list Entire first in the README and sponsors command
- point sponsor page references at jdx.dev
- update release blurb and generated CLI docs

## Tests
- git diff --check
- npm run docs:build from docs/
- mise exec -- cargo run -q -p aube --bin aube -- sponsors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and documentation-only changes to sponsor links and generated CLI help; no runtime or security behavior changes.
> 
> **Overview**
> Aligns sponsor messaging across the repo with **entire.io** as title sponsor and **jdx.dev** as the canonical sponsors hub.
> 
> **README** now lists entire.io before 37signals and links “View all sponsors” to `https://jdx.dev/sponsors.html` instead of `en.dev`. **`aube sponsors`** output adds entire.io at the top of the sponsor list and uses the same jdx.dev wording and URL. Copy shifts from “jdx.dev project family” to **“jdx.dev open source tools”** in the CLI (`sponsors` help in `lib.rs`, `aube.usage.kdl`) and regenerated docs (`commands.json`, `sponsors.md`).
> 
> **Release workflow** sponsor blurb appended to GitHub releases is rewritten to describe maintenance via [@jdx](https://github.com/jdx) and entire.io as title sponsor of the jdx.dev tools, with the sponsorship CTA pointing at `jdx.dev/sponsors.html`. **Docs site** `EndevSponsors.vue` treats footer sponsor tiers as `title` / `premier` / `partner` (replacing `anchor`) so the feed matches the new tier naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3abbaf4436650553c778fbff629fd94d54afaa29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->