### PR TITLE
fix(add): accept dangerously-allow-all-builds

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -97,6 +97,9 @@ cmd add help="Add a dependency" {
     flag --allow-low-downloads help="Bypass the [`lowDownloadThreshold`] confirm prompt / refusal for this invocation" {
         long_help "Bypass the [`lowDownloadThreshold`] confirm prompt / refusal for this invocation.\n\n`aube add` looks up each candidate's weekly download count and prompts (interactive) or fails (CI) when the count is below [`lowDownloadThreshold`]. The flag is intended for the cases where you've already verified the package out-of-band — adding a brand-new niche tool, a fresh fork, an internal scratch package — and don't want the prompt to interrupt scripted workflows. Does not affect the OSV malicious-package check, which remains a hard block."
     }
+    flag --dangerously-allow-all-builds help="Allow every dependency's lifecycle scripts to run" {
+        long_help "Allow every dependency's lifecycle scripts to run.\n\nBypasses the `allowBuilds` allowlist for this invocation. Do not use in CI. Mirrors pnpm's `--dangerously-allow-all-builds`."
+    }
     flag --deny-build help="Mark a dependency's lifecycle scripts as reviewed and denied" var=#true {
         long_help "Mark a dependency's lifecycle scripts as reviewed and denied.\n\nWrites `allowBuilds: { <pkg>: false }` into the workspace yaml (or `package.json#aube.allowBuilds`) before the install runs, so the named package's lifecycle scripts stay skipped without tripping `strictDepBuilds=true`. Repeatable — pass the flag once per package.\n\nConflicts with `--no-save`, which only snapshots `package.json` and the lockfile and would leave an orphaned denial in the workspace yaml on restore. Also conflicts with `--allow-build` for the same package name."
         arg <PKG>

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -101,7 +101,7 @@ cmd add help="Add a dependency" {
         long_help "Allow every dependency's lifecycle scripts to run.\n\nBypasses the `allowBuilds` allowlist for this invocation. Do not use in CI. Mirrors pnpm's `--dangerously-allow-all-builds`."
     }
     flag --deny-build help="Mark a dependency's lifecycle scripts as reviewed and denied" var=#true {
-        long_help "Mark a dependency's lifecycle scripts as reviewed and denied.\n\nWrites `allowBuilds: { <pkg>: false }` into the workspace yaml (or `package.json#aube.allowBuilds`) before the install runs, so the named package's lifecycle scripts stay skipped without tripping `strictDepBuilds=true`. Repeatable — pass the flag once per package.\n\nConflicts with `--no-save`, which only snapshots `package.json` and the lockfile and would leave an orphaned denial in the workspace yaml on restore. Also conflicts with `--allow-build` for the same package name."
+        long_help "Mark a dependency's lifecycle scripts as reviewed and denied.\n\nWrites `allowBuilds: { <pkg>: false }` into the workspace yaml (or `package.json#aube.allowBuilds`) before the install runs, so the named package's lifecycle scripts stay skipped without tripping `strictDepBuilds=true`. Repeatable — pass the flag once per package.\n\nConflicts with `--no-save`, which only snapshots `package.json` and the lockfile and would leave an orphaned denial in the workspace yaml on restore. Also conflicts with `--allow-build` for the same package name and with `--dangerously-allow-all-builds`."
         arg <PKG>
     }
     flag --ignore-scripts help="Skip lifecycle scripts (no-op; aube already skips by default)" hide=#true

