### PR TITLE
ci: gate autorelease on fix and feat commits

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -2,8 +2,7 @@ name: auto-merge-release
 
 on:
   schedule:
-    # 10:00 UTC = 4am CST (winter) / 5am CDT (summer)
-    - cron: "0 10 * * 1"
+    - cron: "0 10 * * *"
   workflow_dispatch:
 
 permissions: {}
@@ -27,6 +26,14 @@ jobs:
           latest_tag=$(git tag --list 'v[0-9]*' --sort=-v:refname | head -1 || true)
           if [ -n "$latest_tag" ]; then
             range="${latest_tag}..HEAD"
+            tag_time=$(git log -1 --format=%ct "$latest_tag")
+            now=$(date +%s)
+            min_age=$((7 * 24 * 60 * 60))
+            age=$((now - tag_time))
+            if [ "$age" -lt "$min_age" ]; then
+              echo "Latest release ${latest_tag} is less than 7 days old; not auto-merging release PRs"
+              exit 0
+            fi
           else
             range="HEAD"
           fi
@@ -49,7 +56,7 @@ jobs:
             exit 0
           fi
 
-          echo "PR #$PR_NUMBER is ready for the Monday morning release window"
+          echo "PR #$PR_NUMBER is ready for the daily release window"
           gh pr merge "$PR_NUMBER" -R jdx/aube --squash --auto
         env:
           GH_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}

--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -15,18 +15,21 @@ jobs:
   merge:
     if: github.repository == 'jdx/aube'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Merge release into main
         run: |
           set -euo pipefail
 
-          latest_tag=$(git tag --list 'v[0-9]*' --sort=-v:refname | head -1 || true)
+          latest_tag=$(git describe --tags --match 'v[0-9]*' --abbrev=0 || true)
           if [ -n "$latest_tag" ]; then
             range="${latest_tag}..HEAD"
-            tag_time=$(git log -1 --format=%ct "$latest_tag")
+            tag_time=$(git for-each-ref --format='%(creatordate:unix)' "refs/tags/$latest_tag")
             now=$(date +%s)
             min_age=$((7 * 24 * 60 * 60))
             age=$((now - tag_time))

--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -21,28 +21,37 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          fetch-tags: true
           persist-credentials: false
       - name: Merge release into main
         run: |
           set -euo pipefail
 
-          latest_tag=$(git describe --tags --match 'v[0-9]*' --abbrev=0 || true)
-          if [ -n "$latest_tag" ]; then
-            range="${latest_tag}..HEAD"
-            tag_time=$(git for-each-ref --format='%(creatordate:unix)' "refs/tags/$latest_tag")
-            now=$(date +%s)
-            min_age=$((7 * 24 * 60 * 60))
-            age=$((now - tag_time))
-            if [ "$age" -lt "$min_age" ]; then
-              echo "Latest release ${latest_tag} is less than 7 days old; not auto-merging release PRs"
-              exit 0
+          if [ "${GITHUB_EVENT_NAME:-}" != "workflow_dispatch" ]; then
+            latest_tag=$(git describe --tags --match 'v[0-9]*' --abbrev=0 || true)
+            if [ -n "$latest_tag" ]; then
+              range="${latest_tag}..HEAD"
+              tag_time=$(git for-each-ref --format='%(creatordate:unix)' "refs/tags/$latest_tag")
+              now=$(date +%s)
+              min_age=$((7 * 24 * 60 * 60))
+              age=$((now - tag_time))
+              if [ "$age" -lt "$min_age" ]; then
+                echo "Latest release ${latest_tag} is less than 7 days old; not auto-merging release PRs"
+                exit 0
+              fi
+            else
+              echo "No v[0-9]* release tag found; allowing bootstrap release"
+              range=""
+            fi
+            if [ -n "$range" ]; then
+              commit_subjects=$(git log --format=%s "$range")
+              if ! grep -Eq '^(fix|feat)(\([^)]+\))?!?: ' <<<"$commit_subjects"; then
+                echo "No pending fix/feat commits since the latest release; not auto-merging release PRs"
+                exit 0
+              fi
             fi
           else
