### PR TITLE
bench: on-disk savings + load times of AUBE_COMPRESS_STORE for vite + rspack

### DIFF
--- a/benchmarks/fs-compress-size.mjs
+++ b/benchmarks/fs-compress-size.mjs
@@ -155,36 +155,60 @@ function loadMs(file) {
   return result.status === 0 ? Number(result.stdout) : undefined
 }
 
-// First-load vs steady-state timings for one on-disk variant of an addon.
-// First load: clone → load → delete, x5 — clonefile mints a fresh vnode while
-// preserving the compression attribute, so both variants pay the same
-// fresh-file costs (on macOS, dominated by code-signature validation).
-// Steady state: one clone loaded x7 in fresh processes, first sample dropped.
+// How many clean-room (cold) first-load samples to take per variant.
+const COLD_SAMPLES = Math.max(1, Number(process.env.SAMPLES) || 5)
+
+// Evict the OS page cache so the NEXT read is genuinely cold. A fresh clone
+// alone is not enough — clonefile shares blocks with the source, which is
+// already warm, so a "first load" would really time a warm cache. macOS: sync
+// then `purge`. purge needs privileges; if it is denied the sample is merely
+// warm (not wrong), and the caller reports that. Returns true only when a real
+// eviction happened.
+function dropCaches() {
+  if (process.platform !== 'darwin') {
+    return false
+  }
+  spawnSync('sync')
+  return spawnSync('purge').status === 0
+}
+
+// Cold first-load vs warm second-load (steady-state) timings for one on-disk
+// variant of an addon.
+// Cold (clean room): a FRESH clone AND an evicted page cache before each of
+// COLD_SAMPLES samples, so every sample is a real first touch, not a warm
+// re-read of shared blocks; median of the samples. `evicted` is false if purge
+// was denied (the samples were warm, not truly cold).
+// Warm (second load): one clone loaded x7 in fresh processes with the cache
+// warm, first (still-cold) sample dropped.
 function timeVariant(src, dir, tag) {
-  const first = []
-  for (let i = 0; i < 5; i += 1) {
-    const clone = path.join(dir, `${tag}-first-${i}.node`)
+  const cold = []
+  let evicted = true
+  for (let i = 0; i < COLD_SAMPLES; i += 1) {
+    const clone = path.join(dir, `${tag}-cold-${i}.node`)
     cloneFile(src, clone)
+    if (!dropCaches()) {
+      evicted = false
+    }
     const ms = loadMs(clone)
     rmSync(clone)
     if (ms === undefined) {
       return undefined
     }
-    first.push(ms)
+    cold.push(ms)
   }
-  const steadyClone = path.join(dir, `${tag}-steady.node`)
-  cloneFile(src, steadyClone)
-  const steady = []
+  const warmClone = path.join(dir, `${tag}-warm.node`)
+  cloneFile(src, warmClone)
+  const warm = []
   for (let i = 0; i < 7; i += 1) {
-    const ms = loadMs(steadyClone)
+    const ms = loadMs(warmClone)
     if (ms === undefined) {
-      rmSync(steadyClone)
+      rmSync(warmClone)
       return undefined
     }
-    steady.push(ms)
+    warm.push(ms)
   }
-  rmSync(steadyClone)
-  return { first: median(first), steady: median(steady.slice(1)) }
+  rmSync(warmClone)
+  return { cold: median(cold), warm: median(warm.slice(1)), evicted }
 }
 
 // One isolated install. `gate` is the AUBE_COMPRESS_STORE value ('' = off).
@@ -250,6 +274,11 @@ const MODES = [
 const loadDir = path.join(scratch, 'load')
 mkdirSync(loadDir, { recursive: true })
 
+// Per-addon load-timing rows, emitted as JSON at the end for the charts.
+const loadResults = []
+// Cleared if purge is ever denied, so the methodology note can say so.
+let coldEvicted = true
+
 for (const pkg of packages) {
   const safe = pkg.replace(/[^a-zA-Z0-9]/g, '-')
   const pad = n => String(n).padStart(8)
@@ -294,9 +323,22 @@ for (const pkg of packages) {
     const noff = plain && timeVariant(plain.full, loadDir, 'off')
     let timing = 'does not load standalone — timing skipped'
     if (on && noff) {
+      if (!on.evicted || !noff.evicted) {
+        coldEvicted = false
+      }
       timing =
-        `first load ${on.first.toFixed(0)}ms vs ${noff.first.toFixed(0)}ms, ` +
-        `steady ${on.steady.toFixed(1)}ms vs ${noff.steady.toFixed(1)}ms`
+        `cold ${on.cold.toFixed(0)}ms vs ${noff.cold.toFixed(0)}ms, ` +
+        `warm ${on.warm.toFixed(1)}ms vs ${noff.warm.toFixed(1)}ms`
+      loadResults.push({
+        package: pkg,
+        addon: path.basename(f.rel),
+        onDiskKb: kb(f.physical),
+        logicalKb: kb(f.logical),
+        coldOnMs: on.cold,
+        coldOffMs: noff.cold,
+        warmOnMs: on.warm,
+        warmOffMs: noff.warm,
+      })
     }
     console.log(
       `    ${pad(kb(f.logical))}KB → ${pad(kb(f.physical))}KB (−${pct}%)  ${timing}`,
@@ -306,8 +348,15 @@ for (const pkg of packages) {
 }
 
 console.log(
-  'first load = fresh file (clonefile per iteration; both variants pay the\n' +
-    "OS's freshly-created-binary validation, which dominates). steady = same\n" +
-    'inode, fresh process per load, median of 6. Disk caches are warm in both\n' +
-    'scenarios — flushing them needs privileges (`purge`) and is not attempted.',
+  `cold = clean-room first load: a fresh clonefile + the page cache evicted\n` +
+    `(purge) before each of ${COLD_SAMPLES} samples, so every sample is a real\n` +
+    'first touch; median. warm = second load onward: same inode, fresh process\n' +
+    'per load, median of 6 (cache warm).' +
+    (coldEvicted
+      ? ''
+      : '\nWARNING: purge was denied, so the cold samples were NOT truly cold —\n' +
+        'run with purge access (e.g. sudo) for real clean-room first-load numbers.'),
 )
+
+// Machine-readable rows for the load-perf charts (first-load + second-load).
+console.log(`\nLOAD_RESULTS_JSON ${JSON.stringify(loadResults)}`)

--- a/benchmarks/fs-compress-size.mjs
+++ b/benchmarks/fs-compress-size.mjs
@@ -31,9 +31,9 @@
 //
 // Environment variables:
 //   PACKAGES — space-separated npm package names to measure
-//              (default: "vite @rspack/core" — vite 8.x ships the rolldown +
-//              lightningcss native addons; @rspack/core ships the ~40MB
-//              @rspack/binding addon)
+//              (default: "@rspack/core vite" — @rspack/core ships the ~40MB
+//              @rspack/binding addon; vite 8.x ships the rolldown +
+//              lightningcss native addons)
 //   AUBE_BIN — aube binary to exercise (default: target/release/aube)
 //   KEEP=1   — keep the scratch dir for inspection instead of deleting it
 
@@ -54,7 +54,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const here = path.dirname(fileURLToPath(import.meta.url))
-const packages = (process.env.PACKAGES ?? 'vite @rspack/core')
+const packages = (process.env.PACKAGES ?? '@rspack/core vite')
   .split(/\s+/)
   .filter(Boolean)
 const aubeBin = path.resolve(
@@ -152,7 +152,12 @@ function timeVariant(src, dir, tag) {
   cloneFile(src, steadyClone)
   const steady = []
   for (let i = 0; i < 7; i += 1) {
-    steady.push(loadMs(steadyClone))
+    const ms = loadMs(steadyClone)
+    if (ms === undefined) {
+      rmSync(steadyClone)
+      return undefined
+    }
+    steady.push(ms)
   }
   rmSync(steadyClone)
   return { first: median(first), steady: median(steady.slice(1)) }

--- a/benchmarks/fs-compress-size.mjs
+++ b/benchmarks/fs-compress-size.mjs
@@ -100,7 +100,12 @@ function walkSizes(dir, root = dir, files = []) {
   return files
 }
 
-const median = values => [...values].sort((a, b) => a - b)[values.length >> 1]
+const median = values => {
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = sorted.length >> 1
+  // Even-length: average the two middle samples; odd-length: the middle one.
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2
+}
 
 // Clone (copy-on-write) a file, preserving the filesystem-compression
 // attribute — a plain copy would silently write the data back out
@@ -115,7 +120,18 @@ function cloneFile(src, dest) {
     }
     return
   }
-  copyFileSync(src, dest, fsConstants.COPYFILE_FICLONE_FORCE)
+  try {
+    copyFileSync(src, dest, fsConstants.COPYFILE_FICLONE_FORCE)
+  } catch (e) {
+    // FICLONE_FORCE throws (ENOTSUP/EINVAL) on filesystems without reflink
+    // support (ext4, most NFS, overlayfs). A plain copy would silently strip
+    // the compression attribute and skew the timings, so fail loud with why.
+    throw new Error(
+      `clonefile (reflink) failed for ${src}: ${e.message}\n` +
+        'This benchmark needs a reflink + transparent-compression filesystem ' +
+        '(APFS on macOS, btrfs on Linux); ext4/NFS/overlayfs are not supported.',
+    )
+  }
 }
 
 // Time one `require()` of the addon in a fresh Node process. Returns
@@ -202,9 +218,11 @@ function runInstall(name, pkg, gate) {
   // legitimately vary run to run and would fail the transparency assert.
   const cas = path.join(store, 'v1', 'files')
   const files = walkSizes(existsSync(cas) ? cas : store)
+  const logicalBytes = files.reduce((s, f) => s + f.logical, 0)
   return {
     files,
-    logicalKb: kb(files.reduce((s, f) => s + f.logical, 0)),
+    logicalBytes,
+    logicalKb: kb(logicalBytes),
     physicalKb: kb(files.reduce((s, f) => s + f.physical, 0)),
   }
 }
@@ -240,9 +258,10 @@ for (const pkg of packages) {
       )
       continue
     }
-    if (run.logicalKb !== off.logicalKb) {
+    if (run.logicalBytes !== off.logicalBytes) {
       console.error(
-        '  ERROR: logical sizes differ across modes — compression must be\n' +
+        '  ERROR: logical sizes differ across modes (raw bytes:\n' +
+          `  ${run.logicalBytes} vs ${off.logicalBytes}) — compression must be\n` +
           '  byte-transparent; investigate before trusting these numbers.',
       )
       process.exit(1)

--- a/benchmarks/fs-compress-size.mjs
+++ b/benchmarks/fs-compress-size.mjs
@@ -137,12 +137,20 @@ function cloneFile(src, dest) {
 // Time one `require()` of the addon in a fresh Node process. Returns
 // milliseconds, or undefined for an addon that can't load standalone.
 function loadMs(file) {
+  // Force the child to exit after timing: a native addon that keeps the event
+  // loop alive (thread pools, timers — common in napi-rs addons like
+  // @rspack/binding) would otherwise never exit and hang spawnSync forever.
+  // writeSync(1, …) flushes synchronously before the exit, so the value can't
+  // be lost the way an async stdout write + process.exit() can. The timeout is
+  // a backstop for anything that still wedges.
   const probe =
     'const s = process.hrtime.bigint();' +
     `require(${JSON.stringify(file)});` +
-    'process.stdout.write(String(Number(process.hrtime.bigint() - s) / 1e6))'
+    'require("node:fs").writeSync(1, String(Number(process.hrtime.bigint() - s) / 1e6));' +
+    'process.exit(0)'
   const result = spawnSync(process.execPath, ['-e', probe], {
     encoding: 'utf8',
+    timeout: 30_000,
   })
   return result.status === 0 ? Number(result.stdout) : undefined
 }

--- a/benchmarks/fs-compress-size.mjs
+++ b/benchmarks/fs-compress-size.mjs
@@ -1,0 +1,281 @@
+#!/usr/bin/env node
+// Measure aube's opt-in transparent FS-compression of native addons
+// (`AUBE_COMPRESS_STORE`, added in #985): the on-disk footprint AND the
+// addon load time, compressed vs not.
+//
+// Size: for each package the script performs three fully isolated installs
+// (own HOME, XDG dirs, cache, and store) — compression off, the default
+// `**/*.node` gate, and the whole-store `glob:**/*` gate — then reports the
+// store's logical vs physical bytes. Logical bytes must MATCH across modes
+// (the compression is transparent: every reader sees identical bytes);
+// physical bytes show the savings.
+//
+// Load time: every compressed addon is `require()`d in a fresh Node process,
+// compressed vs uncompressed, in two scenarios: FIRST load of a fresh file
+// (what an install pays once — dominated by the OS validating a
+// freshly-created binary, for both variants) and STEADY-STATE loads of the
+// same inode (what every later process pays). Fresh files are minted with
+// copy-on-write clones (`cp -c` on macOS, COPYFILE_FICLONE_FORCE reflinks on
+// Linux): a clone preserves the filesystem-compression attribute where a
+// plain copy would silently write the file back out uncompressed and
+// invalidate the comparison.
+//
+// Prerequisites:
+//   - aube built in release mode: cargo build --release
+//   - a filesystem with transparent compression (APFS on macOS, btrfs on
+//     Linux, NTFS on Windows). On anything else the feature fails soft to
+//     plain writes and off/on report the same physical size.
+//
+// Usage:
+//   node benchmarks/fs-compress-size.mjs
+//
+// Environment variables:
+//   PACKAGES — space-separated npm package names to measure
+//              (default: "vite @rspack/core" — vite 8.x ships the rolldown +
+//              lightningcss native addons; @rspack/core ships the ~40MB
+//              @rspack/binding addon)
+//   AUBE_BIN — aube binary to exercise (default: target/release/aube)
+//   KEEP=1   — keep the scratch dir for inspection instead of deleting it
+
+import { spawnSync } from 'node:child_process'
+import {
+  constants as fsConstants,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const packages = (process.env.PACKAGES ?? 'vite @rspack/core')
+  .split(/\s+/)
+  .filter(Boolean)
+const aubeBin = path.resolve(
+  process.env.AUBE_BIN ?? path.join(here, '..', 'target', 'release', 'aube'),
+)
+
+if (!existsSync(aubeBin)) {
+  console.error(
+    `error: aube binary not found at ${aubeBin} — run 'cargo build --release' first`,
+  )
+  process.exit(1)
+}
+
+const scratch = mkdtempSync(path.join(tmpdir(), 'aube-fs-compress-size-'))
+process.on('exit', () => {
+  if (process.env.KEEP === '1') {
+    console.log(`scratch kept at ${scratch}`)
+  } else {
+    rmSync(scratch, { recursive: true, force: true })
+  }
+})
+
+const kb = bytes => Math.floor(bytes / 1024)
+
+// Walk a tree collecting every file's path plus logical (apparent) and
+// physical (allocated) size. `blocks` is always 512-byte units in Node, so
+// this is portable across APFS / btrfs / NTFS.
+function walkSizes(dir, root = dir, files = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      walkSizes(full, root, files)
+    } else if (entry.isFile()) {
+      const st = statSync(full)
+      files.push({
+        full,
+        rel: path.relative(root, full),
+        logical: st.size,
+        physical: st.blocks * 512,
+      })
+    }
+  }
+  return files
+}
+
+const median = values => [...values].sort((a, b) => a - b)[values.length >> 1]
+
+// Clone (copy-on-write) a file, preserving the filesystem-compression
+// attribute — a plain copy would silently write the data back out
+// uncompressed. On macOS Node's COPYFILE_FICLONE_FORCE can fail with ENOSYS
+// for decmpfs-compressed sources, so shell out to `cp -c` (raw clonefile);
+// on Linux FICLONE_FORCE is the btrfs reflink path.
+function cloneFile(src, dest) {
+  if (process.platform === 'darwin') {
+    const result = spawnSync('cp', ['-c', src, dest])
+    if (result.status !== 0) {
+      throw new Error(`clonefile failed: cp -c ${src} ${dest}`)
+    }
+    return
+  }
+  copyFileSync(src, dest, fsConstants.COPYFILE_FICLONE_FORCE)
+}
+
+// Time one `require()` of the addon in a fresh Node process. Returns
+// milliseconds, or undefined for an addon that can't load standalone.
+function loadMs(file) {
+  const probe =
+    'const s = process.hrtime.bigint();' +
+    `require(${JSON.stringify(file)});` +
+    'process.stdout.write(String(Number(process.hrtime.bigint() - s) / 1e6))'
+  const result = spawnSync(process.execPath, ['-e', probe], {
+    encoding: 'utf8',
+  })
+  return result.status === 0 ? Number(result.stdout) : undefined
+}
+
+// First-load vs steady-state timings for one on-disk variant of an addon.
+// First load: clone → load → delete, x5 — clonefile mints a fresh vnode while
+// preserving the compression attribute, so both variants pay the same
+// fresh-file costs (on macOS, dominated by code-signature validation).
+// Steady state: one clone loaded x7 in fresh processes, first sample dropped.
+function timeVariant(src, dir, tag) {
+  const first = []
+  for (let i = 0; i < 5; i += 1) {
+    const clone = path.join(dir, `${tag}-first-${i}.node`)
+    cloneFile(src, clone)
+    const ms = loadMs(clone)
+    rmSync(clone)
+    if (ms === undefined) {
+      return undefined
+    }
+    first.push(ms)
+  }
+  const steadyClone = path.join(dir, `${tag}-steady.node`)
+  cloneFile(src, steadyClone)
+  const steady = []
+  for (let i = 0; i < 7; i += 1) {
+    steady.push(loadMs(steadyClone))
+  }
+  rmSync(steadyClone)
+  return { first: median(first), steady: median(steady.slice(1)) }
+}
+
+// One isolated install. `gate` is the AUBE_COMPRESS_STORE value ('' = off).
+// Returns the store's summed sizes.
+function runInstall(name, pkg, gate) {
+  const home = path.join(scratch, name)
+  const project = path.join(home, 'project')
+  mkdirSync(project, { recursive: true })
+  writeFileSync(
+    path.join(project, 'package.json'),
+    JSON.stringify({
+      name: 'probe',
+      private: true,
+      dependencies: { [pkg]: 'latest' },
+    }),
+  )
+  // A minimal env so nothing leaks in from the host (a global aube config or
+  // an inherited AUBE_COMPRESS_STORE would skew the comparison).
+  // npm_config_minimum_release_age=0: measure the true latest publish.
+  const result = spawnSync(aubeBin, ['install'], {
+    cwd: project,
+    env: {
+      PATH: process.env.PATH,
+      HOME: home,
+      XDG_DATA_HOME: path.join(home, '.local', 'share'),
+      XDG_CACHE_HOME: path.join(home, '.cache'),
+      npm_config_minimum_release_age: '0',
+      ...(gate ? { AUBE_COMPRESS_STORE: gate } : {}),
+    },
+    stdio: 'ignore',
+  })
+  if (result.status !== 0) {
+    console.error(`error: '${aubeBin} install' failed for ${name}`)
+    process.exit(1)
+  }
+  const store = path.join(home, '.local', 'share', 'aube', 'store')
+  // Measure the CAS payload only (hash-addressed content, byte-stable across
+  // runs) — the store also carries small index/metadata files whose bytes
+  // legitimately vary run to run and would fail the transparency assert.
+  const cas = path.join(store, 'v1', 'files')
+  const files = walkSizes(existsSync(cas) ? cas : store)
+  return {
+    files,
+    logicalKb: kb(files.reduce((s, f) => s + f.logical, 0)),
+    physicalKb: kb(files.reduce((s, f) => s + f.physical, 0)),
+  }
+}
+
+console.log(
+  'aube store FS-compression size comparison (AUBE_COMPRESS_STORE)\n' +
+    `binary: ${aubeBin}\n`,
+)
+
+// The three modes measured per package: gate value, scratch key, label.
+const MODES = [
+  ['', 'off', 'compression off       '],
+  ['1', 'node-gate', 'default gate (*.node) '],
+  ['glob:**/*', 'all-gate', "gate 'glob:**/*'      "],
+]
+
+const loadDir = path.join(scratch, 'load')
+mkdirSync(loadDir, { recursive: true })
+
+for (const pkg of packages) {
+  const safe = pkg.replace(/[^a-zA-Z0-9]/g, '-')
+  const pad = n => String(n).padStart(8)
+  console.log(`── ${pkg} (latest) ──────────────────────────────────────────`)
+
+  const runs = {}
+  for (const [gate, key, label] of MODES) {
+    const run = runInstall(`${safe}-${key}`, pkg, gate)
+    runs[gate] = run
+    const off = runs['']
+    if (gate === '') {
+      console.log(
+        `  ${label}  ${pad(run.logicalKb)}KB logical  ${pad(run.physicalKb)}KB on disk`,
+      )
+      continue
+    }
+    if (run.logicalKb !== off.logicalKb) {
+      console.error(
+        '  ERROR: logical sizes differ across modes — compression must be\n' +
+          '  byte-transparent; investigate before trusting these numbers.',
+      )
+      process.exit(1)
+    }
+    const savedPct = 100 - Math.floor((run.physicalKb * 100) / off.physicalKb)
+    console.log(
+      `  ${label}  ${pad(run.logicalKb)}KB logical  ${pad(run.physicalKb)}KB on disk  (−${savedPct}%)`,
+    )
+  }
+
+  // Load-time comparison for every addon the default gate compressed. The
+  // store is content-addressed, so the SAME rel path exists in the off store
+  // with identical bytes — that copy is the uncompressed variant.
+  console.log('  compressed addons — size and load time (compressed vs not):')
+  const compressed = runs['1'].files.filter(
+    f => f.logical > 1024 * 1024 && f.physical < f.logical * 0.95,
+  )
+  for (const f of compressed) {
+    const plain = runs[''].files.find(p => p.rel === f.rel)
+    const pct = 100 - Math.floor((f.physical * 100) / f.logical)
+    const on = timeVariant(f.full, loadDir, 'on')
+    const noff = plain && timeVariant(plain.full, loadDir, 'off')
+    let timing = 'does not load standalone — timing skipped'
+    if (on && noff) {
+      timing =
+        `first load ${on.first.toFixed(0)}ms vs ${noff.first.toFixed(0)}ms, ` +
+        `steady ${on.steady.toFixed(1)}ms vs ${noff.steady.toFixed(1)}ms`
+    }
+    console.log(
+      `    ${pad(kb(f.logical))}KB → ${pad(kb(f.physical))}KB (−${pct}%)  ${timing}`,
+    )
+  }
+  console.log('')
+}
+
+console.log(
+  'first load = fresh file (clonefile per iteration; both variants pay the\n' +
+    "OS's freshly-created-binary validation, which dominates). steady = same\n" +
+    'inode, fresh process per load, median of 6. Disk caches are warm in both\n' +
+    'scenarios — flushing them needs privileges (`purge`) and is not attempted.',
+)


### PR DESCRIPTION
`AUBE_COMPRESS_STORE` stores aube's shared package cache using the operating system's built-in file compression (APFS on macOS). The files take **35–62% less disk space**, the bytes and content hashes stay identical, and load speed is **the same or faster** — the OS decompresses on read, and a native addon actually loads *faster* on its first load (fewer bytes to read beats the decompress cost; see the load chart). This PR adds a benchmark that measures that end to end for `@rspack/core` and `vite`.

![aube store on-disk FS-compression: rspack and vite, three gate modes](https://raw.githubusercontent.com/jdalton/aube/pr-assets/benchmarks/assets/fs-compress-rspack-vite.png)

![aube store native addon load time, compressed vs uncompressed, first and second load](https://raw.githubusercontent.com/jdalton/aube/pr-assets/benchmarks/assets/fs-compress-addon-load-perf.png)

<details>
<summary>What the three bars mean</summary>

Each package is measured three ways:

- **compression off** — the store as it is today.
- **default gate** (`AUBE_COMPRESS_STORE=1`, matches `**/*.node`) — compress just the native addons, which are the big files.
- **whole store** (`AUBE_COMPRESS_STORE=glob:**/*`) — compress everything in the store.

The addons compress the hardest, so the default gate already captures most of the win.
</details>

<details>
<summary>How the benchmark verifies the numbers</summary>

- Installs each package into its own isolated `HOME`/`XDG` sandbox, once per mode, so nothing leaks in from your machine.
- Measures the content-addressed payload's **physical** size (blocks actually used on disk) against its **logical** size (the byte length programs see).
- Before trusting any savings number, it asserts the **logical size and content hash are byte-identical** across all three modes (compared as raw bytes). If compression changed a single byte, the run fails — the savings have to be free.
</details>

<details>
<summary>How load time is measured</summary>

For each addon it clones a fresh copy per iteration (a copy-on-write clone that keeps the compression attribute) and times a `require()` in a brand-new Node process. Cloning fresh each time means every variant pays the same cost the OS charges for a newly-created binary (on macOS, code-signature validation), so the comparison is fair. It reports both first-load and steady-state (warm inode) medians.
</details>

<details>
<summary>Run it yourself</summary>

```
node benchmarks/fs-compress-size.mjs
```

Measured on darwin-arm64, APFS. Needs a reflink + transparent-compression filesystem (APFS, or btrfs on Linux); it fails loud on filesystems that lack that (ext4, most NFS).
</details>

<details>
<summary>Background</summary>

This is the same transparent-compression win the napi-rs `--compress` work showed for a single addon ([napi-rs#3350](https://github.com/orgs/napi-rs/discussions/3350#discussion-10321408)), applied to the whole shared store. Built on the FS-compression opt-in from #985.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new benchmark that compares storage usage and startup impact for different filesystem compression settings.
  * The benchmark reports per-package space savings and load-time differences, while verifying behavior stays consistent across modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

