### PR TITLE
fix(deps): bump crossbeam-epoch to 0.9.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1209,9 +1209,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary
- bump crossbeam-epoch in Cargo.lock from 0.9.18 to 0.9.20
- resolves the cargo audit failure for RUSTSEC-2026-0204 seen on #1004

## Tests
- mise x cargo:cargo-audit@0.22.1 -- cargo audit --deny warnings
- cargo test

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level dependency-only change with no direct code edits; typical low risk for a security advisory fix.
> 
> **Overview**
> Updates the **crossbeam-epoch** lockfile entry from **0.9.18** to **0.9.20** so `cargo audit` no longer flags **RUSTSEC-2026-0204**.
> 
> No application source changes—only `Cargo.lock` version and checksum for this transitive dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 875ebad6036f0d423d5e3df07d8fbac6a34f3ac3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->