--- a/crates/aube/src/commands/add/filtered.rs
+++ b/crates/aube/src/commands/add/filtered.rs
@@ -70,6 +70,10 @@ pub(super) async fn run(
         let mut install_opts = install::InstallOptions::with_mode(
             crate::commands::chained_frozen_mode(install::FrozenMode::Fix),
         );
+        super::apply_dangerously_allow_all_builds(
+            &mut install_opts,
+            args.dangerously_allow_all_builds,
+        );
         install_opts.workspace_filter = filter.clone();
         // See the sibling `aube add` codepath for why this flag is set:
         // live OSV API on the resolved transitives.

--- a/crates/aube/src/commands/add/global.rs
+++ b/crates/aube/src/commands/add/global.rs
@@ -2,6 +2,13 @@ use super::{AddArgs, run};
 use miette::{Context, IntoDiagnostic};
 use std::collections::BTreeMap;
 
+pub(super) struct GlobalAddOptions {
+    pub(super) allow_build: Vec<String>,
+    pub(super) allow_low_downloads: bool,
+    pub(super) dangerously_allow_all_builds: bool,
+    pub(super) deny_build: Vec<String>,
+}
+
 /// `aube add -g <pkg>...` — install into an isolated global install dir
 /// and symlink the resulting binaries into the global bin dir.
 ///
@@ -18,13 +25,9 @@ use std::collections::BTreeMap;
 /// bin linking. Without this guard every failed `add -g` would leak a
 /// subdir that `scan_packages` ignores (no hash symlink) but disk space
 /// keeps.
-#[allow(clippy::too_many_arguments)]
 pub(super) async fn run_global(
     packages: &[String],
-    allow_build: Vec<String>,
-    allow_low_downloads: bool,
-    dangerously_allow_all_builds: bool,
-    deny_build: Vec<String>,
+    options: GlobalAddOptions,
     lockfile: crate::cli_args::LockfileArgs,
     network: crate::cli_args::NetworkArgs,
     virtual_store: crate::cli_args::VirtualStoreArgs,
@@ -75,10 +78,7 @@ pub(super) async fn run_global(
         .collect();
     let result = run_global_inner(
         packages,
-        allow_build,
-        allow_low_downloads,
-        dangerously_allow_all_builds,
-        deny_build,
+        options,
         &layout,
         &install_dir,
         lockfile,
@@ -114,13 +114,9 @@ pub(super) async fn run_global(
     result
 }
 
-#[allow(clippy::too_many_arguments)]
 async fn run_global_inner(
     packages: &[String],
-    allow_build: Vec<String>,
-    allow_low_downloads: bool,
-    dangerously_allow_all_builds: bool,
-    deny_build: Vec<String>,
+    options: GlobalAddOptions,
     layout: &crate::commands::global::GlobalLayout,
     install_dir: &std::path::Path,
     lockfile: crate::cli_args::LockfileArgs,
@@ -128,6 +124,12 @@ async fn run_global_inner(
     virtual_store: crate::cli_args::VirtualStoreArgs,
 ) -> miette::Result<()> {
     use crate::commands::global;
+    let GlobalAddOptions {
+        allow_build,
+        allow_low_downloads,
+        dangerously_allow_all_builds,
+        deny_build,
+    } = options;
 
     // Seed a minimal package.json so the resolver has a project to work
     // against. We never persist metadata beyond this; the install dir is

--- a/crates/aube/src/commands/add/global.rs
+++ b/crates/aube/src/commands/add/global.rs
@@ -18,11 +18,13 @@ use std::collections::BTreeMap;
 /// bin linking. Without this guard every failed `add -g` would leak a
 /// subdir that `scan_packages` ignores (no hash symlink) but disk space
 /// keeps.
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn run_global(
     packages: &[String],
     allow_build: Vec<String>,
-    deny_build: Vec<String>,
     allow_low_downloads: bool,
+    dangerously_allow_all_builds: bool,
+    deny_build: Vec<String>,
     lockfile: crate::cli_args::LockfileArgs,
     network: crate::cli_args::NetworkArgs,
     virtual_store: crate::cli_args::VirtualStoreArgs,
@@ -74,8 +76,9 @@ pub(super) async fn run_global(
     let result = run_global_inner(
         packages,
         allow_build,
-        deny_build,
         allow_low_downloads,
+        dangerously_allow_all_builds,
+        deny_build,
         &layout,
         &install_dir,
         lockfile,
@@ -115,8 +118,9 @@ pub(super) async fn run_global(
 async fn run_global_inner(
     packages: &[String],
     allow_build: Vec<String>,
-    deny_build: Vec<String>,
     allow_low_downloads: bool,
+    dangerously_allow_all_builds: bool,
+    deny_build: Vec<String>,
     layout: &crate::commands::global::GlobalLayout,
     install_dir: &std::path::Path,
     lockfile: crate::cli_args::LockfileArgs,
@@ -197,6 +201,7 @@ async fn run_global_inner(
         // install" even when the user explicitly approved the dep
         // (see Discussion #617).
         allow_build,
+        dangerously_allow_all_builds,
         // Same contract as `allow_build`, but force-denies matching
         // packages so global installs can satisfy `strictDepBuilds=true`
         // while keeping selected lifecycle scripts skipped.

--- a/crates/aube/src/commands/add/mod.rs
+++ b/crates/aube/src/commands/add/mod.rs
@@ -69,6 +69,12 @@ pub struct AddArgs {
     /// which remains a hard block.
     #[arg(long)]
     pub allow_low_downloads: bool,
+    /// Allow every dependency's lifecycle scripts to run.
+    ///
+    /// Bypasses the `allowBuilds` allowlist for this invocation. Do not
+    /// use in CI. Mirrors pnpm's `--dangerously-allow-all-builds`.
+    #[arg(long)]
+    pub dangerously_allow_all_builds: bool,
     /// Mark a dependency's lifecycle scripts as reviewed and denied.
     ///
     /// Writes `allowBuilds: { <pkg>: false }` into the workspace yaml
@@ -214,8 +220,9 @@ pub async fn run(
         save_catalog,
         save_catalog_name,
         allow_build,
-        deny_build,
         allow_low_downloads,
+        dangerously_allow_all_builds,
+        deny_build,
         lockfile,
         network,
         virtual_store,
@@ -237,8 +244,9 @@ pub async fn run(
         return global::run_global(
             packages,
             allow_build,
-            deny_build,
             allow_low_downloads,
+            dangerously_allow_all_builds,
+            deny_build,
             lockfile,
             network,
             virtual_store,
@@ -399,6 +407,7 @@ pub async fn run(
     // `ERR_AUBE_MALICIOUS_PACKAGE` as the CLI-name gate above.
     let mut install_opts =
         install::InstallOptions::with_mode(super::chained_frozen_mode(install::FrozenMode::Fix));
+    apply_dangerously_allow_all_builds(&mut install_opts, dangerously_allow_all_builds);
     install_opts.osv_transitive_check = true;
     let pipeline_result: miette::Result<()> = install::run(install_opts).await;
 
@@ -437,4 +446,17 @@ pub async fn run(
         return Err(first);
     }
     Ok(())
+}
+
+pub(super) fn apply_dangerously_allow_all_builds(
+    install_opts: &mut install::InstallOptions,
+    enabled: bool,
+) {
+    if enabled {
+        install_opts.dangerously_allow_all_builds = true;
+        install_opts.cli_flags.push((
+            "dangerously-allow-all-builds".to_string(),
+            "true".to_string(),
+        ));
+    }
 }

--- a/crates/aube/src/commands/add/mod.rs
+++ b/crates/aube/src/commands/add/mod.rs
@@ -86,11 +86,11 @@ pub struct AddArgs {
     /// Conflicts with `--no-save`, which only snapshots `package.json`
     /// and the lockfile and would leave an orphaned denial in the
     /// workspace yaml on restore. Also conflicts with `--allow-build` for
-    /// the same package name.
+    /// the same package name and with `--dangerously-allow-all-builds`.
     #[arg(
         long = "deny-build",
         value_name = "PKG",
-        conflicts_with = "no_save",
+        conflicts_with_all = ["no_save", "dangerously_allow_all_builds"],
         require_equals = true,
         value_parser = parse_deny_build_value,
     )]
@@ -243,10 +243,12 @@ pub async fn run(
     if global {
         return global::run_global(
             packages,
-            allow_build,
-            allow_low_downloads,
-            dangerously_allow_all_builds,
-            deny_build,
+            global::GlobalAddOptions {
+                allow_build,
+                allow_low_downloads,
+                dangerously_allow_all_builds,
+                deny_build,
+            },
             lockfile,
             network,
             virtual_store,

--- a/crates/aube/src/lib.rs
+++ b/crates/aube/src/lib.rs
@@ -1376,6 +1376,27 @@ mod cli_spec_tests {
     }
 
     #[test]
+    fn add_rejects_deny_build_with_dangerously_allow_all_builds() {
+        let err = match Cli::try_parse_from([
+            "aube",
+            "add",
+            "some-package",
+            "--deny-build=some-package",
+            "--dangerously-allow-all-builds",
+        ]) {
+            Ok(_) => panic!("deny-build should conflict with dangerously-allow-all-builds"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.to_string().contains(
+                "'--deny-build=<PKG>' cannot be used with '--dangerously-allow-all-builds'"
+            ),
+            "{err}"
+        );
+    }
+
+    #[test]
     fn lifter_does_not_eat_lifted_flag_as_kept_flag_value() {
         // Regression: `aube --dir /tmp --frozen-lockfile install` would
         // previously lose `--frozen-lockfile` if `--dir`'s value was

--- a/crates/aube/src/lib.rs
+++ b/crates/aube/src/lib.rs
@@ -1357,6 +1357,25 @@ mod cli_spec_tests {
     }
 
     #[test]
+    fn add_accepts_dangerously_allow_all_builds_after_package() {
+        let cli = Cli::try_parse_from([
+            "aube",
+            "add",
+            "--global",
+            "opencode-ai@1.17.13",
+            "--dangerously-allow-all-builds",
+        ])
+        .expect("add --dangerously-allow-all-builds should parse after a package");
+
+        let Some(Commands::Add(add_args)) = cli.command else {
+            panic!("expected add subcommand");
+        };
+        assert!(add_args.global);
+        assert!(add_args.dangerously_allow_all_builds);
+        assert_eq!(add_args.packages, ["opencode-ai@1.17.13"]);
+    }
+
+    #[test]
     fn lifter_does_not_eat_lifted_flag_as_kept_flag_value() {
         // Regression: `aube --dir /tmp --frozen-lockfile install` would
         // previously lose `--frozen-lockfile` if `--dir`'s value was

--- a/docs/cli/add.md
+++ b/docs/cli/add.md
@@ -46,6 +46,12 @@ Bypass the [`lowDownloadThreshold`] confirm prompt / refusal for this invocation
 
 `aube add` looks up each candidate's weekly download count and prompts (interactive) or fails (CI) when the count is below [`lowDownloadThreshold`]. The flag is intended for the cases where you've already verified the package out-of-band — adding a brand-new niche tool, a fresh fork, an internal scratch package — and don't want the prompt to interrupt scripted workflows. Does not affect the OSV malicious-package check, which remains a hard block.
 
+### `--dangerously-allow-all-builds`
+
+Allow every dependency's lifecycle scripts to run.
+
+Bypasses the `allowBuilds` allowlist for this invocation. Do not use in CI. Mirrors pnpm's `--dangerously-allow-all-builds`.
+
 ### `--deny-build… <PKG>`
 
 Mark a dependency's lifecycle scripts as reviewed and denied.

--- a/docs/cli/add.md
+++ b/docs/cli/add.md
@@ -58,7 +58,7 @@ Mark a dependency's lifecycle scripts as reviewed and denied.
 
 Writes `allowBuilds: { <pkg>: false }` into the workspace yaml (or `package.json#aube.allowBuilds`) before the install runs, so the named package's lifecycle scripts stay skipped without tripping `strictDepBuilds=true`. Repeatable — pass the flag once per package.
 
-Conflicts with `--no-save`, which only snapshots `package.json` and the lockfile and would leave an orphaned denial in the workspace yaml on restore. Also conflicts with `--allow-build` for the same package name.
+Conflicts with `--no-save`, which only snapshots `package.json` and the lockfile and would leave an orphaned denial in the workspace yaml on restore. Also conflicts with `--allow-build` for the same package name and with `--dangerously-allow-all-builds`.
 
 ### `--no-save`
 

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -173,6 +173,19 @@
             "global": false
           },
           {
+            "name": "dangerously-allow-all-builds",
+            "usage": "--dangerously-allow-all-builds",
+            "help": "Allow every dependency's lifecycle scripts to run",
+            "help_long": "Allow every dependency's lifecycle scripts to run.\n\nBypasses the `allowBuilds` allowlist for this invocation. Do not use in CI. Mirrors pnpm's `--dangerously-allow-all-builds`.",
+            "help_first_line": "Allow every dependency's lifecycle scripts to run",
+            "short": [],
+            "long": [
+              "dangerously-allow-all-builds"
+            ],
+            "hide": false,
+            "global": false
+          },
+          {
             "name": "deny-build",
             "usage": "--deny-build… <PKG>",
             "help": "Mark a dependency's lifecycle scripts as reviewed and denied",

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -189,7 +189,7 @@
             "name": "deny-build",
             "usage": "--deny-build… <PKG>",
             "help": "Mark a dependency's lifecycle scripts as reviewed and denied",
-            "help_long": "Mark a dependency's lifecycle scripts as reviewed and denied.\n\nWrites `allowBuilds: { <pkg>: false }` into the workspace yaml (or `package.json#aube.allowBuilds`) before the install runs, so the named package's lifecycle scripts stay skipped without tripping `strictDepBuilds=true`. Repeatable — pass the flag once per package.\n\nConflicts with `--no-save`, which only snapshots `package.json` and the lockfile and would leave an orphaned denial in the workspace yaml on restore. Also conflicts with `--allow-build` for the same package name.",
+            "help_long": "Mark a dependency's lifecycle scripts as reviewed and denied.\n\nWrites `allowBuilds: { <pkg>: false }` into the workspace yaml (or `package.json#aube.allowBuilds`) before the install runs, so the named package's lifecycle scripts stay skipped without tripping `strictDepBuilds=true`. Repeatable — pass the flag once per package.\n\nConflicts with `--no-save`, which only snapshots `package.json` and the lockfile and would leave an orphaned denial in the workspace yaml on restore. Also conflicts with `--allow-build` for the same package name and with `--dangerously-allow-all-builds`.",
             "help_first_line": "Mark a dependency's lifecycle scripts as reviewed and denied",
             "short": [],
             "long": [

--- a/test/global_install.bats
+++ b/test/global_install.bats
@@ -318,6 +318,19 @@ teardown() {
 	assert_success
 }
 
+@test "aube add -g --dangerously-allow-all-builds runs unreviewed builds" {
+	AUBE_STRICT_DEP_BUILDS=true run aube add -g \
+		aube-test-builds-marker@1.0.0 \
+		--dangerously-allow-all-builds
+	assert_success
+	refute_output --partial "must be reviewed before install"
+	refute_output --partial "ignored build scripts"
+
+	pkg_dir="$AUBE_HOME/global-aube"
+	install_dir="$(find "$pkg_dir" -mindepth 1 -maxdepth 1 -type d -print -quit)"
+	assert_file_exists "$install_dir/aube-builds-marker.txt"
+}
+
 @test "aube add -g --deny-build=<pkg> marks a global dep's build scripts reviewed" {
 	AUBE_STRICT_DEP_BUILDS=true run aube add -g \
 		--deny-build=aube-test-builds-marker \


### PR DESCRIPTION
## Summary

- accept `--dangerously-allow-all-builds` on `aube add`
- forward the transient build-policy override through local, filtered, and global add paths
- reject the contradictory combination with `--deny-build=<pkg>`
- document the flag and cover the mise command shape with parser and global-install regressions

## Root cause

The failure was reported in [this mise discussion comment](https://github.com/jdx/mise/discussions/10237#discussioncomment-17540612): mise invokes `aube add --global <package> --dangerously-allow-all-builds`, but aube declared the broad flag only on `InstallArgs`. Clap therefore rejected it before `add` could enter the install pipeline.

`aube add` already chains into that pipeline, and its selective `--allow-build=<pkg>` option is forwarded through the synthetic global install. The broad option was simply absent from `AddArgs` and from that forwarding path. This seems unintentional given aube's pnpm CLI parity goal and pnpm's support for the same command-line setting on `add`. If keeping this escape hatch install-only is intentional, please feel free to close this PR.

The new option is invocation-scoped; it does not persist `dangerouslyAllowAllBuilds=true` in project configuration.

## Validation

- `cargo test -p aube` — 644 unit tests, 7 Rust e2e tests
- `mise run test:bats test/global_install.bats` — 24 tests
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `mise run render`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `aube add --dangerously-allow-all-builds` to permit all dependency lifecycle scripts for a single invocation, bypassing the build allowlist (including for `-g/--global` installs).

* **Bug Fixes**
  * Ensures the flag is correctly applied to the underlying install flow for both local and global additions.

* **Documentation**
  * Documented the new flag and warned against using it in CI.
  * Updated `--deny-build` help to note it conflicts with `--dangerously-allow-all-builds`.

* **Tests**
  * Added regression tests for CLI parsing and the global-build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->