### PR TITLE
feat(resolver): allow trust exclude version ranges

### DIFF
--- a/crates/aube-codes/src/errors.rs
+++ b/crates/aube-codes/src/errors.rs
@@ -211,7 +211,7 @@ pub const ALL: &[CodeMeta] = &[
     CodeMeta {
         name: ERR_AUBE_TRUST_EXCLUDE_INVALID_VERSION_UNION,
         category: category::RESOLVER,
-        description: "A `trustPolicyExclude` pattern had a non-exact version.",
+        description: "A `trustPolicyExclude` pattern had an invalid semver range.",
         exit_code: None,
     },
     CodeMeta {

--- a/crates/aube-resolver/src/trust.rs
+++ b/crates/aube-resolver/src/trust.rs
@@ -249,8 +249,8 @@ fn cutoff_iso8601(minutes_ago: u64) -> Option<String> {
 /// Parsed `trustPolicyExclude` rules. Mirrors pnpm's
 /// `createPackageVersionPolicy` (config/version-policy/src/index.ts).
 /// Each rule is `<name>` (matches all versions, supports `*` glob in
-/// the name) or `<name>@<exact-version>[ || <exact-version>]…` (no
-/// ranges, no name globs combined with versions).
+/// the name) or `<name>@<semver-range>[ || <semver-range>]…` (no name
+/// globs combined with versions).
 pub const DEFAULT_TRUST_POLICY_EXCLUDES: &[&str] = &[
     "chokidar",
     "eslint-config-prettier",
@@ -259,11 +259,12 @@ pub const DEFAULT_TRUST_POLICY_EXCLUDES: &[&str] = &[
     "reselect",
     "semver",
     "ua-parser-js",
+    "undici",
     "undici-types",
     "vite",
 ];
 
-/// A parsed package-version policy: a set of `<name>[@<exact-version>…]`
+/// A parsed package-version policy: a set of `<name>[@<semver-range>…]`
 /// rules with `*` name globs. pnpm backs both `trustPolicyExclude` and
 /// `minimumReleaseAgeExclude` with the same `createPackageVersionPolicy`
 /// engine, so we do too — `TrustExcludeRules` is the neutral
@@ -296,8 +297,8 @@ impl Default for TrustExcludeRules {
 struct TrustExcludeRule {
     name_matcher: NameMatcher,
     /// `None` → rule matches every version of any name match.
-    /// `Some(versions)` → rule matches only those exact versions.
-    exact_versions: Option<Vec<node_semver::Version>>,
+    /// `Some(ranges)` → rule matches any version satisfying one range.
+    version_ranges: Option<Vec<node_semver::Range>>,
 }
 
 #[derive(Debug, Clone)]
@@ -319,9 +320,7 @@ struct GlobMatcher {
 // the specific setting the bad entry came from.
 #[derive(Debug, thiserror::Error, miette::Diagnostic)]
 pub enum TrustExcludeParseError {
-    #[error(
-        "invalid exclude pattern `{pattern}`: only exact versions are allowed in version unions, ranges (^/~/>=) are not supported"
-    )]
+    #[error("invalid exclude pattern `{pattern}`: version selectors must be valid semver ranges")]
     #[diagnostic(code(ERR_AUBE_TRUST_EXCLUDE_INVALID_VERSION_UNION))]
     InvalidVersionUnion { pattern: String },
     #[error(
@@ -354,7 +353,7 @@ impl TrustExcludeRules {
                 .iter()
                 .map(|name| TrustExcludeRule {
                     name_matcher: NameMatcher::compile(name),
-                    exact_versions: None,
+                    version_ranges: None,
                 })
                 .collect(),
         }
@@ -413,10 +412,10 @@ impl TrustExcludeRules {
             if !rule.name_matcher.matches(name) {
                 continue;
             }
-            match &rule.exact_versions {
+            match &rule.version_ranges {
                 None => return true,
-                Some(versions) => {
-                    if versions.iter().any(|v| v == version) {
+                Some(ranges) => {
+                    if ranges.iter().any(|r| version.satisfies(r)) {
                         return true;
                     }
                 }
@@ -432,7 +431,7 @@ impl TrustExcludeRules {
     pub(crate) fn matches_name_only(&self, name: &str) -> bool {
         self.rules
             .iter()
-            .any(|r| r.exact_versions.is_none() && r.name_matcher.matches(name))
+            .any(|r| r.version_ranges.is_none() && r.name_matcher.matches(name))
     }
 }
 
@@ -449,7 +448,7 @@ fn parse_one(pattern: &str) -> Result<TrustExcludeRule, TrustExcludeParseError> 
         None => (pattern, None),
     };
 
-    let exact_versions = match versions_part {
+    let version_ranges = match versions_part {
         None => None,
         Some(versions_str) => {
             if name_part.contains('*') {
@@ -465,12 +464,12 @@ fn parse_one(pattern: &str) -> Result<TrustExcludeRule, TrustExcludeParseError> 
                         pattern: pattern.to_string(),
                     });
                 }
-                let v = node_semver::Version::parse(trimmed).map_err(|_| {
+                let r = node_semver::Range::parse(trimmed).map_err(|_| {
                     TrustExcludeParseError::InvalidVersionUnion {
                         pattern: pattern.to_string(),
                     }
                 })?;
-                parsed.push(v);
+                parsed.push(r);
             }
             Some(parsed)
         }
@@ -478,7 +477,7 @@ fn parse_one(pattern: &str) -> Result<TrustExcludeRule, TrustExcludeParseError> 
 
     Ok(TrustExcludeRule {
         name_matcher: NameMatcher::compile(name_part),
-        exact_versions,
+        version_ranges,
     })
 }
 
@@ -1177,14 +1176,22 @@ mod tests {
     }
 
     #[test]
-    fn exclude_rejects_range_operators() {
-        for bad in ["foo@^1.0.0", "foo@~1.0.0", "foo@>=1.0.0"] {
-            let err = TrustExcludeRules::parse([bad]).expect_err(bad);
-            assert!(matches!(
-                err,
-                TrustExcludeParseError::InvalidVersionUnion { .. }
-            ));
-        }
+    fn exclude_parses_version_ranges() {
+        let r = TrustExcludeRules::parse(["foo@^1.0.0 || ~2.1.0 || >=3.0.0 <4.0.0"]).unwrap();
+        assert!(r.matches("foo", &node_semver::Version::parse("1.2.3").unwrap()));
+        assert!(r.matches("foo", &node_semver::Version::parse("2.1.9").unwrap()));
+        assert!(r.matches("foo", &node_semver::Version::parse("3.5.0").unwrap()));
+        assert!(!r.matches("foo", &node_semver::Version::parse("2.2.0").unwrap()));
+        assert!(!r.matches("foo", &node_semver::Version::parse("4.0.0").unwrap()));
+    }
+
+    #[test]
+    fn exclude_rejects_invalid_version_ranges() {
+        let err = TrustExcludeRules::parse(["foo@definitely-not-a-range"]).expect_err("bad range");
+        assert!(matches!(
+            err,
+            TrustExcludeParseError::InvalidVersionUnion { .. }
+        ));
     }
 
     #[test]
@@ -1200,7 +1207,7 @@ mod tests {
     fn parse_lossy_keeps_valid_drops_invalid() {
         let (rules, errors) = TrustExcludeRules::parse_lossy([
             "good",
-            "bad@^1.0.0",
+            "bad@definitely-not-a-range",
             "@scope/also-good@1.0.0",
             "is-*@nope",
         ]);

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -2169,9 +2169,9 @@ install scripts need network access, shared caches, or filesystem
 writes outside the restricted jail profile.
 
 Patterns use the same forms as `neverBuiltDependencies`: bare package
-names, `name@version` pins, semver range unions, and `*` wildcards such
-as `@scope/*`. Explicit jail exclusions win over the global
-`jailBuilds=true` setting.
+names, exact `name@version` pins, exact version unions, and `*`
+wildcards such as `@scope/*`. Explicit jail exclusions win over the
+global `jailBuilds=true` setting.
 """
 sources.cli = []
 sources.env = ["npm_config_jail_build_exclusions", "NPM_CONFIG_JAIL_BUILD_EXCLUSIONS", "AUBE_JAIL_BUILD_EXCLUSIONS"]

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -240,10 +240,10 @@ default = "undefined"
 docs = """
 Use for trusted internal packages that need to be rolled out immediately
 without waiting for the age gate. Each entry is a bare name (`react`), a
-`*` name glob (`@myorg/*`), or a name with an exact-version union
-(`nx@21.6.5`, `webpack@4.47.0 || 5.102.1`); ranges like `^1.0.0` are not
-allowed. Once `aube audit --fix` learns to record patched versions, it
-will append them to this list automatically.
+`*` name glob (`@myorg/*`), or a name with a semver range union
+(`nx@21.6.5`, `webpack@^4.47.0 || >=5.102.1 <6`). Once
+`aube audit --fix` learns to record patched versions, it will append
+them to this list automatically.
 """
 sources.cli = []
 sources.env = ["npm_config_minimum_release_age_exclude", "NPM_CONFIG_MINIMUM_RELEASE_AGE_EXCLUDE", "AUBE_MINIMUM_RELEASE_AGE_EXCLUDE"]
@@ -582,8 +582,8 @@ description = "Packages exempt from `trustPolicy` checks."
 type = "list<string>"
 default = "[]"
 docs = """
-Patterns: `name`, `name@1.0.0`, `name@1.0.0 || 1.0.1` (exact versions only —
-no `^`/`~`/`>=`), `is-*` (name glob, no version), `@scope/name@1.0.0`.
+Patterns: `name`, `name@1.0.0`, `name@^1.0.0 || >=2 <3`, `is-*`
+(name glob, no version), `@scope/name@1.0.0`.
 Empty list disables user-provided exclusions; aube still applies its built-in
 exclusions for known registry provenance metadata churn.
 """
@@ -2169,9 +2169,9 @@ install scripts need network access, shared caches, or filesystem
 writes outside the restricted jail profile.
 
 Patterns use the same forms as `neverBuiltDependencies`: bare package
-names, exact `name@version` pins, exact version unions, and `*`
-wildcards such as `@scope/*`. Explicit jail exclusions win over the
-global `jailBuilds=true` setting.
+names, `name@version` pins, semver range unions, and `*` wildcards such
+as `@scope/*`. Explicit jail exclusions win over the global
+`jailBuilds=true` setting.
 """
 sources.cli = []
 sources.env = ["npm_config_jail_build_exclusions", "NPM_CONFIG_JAIL_BUILD_EXCLUSIONS", "AUBE_JAIL_BUILD_EXCLUSIONS"]

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -81,7 +81,7 @@
     {
       "name": "ERR_AUBE_TRUST_EXCLUDE_INVALID_VERSION_UNION",
       "category": "Resolver",
-      "description": "A `trustPolicyExclude` pattern had a non-exact version.",
+      "description": "A `trustPolicyExclude` pattern had an invalid semver range.",
       "exit_code": null
     },
     {

--- a/docs/security.md
+++ b/docs/security.md
@@ -151,11 +151,11 @@ Exempt specific packages or versions when needed:
 trustPolicyExclude:
   - "@vendor/legacy-pkg"       # every version of one package
   - "old-thing@1.0.0"          # one exact version
-  - "things@1.0.0 || 1.0.1"    # union of exact versions
+  - "things@^1.0.0 || >=2 <3"  # union of semver ranges
   - "is-*"                     # name glob (globs take no version)
 ```
 
-Versions must be exact — `^`/`~`/`>=` ranges are not accepted.
+Version selectors are npm-style semver ranges.
 
 Default: `no-downgrade`. Set `trustPolicy: off` to disable, or use
 `trustPolicyExclude` for per-package opt-outs.

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -330,10 +330,10 @@ Packages exempt from the minimumReleaseAge requirement.
 
 Use for trusted internal packages that need to be rolled out immediately
 without waiting for the age gate. Each entry is a bare name (`react`), a
-`*` name glob (`@myorg/*`), or a name with an exact-version union
-(`nx@21.6.5`, `webpack@4.47.0 || 5.102.1`); ranges like `^1.0.0` are not
-allowed. Once `aube audit --fix` learns to record patched versions, it
-will append them to this list automatically.
+`*` name glob (`@myorg/*`), or a name with a semver range union
+(`nx@21.6.5`, `webpack@^4.47.0 || >=5.102.1 <6`). Once
+`aube audit --fix` learns to record patched versions, it will append
+them to this list automatically.
 
 ### `minimumReleaseAgeStrict` {#setting-minimumreleaseagestrict}
 
@@ -652,8 +652,8 @@ Packages exempt from `trustPolicy` checks.
 - Workspace YAML keys: `trustPolicyExclude`
 - Managed policy: `managedWins`
 
-Patterns: `name`, `name@1.0.0`, `name@1.0.0 || 1.0.1` (exact versions only —
-no `^`/`~`/`>=`), `is-*` (name glob, no version), `@scope/name@1.0.0`.
+Patterns: `name`, `name@1.0.0`, `name@^1.0.0 || >=2 <3`, `is-*`
+(name glob, no version), `@scope/name@1.0.0`.
 Empty list disables user-provided exclusions; aube still applies its built-in
 exclusions for known registry provenance metadata churn.
 
@@ -2188,9 +2188,9 @@ install scripts need network access, shared caches, or filesystem
 writes outside the restricted jail profile.
 
 Patterns use the same forms as `neverBuiltDependencies`: bare package
-names, exact `name@version` pins, exact version unions, and `*`
-wildcards such as `@scope/*`. Explicit jail exclusions win over the
-global `jailBuilds=true` setting.
+names, `name@version` pins, semver range unions, and `*` wildcards such
+as `@scope/*`. Explicit jail exclusions win over the global
+`jailBuilds=true` setting.
 
 Examples:
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -2188,9 +2188,9 @@ install scripts need network access, shared caches, or filesystem
 writes outside the restricted jail profile.
 
 Patterns use the same forms as `neverBuiltDependencies`: bare package
-names, `name@version` pins, semver range unions, and `*` wildcards such
-as `@scope/*`. Explicit jail exclusions win over the global
-`jailBuilds=true` setting.
+names, exact `name@version` pins, exact version unions, and `*`
+wildcards such as `@scope/*`. Explicit jail exclusions win over the
+global `jailBuilds=true` setting.
 
 Examples:
 


### PR DESCRIPTION
## Summary
- add undici to the built-in trustPolicyExclude defaults
- allow trustPolicyExclude/package-version policy entries to use semver ranges, including range unions
- update trust-policy docs and error metadata for range support

## Tests
- cargo test -p aube-resolver trust::tests:: --lib

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes resolver-side supply-chain exemption matching for trust policy and minimum release age; wider exclude patterns can exempt more versions than before, though exact-version patterns behave the same.
> 
> **Overview**
> **Trust and package-version exclude patterns** (`trustPolicyExclude`, `minimumReleaseAgeExclude`, and the shared `PackageVersionPolicy` parser) now accept **npm-style semver ranges** and `||` unions instead of rejecting `^`/`~`/`>=` and requiring exact versions. Matching uses `version.satisfies(range)` rather than equality on parsed versions.
> 
> **Built-in `trustPolicyExclude` defaults** gain **`undici`** (name-only, all versions), alongside the existing churn list.
> 
> **Docs and diagnostics** are aligned: settings/security copy describes range unions, and `ERR_AUBE_TRUST_EXCLUDE_INVALID_VERSION_UNION` now refers to invalid semver ranges. Tests flip from “reject ranges” to “accept ranges” plus invalid-range rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e8ddfcaa1295a1e6d276acc9ad564bb3ed73623. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated exclusion and trust-policy matching to support npm-style semver ranges, so version selectors now match ranges correctly instead of only exact versions.
  * Improved error messages when an invalid range is provided.

* **Documentation**
  * Clarified supported pattern formats in settings guidance.
  * Updated security documentation and error-code references to reflect semver range usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->