### PR TITLE
fix(resolver): reject malformed jsr package names

### DIFF
--- a/crates/aube-registry/src/jsr.rs
+++ b/crates/aube-registry/src/jsr.rs
@@ -22,10 +22,22 @@ pub const JSR_NPM_SCOPE: &str = "@jsr";
 pub fn jsr_to_npm_name(jsr_name: &str) -> Option<String> {
     let rest = jsr_name.strip_prefix('@')?;
     let (scope, name) = rest.split_once('/')?;
-    if scope.is_empty() || name.is_empty() {
+    if !valid_jsr_name_part(scope) || !valid_jsr_name_part(name) {
         return None;
     }
     Some(format!("@jsr/{scope}__{name}"))
+}
+
+fn valid_jsr_name_part(part: &str) -> bool {
+    if part.is_empty() || matches!(part, "." | "..") {
+        return false;
+    }
+    part.bytes().all(|b| {
+        matches!(
+            b,
+            b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.'
+        )
+    })
 }
 
 /// Inverse of [`jsr_to_npm_name`]. `@jsr/std__collections` → `@std/collections`.
@@ -65,6 +77,12 @@ mod tests {
         assert_eq!(jsr_to_npm_name("@std"), None);
         assert_eq!(jsr_to_npm_name("@/collections"), None);
         assert_eq!(jsr_to_npm_name("@std/"), None);
+        assert_eq!(jsr_to_npm_name("@std/../collections"), None);
+        assert_eq!(jsr_to_npm_name("@std/collections/more"), None);
+        assert_eq!(jsr_to_npm_name("@std//collections"), None);
+        assert_eq!(jsr_to_npm_name("@std/co llections"), None);
+        assert_eq!(jsr_to_npm_name("@std/%2fcollections"), None);
+        assert_eq!(jsr_to_npm_name("@Std/collections"), None);
     }
 
     #[test]

--- a/crates/aube/src/commands/add/spec.rs
+++ b/crates/aube/src/commands/add/spec.rs
@@ -615,6 +615,22 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_pkg_spec_jsr_rejects_path_shapes() {
+        for spec in [
+            "jsr:@std/../collections",
+            "jsr:@std/collections/more",
+            "jsr:@std//collections",
+            "jsr:@std/co llections",
+        ] {
+            let err = parse_pkg_spec(spec).unwrap_err();
+            assert!(
+                err.to_string().contains("invalid jsr: spec"),
+                "{spec} produced unexpected error: {err}"
+            );
+        }
+    }
+
+    #[test]
     fn test_parse_pkg_spec_git_bare_github_shorthand() {
         let s = parse_pkg_spec("kevva/is-negative").unwrap();
         assert_eq!(s.git_spec.as_deref(), Some("kevva/is-negative"));

--- a/test/add.bats
+++ b/test/add.bats
@@ -213,6 +213,19 @@ EOF
 	assert_output --partial 'JSR packages must be scoped'
 }
 
+@test "aube add jsr: rejects package names that escape npm name shape" {
+	cat >package.json <<'EOF'
+{
+  "name": "test-add-jsr-bad-shape",
+  "version": "0.0.0",
+  "dependencies": {}
+}
+EOF
+	run aube add jsr:@std/../collections
+	assert_failure
+	assert_output --partial 'invalid jsr: spec'
+}
+
 @test "aube add: adds multiple packages" {
 	cat >package.json <<'EOF'
 {


### PR DESCRIPTION
## Summary
- reject JSR package names with path-shaped or otherwise invalid scope/name components
- cover the add parser and shell-level `aube add jsr:` rejection path

## Validation
- `cargo test -p aube-registry jsr::tests --lib`
- `cargo test -p aube commands::add::spec::tests::test_parse_pkg_spec_jsr --lib`
- `cargo build`
- `mise run test:bats test/add.bats`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Input validation only on JSR name parsing; legitimate scoped names like `@std/collections` are unchanged.
> 
> **Overview**
> Tightens JSR name validation so path-like or npm-invalid scope/name segments no longer translate to `@jsr/…` registry names.
> 
> **`jsr_to_npm_name`** now runs each scope and name through **`valid_jsr_name_part`**: rejects empty parts, `.` / `..`, uppercase, spaces, encoded slashes, and any character outside lowercase `a-z`, digits, `-`, `_`, and `.`. **`aube add jsr:`** already fails when translation returns `None`, so the same rules surface as **`invalid jsr: spec`** at parse time.
> 
> Coverage adds unit cases in **`aube-registry`** and **`commands/add/spec`**, plus a bats test for **`jsr:@std/../collections`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e63f2f2d86aef7216f81f988787ccc3eb0a8700c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->