### PR TITLE
fix(import): preserve custom registry tarball urls

### DIFF
--- a/crates/aube-lockfile/src/bun/write.rs
+++ b/crates/aube-lockfile/src/bun/write.rs
@@ -335,7 +335,7 @@ pub fn write(
             "libc",
         ];
         for (k, v) in &pkg.extra_meta {
-            if MODELED_META_KEYS.contains(&k.as_str()) {
+            if MODELED_META_KEYS.contains(&k.as_str()) || k == crate::EXTRA_PRESERVE_TARBALL_URL {
                 continue;
             }
             meta.insert(k.clone(), v.clone());

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -25,6 +25,8 @@ pub use source::{
     parse_git_spec, parse_hosted_git, resolve_dep_edge, shared_local_dep_path,
 };
 
+pub(crate) const EXTRA_PRESERVE_TARBALL_URL: &str = "__aube_preserve_tarball_url";
+
 use smallvec::SmallVec;
 use std::collections::{BTreeMap, BTreeSet};
 

--- a/crates/aube-lockfile/src/pnpm/read.rs
+++ b/crates/aube-lockfile/src/pnpm/read.rs
@@ -591,10 +591,19 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         // pnpm records a registry `deprecated:` reason on package
         // entries; stash it on the generic meta map so the writer can
         // re-emit it (matching how bun round-trips the same field).
-        let extra_meta = pkg_info
+        let mut extra_meta = pkg_info
             .and_then(|p| p.deprecated.clone())
             .map(|msg| BTreeMap::from([("deprecated".to_string(), serde_json::Value::String(msg))]))
             .unwrap_or_default();
+        if tarball_url
+            .as_deref()
+            .is_some_and(tarball_url_needs_preserve)
+        {
+            extra_meta.insert(
+                crate::EXTRA_PRESERVE_TARBALL_URL.to_string(),
+                serde_json::Value::Bool(true),
+            );
+        }
         // pnpm's lockfile only stores `hasBin: true/false` (no paths);
         // reconstruct an opaque single-entry map on parse so
         // `!bin.is_empty()` stays equivalent to `hasBin`, then let
@@ -894,6 +903,13 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         extra_fields: BTreeMap::new(),
         workspace_extra_fields: BTreeMap::new(),
     })
+}
+
+fn tarball_url_needs_preserve(url: &str) -> bool {
+    let Some((host, _)) = super::http_url_host_and_path(url) else {
+        return false;
+    };
+    !matches!(host.as_str(), "registry.npmjs.org" | "registry.yarnpkg.com")
 }
 
 /// Convert a raw `variations` variant into the typed graph shape.