-            range="HEAD"
-          fi
-          if ! git log --format=%s "$range" | grep -Eq '^(fix|feat)(\([^)]+\))?!?: '; then
-            echo "No pending fix/feat commits since the latest release; not auto-merging release PRs"
-            exit 0
+            echo "Manual dispatch; skipping release cadence guards"
           fi
 
           PR_NUMBER=$(gh pr list -R jdx/aube --base main --state open --limit 100 --json number,headRefName,headRepositoryOwner,title,updatedAt \

--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -17,9 +17,23 @@ jobs:
     if: github.repository == 'jdx/aube'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
       - name: Merge release into main
         run: |
           set -euo pipefail
+
+          latest_tag=$(git tag --list 'v[0-9]*' --sort=-v:refname | head -1 || true)
+          if [ -n "$latest_tag" ]; then
+            range="${latest_tag}..HEAD"
+          else
+            range="HEAD"
+          fi
+          if ! git log --format=%s "$range" | grep -Eq '^(fix|feat)(\([^)]+\))?!?: '; then
+            echo "No pending fix/feat commits since the latest release; not auto-merging release PRs"
+            exit 0
+          fi
 
           PR_NUMBER=$(gh pr list -R jdx/aube --base main --state open --limit 100 --json number,headRefName,headRepositoryOwner,title,updatedAt \
             --jq '[.[] | select(.headRefName | startswith("release-plz-")) | select(.headRepositoryOwner.login == "jdx") | select(.title | startswith("chore: release "))] | sort_by(.updatedAt) | reverse | .[0].number // empty')

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: "0 0 * * *"
   workflow_dispatch:
 
 permissions:
@@ -15,44 +13,6 @@ env:
   CARGO_INCREMENTAL: "0"
 
 jobs:
-  pending-release:
-    runs-on: ubuntu-latest
-    outputs:
-      has_release_commits: ${{ steps.commits.outputs.has_release_commits }}
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
-      - name: Check release age and fix/feat commits
-        id: commits
-        run: |
-          set -euo pipefail
-
-          latest_tag=$(git tag --list 'v[0-9]*' --sort=-v:refname | head -1 || true)
-          if [ -n "$latest_tag" ]; then
-            range="${latest_tag}..HEAD"
-            echo "Checking pending commits since ${latest_tag}"
-            tag_time=$(git log -1 --format=%ct "$latest_tag")
-            now=$(date +%s)
-            min_age=$((7 * 24 * 60 * 60))
-            age=$((now - tag_time))
-            if [ "$age" -lt "$min_age" ]; then
-              echo "Latest release ${latest_tag} is less than 7 days old; skipping autorelease."
-              echo "has_release_commits=false" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          else
-            range="HEAD"
-            echo "No v* release tag found; checking all commits"
-          fi
-
-          if git log --format=%s "$range" | grep -Eq '^(fix|feat)(\([^)]+\))?!?: '; then
-            echo "has_release_commits=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "No pending fix/feat commits; skipping autorelease."
-            echo "has_release_commits=false" >> "$GITHUB_OUTPUT"
-          fi
-
   # On every push to main: run `release-plz release`. If the current
   # workspace version has no tag yet (because the release PR was just
   # merged), this tags `aube` as `v<version>`, opens a draft GitHub
@@ -61,8 +21,6 @@ jobs:
   # no-op.
   release-plz-release:
     name: release-plz release
-    needs: pending-release
-    if: needs.pending-release.outputs.has_release_commits == 'true'
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
     # Two commits landing on main in quick succession must not double-publish.
     concurrency:
@@ -261,8 +219,6 @@ jobs:
   # an out-of-date `aube.usage.kdl`.
   release-plz-pr:
     name: release-plz PR
-    needs: pending-release
-    if: needs.pending-release.outputs.has_release_commits == 'true'
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
     permissions:
       contents: write

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 permissions:
@@ -21,7 +23,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      - name: Check for fix/feat commits since the latest release
+      - name: Check release age and fix/feat commits
         id: commits
         run: |
           set -euo pipefail
@@ -30,6 +32,15 @@ jobs:
           if [ -n "$latest_tag" ]; then
             range="${latest_tag}..HEAD"
             echo "Checking pending commits since ${latest_tag}"
+            tag_time=$(git log -1 --format=%ct "$latest_tag")
+            now=$(date +%s)
+            min_age=$((7 * 24 * 60 * 60))
+            age=$((now - tag_time))
+            if [ "$age" -lt "$min_age" ]; then
+              echo "Latest release ${latest_tag} is less than 7 days old; skipping autorelease."
+              echo "has_release_commits=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           else
             range="HEAD"
             echo "No v* release tag found; checking all commits"

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -13,6 +13,35 @@ env:
   CARGO_INCREMENTAL: "0"
 
 jobs:
+  pending-release:
+    runs-on: ubuntu-latest
+    outputs:
+      has_release_commits: ${{ steps.commits.outputs.has_release_commits }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - name: Check for fix/feat commits since the latest release
+        id: commits
+        run: |
+          set -euo pipefail
+
+          latest_tag=$(git tag --list 'v[0-9]*' --sort=-v:refname | head -1 || true)
+          if [ -n "$latest_tag" ]; then
+            range="${latest_tag}..HEAD"
+            echo "Checking pending commits since ${latest_tag}"
+          else
+            range="HEAD"
+            echo "No v* release tag found; checking all commits"
+          fi
+
+          if git log --format=%s "$range" | grep -Eq '^(fix|feat)(\([^)]+\))?!?: '; then
+            echo "has_release_commits=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No pending fix/feat commits; skipping autorelease."
+            echo "has_release_commits=false" >> "$GITHUB_OUTPUT"
+          fi
+
   # On every push to main: run `release-plz release`. If the current
   # workspace version has no tag yet (because the release PR was just
   # merged), this tags `aube` as `v<version>`, opens a draft GitHub
@@ -21,6 +50,8 @@ jobs:
   # no-op.
   release-plz-release:
     name: release-plz release
+    needs: pending-release
+    if: needs.pending-release.outputs.has_release_commits == 'true'
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
     # Two commits landing on main in quick succession must not double-publish.
     concurrency:
@@ -219,6 +250,8 @@ jobs:
   # an out-of-date `aube.usage.kdl`.
   release-plz-pr:
     name: release-plz PR
+    needs: pending-release
+    if: needs.pending-release.outputs.has_release_commits == 'true'
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
     permissions:
       contents: write


### PR DESCRIPTION
## What changed

- Adds a preflight check to the release-plz workflow that looks for pending `fix` or `feat` conventional commits since the latest `v[0-9]*` release tag.
- Skips both the release and release-PR jobs when no release-worthy commits are pending.
- Adds the same guard before the scheduled release PR auto-merge.

## Why

This keeps automatic releases from running for maintenance-only commit ranges, while still allowing real fix/feature changes to publish automatically.

## Validation

- `actionlint .github/workflows/release-plz.yml .github/workflows/auto-merge-release.yml`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes to when and whether release-plz PRs auto-merge; no application runtime impact.
> 
> **Overview**
> The **auto-merge-release** workflow now runs **daily** (10:00 UTC) instead of only on Mondays, and the merge job **checks out the repo** with full history and tags so release guards can run in-shell.
> 
> On **scheduled** runs (not `workflow_dispatch`), it **exits without merging** when the latest `v[0-9]*` tag is **younger than 7 days**, or when there are **no `fix`/`feat` conventional commits** (including breaking `!`) since that tag; manual dispatch skips those guards. Log copy now refers to a **daily** release window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 640fe72a75d6fbe75b060d23171ec9e34a02f747. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->