### PR TITLE
feat(scripts): pass resolved proxy to lifecycle scripts

### DIFF
--- a/crates/aube-scripts/src/lib.rs
+++ b/crates/aube-scripts/src/lib.rs
@@ -56,6 +56,17 @@ pub struct ScriptSettings {
     /// first use) the real node-gyp and forwards argv. `None` leaves
     /// `npm_config_node_gyp` unset.
     pub node_gyp_js: Option<PathBuf>,
+    /// The proxy aube resolved for its own registry traffic, re-exported
+    /// to lifecycle scripts as the standard `HTTPS_PROXY` / `HTTP_PROXY`
+    /// / `NO_PROXY` env vars (plus `NODE_USE_ENV_PROXY=1`) so a script's
+    /// own `fetch()` / `http` calls honor the same proxy. aube reaches
+    /// scripts as `npm_config_proxy`, which Node ignores — only these
+    /// vars work. `None` on each leaves the corresponding var unset; the
+    /// proxy block is skipped entirely when both `http_proxy` and
+    /// `https_proxy` are `None`.
+    pub http_proxy: Option<String>,
+    pub https_proxy: Option<String>,
+    pub no_proxy: Option<String>,
 }
 
 /// Native build jail applied to dependency lifecycle scripts.
@@ -553,6 +564,32 @@ fn apply_script_settings_env(cmd: &mut tokio::process::Command, settings: &Scrip
     }
     if settings.shell_emulator {
         cmd.env("npm_config_shell_emulator", "true");
+    }
+    // Proxy passthrough. aube already resolved a proxy for its own
+    // registry traffic and forwards it to scripts as `npm_config_proxy`,
+    // but Node's built-in `fetch`/`http`/`https` only read the standard
+    // `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` vars, and only when
+    // `NODE_USE_ENV_PROXY=1` is set (Node 24+). Stamp all four so a
+    // dependency's install script hits the same proxy aube does. A proxy
+    // URL is not a secret, so this is safe to leak past the jail. Skip
+    // the whole block when no proxy is configured — no reason to flip
+    // Node's experimental env-proxy flag (which warns on Node 24) for a
+    // direct connection. Use the plain env var, never
+    // `NODE_OPTIONS=--use-env-proxy`: Node < 24 rejects that unknown
+    // flag and refuses to start, breaking installs; the plain var is
+    // silently ignored there instead. Set after `env_clear` (like `NODE`
+    // above) so it survives the jail.
+    if settings.http_proxy.is_some() || settings.https_proxy.is_some() {
+        if let Some(https) = settings.https_proxy.as_deref() {
+            cmd.env("HTTPS_PROXY", https);
+        }
+        if let Some(http) = settings.http_proxy.as_deref() {
+            cmd.env("HTTP_PROXY", http);
+        }
+        if let Some(no_proxy) = settings.no_proxy.as_deref() {
+            cmd.env("NO_PROXY", no_proxy);
+        }
+        cmd.env("NODE_USE_ENV_PROXY", "1");
     }
 }
 
