### PR TITLE
fix(resolver): derive integrity from dist.shasum when dist.integrity is absent

### DIFF
--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -913,7 +913,18 @@ impl<'a> ResolveDriver<'a> {
             .or_default()
             .push(version.clone());
 
-        let integrity = version_meta.dist.as_ref().and_then(|d| d.integrity.clone());
+        // Prefer the modern SRI `dist.integrity`; fall back to the
+        // legacy hex `dist.shasum` (as `sha1-<base64>`) the way npm's
+        // classic client does. Scoped/private registries that predate —
+        // or proxy without regenerating — `dist.integrity` still ship
+        // `dist.shasum`, and deriving a verifiable integrity here keeps
+        // them off the unverifiable tarball-only path, whose lockfile
+        // entry the parser then rejects with no bypass.
+        let integrity = version_meta.dist.as_ref().and_then(|d| {
+            d.integrity
+                .clone()
+                .or_else(|| d.shasum.as_deref().and_then(aube_store::shasum_to_sri))
+        });
         // Always stash the registry tarball URL on the locked
         // package. pnpm / yarn writers gate emission on
         // `lockfile_include_tarball_url` (so the pnpm

--- a/crates/aube-store/src/integrity.rs
+++ b/crates/aube-store/src/integrity.rs
@@ -354,3 +354,67 @@ pub fn integrity_to_hex(integrity: &str) -> Option<String> {
     let bytes = base64::engine::general_purpose::STANDARD.decode(b64).ok()?;
     Some(hex::encode(bytes))
 }
+
+/// Convert a legacy `dist.shasum` (hex-encoded SHA-1) into an SRI
+/// `sha1-<base64>` integrity string — the inverse of the sha1 branch of
+/// [`integrity_to_hex`]. Registries that predate npm's 2017 SRI rollout,
+/// or proxies that strip the modern `dist.integrity` field, still ship
+/// `dist.shasum`, and npm's classic client has always treated it as the
+/// package's verification hash. Deriving `sha1-…` from it lets the
+/// resolver record a verifiable integrity instead of falling through to
+/// an unverifiable tarball-only resolution. Returns `None` unless the
+/// input is a well-formed 40-char hex digest, so a malformed/absent
+/// field cleanly degrades to the existing no-integrity path rather than
+/// minting a bogus SRI.
+pub fn shasum_to_sri(shasum: &str) -> Option<String> {
+    let shasum = shasum.trim();
+    if shasum.len() != 40 || !shasum.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    let bytes = hex::decode(shasum).ok()?;
+    use base64::Engine;
+    Some(format!(
+        "sha1-{}",
+        base64::engine::general_purpose::STANDARD.encode(bytes)
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shasum_to_sri_matches_npm_classic_encoding() {
+        // The exact value yarn's classic resolver computed for the
+        // package in discussion #979: hex sha1 -> `sha1-<base64>`.
+        assert_eq!(
+            shasum_to_sri("dc96d6d3268bbc55103ce55cd4608d43d3b7ff72").as_deref(),
+            Some("sha1-3JbW0yaLvFUQPOVc1GCNQ9O3/3I=")
+        );
+    }
+
+    #[test]
+    fn shasum_to_sri_round_trips_through_integrity_to_hex() {
+        let hex = "dc96d6d3268bbc55103ce55cd4608d43d3b7ff72";
+        let sri = shasum_to_sri(hex).unwrap();
+        assert_eq!(integrity_to_hex(&sri).as_deref(), Some(hex));
+    }
+
+    #[test]
+    fn shasum_to_sri_is_lenient_about_surrounding_whitespace() {
+        assert!(shasum_to_sri("  dc96d6d3268bbc55103ce55cd4608d43d3b7ff72\n").is_some());
+    }
+
+    #[test]
+    fn shasum_to_sri_rejects_malformed_input() {
+        // Wrong length (sha256-sized), non-hex, and empty all degrade to
+        // None so callers fall back to the no-integrity path instead of
+        // recording a bogus SRI.
+        assert_eq!(shasum_to_sri(&"a".repeat(64)), None);
+        assert_eq!(
+            shasum_to_sri("dc96d6d3268bbc55103ce55cd4608d43d3b7ffzz"),
+            None
+        );
+        assert_eq!(shasum_to_sri(""), None);
+    }
+}

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -27,8 +27,8 @@ use git::{
 pub use index::{PackageIndex, StoredFile, index_content_fingerprint};
 pub use integrity::{
     SHA512_INTEGRITY_PREFIX, integrity_to_hex, sha512_integrity, sha512_integrity_from_digest,
-    validate_and_encode_name, validate_pkg_content, validate_version, verify_integrity,
-    verify_precomputed_sha512,
+    shasum_to_sri, validate_and_encode_name, validate_pkg_content, validate_version,
+    verify_integrity, verify_precomputed_sha512,
 };
 #[cfg(test)]
 pub(crate) use tarball::normalize_tar_entry_path;

--- a/test/lockfile_settings.bats
+++ b/test/lockfile_settings.bats
@@ -257,6 +257,98 @@ NODE
 	assert_success
 }
 
+# Regression for discussion #979 Bug 1: a registry version whose
+# packument carries only the legacy `dist.shasum` (hex sha1) and no
+# modern `dist.integrity`. aube must derive `sha1-<base64>` from the
+# shasum the way npm's classic client does, write a verifiable lockfile
+# entry, and re-read it — instead of writing an unverifiable tarball-only
+# resolution the parser then rejects with ERR_AUBE_LOCKFILE_PARSE.
+@test "registry dist.shasum with no dist.integrity is derived, not left tarball-only" {
+	mkdir -p package
+	cat >package/package.json <<-'EOF'
+		{
+		  "name": "shasum-pkg",
+		  "version": "1.0.0"
+		}
+	EOF
+	tar -czf shasum-pkg-1.0.0.tgz package
+	shasum="$(node -e "const crypto = require('node:crypto'); const fs = require('node:fs'); console.log(crypto.createHash('sha1').update(fs.readFileSync('shasum-pkg-1.0.0.tgz')).digest('hex'))")"
+
+	cat >shasum-registry.mjs <<'NODE'
+import http from 'node:http';
+import fs from 'node:fs';
+
+const shasum = process.env.SHASUM_PKG_SHASUM;
+const tarball = fs.readFileSync('shasum-pkg-1.0.0.tgz');
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/shasum-pkg') {
+    const tarballUrl = `http://${req.headers.host}/shasum-pkg/-/shasum-pkg-1.0.0.tgz`;
+    res.setHeader('content-type', 'application/json');
+    // Note: `dist` has `shasum` but deliberately no `integrity`.
+    res.end(JSON.stringify({
+      name: 'shasum-pkg',
+      'dist-tags': { latest: '1.0.0' },
+      versions: {
+        '1.0.0': {
+          name: 'shasum-pkg',
+          version: '1.0.0',
+          dist: { tarball: tarballUrl, shasum }
+        }
+      },
+      time: { '1.0.0': '2024-01-01T00:00:00.000Z' }
+    }));
+    return;
+  }
+  if (req.method === 'GET' && req.url === '/shasum-pkg/-/shasum-pkg-1.0.0.tgz') {
+    res.setHeader('content-type', 'application/octet-stream');
+    res.end(tarball);
+    return;
+  }
+  res.statusCode = 404;
+  res.end('{}');
+});
+server.listen(0, '127.0.0.1', () => {
+  fs.writeFileSync('shasum-registry-port', String(server.address().port));
+});
+NODE
+	SHASUM_PKG_SHASUM="$shasum" node shasum-registry.mjs &
+	SPLIT_REGISTRY_PID=$!
+	for _ in 1 2 3 4 5 6 7 8 9 10; do
+		[ -f shasum-registry-port ] && break
+		sleep 0.1
+	done
+	registry="http://127.0.0.1:$(cat shasum-registry-port)"
+
+	cat >package.json <<-'EOF'
+		{
+		  "name": "test-shasum-fallback",
+		  "version": "1.0.0",
+		  "dependencies": { "shasum-pkg": "1.0.0" }
+		}
+	EOF
+	cat >.npmrc <<-EOF
+		registry=$registry
+	EOF
+
+	run aube install --no-frozen-lockfile
+	assert_success
+
+	# The lockfile records a verifiable sha1 SRI derived from the shasum,
+	# not a bare tarball-only resolution.
+	run grep -F "sha1-" aube-lock.yaml
+	assert_success
+
+	# A re-read (here via a frozen install after clearing the store) must
+	# parse the entry rather than failing with ERR_AUBE_LOCKFILE_PARSE.
+	rm -rf node_modules "$XDG_DATA_HOME/aube/store" "$XDG_CACHE_HOME/aube/packuments-v1"
+
+	run aube install --frozen-lockfile
+	kill "$SPLIT_REGISTRY_PID"
+	wait "$SPLIT_REGISTRY_PID" 2>/dev/null || true
+	unset SPLIT_REGISTRY_PID
+	assert_success
+}
+
 @test "lockfileIncludeTarballUrl=false (default) omits tarball URLs" {
 	cat >package.json <<-'EOF'
 		{


### PR DESCRIPTION
## What

Fixes the root cause of Bug 1 in [discussion #979](https://github.com/jdx/aube/discussions/979): a package from a scoped/custom registry whose packument carries only the legacy hex `dist.shasum` (no modern SRI `dist.integrity`) would permanently brick a project's lockfile.

## Why

The resolver derived integrity **only** from `dist.integrity`:

```rust
let integrity = version_meta.dist.as_ref().and_then(|d| d.integrity.clone());
```

When absent, it warned (`WARN_AUBE_MISSING_INTEGRITY`) and wrote an unverifiable tarball-only resolution:

```yaml
'@vendor/pkg@4.2.4':
  resolution: {tarball: https://npm.example-vendor.com/@vendor/pkg/-/pkg-4.2.4.tgz}
```

But on the *next* command the lockfile parser rejects that same entry unconditionally (`resolution_requires_integrity`, no `strictStoreIntegrity` gate), with no flag to recover:

```
ERR_AUBE_LOCKFILE_PARSE
  ╰─▶ lockfile entry "@vendor/pkg@4.2.4" has a remote tarball resolution without integrity
```

As the reporter diagnosed, the registry isn't giving us *nothing* to verify with — it ships `dist.shasum` (hex sha1), the field npm's classic client has always treated as the verification hash. aube's own store already accepts `sha1-<base64>` SRIs, so it was simply missing a fallback it's fully equipped to use.

## Change

- New `aube_store::shasum_to_sri` — converts a well-formed 40-char hex `dist.shasum` into `sha1-<base64>` (the inverse of the existing `integrity_to_hex` sha1 branch); malformed/absent input degrades to `None`.
- Resolver falls back to it when `dist.integrity` is absent, so a **verifiable** entry gets written in the first place — the parser gap becomes moot for this case, and content verification is now performed rather than skipped.

## Tests

- Unit tests for `shasum_to_sri` (npm-classic encoding parity using #979's exact value, round-trip through `integrity_to_hex`, whitespace tolerance, malformed rejection).
- A bats regression test (`test/lockfile_settings.bats`) serving a packument with `dist.shasum` and no `dist.integrity`, asserting the lockfile records a `sha1-` SRI and that a subsequent frozen install re-reads it instead of failing to parse. Verified it fails without the resolver change.

## Not in this PR (follow-ups noted from #979)

- **Bug 1 parser strictness:** gating `resolution_requires_integrity` on `strictStoreIntegrity` (to recover already-bricked lockfiles where the registry supplies *neither* hash) — needs settings threaded into the parser.
- **Bug 2 `aube import`:** the yarn-classic parser drops `resolved` into `tarball_url`, and the pnpm writer's `registry_tarball_url_is_not_derivable` is host-blind (matches on path suffix only), so a scoped-registry tarball URL isn't preserved. This is a separate, broader change and deserves its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*This PR was generated by Claude.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes resolver lockfile integrity for shasum-only registry metadata; behavior is narrow and covered by tests, but affects install/verify paths for legacy registries.
> 
> **Overview**
> Fixes lockfiles **bricking** on registries that only expose legacy **`dist.shasum`** (hex SHA-1) and omit **`dist.integrity`**.
> 
> The resolver now prefers **`dist.integrity`**, then falls back to **`aube_store::shasum_to_sri`** to record **`sha1-<base64>`** (npm classic behavior) instead of a **tarball-only** resolution that the lockfile parser rejects on the next run.
> 
> Adds **`shasum_to_sri`** in `aube-store` (validation, round-trip with `integrity_to_hex`, unit tests) and a **bats** regression with a mock registry serving shasum-only packuments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ffbffbc90cf6506620ba933506caab6681bb6bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->