### PR TITLE
feat(scripts): allow git repository build approvals

### DIFF
--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -499,6 +499,18 @@ impl LockedPackage {
             .map(|source| format!("{}@{}", self.registry_name(), source.specifier()))
     }
 
+    /// Repository-wide approval key for a Git-backed package source.
+    ///
+    /// Unlike [`Self::source_approval_key`], this deliberately omits the
+    /// resolved commit. It is only used for an explicit `allowBuilds`
+    /// `git+<repository>` rule, never for package-name approval.
+    pub fn git_repository_approval_key(&self) -> Option<String> {
+        let LocalSource::Git(git) = self.local_source.as_ref()? else {
+            return None;
+        };
+        Some(format!("{}@git+{}", self.registry_name(), git.url))
+    }
+
     /// Declared peer ranges with pnpm's meta-only peers folded in as `*`.
     ///
     /// pnpm records a `peerDependencies: { x: '*' }` entry for every
@@ -586,6 +598,23 @@ mod locked_package_tests {
         assert_eq!(
             pkg.source_approval_key(),
             Some("pkg@https://example.com/pkg.tgz".to_string())
+        );
+    }
+
+    #[test]
+    fn git_repository_approval_key_omits_resolved_commit() {
+        let mut pkg = pkg();
+        pkg.local_source = Some(LocalSource::Git(GitSource {
+            url: "https://github.com/acme/pkg.git".to_string(),
+            committish: Some("main".to_string()),
+            resolved: "0123456789012345678901234567890123456789".to_string(),
+            integrity: None,
+            subpath: None,
+        }));
+
+        assert_eq!(
+            pkg.git_repository_approval_key(),
+            Some("pkg@git+https://github.com/acme/pkg.git".to_string())
         );
     }
 }

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -508,7 +508,11 @@ impl LockedPackage {
         let LocalSource::Git(git) = self.local_source.as_ref()? else {
             return None;
         };
-        Some(format!("{}@git+{}", self.registry_name(), git.url))
+        Some(format!(
+            "{}@git+{}",
+            self.registry_name(),
+            git.url.strip_prefix("git+").unwrap_or(&git.url)
+        ))
     }
 
     /// Declared peer ranges with pnpm's meta-only peers folded in as `*`.
@@ -615,6 +619,23 @@ mod locked_package_tests {
         assert_eq!(
             pkg.git_repository_approval_key(),
             Some("pkg@git+https://github.com/acme/pkg.git".to_string())
+        );
+    }
+
+    #[test]
+    fn git_repository_approval_key_normalizes_an_existing_git_prefix() {
+        let mut pkg = pkg();
+        pkg.local_source = Some(LocalSource::Git(GitSource {
+            url: "git+ssh://git@github.com/acme/pkg.git".to_string(),
+            committish: None,
+            resolved: "0123456789012345678901234567890123456789".to_string(),
+            integrity: None,
+            subpath: None,
+        }));
+
+        assert_eq!(
+            pkg.git_repository_approval_key(),
+            Some("pkg@git+ssh://git@github.com/acme/pkg.git".to_string())
         );
     }
 }

--- a/crates/aube-scripts/src/policy.rs
+++ b/crates/aube-scripts/src/policy.rs
@@ -13,6 +13,8 @@
 //! - `"esbuild"` — bare name, matches every version of the package
 //! - `"esbuild@0.19.0"` — exact version match
 //! - `"esbuild@0.19.0 || 0.20.0"` — exact version union
+//! - `"esbuild@git+https://github.com/acme/esbuild.git"` — every commit
+//!   from one Git repository
 //!
 //! Semver ranges are intentionally *not* supported, matching pnpm's
 //! `expandPackageVersionSpecs` behavior: if you pin a version in the