@@ -1329,6 +1366,72 @@ mod jail_tests {
         assert_eq!(env("npm_lifecycle_event"), Some("postinstall"));
         assert_eq!(env("npm_package_name"), Some("pkg"));
         assert_eq!(env("npm_package_version"), Some("1.2.3"));
+    }
+
+    fn proxy_env(settings: ScriptSettings) -> impl Fn(&str) -> Option<String> {
+        let mut cmd = tokio::process::Command::new("node");
+        apply_script_settings_env(&mut cmd, &settings);
+        let envs: Vec<_> = cmd
+            .as_std()
+            .get_envs()
+            .map(|(k, v)| {
+                (
+                    k.to_string_lossy().into_owned(),
+                    v.map(|v| v.to_string_lossy().into_owned()),
+                )
+            })
+            .collect();
+        move |name: &str| {
+            envs.iter()
+                .find(|(k, _)| k == name)
+                .and_then(|(_, v)| v.clone())
+        }
+    }
+
+    #[test]
+    fn proxy_vars_stamped_when_proxy_configured() {
+        let env = proxy_env(ScriptSettings {
+            https_proxy: Some("http://proxy.example:8080".to_string()),
+            http_proxy: Some("http://proxy.example:8080".to_string()),
+            no_proxy: Some("localhost,127.0.0.1".to_string()),
+            ..Default::default()
+        });
+        assert_eq!(
+            env("HTTPS_PROXY").as_deref(),
+            Some("http://proxy.example:8080")
+        );
+        assert_eq!(
+            env("HTTP_PROXY").as_deref(),
+            Some("http://proxy.example:8080")
+        );
+        assert_eq!(env("NO_PROXY").as_deref(), Some("localhost,127.0.0.1"));
+        // Node ignores the proxy vars unless this flag is set (Node 24+);
+        // it must be the plain env var, not `--use-env-proxy`.
+        assert_eq!(env("NODE_USE_ENV_PROXY").as_deref(), Some("1"));
+    }
+
+    #[test]
+    fn proxy_block_skipped_when_no_proxy_configured() {
+        // With no proxy resolved, none of the passthrough vars — and
+        // crucially not the experimental `NODE_USE_ENV_PROXY` flag —
+        // should be stamped onto the script env.
+        let env = proxy_env(ScriptSettings::default());
+        assert_eq!(env("HTTPS_PROXY"), None);
+        assert_eq!(env("HTTP_PROXY"), None);
+        assert_eq!(env("NO_PROXY"), None);
+        assert_eq!(env("NODE_USE_ENV_PROXY"), None);
+    }
+
+    #[test]
+    fn no_proxy_alone_does_not_trigger_passthrough() {
+        // `NO_PROXY` without an actual proxy URL is meaningless, and we
+        // must not flip Node's env-proxy flag for a direct connection.
+        let env = proxy_env(ScriptSettings {
+            no_proxy: Some("example.com".to_string()),
+            ..Default::default()
+        });
+        assert_eq!(env("NO_PROXY"), None);
+        assert_eq!(env("NODE_USE_ENV_PROXY"), None);
     }
 }
 

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -1225,9 +1225,10 @@ sources.cli = []
 sources.env = ["npm_config_proxy", "NPM_CONFIG_PROXY", "npm_config_https_proxy", "NPM_CONFIG_HTTPS_PROXY", "AUBE_HTTPS_PROXY", "https_proxy", "HTTPS_PROXY"]
 sources.npmrc = ["https-proxy", "httpsProxy", "proxy"]
 examples = []
-# Consumed inside `aube_registry::config::NpmConfig::load`, before
-# the CLI has a `ResolveCtx`; keep this metadata grepable for docs.
-typedAccessorUnused = true
+# Consumed inside `aube_registry::config::NpmConfig::load` for the
+# registry client, and additionally via the typed accessor in
+# `configure_script_settings` to re-export the proxy to lifecycle
+# scripts (`HTTPS_PROXY` + `NODE_USE_ENV_PROXY`).
 npmShared = true
 
 [httpProxy]
@@ -1245,9 +1246,11 @@ sources.cli = []
 sources.env = ["PROXY", "proxy", "npm_config_http_proxy", "NPM_CONFIG_HTTP_PROXY", "AUBE_HTTP_PROXY", "http_proxy", "HTTP_PROXY"]
 sources.npmrc = ["http-proxy", "httpProxy"]
 examples = []
-# Consumed inside `aube_registry::config::NpmConfig::load`, before
-# the CLI has a `ResolveCtx`; keep this metadata grepable for docs.
-typedAccessorUnused = true
+# Consumed inside `aube_registry::config::NpmConfig::load` for the
+# registry client, and additionally via the typed accessor in
+# `configure_script_settings` to re-export the proxy to lifecycle
+# scripts (`HTTP_PROXY` + `NODE_USE_ENV_PROXY`). The `httpsProxy`
+# fallback is replicated at that call site.
 npmShared = true
 
 [noProxy]