--- a/crates/aube-lockfile/src/pnpm/tests.rs
+++ b/crates/aube-lockfile/src/pnpm/tests.rs
@@ -3744,7 +3744,7 @@ fn writer_omits_derivable_registry_tarball_url_with_query() {
                 integrity: Some("sha512-private".to_string()),
                 dep_path: "@scope/pkg@1.0.0".to_string(),
                 tarball_url: Some(
-                    "https://registry.example.test/@scope/pkg/-/pkg-1.0.0.tgz?signature=abc#sha"
+                    "https://registry.npmjs.org/@scope/pkg/-/pkg-1.0.0.tgz?signature=abc#sha"
                         .to_string(),
                 ),
                 ..Default::default()

--- a/crates/aube-lockfile/src/pnpm/write.rs
+++ b/crates/aube-lockfile/src/pnpm/write.rs
@@ -262,6 +262,11 @@ pub fn write(path: &Path, graph: &LockfileGraph, manifest: &PackageJson) -> Resu
         let is_jsr_registry_pkg = pkg.registry_name().starts_with("@jsr/");
         let preserve_tarball_url = graph.settings.lockfile_include_tarball_url
             || is_jsr_registry_pkg
+            || pkg
+                .extra_meta
+                .get(crate::EXTRA_PRESERVE_TARBALL_URL)
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
             || registry_tarball_url_is_not_derivable(
                 pkg.registry_name(),
                 &pkg.version,
@@ -706,15 +711,13 @@ fn registry_tarball_url_is_not_derivable(
     let Some(url) = tarball_url else {
         return false;
     };
-    let Some((host, path)) = super::http_url_host_and_path(url) else {
-        return true;
-    };
-    if !matches!(host.as_str(), "registry.npmjs.org" | "registry.yarnpkg.com") {
-        return true;
-    }
     let basename = name.rsplit('/').next().unwrap_or(name);
     let expected_suffix = format!("/-/{basename}-{version}.tgz");
-    !path.ends_with(&expected_suffix)
+    let path_only = url.split_once('?').map_or(url, |(path, _)| path);
+    let path_only = path_only
+        .split_once('#')
+        .map_or(path_only, |(path, _)| path);
+    !path_only.ends_with(&expected_suffix)
 }
 
 fn pruned_time_entries(

--- a/crates/aube-lockfile/src/pnpm/write.rs
+++ b/crates/aube-lockfile/src/pnpm/write.rs
@@ -706,13 +706,15 @@ fn registry_tarball_url_is_not_derivable(
     let Some(url) = tarball_url else {
         return false;
     };
+    let Some((host, path)) = super::http_url_host_and_path(url) else {
+        return true;
+    };
+    if !matches!(host.as_str(), "registry.npmjs.org" | "registry.yarnpkg.com") {
+        return true;
+    }
     let basename = name.rsplit('/').next().unwrap_or(name);
     let expected_suffix = format!("/-/{basename}-{version}.tgz");
-    let path_only = url.split_once('?').map_or(url, |(path, _)| path);
-    let path_only = path_only
-        .split_once('#')
-        .map_or(path_only, |(path, _)| path);
-    !path_only.ends_with(&expected_suffix)
+    !path.ends_with(&expected_suffix)
 }
 
 fn pruned_time_entries(

--- a/crates/aube-lockfile/src/yarn/classic.rs
+++ b/crates/aube-lockfile/src/yarn/classic.rs
@@ -1,4 +1,4 @@
-use crate::{DepType, DirectDep, Error, LockedPackage, LockfileGraph};
+use crate::{DepType, DirectDep, Error, LocalSource, LockedPackage, LockfileGraph};
 use std::collections::BTreeMap;
 use std::path::Path;
 
@@ -70,12 +70,17 @@ pub(super) fn parse_classic_str(
                 .iter()
                 .map(|(n, r)| (n.clone(), r.clone()))
                 .collect();
+            let tarball_url = block
+                .fields
+                .get("resolved")
+                .and_then(|url| yarn_resolved_tarball_url(url));
             packages.insert(
                 dep_path.clone(),
                 LockedPackage {
                     name: name.clone(),
                     version: version.clone(),
                     integrity: block.fields.get("integrity").cloned(),
+                    tarball_url,
                     // Store raw "name@range" pairs for now; resolve below.
                     dependencies: block
                         .dependencies
@@ -277,6 +282,11 @@ fn unquote_yarn_scalar(value: &str) -> &str {
     } else {
         value
     }
+}
+
+fn yarn_resolved_tarball_url(resolved: &str) -> Option<String> {
+    let url = resolved.split_once('#').map_or(resolved, |(url, _)| url);
+    LocalSource::looks_like_remote_tarball_url(url).then(|| url.to_string())
 }
 
 /// Extract the package name from a spec like `foo@^1.0.0` or `@scope/pkg@^1.0.0`.

--- a/crates/aube-lockfile/src/yarn/classic.rs
+++ b/crates/aube-lockfile/src/yarn/classic.rs
@@ -1,4 +1,7 @@
-use crate::{DepType, DirectDep, Error, LocalSource, LockedPackage, LockfileGraph};
+use crate::{
+    DepType, DirectDep, EXTRA_PRESERVE_TARBALL_URL, Error, LocalSource, LockedPackage,
+    LockfileGraph,
+};
 use std::collections::BTreeMap;
 use std::path::Path;
 
@@ -74,6 +77,16 @@ pub(super) fn parse_classic_str(
                 .fields
                 .get("resolved")
                 .and_then(|url| yarn_resolved_tarball_url(url));
+            let extra_meta = tarball_url
+                .as_deref()
+                .filter(|url| yarn_resolved_tarball_url_needs_preserve(url))
+                .map(|_| {
+                    BTreeMap::from([(
+                        EXTRA_PRESERVE_TARBALL_URL.to_string(),
+                        serde_json::Value::Bool(true),
+                    )])
+                })
+                .unwrap_or_default();
             packages.insert(
                 dep_path.clone(),
                 LockedPackage {
@@ -90,6 +103,7 @@ pub(super) fn parse_classic_str(
                     dep_path,
                     declared_dependencies: declared,
                     alias_of: alias_of.clone(),
+                    extra_meta,
                     ..Default::default()
                 },
             );
@@ -286,7 +300,38 @@ fn unquote_yarn_scalar(value: &str) -> &str {
 
 fn yarn_resolved_tarball_url(resolved: &str) -> Option<String> {
     let url = resolved.split_once('#').map_or(resolved, |(url, _)| url);
+    if crate::parse_git_spec(url).is_some() {
+        return None;
+    }
+    if !yarn_resolved_tarball_url_needs_preserve(url) {
+        return None;
+    }
     LocalSource::looks_like_remote_tarball_url(url).then(|| url.to_string())
+}
+
+fn yarn_resolved_tarball_url_needs_preserve(url: &str) -> bool {
+    let Some(host) = http_url_host(url) else {
+        return false;
+    };
+    !matches!(host.as_str(), "registry.npmjs.org" | "registry.yarnpkg.com")
+}
+
+fn http_url_host(url: &str) -> Option<String> {
+    let rest = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))?;
+    let authority = rest
+        .split_once('/')
+        .map_or(rest, |(authority, _)| authority);
+    let host_port = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    Some(
+        host_port
+            .split_once(':')
+            .map_or(host_port, |(host, _)| host)
+            .to_ascii_lowercase(),
+    )
 }
 
 /// Extract the package name from a spec like `foo@^1.0.0` or `@scope/pkg@^1.0.0`.

--- a/crates/aube-lockfile/src/yarn/tests.rs
+++ b/crates/aube-lockfile/src/yarn/tests.rs
@@ -71,6 +71,10 @@ bar@^2.0.0:
     let foo = &graph.packages["foo@1.2.3"];
     assert_eq!(foo.integrity.as_deref(), Some("sha512-aaa"));
     assert_eq!(
+        foo.tarball_url.as_deref(),
+        Some("https://example.com/foo-1.2.3.tgz")
+    );
+    assert_eq!(
         foo.dependencies.get("bar").map(String::as_str),
         Some("2.5.0")
     );
@@ -79,6 +83,37 @@ bar@^2.0.0:
     assert_eq!(root.len(), 1);
     assert_eq!(root[0].name, "foo");
     assert_eq!(root[0].dep_path, "foo@1.2.3");
+}
+
+#[test]
+fn classic_import_preserves_custom_registry_tarball_url() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let content = r#"# yarn lockfile v1
+
+"@scope/pkg@^1.0.0":
+  version "1.0.0"
+  resolved "https://npm.example.test/@scope/pkg/-/pkg-1.0.0.tgz#0123456789abcdef0123456789abcdef01234567"
+  integrity sha512-private
+"#;
+    std::fs::write(tmp.path(), content).unwrap();
+    let manifest = make_manifest(&[("@scope/pkg", "^1.0.0")], &[]);
+    let graph = parse(tmp.path(), &manifest).unwrap();
+    let pkg = graph
+        .packages
+        .get("@scope/pkg@1.0.0")
+        .expect("scoped package");
+    assert_eq!(
+        pkg.tarball_url.as_deref(),
+        Some("https://npm.example.test/@scope/pkg/-/pkg-1.0.0.tgz")
+    );
+
+    let out = tempfile::NamedTempFile::new().unwrap();
+    crate::pnpm::write(out.path(), &graph, &manifest).unwrap();
+    let yaml = std::fs::read_to_string(out.path()).unwrap();
+    assert!(
+        yaml.contains("tarball: https://npm.example.test/@scope/pkg/-/pkg-1.0.0.tgz"),
+        "{yaml}"
+    );
 }
 
 #[test]

--- a/crates/aube-lockfile/src/yarn/tests.rs
+++ b/crates/aube-lockfile/src/yarn/tests.rs
@@ -117,6 +117,25 @@ fn classic_import_preserves_custom_registry_tarball_url() {
 }
 
 #[test]
+fn classic_parse_does_not_treat_git_resolved_url_as_tarball_url() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let content = r#"# yarn lockfile v1
+
+"git-pkg@git+https://github.com/acme/git-pkg.git#main":
+  version "1.0.0"
+  resolved "https://github.com/acme/git-pkg.git#abcdef0123456789abcdef0123456789abcdef01"
+"#;
+    std::fs::write(tmp.path(), content).unwrap();
+    let manifest = make_manifest(
+        &[("git-pkg", "git+https://github.com/acme/git-pkg.git#main")],
+        &[],
+    );
+    let graph = parse(tmp.path(), &manifest).unwrap();
+    let pkg = graph.packages.get("git-pkg@1.0.0").expect("git package");
+    assert!(pkg.tarball_url.is_none());
+}
+
+#[test]
 fn test_parse_scoped_and_multi_spec() {
     let tmp = tempfile::NamedTempFile::new().unwrap();
     let content = r#"# yarn lockfile v1

--- a/crates/aube-lockfile/src/yarn/tests.rs
+++ b/crates/aube-lockfile/src/yarn/tests.rs
@@ -114,6 +114,15 @@ fn classic_import_preserves_custom_registry_tarball_url() {
         yaml.contains("tarball: https://npm.example.test/@scope/pkg/-/pkg-1.0.0.tgz"),
         "{yaml}"
     );
+
+    let round_trip_graph = crate::pnpm::parse(out.path()).unwrap();
+    let second_out = tempfile::NamedTempFile::new().unwrap();
+    crate::pnpm::write(second_out.path(), &round_trip_graph, &manifest).unwrap();
+    let second_yaml = std::fs::read_to_string(second_out.path()).unwrap();
+    assert!(
+        second_yaml.contains("tarball: https://npm.example.test/@scope/pkg/-/pkg-1.0.0.tgz"),
+        "{second_yaml}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What

- Preserves Yarn classic `resolved` tarball URLs on imported registry packages, stripping Yarn's trailing `#sha1` fragment before storing the URL.
- Treats registry tarball URLs as derivable only for known public npm/yarn registry hosts with the expected package tarball path.
- Keeps custom/scoped registry hosts in `resolution.tarball` when writing aube/pnpm lockfiles.

## Why

The follow-up from #994 noted that `aube import` could lose scoped/custom registry tarball URLs. The yarn-classic reader did not carry `resolved` into the graph, and the pnpm writer considered a URL derivable when only the path suffix matched, ignoring the host.

## Tests

- `cargo fmt --check`
- `cargo test -p aube-lockfile custom_registry_tarball_url`
- `cargo test -p aube-lockfile writer_omits_derivable_registry_tarball_url_with_query`
- `cargo check -p aube-lockfile`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile parse/write and metadata round-trip only; no install, auth, or resolver behavior changes beyond retaining URLs that were already in the source lockfile.
> 
> **Overview**
> **Fixes loss of custom/scoped registry tarball URLs** when importing Yarn classic lockfiles and re-writing as pnpm/aube lockfiles.
> 
> The Yarn v1 reader now lifts non-git `resolved` URLs into `LockedPackage.tarball_url` (stripping Yarn’s `#sha1` fragment) and tags entries whose host is not `registry.npmjs.org` or `registry.yarnpkg.com` with an internal `__aube_preserve_tarball_url` flag in `extra_meta`. The pnpm reader applies the same host rule when a `resolution.tarball` is present; the pnpm writer keeps emitting `tarball:` when that flag is set (alongside existing JSR / `lockfileIncludeTarballUrl` / non-derivable URL logic). The bun writer skips re-emitting that internal key so it does not leak into lockfile output.
> 
> Tests cover Yarn classic import, pnpm round-trip for a private registry host, and ensuring git `resolved` values are not treated as tarball URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3be7fbcc416629b049f6f2f57622fd9593db22ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->