@@ -56,6 +58,12 @@ pub struct BuildPolicy {
     /// entries so a typo like `pkg@latest` still warns.
     allowed_sources: HashSet<String>,
     denied_sources: HashSet<String>,
+    /// Git repository approval keys such as
+    /// `pkg@git+https://github.com/acme/pkg.git`. These intentionally omit
+    /// the resolved commit so an audited branch may advance without a new
+    /// approval, while never approving a different repository by name alone.
+    allowed_git_repositories: HashSet<String>,
+    denied_git_repositories: HashSet<String>,
     /// Bare-name patterns containing `*` wildcards. Checked with a
     /// linear scan after the exact-match sets; wildcard rules are rare
     /// enough that the linear pass is cheaper than building an
@@ -101,6 +109,8 @@ impl BuildPolicy {
         let mut denied = HashSet::new();
         let mut allowed_sources = HashSet::new();
         let mut denied_sources = HashSet::new();
+        let mut allowed_git_repositories = HashSet::new();
+        let mut denied_git_repositories = HashSet::new();
         let mut allowed_wildcards = Vec::new();
         let mut denied_wildcards = Vec::new();
         let mut warnings = Vec::new();
@@ -139,7 +149,12 @@ impl BuildPolicy {
                     } else {
                         &mut denied_sources
                     };
-                    sort_entries(expanded, exact, source, wild);
+                    let git_repositories = if bool_value {
+                        &mut allowed_git_repositories
+                    } else {
+                        &mut denied_git_repositories
+                    };
+                    sort_entries(expanded, exact, source, git_repositories, wild);
                 }
                 Err(e) => warnings.push(e),
             }
@@ -156,6 +171,7 @@ impl BuildPolicy {
                     expanded,
                     &mut allowed,
                     &mut allowed_sources,
+                    &mut allowed_git_repositories,
                     &mut allowed_wildcards,
                 ),
                 Err(e) => warnings.push(e),
@@ -167,6 +183,7 @@ impl BuildPolicy {
                     expanded,
                     &mut denied,
                     &mut denied_sources,
+                    &mut denied_git_repositories,
                     &mut denied_wildcards,
                 ),
                 Err(e) => warnings.push(e),
@@ -180,6 +197,8 @@ impl BuildPolicy {
                 denied,
                 allowed_sources,
                 denied_sources,
+                allowed_git_repositories,
+                denied_git_repositories,
                 allowed_wildcards,
                 denied_wildcards,
             },