@@ -1265,10 +1268,10 @@ sources.env = ["npm_config_noproxy", "NPM_CONFIG_NOPROXY", "npm_config_no_proxy"
 sources.npmrc = ["noproxy", "noProxy", "no-proxy"]
 examples = []
 # Consumed inside `aube_registry::config::NpmConfig::apply` via a
-# string-keyed match on the raw `.npmrc` entries, because the registry
-# client is built before a `ResolveCtx` exists. Same pattern as every
-# other reqwest-level knob below.
-typedAccessorUnused = true
+# string-keyed match on the raw `.npmrc` entries for the registry
+# client, and additionally via the typed accessor in
+# `configure_script_settings` to re-export `NO_PROXY` to lifecycle
+# scripts.
 npmShared = true
 
 [localAddress]

--- a/crates/aube/src/commands/script_settings.rs
+++ b/crates/aube/src/commands/script_settings.rs
@@ -21,6 +21,17 @@ pub(crate) fn configure_script_settings(
     // falls back to the ambient `node` on PATH so `npm_node_execpath` /
     // `NODE` are populated for lifecycle scripts the way pnpm/npm do.
     let runtime = crate::runtime::current();
+    // Resolve the proxy the same way the registry client does, so a
+    // dependency's install script honors it too. `httpProxy` inherits
+    // from the resolved `httpsProxy` (npm/pnpm parity: a lone
+    // `https-proxy=` line configures both schemes) — replicate that
+    // fallback here, since the generated accessors only walk each
+    // setting's own sources. `noProxy` has no cross-setting inheritance.
+    let https_proxy = aube_settings::resolved::https_proxy(ctx).and_then(non_empty_string);
+    let http_proxy = aube_settings::resolved::http_proxy(ctx)
+        .and_then(non_empty_string)
+        .or_else(|| https_proxy.clone());
+    let no_proxy = aube_settings::resolved::no_proxy(ctx).and_then(non_empty_string);
     aube_scripts::set_script_settings(aube_scripts::ScriptSettings {
         node_options,
         script_shell,
@@ -36,6 +47,9 @@ pub(crate) fn configure_script_settings(
         // aube's cache; a write failure here is non-fatal (the var just
         // stays unset, matching pre-parity behavior).
         node_gyp_js: super::install::node_gyp_bootstrap::lazy_js_shim_path().ok(),
+        http_proxy,
+        https_proxy,
+        no_proxy,
     });
 }
 


### PR DESCRIPTION
## Summary
- pass the resolved HTTP/HTTPS/NO_PROXY settings into lifecycle script environments
- set NODE_USE_ENV_PROXY only when a proxy is configured so Node 24+ honors the same proxy as aube
- document the settings accessors now used by script configuration

Closes #983

## Tests
- cargo fmt --check
- cargo test -p aube-scripts proxy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to script environment when proxy settings are set; no proxy means unchanged env, with tests guarding edge cases.
> 
> **Overview**
> Lifecycle scripts now receive the same outbound proxy aube uses for registry traffic, via standard **`HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY`** and **`NODE_USE_ENV_PROXY=1`** (Node 24+), because Node ignores `npm_config_proxy` for built-in `fetch`/`http`.
> 
> **`configure_script_settings`** resolves `httpsProxy`, `httpProxy` (falling back to HTTPS per npm/pnpm), and `noProxy` from settings, then stores them on **`ScriptSettings`**. **`apply_script_settings_env`** sets those vars only when at least one proxy URL is present—**`NO_PROXY` alone does not** enable the block, avoiding experimental proxy warnings on direct connections. **`NODE_USE_ENV_PROXY`** is used instead of **`NODE_OPTIONS=--use-env-proxy`** so older Node versions still start.
> 
> Settings metadata for **`httpsProxy`**, **`httpProxy`**, and **`noProxy`** now documents script re-export. Unit tests cover stamped env, no-proxy skip, and no-proxy-only skip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaef1f88b1d15717a8e80164506153bb6a4c9d74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->