### PR TITLE
test(resolver): cover self-contained peer closures

### DIFF
--- a/crates/aube-resolver/src/peer_context.rs
+++ b/crates/aube-resolver/src/peer_context.rs
@@ -1994,4 +1994,72 @@ mod tests {
             "a required peer should still resolve through the graph-wide scan"
         );
     }
+
+    #[test]
+    fn self_contained_subtree_peer_does_not_bind_to_root_version() {
+        let mut g = LockfileGraph::default();
+        g.importers.insert(
+            ".".to_string(),
+            vec![
+                DirectDep {
+                    name: "closure-plugins".to_string(),
+                    dep_path: "closure-plugins@1.0.0".to_string(),
+                    dep_type: DepType::Production,
+                    specifier: Some("1.0.0".to_string()),
+                },
+                DirectDep {
+                    name: "closure-peer-x".to_string(),
+                    dep_path: "closure-peer-x@2.0.0".to_string(),
+                    dep_type: DepType::Production,
+                    specifier: Some("2.0.0".to_string()),
+                },
+            ],
+        );
+
+        let closure = locked(
+            "closure-plugins",
+            &[
+                ("closure-lib-a", "1.0.0"),
+                ("closure-lib-b", "1.0.0"),
+                ("closure-peer-x", "1.0.0"),
+            ],
+        );
+        let mut lib_a = locked("closure-lib-a", &[]);
+        lib_a
+            .peer_dependencies
+            .insert("closure-peer-x".to_string(), "^1.0.0".to_string());
+        let mut lib_b = locked("closure-lib-b", &[]);
+        lib_b
+            .peer_dependencies
+            .insert("closure-peer-x".to_string(), "^1.0.0".to_string());
+        let inner_peer = locked("closure-peer-x", &[]);
+        let mut root_peer = locked("closure-peer-x", &[]);
+        root_peer.version = "2.0.0".to_string();
+        root_peer.dep_path = "closure-peer-x@2.0.0".to_string();
+
+        for pkg in [closure, lib_a, lib_b, inner_peer, root_peer] {
+            g.packages.insert(pkg.dep_path.clone(), pkg);
+        }
+
+        let out = apply_peer_contexts(g, &PeerContextOptions::default()).expect("peer pass");
+
+        for package in ["closure-lib-a", "closure-lib-b"] {
+            assert!(
+                out.packages
+                    .contains_key(&format!("{package}@1.0.0(closure-peer-x@1.0.0)")),
+                "{package} must use the subtree's peer provider"
+            );
+            assert!(
+                !out.packages
+                    .contains_key(&format!("{package}@1.0.0(closure-peer-x@2.0.0)")),
+                "{package} must not use the root's incompatible peer provider"
+            );
+        }
+        assert!(
+            out.importers["."]
+                .iter()
+                .any(|dep| dep.dep_path == "closure-peer-x@2.0.0"),
+            "the root keeps its explicitly declared peer version"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- add the pnpm 11.11 peer-closure regression shape to Aube’s peer-context tests
- verify subtree peer consumers bind to the local provider, not an incompatible root version
- verify the root retains its explicitly declared provider

## Tests
- `cargo fmt --check`
- `cargo test -p aube-resolver peer_context`
- `cargo clippy -p aube-resolver --all-targets -- -D warnings`

*This pull request was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code modifications; it documents expected peer-resolution behavior for future regressions.
> 
> **Overview**
> Adds a **peer-context regression test** for the pnpm 11.11 “peer closure” layout: a root that declares `closure-peer-x@2.0.0` while `closure-plugins` carries an inner `closure-peer-x@1.0.0` and libraries that peer on `^1.0.0`.
> 
> After `apply_peer_contexts`, the test expects `closure-lib-a` and `closure-lib-b` to contextualize with `(closure-peer-x@1.0.0)` and **not** bind to the root’s `2.0.0` provider, while the root importer still keeps `closure-peer-x@2.0.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ec55b9f49947e51ddc39a12c10726b0747e3cfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage ensuring nested package trees resolve peer dependencies to their local compatible versions.
  * Verified that incompatible root-level versions do not override subtree peer resolutions.
  * Confirmed direct root dependencies continue resolving to their explicitly declared versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->