### PR TITLE
feat(store): opt-in transparent FS-compression of native addons on import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,6 +508,7 @@ dependencies = [
  "aube-util",
  "base64",
  "blake3",
+ "decmpfs",
  "flate2",
  "hex",
  "libc",
@@ -523,6 +524,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "xx",
+ "zstd",
 ]
 
 [[package]]
@@ -1328,6 +1330,16 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "decmpfs"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "sha2 0.10.9",
+ "windows-sys 0.59.0",
+ "zstd",
+]
 
 [[package]]
 name = "defmt"
@@ -5755,6 +5767,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,6 +1334,8 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 [[package]]
 name = "decmpfs"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "651715809b4119e14ba1ba88650756d8a7012686473a32ec14c0e602e90fc47f"
 dependencies = [
  "libc",
  "sha2 0.10.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,8 +68,8 @@ reflink-copy = "0.1"
 # OS-level transparent per-file compression (APFS decmpfs / btrfs / NTFS)
 # applied to native addons as they land in the CAS. The `addon` feature
 # unwraps a napi `--compress` hybrid back to the raw `.node` before the
-# kernel re-compresses it transparently. Path dep — local to the fleet.
-decmpfs = { path = "../decmpfs", features = ["addon"] }
+# kernel re-compresses it transparently.
+decmpfs = { version = "0.1", features = ["addon"] }
 glob = "0.3"
 # BurntSushi's gitignore matcher (from ripgrep). Used by `aube pack` /
 # `aube publish` to honor `.npmignore` / `.gitignore` with full

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,11 @@ hex = "0.4"
 # Filesystem
 xx = { version = "2", features = ["fslock"] }
 reflink-copy = "0.1"
+# OS-level transparent per-file compression (APFS decmpfs / btrfs / NTFS)
+# applied to native addons as they land in the CAS. The `addon` feature
+# unwraps a napi `--compress` hybrid back to the raw `.node` before the
+# kernel re-compresses it transparently. Path dep — local to the fleet.
+decmpfs = { path = "../decmpfs", features = ["addon"] }
 glob = "0.3"
 # BurntSushi's gitignore matcher (from ripgrep). Used by `aube pack` /
 # `aube publish` to honor `.npmignore` / `.gitignore` with full

--- a/crates/aube-store/Cargo.toml
+++ b/crates/aube-store/Cargo.toml
@@ -19,6 +19,7 @@ miette = { workspace = true }
 sha1 = { workspace = true }
 sha2 = { workspace = true }
 blake3 = { workspace = true }
+decmpfs = { workspace = true }
 hex = { workspace = true }
 base64 = { workspace = true }
 flate2 = { workspace = true }
@@ -37,3 +38,6 @@ libc = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
+# Synthesize a napi `--compress` hybrid in the store-compression tests
+# (the gated import unwraps it back to the raw addon before CAS).
+zstd = { workspace = true }

--- a/crates/aube-store/src/cas.rs
+++ b/crates/aube-store/src/cas.rs
@@ -63,6 +63,13 @@ pub(crate) fn cas_file_matches_len(path: &Path, expected_len: u64) -> bool {
         .unwrap_or(false)
 }
 
+fn wait_for_cas_file_len(path: &Path, expected_len: u64) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(50);
+    while !cas_file_matches_len(path, expected_len) && std::time::Instant::now() < deadline {
+        std::thread::sleep(std::time::Duration::from_micros(250));
+    }
+}
+
 /// The opt-in store-compression gate, resolved once from the
 /// environment. Returns `Some(gate)` only when `AUBE_COMPRESS_STORE` is
 /// set; otherwise `None` and the CAS write path is byte-for-byte the
