### PR TITLE
schedule releases for Monday morning

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -1,0 +1,37 @@
+name: auto-merge-release
+
+on:
+  schedule:
+    # 10:00 UTC = 4am CST (winter) / 5am CDT (summer)
+    - cron: "0 10 * * 1"
+  workflow_dispatch:
+
+jobs:
+  merge:
+    if: github.repository == 'jdx/aube'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge release into main
+        run: |
+          PR_NUMBER=$(gh pr list -R jdx/aube --base main --state open --json number,headRefName,title \
+            --jq '[.[] | select(.headRefName | startswith("release-plz-")) | select(.title | startswith("chore: release "))][0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open release-plz release PR to main"
+            exit 0
+          fi
+
+          BODY=$(gh pr view "$PR_NUMBER" -R jdx/aube --json body --jq '.body // ""')
+          TRIMMED_BODY=$(echo "$BODY" | tr -d '[:space:]')
+          if [ -z "$TRIMMED_BODY" ]; then
+            echo "PR #$PR_NUMBER has no description, never merging"
+            exit 0
+          fi
+
+          echo "PR #$PR_NUMBER is ready for the Monday morning release window"
+
+          gh pr merge "$PR_NUMBER" -R jdx/aube --squash --auto || {
+            echo "Merge failed or PR not ready, will retry on the next run"
+            exit 0
+          }
+        env:
+          GH_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}

--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -19,8 +19,10 @@ jobs:
     steps:
       - name: Merge release into main
         run: |
-          PR_NUMBER=$(gh pr list -R jdx/aube --base main --state open --json number,headRefName,title,updatedAt \
-            --jq '[.[] | select(.headRefName | startswith("release-plz-")) | select(.title | startswith("chore: release "))] | sort_by(.updatedAt) | reverse | .[0].number // empty')
+          set -euo pipefail
+
+          PR_NUMBER=$(gh pr list -R jdx/aube --base main --state open --limit 100 --json number,headRefName,headRepositoryOwner,title,updatedAt \
+            --jq '[.[] | select(.headRefName | startswith("release-plz-")) | select(.headRepositoryOwner.login == "jdx") | select(.title | startswith("chore: release "))] | sort_by(.updatedAt) | reverse | .[0].number // empty')
           if [ -z "$PR_NUMBER" ]; then
             echo "No open release-plz release PR to main"
             exit 0

--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -6,11 +6,16 @@ on:
     - cron: "0 10 * * 1"
   workflow_dispatch:
 
+permissions: {}
+
+concurrency:
+  group: auto-merge-release
+  cancel-in-progress: false
+
 jobs:
   merge:
     if: github.repository == 'jdx/aube'
     runs-on: ubuntu-latest
-    permissions: {}
     steps:
       - name: Merge release into main
         run: |
@@ -29,10 +34,6 @@ jobs:
           fi
 
           echo "PR #$PR_NUMBER is ready for the Monday morning release window"
-
-          gh pr merge "$PR_NUMBER" -R jdx/aube --squash --auto || {
-            echo "Merge failed or PR not ready, will retry on the next run"
-            exit 0
-          }
+          gh pr merge "$PR_NUMBER" -R jdx/aube --squash --auto
         env:
           GH_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}

--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -10,11 +10,12 @@ jobs:
   merge:
     if: github.repository == 'jdx/aube'
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Merge release into main
         run: |
-          PR_NUMBER=$(gh pr list -R jdx/aube --base main --state open --json number,headRefName,title \
-            --jq '[.[] | select(.headRefName | startswith("release-plz-")) | select(.title | startswith("chore: release "))][0].number // empty')
+          PR_NUMBER=$(gh pr list -R jdx/aube --base main --state open --json number,headRefName,title,updatedAt \
+            --jq '[.[] | select(.headRefName | startswith("release-plz-")) | select(.title | startswith("chore: release "))] | sort_by(.updatedAt) | reverse | .[0].number // empty')
           if [ -z "$PR_NUMBER" ]; then
             echo "No open release-plz release PR to main"
             exit 0
@@ -23,7 +24,7 @@ jobs:
           BODY=$(gh pr view "$PR_NUMBER" -R jdx/aube --json body --jq '.body // ""')
           TRIMMED_BODY=$(echo "$BODY" | tr -d '[:space:]')
           if [ -z "$TRIMMED_BODY" ]; then
-            echo "PR #$PR_NUMBER has no description, never merging"
+            echo "Skipping merge: PR #$PR_NUMBER has an empty body; will retry on the next scheduled run"
             exit 0
           fi
 


### PR DESCRIPTION
## Summary

- Add an auto-merge workflow for release-plz release PRs.
- Run it Monday morning only at `0 10 * * 1` UTC, matching mise.

## Validation

- `actionlint .github/workflows/auto-merge-release.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automated merges to main depend on PR selection heuristics and a privileged token; a misidentified or premature merge would ship a release without a human click.
> 
> **Overview**
> Adds **`auto-merge-release`**, a GitHub Actions workflow that lands **release-plz** release PRs into **`main`** on a fixed weekly window instead of merging them as soon as they open.
> 
> It runs **Mondays at 10:00 UTC** (with **`workflow_dispatch`** for manual runs), only on **`jdx/aube`**, with a concurrency group so overlapping runs don’t cancel each other. The job uses **`gh`** and **`AUBE_GH_TOKEN`** to pick the newest open PR whose head is **`release-plz-*`**, title starts with **`chore: release `**, and owner is **`jdx`**. It **skips** merge if no PR matches or if the PR body is empty (whitespace-only), then **`gh pr merge --squash --auto`** when ready.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d21552c8ed6eef41e629ec586ffdb2e698a829a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->