### PR TITLE
fix(publish): redact inline registry credentials

### DIFF
--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -472,9 +472,10 @@ async fn publish_one(
             });
         }
         return Err(miette!(
-            "{}: {name}@{version} is already on {registry_url}\n\
+            "{}: {name}@{version} is already on {}\n\
              help: pass --force to republish (the registry must allow it; npm's public registry does not)",
-            aube_util::cmd("publish")
+            aube_util::cmd("publish"),
+            aube_util::url::redact_url(&registry_url),
         ));
     }
 
@@ -740,7 +741,12 @@ async fn exchange_npm_oidc_token(
         .send()
         .await
         .into_diagnostic()
-        .wrap_err_with(|| format!("failed to exchange npm OIDC token at {endpoint}"))?;
+        .wrap_err_with(|| {
+            format!(
+                "failed to exchange npm OIDC token at {}",
+                aube_util::url::redact_url(&endpoint)
+            )
+        })?;
     if !resp.status().is_success() {
         tracing::debug!(
             status = %resp.status(),
@@ -932,7 +938,7 @@ fn emit_outcome_line(outcome: &PublishOutcome) {
                 "+ {}@{} (dry run, would PUT to {})",
                 outcome.name,
                 outcome.version,
-                put_url(&outcome.registry_url, &outcome.name)
+                aube_util::url::redact_url(&put_url(&outcome.registry_url, &outcome.name))
             );
             if let Some(archive) = &outcome.archive {
                 for f in &archive.files {
@@ -1608,6 +1614,16 @@ mod tests {
         assert_eq!(
             registry_uri_key_pub("https://registry.npmjs.org/"),
             "//registry.npmjs.org/"
+        );
+    }
+
+    #[test]
+    fn publish_target_display_redacts_inline_registry_credentials() {
+        let target = put_url("https://user:secret@registry.example/", "@scope/pkg");
+
+        assert_eq!(
+            aube_util::url::redact_url(&target),
+            "https://***@registry.example/%40scope%2fpkg"
         );
     }
 }

--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -934,12 +934,7 @@ fn emit_outcome(outcome: &PublishOutcome, as_json: bool) -> miette::Result<()> {
 fn emit_outcome_line(outcome: &PublishOutcome) {
     match outcome.status {
         PublishStatus::DryRun => {
-            println!(
-                "+ {}@{} (dry run, would PUT to {})",
-                outcome.name,
-                outcome.version,
-                aube_util::url::redact_url(&put_url(&outcome.registry_url, &outcome.name))
-            );
+            println!("{}", dry_run_outcome_line(outcome));
             if let Some(archive) = &outcome.archive {
                 for f in &archive.files {
                     println!("  {f}");
@@ -956,6 +951,15 @@ fn emit_outcome_line(outcome: &PublishOutcome) {
             );
         }
     }
+}
+
+fn dry_run_outcome_line(outcome: &PublishOutcome) -> String {
+    format!(
+        "+ {}@{} (dry run, would PUT to {})",
+        outcome.name,
+        outcome.version,
+        aube_util::url::redact_url(&put_url(&outcome.registry_url, &outcome.name))
+    )
 }
 
 fn emit_json_outcomes(outcomes: &[PublishOutcome]) -> miette::Result<()> {
@@ -1619,11 +1623,17 @@ mod tests {
 
     #[test]
     fn publish_target_display_redacts_inline_registry_credentials() {
-        let target = put_url("https://user:secret@registry.example/", "@scope/pkg");
+        let outcome = PublishOutcome {
+            name: "@scope/pkg".to_string(),
+            version: "1.0.0".to_string(),
+            registry_url: "https://user:secret@registry.example/".to_string(),
+            archive: None,
+            status: PublishStatus::DryRun,
+        };
 
         assert_eq!(
-            aube_util::url::redact_url(&target),
-            "https://***@registry.example/%40scope%2fpkg"
+            dry_run_outcome_line(&outcome),
+            "+ @scope/pkg@1.0.0 (dry run, would PUT to https://***@registry.example/@scope%2Fpkg)"
         );
     }
 }


### PR DESCRIPTION
## Summary
- redact registry URLs in publish diagnostics and dry-run output
- redact the OIDC token-exchange endpoint
- cover scoped package target rendering with inline credentials

## Tests
- `cargo fmt --check`
- `cargo test -p aube publish`

*This pull request was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change; publish and auth behavior are unchanged.
> 
> **Overview**
> Publish user-facing output and errors no longer echo raw registry URLs when those URLs embed credentials (e.g. `user:secret@host`).
> 
> The **already published** error, **OIDC token exchange** failure wrapper, and **`--dry-run`** “would PUT to …” line now pass URLs through `aube_util::url::redact_url`. Dry-run text is centralized in `dry_run_outcome_line`, with a unit test asserting scoped package targets redact inline auth while keeping the encoded path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5accc1245e41343a2752229ad819fcaa40dbb3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive registry credentials are now redacted from publish command messages, including dry-run output and authentication error details.
  * Improved protection for URLs shown when packages are already present in a registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->