@@ -509,12 +516,7 @@ impl Store {
             // the partial file to settle. If it stays mismatched past
             // the deadline, treat it as (a) and recover.
             if !cas_file_matches_len(&store_path, content.len() as u64) {
-                let deadline = std::time::Instant::now() + std::time::Duration::from_millis(50);
-                while !cas_file_matches_len(&store_path, content.len() as u64)
-                    && std::time::Instant::now() < deadline
-                {
-                    std::thread::sleep(std::time::Duration::from_micros(250));
-                }
+                wait_for_cas_file_len(&store_path, content.len() as u64);
             }
             if !cas_file_matches_len(&store_path, content.len() as u64) {
                 let _ = xx::file::remove_file(&store_path);
@@ -679,6 +681,9 @@ impl Store {
         // for a compressed Outcome, but a fail-soft plain fallback inside
         // `compress_bytes` could still race a concurrent writer.
         if !cas_file_matches_len(&store_path, stored_bytes.len() as u64) {
+            wait_for_cas_file_len(&store_path, stored_bytes.len() as u64);
+        }
+        if !cas_file_matches_len(&store_path, stored_bytes.len() as u64) {
             let _ = xx::file::remove_file(&store_path);
             return self.import_bytes(stored_bytes, executable);
         }
@@ -693,9 +698,6 @@ impl Store {
         self.finish_gated(hex_hash, store_path, executable, stored_bytes.len())
     }
 
-    /// Shared tail of `import_bytes_gated`: write the executable marker
-    /// (if any) and build the `StoredFile`. Mirrors the marker handling
-    /// in `import_bytes`.
     /// Write the sidecar `<store_path>-exec` marker that records a CAS entry
     /// as executable. Shared by `import_bytes` and `finish_gated`.
     fn write_exec_marker(&self, store_path: &Path) -> Result<(), Error> {
@@ -704,6 +706,9 @@ impl Store {
         Ok(())
     }
 
+    /// Shared tail of `import_bytes_gated`: write the executable marker
+    /// (if any) and build the `StoredFile`. Mirrors the marker handling
+    /// in `import_bytes`.
     fn finish_gated(
         &self,
         hex_hash: String,

--- a/crates/aube-store/src/cas.rs
+++ b/crates/aube-store/src/cas.rs
@@ -124,6 +124,33 @@ pub(crate) fn parse_compress_store_gate(spec: &str) -> Option<Gate> {
     }
 }
 
+#[cfg(test)]
+mod compress_gate_tests {
+    use super::parse_compress_store_gate;
+
+    #[test]
+    fn affirmative_and_directives_yield_a_gate() {
+        // Bare/affirmative or unrecognized values → the fleet default gate.
+        for spec in ["", "1", "true", "on", "yes", "whatever"] {
+            assert!(
+                parse_compress_store_gate(spec).is_some(),
+                "spec {spec:?} should produce a gate"
+            );
+        }
+        // Explicit glob / size directives parse into a gate.
+        assert!(parse_compress_store_gate("glob:**/*.so").is_some());
+        assert!(parse_compress_store_gate("size:>= 1MB").is_some());
+        assert!(parse_compress_store_gate("glob:**/*.node;size:>= 512KB").is_some());
+    }
+
+    #[test]
+    fn malformed_size_predicate_fails_closed() {
+        // A bad size predicate disables compression (None) rather than
+        // silently widening the gate — the addon still lands plain.
+        assert!(parse_compress_store_gate("size:banana").is_none());
+    }
+}
+
 /// Outcome of `create_cas_file`. `Created` means we wrote the bytes
 /// at the final path; `AlreadyExisted` means another writer (or a
 /// previous import) had already committed bit-identical content. The

--- a/crates/aube-store/src/cas.rs
+++ b/crates/aube-store/src/cas.rs
@@ -89,9 +89,10 @@ fn store_compression_gate() -> Option<&'static Gate> {
 
 /// Pure parse of an `AUBE_COMPRESS_STORE` value into a `Gate`. Split out
 /// so the directive grammar is unit-testable without the process-global
-/// env `OnceLock`. `None` means "no gate" (compression off): an empty
-/// value never reaches here (the env var being unset is handled by the
-/// caller), and a malformed size predicate fails closed.
+/// env `OnceLock`. `None` means "no gate" (compression off): the env var
+/// being *unset* short-circuits in the caller, but a set-but-empty value
+/// (`AUBE_COMPRESS_STORE=`) reaches here and is treated as affirmative
+/// (the default `**/*.node` gate). A malformed size predicate fails closed.
 pub(crate) fn parse_compress_store_gate(spec: &str) -> Option<Gate> {
     let trimmed = spec.trim();
     // A bare/affirmative value means "use the fleet default gate".
@@ -554,8 +555,7 @@ impl Store {
             // that's carried in `StoredFile.executable`, threaded
             // through the `PackageIndex` and the linker. So flipping
             // a marker-absent-to-present for a shared hash is safe.
-            let exec_marker = PathBuf::from(format!("{}-exec", store_path.display()));
-            self.create_cas_file(&exec_marker, None)?;
+            self.write_exec_marker(&store_path)?;
         }
 
         Ok(StoredFile {
@@ -622,13 +622,27 @@ impl Store {
             return self.import_bytes(stored_bytes, executable);
         }
 
+        let hash_t0 = std::time::Instant::now();
         let hex_hash = blake3_hex(stored_bytes);
+        if aube_util::diag::enabled() {
+            aube_util::diag::event_lazy(
+                aube_util::diag::Category::Store,
+                "blake3_hash",
+                hash_t0.elapsed(),
+                || format!(r#"{{"size":{}}}"#, stored_bytes.len()),
+            );
+        }
         let store_path = self.file_path_from_hex(&hex_hash);
 
         // If a prior import already committed this content, reuse it —
         // the file is already stored (compressed or not) and the kernel
         // reads it back identically. Matches `import_bytes`'s CAS-dedupe.
         if cas_file_matches_len(&store_path, stored_bytes.len() as u64) {
+            if aube_util::diag::enabled() {
+                aube_util::diag::instant_lazy(aube_util::diag::Category::Store, "cas_hit", || {
+                    format!(r#"{{"size":{}}}"#, stored_bytes.len())
+                });
+            }
             return self.finish_gated(hex_hash, store_path, executable, stored_bytes.len());
         }
 
@@ -669,12 +683,27 @@ impl Store {
             return self.import_bytes(stored_bytes, executable);
         }
 
+        // New content just landed (compressed, or fail-soft plain) — mirror
+        // `import_bytes`'s `cas_miss` so gated installs classify identically.
+        if aube_util::diag::enabled() {
+            aube_util::diag::instant_lazy(aube_util::diag::Category::Store, "cas_miss", || {
+                format!(r#"{{"size":{}}}"#, stored_bytes.len())
+            });
+        }
         self.finish_gated(hex_hash, store_path, executable, stored_bytes.len())
     }
 
     /// Shared tail of `import_bytes_gated`: write the executable marker
     /// (if any) and build the `StoredFile`. Mirrors the marker handling
     /// in `import_bytes`.
+    /// Write the sidecar `<store_path>-exec` marker that records a CAS entry
+    /// as executable. Shared by `import_bytes` and `finish_gated`.
+    fn write_exec_marker(&self, store_path: &Path) -> Result<(), Error> {
+        let exec_marker = PathBuf::from(format!("{}-exec", store_path.display()));
+        self.create_cas_file(&exec_marker, None)?;
+        Ok(())
+    }
+
     fn finish_gated(
         &self,
         hex_hash: String,
@@ -683,8 +712,7 @@ impl Store {
         len: usize,
     ) -> Result<StoredFile, Error> {
         if executable {
-            let exec_marker = PathBuf::from(format!("{}-exec", store_path.display()));
-            self.create_cas_file(&exec_marker, None)?;
+            self.write_exec_marker(&store_path)?;
         }
         Ok(StoredFile {
             hex_hash,

--- a/crates/aube-store/src/cas.rs
+++ b/crates/aube-store/src/cas.rs
@@ -1,4 +1,5 @@
 use crate::{Error, Store, StoredFile};
+use decmpfs::Gate;
 use std::cell::RefCell;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
@@ -60,6 +61,67 @@ pub(crate) fn cas_file_matches_len(path: &Path, expected_len: u64) -> bool {
     path.metadata()
         .map(|metadata| metadata.len() == expected_len)
         .unwrap_or(false)
+}
+
+/// The opt-in store-compression gate, resolved once from the
+/// environment. Returns `Some(gate)` only when `AUBE_COMPRESS_STORE` is
+/// set; otherwise `None` and the CAS write path is byte-for-byte the
+/// pre-existing one.
+///
+/// The toggle's value selects the gate:
+///   - `AUBE_COMPRESS_STORE=1` (or any non-`size:`/non-`glob:` value) →
+///     the fleet default `**/*.node`, no size floor.
+///   - `AUBE_COMPRESS_STORE="glob:<pat>"` → that glob, no size floor.
+///   - `AUBE_COMPRESS_STORE="size:<pred>"` → `**/*.node` AND a size
+///     predicate (e.g. `size:>= 1MB`).
+///   - `AUBE_COMPRESS_STORE="glob:<pat>;size:<pred>"` → both.
+///
+/// A malformed size predicate disables compression (returns `None`)
+/// rather than silently widening the gate; the addon still lands plain.
+fn store_compression_gate() -> Option<&'static Gate> {
+    static GATE: std::sync::OnceLock<Option<Gate>> = std::sync::OnceLock::new();
+    GATE.get_or_init(|| {
+        let raw = aube_util::env::embedder_env("COMPRESS_STORE")?;
+        parse_compress_store_gate(&raw.to_string_lossy())
+    })
+    .as_ref()
+}
+
+/// Pure parse of an `AUBE_COMPRESS_STORE` value into a `Gate`. Split out
+/// so the directive grammar is unit-testable without the process-global
+/// env `OnceLock`. `None` means "no gate" (compression off): an empty
+/// value never reaches here (the env var being unset is handled by the
+/// caller), and a malformed size predicate fails closed.
+pub(crate) fn parse_compress_store_gate(spec: &str) -> Option<Gate> {
+    let trimmed = spec.trim();
+    // A bare/affirmative value means "use the fleet default gate".
+    if trimmed.is_empty() || matches!(trimmed, "1" | "true" | "on" | "yes") {
+        return Some(Gate::default());
+    }
+    let mut glob: Option<&str> = None;
+    let mut size: Option<&str> = None;
+    for part in trimmed.split(';') {
+        let part = part.trim();
+        if let Some(rest) = part.strip_prefix("glob:") {
+            glob = Some(rest.trim());
+        } else if let Some(rest) = part.strip_prefix("size:") {
+            size = Some(rest.trim());
+        }
+    }
+    // No recognized directive → treat the value as affirmative.
+    if glob.is_none() && size.is_none() {
+        return Some(Gate::default());
+    }
+    match Gate::new(glob.or(Some(decmpfs::DEFAULT_GLOB)), size) {
+        Ok(gate) => Some(gate),
+        Err(err) => {
+            warn!(
+                "AUBE_COMPRESS_STORE has an invalid size predicate ({err}); \
+                 store compression disabled"
+            );
+            None
+        }
+    }
 }
 
 /// Outcome of `create_cas_file`. `Created` means we wrote the bytes
@@ -474,6 +536,134 @@ impl Store {
             store_path,
             executable,
             size: Some(content.len() as u64),
+        })
+    }
+
+    /// Import a tar entry's content, applying OS-level transparent
+    /// compression to the entries the store-compression gate selects.
+    ///
+    /// When `AUBE_COMPRESS_STORE` is unset this is exactly
+    /// [`Store::import_bytes`] — same CAS key, same write path. When it
+    /// is set and `rel_path` + size match the gate, the entry is first
+    /// unwrapped if it is a napi `--compress` hybrid (so the CAS stores
+    /// the raw `.node`, not the wrapper) and then written into the CAS
+    /// as a transparently-compressed file in ONE pass via
+    /// [`decmpfs::compress_bytes`] — never a write-then-read-back. The
+    /// kernel decompresses on read, so the stored file keeps its logical
+    /// size and exact bytes; `cas_file_matches_len` and the BLAKE3 CAS
+    /// key are computed against that logical content, unchanged.
+    ///
+    /// Fail-soft: `compress_bytes` itself falls back to a plain atomic
+    /// write on an unsupported FS or any backend error, so a matched
+    /// entry always lands. The gate firing only changes how the bytes
+    /// are stored, never whether they are.
+    pub fn import_bytes_gated(
+        &self,
+        rel_path: &str,
+        content: &[u8],
+        executable: bool,
+    ) -> Result<StoredFile, Error> {
+        self.import_bytes_with_gate(rel_path, content, executable, store_compression_gate())
+    }
+
+    /// Gate-injectable core of [`Store::import_bytes_gated`]. `gate` of
+    /// `None` is the byte-identical pre-existing CAS path. Separated from
+    /// the public method so tests can drive the compressed path with an
+    /// explicit gate rather than racing the process-global env toggle.
+    pub(crate) fn import_bytes_with_gate(
+        &self,
+        rel_path: &str,
+        content: &[u8],
+        executable: bool,
+        gate: Option<&Gate>,
+    ) -> Result<StoredFile, Error> {
+        let Some(gate) = gate else {
+            return self.import_bytes(content, executable);
+        };
+
+        // Unwrap a napi `--compress` hybrid to the raw addon before the
+        // gate's size check and the CAS hash — a non-hybrid `.node`
+        // returns `None`, so this is a no-op for ordinary addons and the
+        // bytes (and CAS key) are identical to the ungated path.
+        let unwrapped = decmpfs::addon::unwrap_if_hybrid(content);
+        let stored_bytes: &[u8] = unwrapped.as_deref().unwrap_or(content);
+
+        if !gate.matches(rel_path, stored_bytes.len() as u64) {
+            // Not a gated entry. Store the (possibly unwrapped) bytes
+            // through the normal CAS path so a hybrid still lands as its
+            // raw addon even when too small to compress.
+            return self.import_bytes(stored_bytes, executable);
+        }
+
+        let hex_hash = blake3_hex(stored_bytes);
+        let store_path = self.file_path_from_hex(&hex_hash);
+
+        // If a prior import already committed this content, reuse it —
+        // the file is already stored (compressed or not) and the kernel
+        // reads it back identically. Matches `import_bytes`'s CAS-dedupe.
+        if cas_file_matches_len(&store_path, stored_bytes.len() as u64) {
+            return self.finish_gated(hex_hash, store_path, executable, stored_bytes.len());
+        }
+
+        // Ensure the shard exists; `compress_bytes` writes the final
+        // path directly (its own sibling-temp + rename), so it relies on
+        // the parent dir being present just like the slow CAS path.
+        if let Some(parent) = store_path.parent()
+            && !parent.exists()
+        {
+            std::fs::create_dir_all(parent).map_err(|e| Error::Io(parent.to_path_buf(), e))?;
+        }
+
+        // One-pass compressed write. The gate is honored inside
+        // `compress_bytes` too, but we pass `Gate::any()` because we have
+        // already matched against `rel_path` (a CAS path no longer
+        // carries the package-relative name the glob expects).
+        match decmpfs::compress_bytes(&store_path, stored_bytes, &Gate::any()) {
+            Ok(_) => {}
+            Err(err) => {
+                // A genuine I/O failure from the one-pass writer. Fall
+                // back to the fully-guarded CAS path so the install is
+                // never left without the file.
+                warn!(
+                    "decmpfs one-pass write failed for {} ({err}); \
+                     falling back to the plain CAS path",
+                    store_path.display()
+                );
+                return self.import_bytes(stored_bytes, executable);
+            }
+        }
+
+        // Guard against a torn/short write the same way `import_bytes`
+        // does. decmpfs verifies the kernel read-back equals the bytes
+        // for a compressed Outcome, but a fail-soft plain fallback inside
+        // `compress_bytes` could still race a concurrent writer.
+        if !cas_file_matches_len(&store_path, stored_bytes.len() as u64) {
+            let _ = xx::file::remove_file(&store_path);
+            return self.import_bytes(stored_bytes, executable);
+        }
+
+        self.finish_gated(hex_hash, store_path, executable, stored_bytes.len())
+    }
+
+    /// Shared tail of `import_bytes_gated`: write the executable marker
+    /// (if any) and build the `StoredFile`. Mirrors the marker handling
+    /// in `import_bytes`.
+    fn finish_gated(
+        &self,
+        hex_hash: String,
+        store_path: PathBuf,
+        executable: bool,
+        len: usize,
+    ) -> Result<StoredFile, Error> {
+        if executable {
+            let exec_marker = PathBuf::from(format!("{}-exec", store_path.display()));
+            self.create_cas_file(&exec_marker, None)?;
+        }
+        Ok(StoredFile {
+            hex_hash,
+            store_path,
+            executable,
+            size: Some(len as u64),
         })
     }
 }

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -16,6 +16,8 @@ pub use git::{
 
 #[cfg(test)]
 pub(crate) use cas::blake3_hex;
+#[cfg(test)]
+pub(crate) use cas::parse_compress_store_gate;
 pub(crate) use cas::cas_file_matches_len;
 use cas::copy_dir_recursive;
 #[cfg(test)]
@@ -499,6 +501,191 @@ mod tests {
         // Importing same content returns same hash (idempotent)
         let stored2 = store.import_bytes(content, false).unwrap();
         assert_eq!(stored.hex_hash, stored2.hex_hash);
+    }
+
+    // ---- store-compression gate (AUBE_COMPRESS_STORE) ----------------
+
+    #[test]
+    fn parse_compress_store_gate_affirmative_is_default_node_glob() {
+        for val in ["1", "true", "on", "yes", ""] {
+            let gate = parse_compress_store_gate(val).expect("affirmative → gate");
+            assert_eq!(gate.glob(), Some("**/*.node"));
+            assert_eq!(gate.size(), None);
+        }
+    }
+
+    #[test]
+    fn parse_compress_store_gate_reads_glob_and_size_directives() {
+        let gate = parse_compress_store_gate("glob:**/*.dylib;size:>= 1MB").unwrap();
+        assert_eq!(gate.glob(), Some("**/*.dylib"));
+        assert!(gate.matches("a/b.dylib", 2_000_000));
+        assert!(!gate.matches("a/b.dylib", 500_000));
+
+        // size: alone keeps the default glob.
+        let gate = parse_compress_store_gate("size:> 100").unwrap();
+        assert_eq!(gate.glob(), Some("**/*.node"));
+        assert!(gate.matches("x.node", 200));
+        assert!(!gate.matches("x.node", 50));
+
+        // An unrecognized directive falls back to the default gate.
+        assert!(parse_compress_store_gate("garbage").is_some());
+    }
+
+    #[test]
+    fn parse_compress_store_gate_fails_closed_on_bad_size() {
+        // A malformed size predicate disables compression rather than
+        // widening the gate.
+        assert!(parse_compress_store_gate("size:< 1MB").is_none());
+        assert!(parse_compress_store_gate("size:nonsense").is_none());
+    }
+
+    #[test]
+    fn import_bytes_gated_off_is_byte_identical_to_import_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("files"));
+
+        // A fake addon (ELF magic so a backend would attempt to compress
+        // it on a supporting FS).
+        let mut content = vec![0x7f, b'E', b'L', b'F'];
+        content.extend_from_slice(&[7u8; 9000]);
+
+        let plain = store.import_bytes(&content, false).unwrap();
+        // gate=None → exact same CAS key and bytes.
+        let gated = store
+            .import_bytes_with_gate("build/Release/x.node", &content, false, None)
+            .unwrap();
+        assert_eq!(plain.hex_hash, gated.hex_hash);
+        assert_eq!(gated.size, Some(content.len() as u64));
+        assert_eq!(std::fs::read(&gated.store_path).unwrap(), content);
+    }
+
+    #[test]
+    fn import_bytes_gated_stores_node_addon_transparently() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("files"));
+        store.ensure_shards_exist().unwrap();
+
+        let mut content = vec![0x7f, b'E', b'L', b'F'];
+        content.extend_from_slice(&[0x5au8; 12_000]);
+        let gate = decmpfs::Gate::default();
+
+        let stored = store
+            .import_bytes_with_gate("build/Release/addon.node", &content, false, Some(&gate))
+            .unwrap();
+
+        // Whether the FS compressed it or fell back to a plain write, the
+        // file MUST land with the exact bytes and the logical size — the
+        // kernel-transparent contract `cas_file_matches_len` relies on.
+        assert!(stored.store_path.exists(), "addon landed in the CAS");
+        assert_eq!(stored.size, Some(content.len() as u64));
+        assert!(cas_file_matches_len(
+            &stored.store_path,
+            content.len() as u64
+        ));
+        assert_eq!(std::fs::read(&stored.store_path).unwrap(), content);
+        // CAS key is the BLAKE3 of the stored (logical) content.
+        assert_eq!(stored.hex_hash, blake3_hex(&content));
+    }
+
+    #[test]
+    fn import_bytes_gated_excludes_non_node_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("files"));
+        store.ensure_shards_exist().unwrap();
+
+        let content = b"module.exports = 1;\n".to_vec();
+        let gate = decmpfs::Gate::default();
+        // A `.js` file does not match `**/*.node` → plain CAS path, but
+        // still lands with the same key as the ungated import.
+        let gated = store
+            .import_bytes_with_gate("index.js", &content, false, Some(&gate))
+            .unwrap();
+        assert_eq!(gated.hex_hash, blake3_hex(&content));
+        assert_eq!(std::fs::read(&gated.store_path).unwrap(), content);
+    }
+
+    #[test]
+    fn import_bytes_gated_unwraps_a_napi_compress_hybrid() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("files"));
+        store.ensure_shards_exist().unwrap();
+
+        // The raw addon the hybrid wraps.
+        let raw = {
+            let mut v = vec![0x7f, b'E', b'L', b'F'];
+            v.extend_from_slice(&[0x66u8; 6000]);
+            v
+        };
+        let hybrid = synth_elf_hybrid(&raw);
+
+        let gate = decmpfs::Gate::default();
+        let stored = store
+            .import_bytes_with_gate("build/Release/native.node", &hybrid, false, Some(&gate))
+            .unwrap();
+
+        // The CAS stores the UNWRAPPED raw addon, not the hybrid wrapper.
+        assert_eq!(stored.size, Some(raw.len() as u64));
+        assert_eq!(stored.hex_hash, blake3_hex(&raw));
+        assert_eq!(std::fs::read(&stored.store_path).unwrap(), raw);
+    }
+
+    /// Build a synthetic napi `--compress` hybrid: a minimal ELF64 with a
+    /// `.PRESSED_DATA` section holding the bin-infra pressed-data blob for
+    /// `raw`. Mirrors decmpfs's own addon round-trip fixture.
+    #[cfg(test)]
+    fn synth_elf_hybrid(raw: &[u8]) -> Vec<u8> {
+        use sha2::{Digest as _, Sha512};
+
+        // Pressed-data blob: magic + sizes + cache key + platform +
+        // SHA-512(payload) + has_config=0 + zstd payload.
+        const MAGIC: &[u8; 32] = b"__SMOL_PRESSED_DATA_MAGIC_MARKER";
+        let payload = zstd::stream::encode_all(raw, 3).unwrap();
+        let mut hasher = Sha512::new();
+        hasher.update(&payload);
+        let hash = hasher.finalize();
+        let mut blob = Vec::new();
+        blob.extend_from_slice(MAGIC);
+        blob.extend_from_slice(&(payload.len() as u64).to_le_bytes());
+        blob.extend_from_slice(&(raw.len() as u64).to_le_bytes());
+        blob.extend_from_slice(&[b'a'; 16]); // cache key
+        blob.extend_from_slice(&[1u8, 1u8, 255u8]); // platform/arch/libc
+        blob.extend_from_slice(&hash);
+        blob.push(0u8); // has_config = 0
+        blob.extend_from_slice(&payload);
+
+        // Minimal ELF64: ehdr + strtab + 2 section headers + blob.
+        let shentsize = 64usize;
+        let mut strtab = vec![0u8];
+        let shstrtab_name = strtab.len() as u32;
+        strtab.extend_from_slice(b".shstrtab\0");
+        let pressed_name = strtab.len() as u32;
+        strtab.extend_from_slice(b".PRESSED_DATA\0");
+
+        let ehdr_len = 64usize;
+        let strtab_off = ehdr_len;
+        let shoff = strtab_off + strtab.len();
+        let blob_off = shoff + 2 * shentsize;
+
+        let mut bin = vec![0u8; blob_off];
+        bin[0..4].copy_from_slice(&[0x7f, b'E', b'L', b'F']);
+        bin[4] = 2; // EI_CLASS = 64-bit
+        bin[40..48].copy_from_slice(&(shoff as u64).to_le_bytes());
+        bin[58..60].copy_from_slice(&(shentsize as u16).to_le_bytes());
+        bin[60..62].copy_from_slice(&2u16.to_le_bytes());
+        bin[62..64].copy_from_slice(&0u16.to_le_bytes()); // e_shstrndx = 0
+        bin[strtab_off..strtab_off + strtab.len()].copy_from_slice(&strtab);
+
+        let sh0 = shoff;
+        bin[sh0..sh0 + 4].copy_from_slice(&shstrtab_name.to_le_bytes());
+        bin[sh0 + 24..sh0 + 32].copy_from_slice(&(strtab_off as u64).to_le_bytes());
+        bin[sh0 + 32..sh0 + 40].copy_from_slice(&(strtab.len() as u64).to_le_bytes());
+
+        let sh1 = shoff + shentsize;
+        bin[sh1..sh1 + 4].copy_from_slice(&pressed_name.to_le_bytes());
+        bin[sh1 + 24..sh1 + 32].copy_from_slice(&(blob_off as u64).to_le_bytes());
+        bin[sh1 + 32..sh1 + 40].copy_from_slice(&(blob.len() as u64).to_le_bytes());
+        bin.extend_from_slice(&blob);
+        bin
     }
 
     #[test]

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -16,10 +16,10 @@ pub use git::{
 
 #[cfg(test)]
 pub(crate) use cas::blake3_hex;
-#[cfg(test)]
-pub(crate) use cas::parse_compress_store_gate;
 pub(crate) use cas::cas_file_matches_len;
 use cas::copy_dir_recursive;
+#[cfg(test)]
+pub(crate) use cas::parse_compress_store_gate;
 #[cfg(test)]
 use git::{
     codeload_cache_paths, extract_codeload_tarball_at, git_commit_matches, validate_git_positional,

--- a/crates/aube-store/src/tarball.rs
+++ b/crates/aube-store/src/tarball.rs
@@ -52,12 +52,12 @@ impl Store {
             };
             #[cfg(not(unix))]
             let executable = false;
-            let stored = self.import_bytes(&content, executable)?;
             let rel = path
                 .strip_prefix(base)
                 .map_err(|e| Error::Tar(format!("strip_prefix: {e}")))?
                 .to_string_lossy()
                 .replace('\\', "/");
+            let stored = self.import_bytes_gated(&rel, &content, executable)?;
             index.insert(rel, stored);
         }
         Ok(())
@@ -151,7 +151,7 @@ impl Store {
             let chunk_t0 = std::time::Instant::now();
             if parallel_disabled || chunk.len() < PARALLEL_IMPORT_THRESHOLD {
                 for (rel_path, content, executable) in chunk {
-                    let stored = self.import_bytes(&content, executable)?;
+                    let stored = self.import_bytes_gated(&rel_path, &content, executable)?;
                     index.insert(rel_path, stored);
                 }
             } else {
@@ -172,7 +172,7 @@ impl Store {
                     .into_par_iter()
                     .with_min_len(RAYON_TASK_MIN_LEN)
                     .map(|(rel_path, content, executable)| {
-                        self.import_bytes(&content, executable)
+                        self.import_bytes_gated(&rel_path, &content, executable)
                             .map(|stored| (rel_path, stored))
                     })
                     .collect();


### PR DESCRIPTION
Native addons (`.node` files — the compiled binaries some packages ship) are often the **biggest files** in `node_modules`. This adds an **opt-in** setting that stores them compressed on disk, so they take less space with **no runtime cost** — the operating system decompresses them on read, at native speed. Default installs are unchanged unless you turn it on.

<details>
<summary>Why this matters</summary>

A single native addon can be tens of megabytes, and a big dependency graph can have many of them. That's a lot of disk for files that mostly sit there.

macOS, Linux (btrfs), and Windows (NTFS) all support **transparent filesystem compression**: the file is stored compressed, but any program that opens it sees the normal, full-size bytes — the kernel decompresses on the fly. So you get the disk savings for free, without the addon loading any slower or any tool needing to know it's compressed.

The same idea was proposed for Homebrew — compress formulae on install with `ditto --hfsCompression` — but declined as not-planned ([Homebrew/brew#20905](https://github.com/Homebrew/brew/issues/20905)); the maintainer was open to it only as an **opt-in environment variable**, which is exactly the opt-in shape this takes for aube's package store. Size/speed numbers and how it holds up across copy/move/link live in the discussion this builds on: [napi-rs/napi-rs#3350](https://github.com/napi-rs/napi-rs/discussions/3350).

Important distinction for our work: brew measured the write/install side (compressing *during* the copy is slow), which is a different axis from the read/load side our aube + rspack benchmarks measure (loading an already-compressed file is same-or-faster). aube sidesteps brew's two big objections — it writes compressed in one pass (`decmpfs::compress_bytes`, no copy-then-recompress) and stores the raw `.node` (not a worse-than-tarball keg), so the install-time and size regressions brew hit don't apply the same way.

</details>

<details>
<summary>How it works</summary>

aube keeps one shared copy of every package file in its content-addressed store (the CAS) and links that copy into each project's `node_modules`. This feature hooks the moment a file is written into that store:

1. **You opt in** with the `AUBE_COMPRESS_STORE` environment variable (off by default).
2. When a file **matches the gate** (by default, anything ending in `.node`), instead of a normal write aube writes it as a **transparently-compressed file in one pass** using the [`decmpfs`](https://crates.io/crates/decmpfs) crate (`decmpfs::compress_bytes`). No "write it, then read it back and recompress" — it's written compressed the first time.
3. The stored file keeps its **exact bytes, logical size, and content hash** — the CAS key doesn't change, so nothing downstream can tell the difference.
4. If the file is a napi `--compress` "hybrid" addon, aube **unwraps it to the raw addon first**, so we store the real `.node` (and don't double-compress).
5. Because aube links from the store with reflink/hardlink, that **one compressed copy is shared** into every project — compress once, benefit everywhere.

It's **fail-soft**: on a filesystem that doesn't support compression, or on any error, `compress_bytes` falls back to a plain write. A matched file always lands — turning this on only changes *how* bytes are stored, never *whether* they are.

</details>

<details>
<summary>How to turn it on</summary>

Set `AUBE_COMPRESS_STORE`. The value picks the gate (which files get compressed):

| Value | Meaning |
|---|---|
| `1` (or any bare value) | the default gate: everything matching `**/*.node` |
| `glob:<pattern>` | only files matching your glob, e.g. `glob:**/*.wasm` |
| `size:<predicate>` | `**/*.node` **and** a size floor, e.g. `size:>= 1MB` |
| `glob:<pattern>;size:<predicate>` | both a glob and a size floor |

A malformed size predicate is rejected (compression stays off, with a warning) rather than silently compressing everything.

</details>

<details>
<summary>Testing & safety</summary>

- **Off by default.** With `AUBE_COMPRESS_STORE` unset, the write path is byte-for-byte the existing one.
- **Scoped.** The default gate is `.node` only.
- **Same hash.** The CAS content key is computed on the logical bytes, so dedup and integrity are unchanged.
- **Fail-soft.** Unsupported filesystem or any backend error falls back to a plain write; installs never break.
- **Diagnostics.** The compressed write path emits the same `blake3_hash` / `cas_hit` / `cas_miss` diag events as the normal path, so `--diag` output stays accurate.
- **Tests.** Unit tests for the gate grammar (including malformed-input fail-closed) plus integration tests for the disabled / enabled / excluded / hybrid-unwrap cases. `cargo test -p aube-store` is green (105 tests).

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional store compression for eligible files during import, helping reduce storage usage automatically.
  * Expanded tarball and directory imports to use the same compression-aware behavior.

* **Bug Fixes**
  * Improved handling of compressed file imports to preserve original content and file metadata.
  * Added safer fallback behavior so imports continue normally if compression cannot be applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