@@ -191,6 +210,7 @@ impl BuildPolicy {
     pub fn denylist(denied_patterns: &[String]) -> (Self, Vec<BuildPolicyError>) {
         let mut denied = HashSet::new();
         let mut denied_sources = HashSet::new();
+        let mut denied_git_repositories = HashSet::new();
         let mut denied_wildcards = Vec::new();
         let mut warnings = Vec::new();
         for pattern in denied_patterns {
@@ -199,6 +219,7 @@ impl BuildPolicy {
                     expanded,
                     &mut denied,
                     &mut denied_sources,
+                    &mut denied_git_repositories,
                     &mut denied_wildcards,
                 ),
                 Err(e) => warnings.push(e),
@@ -211,6 +232,8 @@ impl BuildPolicy {
                 denied,
                 allowed_sources: HashSet::new(),
                 denied_sources,
+                allowed_git_repositories: HashSet::new(),
+                denied_git_repositories,
                 allowed_wildcards: Vec::new(),
                 denied_wildcards,
             },
@@ -237,6 +260,18 @@ impl BuildPolicy {
         version: &str,
         source_key: Option<&str>,
     ) -> AllowDecision {
+        self.decide_package_with_git_repository(name, version, source_key, None)
+    }
+
+    /// Decide whether a package may run lifecycle scripts, accepting an
+    /// optional repository identity for Git-backed packages.
+    pub fn decide_package_with_git_repository(
+        &self,
+        name: &str,
+        version: &str,
+        source_key: Option<&str>,
+        git_repository_key: Option<&str>,
+    ) -> AllowDecision {
         // Reusable thread-local buffer for the `name@version` probe key.
         // Avoids a `format!` allocation on every call — ~2k throwaway
         // Strings on a typical install otherwise.
@@ -254,6 +289,11 @@ impl BuildPolicy {
         {
             return AllowDecision::Deny;
         }
+        if let Some(git_repository_key) = git_repository_key
+            && self.denied_git_repositories.contains(git_repository_key)
+        {
+            return AllowDecision::Deny;
+        }
         // Build the `name@version` probe key once and answer both the
         // deny and the allow lookups from a single buffer borrow.
         let (denied_versioned, allowed_versioned) = KEY_BUF.with(|buf| {
@@ -268,6 +308,11 @@ impl BuildPolicy {
             return AllowDecision::Deny;
         }
         if self.allow_all {
+            return AllowDecision::Allow;
+        }
+        if let Some(git_repository_key) = git_repository_key
+            && self.allowed_git_repositories.contains(git_repository_key)
+        {
             return AllowDecision::Allow;
         }
         if let Some(source_key) = source_key {
@@ -293,6 +338,7 @@ impl BuildPolicy {
         self.allow_all
             || !self.allowed.is_empty()
             || !self.allowed_sources.is_empty()
+            || !self.allowed_git_repositories.is_empty()
             || !self.allowed_wildcards.is_empty()
     }
 
@@ -306,6 +352,10 @@ impl BuildPolicy {
             .extend(other.allowed_sources.iter().cloned());
         self.denied_sources
             .extend(other.denied_sources.iter().cloned());
+        self.allowed_git_repositories
+            .extend(other.allowed_git_repositories.iter().cloned());
+        self.denied_git_repositories
+            .extend(other.denied_git_repositories.iter().cloned());
         merge_unique(&mut self.allowed_wildcards, &other.allowed_wildcards);
         merge_unique(&mut self.denied_wildcards, &other.denied_wildcards);
     }
@@ -342,6 +392,7 @@ fn sort_entries(
     entries: Vec<String>,
     exact: &mut HashSet<String>,
     sources: &mut HashSet<String>,
+    git_repositories: &mut HashSet<String>,
     wildcards: &mut Vec<String>,
 ) {
     for entry in entries {
@@ -349,6 +400,8 @@ fn sort_entries(
             if !wildcards.iter().any(|p| p == &entry) {
                 wildcards.push(entry);
             }
+        } else if is_git_repository_key(&entry) {
+            git_repositories.insert(entry);
         } else if is_source_key(&entry) {
             sources.insert(entry);
         } else {
@@ -452,6 +505,14 @@ fn expand_spec(pattern: &str) -> Result<Vec<String>, BuildPolicyError> {
 fn is_source_key(key: &str) -> bool {
     let (_, version) = split_name_and_versions(key);
     is_source_version(version)
+}
+
+fn is_git_repository_key(key: &str) -> bool {
+    let (_, source) = split_name_and_versions(key);
+    !source.contains('#')
+        && ["git+https://", "git+http://", "git+ssh://", "git+file://"]
+            .iter()
+            .any(|prefix| source.starts_with(prefix))
 }
 
 fn is_source_version(version: &str) -> bool {
@@ -580,6 +641,65 @@ mod tests {
         assert_eq!(
             p.decide_package("raw-git", "1.0.0", Some("raw-git@github:owner/repo")),
             AllowDecision::Allow
+        );
+    }
+
+    #[test]
+    fn git_repository_rule_allows_every_resolved_commit() {
+        let p = policy(&[("gitdep@git+https://github.com/acme/gitdep.git", true)]);
+
+        for source_key in [
+            "gitdep@https://github.com/acme/gitdep.git#0123456789012345678901234567890123456789",
+            "gitdep@https://github.com/acme/gitdep.git#abcdefabcdefabcdefabcdefabcdefabcdefabcd",
+        ] {
+            assert_eq!(
+                p.decide_package_with_git_repository(
+                    "gitdep",
+                    "1.0.0",
+                    Some(source_key),
+                    Some("gitdep@git+https://github.com/acme/gitdep.git"),
+                ),
+                AllowDecision::Allow
+            );
+        }
+
+        assert_eq!(
+            p.decide_package_with_git_repository(
+                "gitdep",
+                "1.0.0",
+                Some("gitdep@https://github.com/acme/other.git#0123456789012345678901234567890123456789"),
+                Some("gitdep@git+https://github.com/acme/other.git"),
+            ),
+            AllowDecision::Unspecified
+        );
+    }
+
+    #[test]
+    fn git_repository_deny_and_package_deny_override_repository_allow() {
+        let p = policy(&[
+            ("gitdep@git+https://github.com/acme/gitdep.git", true),
+            ("other@git+https://github.com/acme/other.git", false),
+            ("blocked", false),
+            ("blocked@git+https://github.com/acme/blocked.git", true),
+        ]);
+
+        assert_eq!(
+            p.decide_package_with_git_repository(
+                "other",
+                "1.0.0",
+                Some("other@https://github.com/acme/other.git#0123456789012345678901234567890123456789"),
+                Some("other@git+https://github.com/acme/other.git"),
+            ),
+            AllowDecision::Deny
+        );
+        assert_eq!(
+            p.decide_package_with_git_repository(
+                "blocked",
+                "1.0.0",
+                Some("blocked@https://github.com/acme/blocked.git#0123456789012345678901234567890123456789"),
+                Some("blocked@git+https://github.com/acme/blocked.git"),
+            ),
+            AllowDecision::Deny
         );
     }
 

--- a/crates/aube-scripts/src/policy.rs
+++ b/crates/aube-scripts/src/policy.rs
@@ -510,9 +510,15 @@ fn is_source_key(key: &str) -> bool {
 fn is_git_repository_key(key: &str) -> bool {
     let (_, source) = split_name_and_versions(key);
     !source.contains('#')
-        && ["git+https://", "git+http://", "git+ssh://", "git+file://"]
-            .iter()
-            .any(|prefix| source.starts_with(prefix))
+        && [
+            "git+https://",
+            "git+http://",
+            "git+ssh://",
+            "git+file://",
+            "git+git://",
+        ]
+        .iter()
+        .any(|prefix| source.starts_with(prefix))
 }
 
 fn is_source_version(version: &str) -> bool {
@@ -671,6 +677,21 @@ mod tests {
                 Some("gitdep@git+https://github.com/acme/other.git"),
             ),
             AllowDecision::Unspecified
+        );
+    }
+
+    #[test]
+    fn git_repository_rule_accepts_native_git_transport() {
+        let p = policy(&[("gitdep@git+git://github.com/acme/gitdep.git", true)]);
+
+        assert_eq!(
+            p.decide_package_with_git_repository(
+                "gitdep",
+                "1.0.0",
+                Some("gitdep@git://github.com/acme/gitdep.git#0123456789012345678901234567890123456789"),
+                Some("gitdep@git+git://github.com/acme/gitdep.git"),
+            ),
+            AllowDecision::Allow
         );
     }
 

--- a/crates/aube/src/commands/ignored_builds.rs
+++ b/crates/aube/src/commands/ignored_builds.rs
@@ -158,8 +158,14 @@ pub(super) fn collect_ignored(project_dir: &std::path::Path) -> miette::Result<V
         // real pkg name. npm: alias would sneak past otherwise. Same
         // fix as every other policy.decide callsite.
         let source_key = pkg.source_approval_key();
+        let git_repository_key = pkg.git_repository_approval_key();
         if matches!(
-            policy.decide_package(pkg.registry_name(), &pkg.version, source_key.as_deref()),
+            policy.decide_package_with_git_repository(
+                pkg.registry_name(),
+                &pkg.version,
+                source_key.as_deref(),
+                git_repository_key.as_deref(),
+            ),
             aube_scripts::AllowDecision::Allow
         ) {
             continue;

--- a/crates/aube/src/commands/ignored_builds.rs
+++ b/crates/aube/src/commands/ignored_builds.rs
@@ -151,23 +151,13 @@ pub(super) fn collect_ignored(project_dir: &std::path::Path) -> miette::Result<V
     let mut out: Vec<IgnoredEntry> = Vec::new();
 
     for pkg in graph.packages.values() {
-        if !seen.insert((pkg.name.clone(), pkg.version.clone())) {
-            continue;
-        }
         // Match on registry_name, not pkg.name. Allowlist pins the
         // real pkg name. npm: alias would sneak past otherwise. Same
         // fix as every other policy.decide callsite.
-        let source_key = pkg.source_approval_key();
-        let git_repository_key = pkg.git_repository_approval_key();
-        if matches!(
-            policy.decide_package_with_git_repository(
-                pkg.registry_name(),
-                &pkg.version,
-                source_key.as_deref(),
-                git_repository_key.as_deref(),
-            ),
-            aube_scripts::AllowDecision::Allow
-        ) {
+        if super::install::package_build_is_allowed(&policy, pkg) {
+            continue;
+        }
+        if !seen.insert((pkg.name.clone(), pkg.version.clone())) {
             continue;
         }
         let Some(suspicions) = lifecycle_scripts_with_suspicions(

--- a/crates/aube/src/commands/install/lifecycle.rs
+++ b/crates/aube/src/commands/install/lifecycle.rs
@@ -155,10 +155,21 @@ impl JailBuildPolicy {
         )
     }
 
-    fn should_jail(&self, name: &str, version: &str, source_key: Option<&str>) -> bool {
+    fn should_jail(
+        &self,
+        name: &str,
+        version: &str,
+        source_key: Option<&str>,
+        git_repository_key: Option<&str>,
+    ) -> bool {
         self.enabled
             && !matches!(
-                self.denylist.decide_package(name, version, source_key),
+                self.denylist.decide_package_with_git_repository(
+                    name,
+                    version,
+                    source_key,
+                    git_repository_key,
+                ),
                 aube_scripts::AllowDecision::Deny
             )
     }
@@ -168,10 +179,11 @@ impl JailBuildPolicy {
         name: &str,
         version: &str,
         source_key: Option<&str>,
+        git_repository_key: Option<&str>,
         package_dir: &std::path::Path,
         project_dir: &std::path::Path,
     ) -> Option<aube_scripts::ScriptJail> {
-        if !self.should_jail(name, version, source_key) {
+        if !self.should_jail(name, version, source_key, git_repository_key) {
             return None;
         }
         let mut env = Vec::new();
@@ -392,6 +404,7 @@ pub(crate) async fn run_dep_lifecycle_scripts(
         registry_name: String,
         version: String,
         source_key: Option<String>,
+        git_repository_key: Option<String>,
         package_dir: std::path::PathBuf,
         /// Directory containing the dep package and its sibling
         /// symlinks — i.e. `package_dir`'s enclosing `node_modules/`.
@@ -421,7 +434,13 @@ pub(crate) async fn run_dep_lifecycle_scripts(
             // through the allowlist. registry_name() strips alias back to
             // real name.
             let source_key = pkg.source_approval_key();
-            match policy.decide_package(pkg.registry_name(), &pkg.version, source_key.as_deref()) {
+            let git_repository_key = pkg.git_repository_approval_key();
+            match policy.decide_package_with_git_repository(
+                pkg.registry_name(),
+                &pkg.version,
+                source_key.as_deref(),
+                git_repository_key.as_deref(),
+            ) {
                 aube_scripts::AllowDecision::Allow => {}
                 aube_scripts::AllowDecision::Deny | aube_scripts::AllowDecision::Unspecified => {
                     continue;
@@ -500,6 +519,7 @@ pub(crate) async fn run_dep_lifecycle_scripts(
             registry_name: pkg.registry_name().to_string(),
             version: pkg.version.clone(),
             source_key: pkg.source_approval_key(),
+            git_repository_key: pkg.git_repository_approval_key(),
             package_dir,
             dep_modules_dir,
             manifest: dep_manifest,
@@ -582,6 +602,7 @@ pub(crate) async fn run_dep_lifecycle_scripts(
                 &job.registry_name,
                 &job.version,
                 job.source_key.as_deref(),
+                job.git_repository_key.as_deref(),
                 &job.package_dir,
                 &project_dir,
             );
@@ -1113,8 +1134,14 @@ pub(super) fn unreviewed_dep_builds(
     let mut unreviewed = Vec::new();
     for (dep_path, pkg) in &graph.packages {
         let source_key = pkg.source_approval_key();
+        let git_repository_key = pkg.git_repository_approval_key();
         if !matches!(
-            policy.decide_package(pkg.registry_name(), &pkg.version, source_key.as_deref()),
+            policy.decide_package_with_git_repository(
+                pkg.registry_name(),
+                &pkg.version,
+                source_key.as_deref(),
+                git_repository_key.as_deref(),
+            ),
             aube_scripts::AllowDecision::Unspecified
         ) {
             continue;

--- a/crates/aube/src/commands/install/link.rs
+++ b/crates/aube/src/commands/install/link.rs
@@ -266,17 +266,7 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
         } else {
             let engine = node_version.map(aube_lockfile::graph_hash::engine_name_default);
             let allow = |pkg: &aube_lockfile::LockedPackage| {
-                let source_key = pkg.source_approval_key();
-                let git_repository_key = pkg.git_repository_approval_key();
-                matches!(
-                    build_policy.decide_package_with_git_repository(
-                        pkg.registry_name(),
-                        &pkg.version,
-                        source_key.as_deref(),
-                        git_repository_key.as_deref(),
-                    ),
-                    aube_scripts::AllowDecision::Allow
-                )
+                super::package_build_is_allowed(build_policy, pkg)
             };
             aube_lockfile::graph_hash::compute_graph_hashes_full(
                 graph_for_link,

--- a/crates/aube/src/commands/install/link.rs
+++ b/crates/aube/src/commands/install/link.rs
@@ -266,11 +266,14 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
         } else {
             let engine = node_version.map(aube_lockfile::graph_hash::engine_name_default);
             let allow = |pkg: &aube_lockfile::LockedPackage| {
+                let source_key = pkg.source_approval_key();
+                let git_repository_key = pkg.git_repository_approval_key();
                 matches!(
-                    build_policy.decide_package(
+                    build_policy.decide_package_with_git_repository(
                         pkg.registry_name(),
                         &pkg.version,
-                        pkg.source_approval_key().as_deref(),
+                        source_key.as_deref(),
+                        git_repository_key.as_deref(),
                     ),
                     aube_scripts::AllowDecision::Allow
                 )

--- a/crates/aube/src/commands/install/materialize.rs
+++ b/crates/aube/src/commands/install/materialize.rs
@@ -148,11 +148,14 @@ pub(super) async fn run_gvs_prewarm_materializer(
             "graph_hash_compute",
         );
         let allow = |pkg: &aube_lockfile::LockedPackage| {
+            let source_key = pkg.source_approval_key();
+            let git_repository_key = pkg.git_repository_approval_key();
             matches!(
-                build_policy_for_hash.decide_package(
+                build_policy_for_hash.decide_package_with_git_repository(
                     pkg.registry_name(),
                     &pkg.version,
-                    pkg.source_approval_key().as_deref(),
+                    source_key.as_deref(),
+                    git_repository_key.as_deref(),
                 ),
                 aube_scripts::AllowDecision::Allow
             )

--- a/crates/aube/src/commands/install/materialize.rs
+++ b/crates/aube/src/commands/install/materialize.rs
@@ -148,17 +148,7 @@ pub(super) async fn run_gvs_prewarm_materializer(
             "graph_hash_compute",
         );
         let allow = |pkg: &aube_lockfile::LockedPackage| {
-            let source_key = pkg.source_approval_key();
-            let git_repository_key = pkg.git_repository_approval_key();
-            matches!(
-                build_policy_for_hash.decide_package_with_git_repository(
-                    pkg.registry_name(),
-                    &pkg.version,
-                    source_key.as_deref(),
-                    git_repository_key.as_deref(),
-                ),
-                aube_scripts::AllowDecision::Allow
-            )
+            super::package_build_is_allowed(&build_policy_for_hash, pkg)
         };
         let patch_hash_fn = |name: &str, version: &str| -> Option<String> {
             let key = format!("{name}@{version}");

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -80,6 +80,23 @@ const TRUST_POLICY_VALIDATION_CACHE_DIR: &str = "trust-policy-v1";
 const TRUST_POLICY_VALIDATION_CACHE_TTL: std::time::Duration =
     std::time::Duration::from_secs(5 * 60);
 
+pub(crate) fn package_build_is_allowed(
+    policy: &aube_scripts::BuildPolicy,
+    pkg: &aube_lockfile::LockedPackage,
+) -> bool {
+    let source_key = pkg.source_approval_key();
+    let git_repository_key = pkg.git_repository_approval_key();
+    matches!(
+        policy.decide_package_with_git_repository(
+            pkg.registry_name(),
+            &pkg.version,
+            source_key.as_deref(),
+            git_repository_key.as_deref(),
+        ),
+        aube_scripts::AllowDecision::Allow
+    )
+}
+
 #[derive(serde::Deserialize, serde::Serialize)]
 struct TrustPolicyValidationStamp {
     key: String,

--- a/docs/security.md
+++ b/docs/security.md
@@ -55,6 +55,15 @@ aube approve-builds
 Root-package lifecycle scripts (your own project's) still run normally; only
 dependency scripts need approval.
 
+For a Git dependency that tracks a branch, approve the package and repository
+URL rather than a resolved commit. The rule remains limited to that repository;
+a package-name-only rule never approves Git-sourced code:
+
+```yaml
+allowBuilds:
+  native-addon@git+https://github.com/acme/native-addon.git: true
+```
+
 Settings: [`allowBuilds`](/settings/#setting-allowbuilds). Install adds
 unreviewed build packages to `aube-workspace.yaml` (or `pnpm-workspace.yaml`
 if one already exists) as `false`; approving them flips the entry to `true`.


### PR DESCRIPTION
## Summary
- support `allowBuilds` rules keyed by a package and normalized Git repository URL
- retain exact source approvals and make all deny rules win
- apply repository rules consistently to lifecycle execution, jailing, ignored-build reporting, and graph hashes

## Tests
- `cargo fmt --check`
- `cargo test -p aube -p aube-scripts -p aube-lockfile`
- `cargo clippy -p aube -p aube-scripts -p aube-lockfile --all-targets -- -D warnings`

*This pull request was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dependency lifecycle allow/deny logic for Git sources; scope is limited to explicit repo keys with denies still overriding allows.
> 
> **Overview**
> Adds **repository-scoped** `allowBuilds` rules for Git dependencies, e.g. `native-addon@git+https://github.com/acme/native-addon.git`, so an audited repo can move to new commits without re-approving each resolved SHA. Keys omit the commit (`LockedPackage::git_repository_approval_key`); exact per-source keys and name-only registry approvals stay unchanged.
> 
> `BuildPolicy` parses these into separate allow/deny sets, evaluates them in `decide_package_with_git_repository` (repo deny/allow with existing deny-wins precedence), and documents the new key shape. Install paths share `package_build_is_allowed` for lifecycle runs, script jailing, ignored-build reporting, and graph-hash “build allowed” checks. Security docs describe the YAML pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c40a0ae13d5d29cc82b35f09c15b74820f0a6f66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Git repository–based build approvals for Git dependencies that don’t depend on resolved commits.
  * Git repository allow/deny rules are now applied consistently during dependency lifecycles and installation graph/hash checks.
  * Repository-level denies take precedence, and repository-level allows are granted before existing package/source rules.
* **Bug Fixes**
  * Improved approval matching to treat Git URLs with an existing `git+` prefix correctly.
* **Documentation**
  * Clarified `allowBuilds` guidance with examples for approving package and repository URL keys (not commits).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->