### PR TITLE
fix(lockfile): gate tarball integrity parse errors on strict mode

### DIFF
--- a/crates/aube-lockfile/src/io.rs
+++ b/crates/aube-lockfile/src/io.rs
@@ -26,6 +26,21 @@ pub enum LockfileKind {
     Bun,
 }
 
+/// Options that affect lockfile parsing without changing the graph
+/// shape. Defaults preserve the historic strict parser behavior.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParseOptions {
+    pub strict_store_integrity: bool,
+}
+
+impl Default for ParseOptions {
+    fn default() -> Self {
+        Self {
+            strict_store_integrity: true,
+        }
+    }
+}
+
 impl LockfileKind {
     pub fn filename(self) -> &'static str {
         match self {
@@ -287,13 +302,23 @@ pub fn parse_lockfile_with_kind(
     project_dir: &Path,
     manifest: &aube_manifest::PackageJson,
 ) -> Result<(LockfileGraph, LockfileKind), Error> {
+    parse_lockfile_with_kind_and_options(project_dir, manifest, ParseOptions::default())
+}
+
+/// Like [`parse_lockfile_with_kind`] but lets callers opt into parser
+/// behavior driven by resolved install settings.
+pub fn parse_lockfile_with_kind_and_options(
+    project_dir: &Path,
+    manifest: &aube_manifest::PackageJson,
+    options: ParseOptions,
+) -> Result<(LockfileGraph, LockfileKind), Error> {
     reject_bun_binary(project_dir)?;
     for (path, kind) in lockfile_candidates(project_dir, /*include_aube=*/ true) {
         if !path.exists() {
             continue;
         }
         let kind = refine_yarn_kind(&path, kind);
-        let graph = parse_one(&path, kind, manifest)?;
+        let graph = parse_one(&path, kind, manifest, options)?;
         return Ok((graph, kind));
     }
     Err(Error::NotFound(project_dir.to_path_buf()))
@@ -315,7 +340,7 @@ pub fn parse_for_import(
             continue;
         }
         let kind = refine_yarn_kind(&path, kind);
-        let graph = parse_one(&path, kind, manifest)?;
+        let graph = parse_one(&path, kind, manifest, ParseOptions::default())?;
         return Ok((graph, kind));
     }
     Err(Error::NotFound(project_dir.to_path_buf()))
@@ -395,6 +420,7 @@ fn parse_one(
     path: &Path,
     kind: LockfileKind,
     manifest: &aube_manifest::PackageJson,
+    options: ParseOptions,
 ) -> Result<LockfileGraph, Error> {
     let _diag = aube_util::diag::Span::new(aube_util::diag::Category::Lockfile, "parse_one")
         .with_meta_fn(|| {
@@ -415,7 +441,7 @@ fn parse_one(
         // now — same parser, same writer — so we piggyback on the pnpm
         // module. Keeping the variant distinct lets detection/import
         // treat the two differently even though the bytes are the same.
-        LockfileKind::Aube | LockfileKind::Pnpm => pnpm::parse(path),
+        LockfileKind::Aube | LockfileKind::Pnpm => pnpm::parse_with_options(path, options),
         // yarn.rs::parse peeks the file for `__metadata:` and
         // dispatches between classic (v1) and berry (v2+) internally,
         // so we can hand both kinds to the same entry point. The

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -12,10 +12,11 @@ pub mod yarn;
 
 pub use drift::DriftStatus;
 pub use io::{
-    Error, LockfileKind, active_lockfile_has_conflict_markers, aube_lock_filename,
+    Error, LockfileKind, ParseOptions, active_lockfile_has_conflict_markers, aube_lock_filename,
     build_canonical_map, detect_existing_lockfile_kind, parse_for_import, parse_json,
-    parse_lockfile, parse_lockfile_with_kind, pnpm_lock_filename, read_lockfile, write_lockfile,
-    write_lockfile_as, write_lockfile_preserving_existing,
+    parse_lockfile, parse_lockfile_with_kind, parse_lockfile_with_kind_and_options,
+    pnpm_lock_filename, read_lockfile, write_lockfile, write_lockfile_as,
+    write_lockfile_preserving_existing,
 };
 pub(crate) use io::{atomic_write_lockfile, current_git_branch};
 pub use merge::{MergeReport, merge_branch_lockfiles};

--- a/crates/aube-lockfile/src/pnpm/mod.rs
+++ b/crates/aube-lockfile/src/pnpm/mod.rs
@@ -10,7 +10,7 @@ mod write;
 mod tests;
 
 pub use checksum::{package_extensions_checksum, pnpmfile_checksum};
-pub use read::parse;
+pub use read::{parse, parse_with_options};
 pub use write::write;
 
 /// Benchmark-only shims comparing the byte-cursor subset parser against

--- a/crates/aube-lockfile/src/pnpm/read.rs
+++ b/crates/aube-lockfile/src/pnpm/read.rs
@@ -7,7 +7,7 @@ use super::raw::{
 };
 use crate::{
     CatalogEntry, DepType, DirectDep, Error, LocalSource, LockedPackage, LockfileGraph,
-    PeerDepMeta, RuntimePin, RuntimeTarget, RuntimeVariant, git_commits_match,
+    ParseOptions, PeerDepMeta, RuntimePin, RuntimeTarget, RuntimeVariant, git_commits_match,
 };
 use aube_util::path::normalize_lexical;
 use std::collections::BTreeMap;
@@ -34,6 +34,10 @@ fn rebase_importer_local(local: LocalSource, importer_path: &str) -> LocalSource
 
 /// Parse a pnpm-lock.yaml file into a LockfileGraph.
 pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
+    parse_with_options(path, ParseOptions::default())
+}
+
+pub fn parse_with_options(path: &Path, options: ParseOptions) -> Result<LockfileGraph, Error> {
     let content = crate::read_lockfile(path)?;
     let raw = parse_raw_lockfile(&content)
         .map_err(|e| Error::parse_yaml_err(path, content.clone(), &e))?;
@@ -638,7 +642,8 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
             Some(LocalSource::RemoteTarball(_)) if !version_is_http_url => None,
             other => other,
         };
-        if integrity.is_none()
+        if options.strict_store_integrity
+            && integrity.is_none()
             && resolution_requires_integrity(
                 pkg_info.and_then(|p| p.resolution.as_ref()),
                 &local_source,

--- a/crates/aube-lockfile/src/pnpm/tests.rs
+++ b/crates/aube-lockfile/src/pnpm/tests.rs
@@ -1,9 +1,10 @@
 use super::{
     dep_path::{parse_dep_path, version_to_dep_path},
-    parse, write,
+    parse, parse_with_options, write,
 };
 use crate::{
     CatalogEntry, DepType, DirectDep, GitSource, LocalSource, LockedPackage, LockfileGraph,
+    ParseOptions,
 };
 use aube_manifest::PackageJson;
 use std::collections::BTreeMap;
@@ -3440,6 +3441,44 @@ snapshots:
             "{scheme}: {err}"
         );
     }
+}
+
+#[test]
+fn parser_allows_remote_tarball_resolution_without_integrity_when_not_strict() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("pnpm-lock.yaml");
+    std::fs::write(
+        &path,
+        r#"
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      demo:
+        specifier: 1.0.0
+        version: 1.0.0
+packages:
+  demo@1.0.0:
+    resolution: {tarball: https://registry.npmjs.org/demo/-/demo-1.0.0.tgz}
+snapshots:
+  demo@1.0.0: {}
+"#,
+    )
+    .unwrap();
+
+    let graph = parse_with_options(
+        &path,
+        ParseOptions {
+            strict_store_integrity: false,
+        },
+    )
+    .unwrap();
+    let pkg = graph.packages.get("demo@1.0.0").expect("demo package");
+    assert!(pkg.integrity.is_none());
+    assert_eq!(
+        pkg.tarball_url.as_deref(),
+        Some("https://registry.npmjs.org/demo/-/demo-1.0.0.tgz")
+    );
 }
 
 #[test]

--- a/crates/aube/src/commands/install/lockfile_dir.rs
+++ b/crates/aube/src/commands/install/lockfile_dir.rs
@@ -1,34 +1,24 @@
-/// Read a lockfile from `lockfile_dir` and remap its importer key
-/// for the current project from the project's relative-path key to
-/// `"."`, so the rest of the install pipeline can keep treating the
-/// project as the root importer. No-op when `importer_key == "."`.
-pub(super) fn parse_lockfile_dir_remapped(
-    lockfile_dir: &std::path::Path,
-    importer_key: &str,
-    manifest: &aube_manifest::PackageJson,
-) -> Result<aube_lockfile::LockfileGraph, aube_lockfile::Error> {
-    let mut graph = aube_lockfile::parse_lockfile(lockfile_dir, manifest)?;
+fn remap_lockfile_importer(graph: &mut aube_lockfile::LockfileGraph, importer_key: &str) {
     if importer_key != "."
         && let Some(deps) = graph.importers.remove(importer_key)
     {
         graph.importers.insert(".".to_string(), deps);
     }
-    Ok(graph)
 }
 
-/// Same as [`parse_lockfile_dir_remapped`] but preserves the detected
-/// kind for callers that need format-aware behavior.
-pub(super) fn parse_lockfile_dir_remapped_with_kind(
+/// Read a lockfile from `lockfile_dir`, preserve the detected kind,
+/// and remap its importer key for the current project from the
+/// project's relative-path key to `"."`. No-op when
+/// `importer_key == "."`.
+pub(super) fn parse_lockfile_dir_remapped_with_kind_and_options(
     lockfile_dir: &std::path::Path,
     importer_key: &str,
     manifest: &aube_manifest::PackageJson,
+    options: aube_lockfile::ParseOptions,
 ) -> Result<(aube_lockfile::LockfileGraph, aube_lockfile::LockfileKind), aube_lockfile::Error> {
-    let (mut graph, kind) = aube_lockfile::parse_lockfile_with_kind(lockfile_dir, manifest)?;
-    if importer_key != "."
-        && let Some(deps) = graph.importers.remove(importer_key)
-    {
-        graph.importers.insert(".".to_string(), deps);
-    }
+    let (mut graph, kind) =
+        aube_lockfile::parse_lockfile_with_kind_and_options(lockfile_dir, manifest, options)?;
+    remap_lockfile_importer(&mut graph, importer_key);
     Ok((graph, kind))
 }
 

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -482,12 +482,16 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     if opts.network_mode == aube_registry::NetworkMode::Offline {
         runtime_settings.network = aube_runtime::NetworkMode::Offline;
     }
+    let strict_store_integrity_setting = settings::resolve_strict_store_integrity(&settings_ctx);
+    let lockfile_parse_options = aube_lockfile::ParseOptions {
+        strict_store_integrity: strict_store_integrity_setting,
+    };
     if !opts.dry_run {
         crate::runtime::ensure(
             &cwd,
             Some(&manifest),
             runtime_settings,
-            crate::runtime::lockfile_node_pin(&cwd, &manifest).as_ref(),
+            crate::runtime::lockfile_node_pin(&cwd, &manifest, lockfile_parse_options).as_ref(),
         )
         .await?;
     }
@@ -535,10 +539,6 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     let network_concurrency_setting = resolve_network_concurrency(&settings_ctx);
     let link_concurrency_setting = resolve_link_concurrency(&settings_ctx);
     let verify_store_integrity_setting = resolve_verify_store_integrity(&settings_ctx);
-    let strict_store_integrity_setting = settings::resolve_strict_store_integrity(&settings_ctx);
-    let lockfile_parse_options = aube_lockfile::ParseOptions {
-        strict_store_integrity: strict_store_integrity_setting,
-    };
     let strict_store_pkg_content_check_setting =
         resolve_strict_store_pkg_content_check(&settings_ctx);
     let side_effects_cache_setting = resolve_side_effects_cache(&settings_ctx);

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -49,7 +49,7 @@ use lifecycle::{
     resolve_link_strategy, run_import_on_blocking, run_root_lifecycle, validate_required_scripts,
 };
 use lockfile_dir::{
-    parse_lockfile_dir_remapped, parse_lockfile_dir_remapped_with_kind, write_lockfile_dir_remapped,
+    parse_lockfile_dir_remapped_with_kind_and_options, write_lockfile_dir_remapped,
 };
 use materialize::{
     GvsPrewarmInputs, combine_install_pipeline_errors, materialize_channel, spawn_gvs_prewarm,
@@ -536,6 +536,9 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     let link_concurrency_setting = resolve_link_concurrency(&settings_ctx);
     let verify_store_integrity_setting = resolve_verify_store_integrity(&settings_ctx);
     let strict_store_integrity_setting = settings::resolve_strict_store_integrity(&settings_ctx);
+    let lockfile_parse_options = aube_lockfile::ParseOptions {
+        strict_store_integrity: strict_store_integrity_setting,
+    };
     let strict_store_pkg_content_check_setting =
         resolve_strict_store_pkg_content_check(&settings_ctx);
     let side_effects_cache_setting = resolve_side_effects_cache(&settings_ctx);
@@ -693,6 +696,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         &lockfile_dir,
         &lockfile_importer_key,
         &manifest,
+        lockfile_parse_options,
     )?;
     let lockfile_conflict_marker_warning_emitted = lockfile_pre_parse.is_none()
         && lockfile_enabled
@@ -721,6 +725,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 lockfile_dir: &lockfile_dir,
                 lockfile_importer_key: &lockfile_importer_key,
                 manifest: &manifest,
+                parse_options: lockfile_parse_options,
                 manifests: &manifests,
                 ws_config: &ws_config_shared,
                 workspace_catalogs: &workspace_catalogs,
@@ -747,6 +752,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             lockfile_dir: &lockfile_dir,
             lockfile_importer_key: &lockfile_importer_key,
             manifest: &manifest,
+            parse_options: lockfile_parse_options,
             manifests: &manifests,
             per_project_write_selection: per_project_write_selection.as_ref(),
             ws_config: &ws_config_shared,
@@ -860,6 +866,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         lockfile_dir: &lockfile_dir,
         lockfile_importer_key: &lockfile_importer_key,
         manifest: &manifest,
+        parse_options: lockfile_parse_options,
         manifests: &manifests,
         ws_config: &ws_config_shared,
         workspace_catalogs: &workspace_catalogs,
@@ -1068,10 +1075,11 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                 // empty placeholder.
                 let lockfile_estimate =
                     existing_for_resolver.map(|g| g.packages.len()).or_else(|| {
-                        parse_lockfile_dir_remapped_with_kind(
+                        parse_lockfile_dir_remapped_with_kind_and_options(
                             &lockfile_dir,
                             &lockfile_importer_key,
                             &manifest,
+                            lockfile_parse_options,
                         )
                         .ok()
                         .map(|(g, _)| g.packages.len())
@@ -1678,9 +1686,12 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             // YAML parse pass over the same 5-50 KB file.
             if let Some((prior, _)) = lockfile_pre_parse.as_ref() {
                 graph.overlay_metadata_from(prior);
-            } else if let Ok(prior) =
-                parse_lockfile_dir_remapped(&lockfile_dir, &lockfile_importer_key, &manifest)
-            {
+            } else if let Ok((prior, _)) = parse_lockfile_dir_remapped_with_kind_and_options(
+                &lockfile_dir,
+                &lockfile_importer_key,
+                &manifest,
+                lockfile_parse_options,
+            ) {
                 graph.overlay_metadata_from(&prior);
             }
             tracing::debug!("Resolved {} packages", graph.packages.len());

--- a/crates/aube/src/commands/install/resolve.rs
+++ b/crates/aube/src/commands/install/resolve.rs
@@ -5,7 +5,9 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use super::frozen::FrozenMode;
-use super::lockfile_dir::{parse_lockfile_dir_remapped_with_kind, write_lockfile_dir_remapped};
+use super::lockfile_dir::{
+    parse_lockfile_dir_remapped_with_kind_and_options, write_lockfile_dir_remapped,
+};
 use super::settings::{
     ResolverConfigInputs, configure_resolver, maybe_cleanup_unused_catalogs,
     stamp_pnpm_config_checksums,
@@ -20,11 +22,17 @@ pub(super) fn pre_parse_lockfile(
     lockfile_dir: &Path,
     lockfile_importer_key: &str,
     manifest: &aube_manifest::PackageJson,
+    parse_options: aube_lockfile::ParseOptions,
 ) -> miette::Result<ParsedLockfile> {
     if !lockfile_enabled || !matches!(mode, FrozenMode::Fix | FrozenMode::Prefer) {
         return Ok(None);
     }
-    match parse_lockfile_dir_remapped_with_kind(lockfile_dir, lockfile_importer_key, manifest) {
+    match parse_lockfile_dir_remapped_with_kind_and_options(
+        lockfile_dir,
+        lockfile_importer_key,
+        manifest,
+        parse_options,
+    ) {
         Ok(parsed) => Ok(Some(parsed)),
         Err(aube_lockfile::Error::NotFound(_)) => Ok(None),
         Err(e) if active_lockfile_has_conflict_markers(lockfile_dir) => {
@@ -41,6 +49,7 @@ pub(super) struct LockfileOnlyInput<'a> {
     pub lockfile_dir: &'a Path,
     pub lockfile_importer_key: &'a str,
     pub manifest: &'a aube_manifest::PackageJson,
+    pub parse_options: aube_lockfile::ParseOptions,
     pub manifests: &'a [(String, aube_manifest::PackageJson)],
     pub per_project_write_selection: Option<&'a std::collections::BTreeSet<String>>,
     pub ws_config: &'a aube_manifest::workspace::WorkspaceConfig,
@@ -74,6 +83,7 @@ pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::R
         lockfile_dir,
         lockfile_importer_key,
         manifest,
+        parse_options,
         manifests,
         per_project_write_selection,
         ws_config,
@@ -115,10 +125,11 @@ pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::R
         if let Some((g, k)) = lockfile_pre_parse {
             Ok((g, *k))
         } else {
-            parsed_owned = parse_lockfile_dir_remapped_with_kind(
+            parsed_owned = parse_lockfile_dir_remapped_with_kind_and_options(
                 lockfile_dir,
                 lockfile_importer_key,
                 manifest,
+                parse_options,
             );
             match &parsed_owned {
                 Ok((g, k)) => Ok((g, *k)),
@@ -140,10 +151,11 @@ pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::R
             // about to abort anyway so speed does not matter here.
             // What matters: keeping the source span and miette help
             // text instead of flattening to one line via `{e}`.
-            match parse_lockfile_dir_remapped_with_kind(
+            match parse_lockfile_dir_remapped_with_kind_and_options(
                 lockfile_dir,
                 lockfile_importer_key,
                 manifest,
+                parse_options,
             ) {
                 Ok(_) => {
                     // Race: second parse succeeded while first failed.
@@ -361,6 +373,7 @@ pub(super) struct SelectLockfileInput<'a> {
     pub lockfile_dir: &'a Path,
     pub lockfile_importer_key: &'a str,
     pub manifest: &'a aube_manifest::PackageJson,
+    pub parse_options: aube_lockfile::ParseOptions,
     pub manifests: &'a [(String, aube_manifest::PackageJson)],
     pub ws_config: &'a aube_manifest::workspace::WorkspaceConfig,
     pub workspace_catalogs: &'a crate::commands::CatalogMap,
@@ -378,6 +391,7 @@ pub(super) fn select_lockfile_result(
         lockfile_dir,
         lockfile_importer_key,
         manifest,
+        parse_options,
         manifests,
         ws_config,
         workspace_catalogs,
@@ -398,10 +412,11 @@ pub(super) fn select_lockfile_result(
         FrozenMode::Fix => Ok(Err(aube_lockfile::Error::NotFound(cwd.to_path_buf()))),
         FrozenMode::Frozen => {
             // Use the lockfile, but error out on any drift across all workspace importers.
-            let parsed = parse_lockfile_dir_remapped_with_kind(
+            let parsed = parse_lockfile_dir_remapped_with_kind_and_options(
                 lockfile_dir,
                 lockfile_importer_key,
                 manifest,
+                parse_options,
             );
             if let Ok((ref graph, kind)) = parsed {
                 if let DriftStatus::Stale { reason } =

--- a/crates/aube/src/runtime.rs
+++ b/crates/aube/src/runtime.rs
@@ -191,6 +191,7 @@ impl RuntimeSettings {
 pub(crate) fn lockfile_node_pin(
     project_dir: &Path,
     manifest: &PackageJson,
+    parse_options: aube_lockfile::ParseOptions,
 ) -> Option<aube_lockfile::RuntimePin> {
     let pinned = [aube_util::embedder().lockfile_basename, "pnpm-lock.yaml"]
         .iter()
@@ -202,7 +203,9 @@ pub(crate) fn lockfile_node_pin(
     if !pinned {
         return None;
     }
-    let graph = aube_lockfile::parse_lockfile(project_dir, manifest).ok()?;
+    let (graph, _) =
+        aube_lockfile::parse_lockfile_with_kind_and_options(project_dir, manifest, parse_options)
+            .ok()?;
     graph.runtimes.get("node").cloned()
 }
 
@@ -217,9 +220,14 @@ pub async fn ensure_for_cwd(cwd: &Path) -> miette::Result<&'static RuntimeContex
     let manifest =
         aube_manifest::PackageJson::from_path_cached(&project_dir.join("package.json")).ok();
     let settings = crate::commands::with_settings_ctx(&project_dir, RuntimeSettings::from_ctx);
+    let parse_options =
+        crate::commands::with_settings_ctx(&project_dir, |ctx| aube_lockfile::ParseOptions {
+            strict_store_integrity: aube_settings::resolved::strict_store_integrity(ctx)
+                || aube_settings::resolved::paranoid(ctx),
+        });
     let pin = manifest
         .as_deref()
-        .and_then(|m| lockfile_node_pin(&project_dir, m));
+        .and_then(|m| lockfile_node_pin(&project_dir, m, parse_options));
     ensure(&project_dir, manifest.as_deref(), settings, pin.as_ref()).await
 }
 


### PR DESCRIPTION
## What

- Adds lockfile parse options so install can pass the resolved `strictStoreIntegrity` setting into the pnpm/aube lockfile parser.
- Keeps the parser's default behavior strict for existing library callers and import paths.
- Allows normal installs to read tarball-only remote registry lockfile entries when `strictStoreIntegrity=false`, so a bricked lockfile can be recovered instead of failing before resolution.

## Why

PR #994 fixed new shasum-only registry metadata by writing a verifiable `sha1-` integrity value. Existing lockfiles that were already written with only `resolution.tarball` still failed during parse even though `strictStoreIntegrity` defaults to false.

## Tests

- `cargo fmt --check`
- `cargo test -p aube-lockfile remote_tarball_resolution_without_integrity`
- `cargo check -p aube`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes lockfile parse behavior on the install hot path and affects when corrupt or integrity-less tarball resolutions are accepted versus rejected; defaults stay strict for import and direct API use.
> 
> **Overview**
> **Fixes installs failing at lockfile parse** when pnpm/aube entries have a registry `resolution.tarball` but no `integrity`, which older lockfiles can still contain after metadata handling changed.
> 
> Introduces **`ParseOptions`** (`strict_store_integrity`, default **strict** for library callers and `parse_for_import`) and **`parse_lockfile_with_kind_and_options`**, wired through pnpm **`parse_with_options`**. The “remote tarball resolution without integrity” error now runs only when **`strict_store_integrity`** is true.
> 
> **Install** resolves **`strictStoreIntegrity`** (and **`paranoid`**) once into **`lockfile_parse_options`** and passes it through pre-parse, frozen/dry-run selection, lockfile-only, metadata overlay, `--lockfile-dir` remapping, and **`lockfile_node_pin`** / **`ensure_for_cwd`** so non-strict installs can read tarball-only entries and recover via re-resolve instead of aborting before resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 440a42471c5c3ee93e558ef00a82157f962458e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->