### PR TITLE
fix(install): ignore stale pnpm patch entries

### DIFF
--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1694,6 +1694,16 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
             ) {
                 graph.overlay_metadata_from(&prior);
             }
+            // A pnpm lockfile's patchedDependencies block describes the
+            // resolution that produced that lockfile; it is not authoritative
+            // after manifest/workspace drift forced a fresh resolve. Replace
+            // the metadata overlaid above with the current declarations so a
+            // deleted patch from the stale lockfile is neither read during
+            // materialization nor written back. This also prevents pnpm 11's
+            // hash-only scalar entries from being mistaken for file paths.
+            if matches!(source_kind_before, Some(aube_lockfile::LockfileKind::Pnpm)) {
+                graph.patched_dependencies = crate::patches::read_patched_dependencies(&cwd)?;
+            }
             tracing::debug!("Resolved {} packages", graph.packages.len());
             // Seed the chain index for diagnostic enrichment. Any
             // post-resolver error wrapping `(name, version)` via

--- a/test/patch.bats
+++ b/test/patch.bats
@@ -114,3 +114,107 @@ EOF
 	assert_failure
 	assert_output --partial "is not installed"
 }
+
+@test "non-frozen install ignores stale pnpm lockfile patch entries" {
+	cat >package.json <<'EOF'
+{
+  "name": "stale-patch-test",
+  "version": "1.0.0",
+  "dependencies": { "is-odd": "3.0.1" }
+}
+EOF
+	cat >pnpm-workspace.yaml <<'EOF'
+packages:
+  - .
+patchedDependencies:
+  is-odd@3.0.1: patches/is-odd@3.0.1.patch
+EOF
+	mkdir patches
+	cat >patches/is-odd@3.0.1.patch <<'EOF'
+diff --git a/index.js b/index.js
+index 79d1f22a8e7a27efb8841bb83cb682ea1ff3a59c..1e33b4cf949b73bde8861ad65de71b4e46360259 100644
+--- a/index.js
++++ b/index.js
+@@ -24,1 +24,2 @@ module.exports = function isOdd(value) {
+ };
++module.exports.patched = 'v1';
+EOF
+	cat >pnpm-lock.yaml <<'EOF'
+lockfileVersion: '9.0'
+patchedDependencies:
+  is-odd@3.0.0:
+    hash: stale
+    path: patches/is-odd@3.0.0.patch
+importers:
+  .:
+    dependencies:
+      is-odd:
+        specifier: 3.0.0
+        version: 3.0.0
+packages:
+  is-odd@3.0.0:
+    resolution: {integrity: sha512-stale}
+snapshots:
+  is-odd@3.0.0: {}
+EOF
+
+	run aube install --no-frozen-lockfile --ignore-scripts
+	assert_success
+	run node -e 'const odd = require("is-odd"); if (!odd.patched) process.exit(1)'
+	assert_success
+	run grep -q 'is-odd@3.0.0' pnpm-lock.yaml
+	assert_failure
+	run grep -q 'is-odd@3.0.1:' pnpm-lock.yaml
+	assert_success
+}
+
+@test "non-frozen install ignores stale pnpm hash-only patch entries" {
+	cat >package.json <<'EOF'
+{
+  "name": "stale-hash-patch-test",
+  "version": "1.0.0",
+  "dependencies": { "is-odd": "3.0.1" }
+}
+EOF
+	cat >pnpm-workspace.yaml <<'EOF'
+packages:
+  - .
+patchedDependencies:
+  is-odd@3.0.1: patches/is-odd@3.0.1.patch
+EOF
+	mkdir patches
+	cat >patches/is-odd@3.0.1.patch <<'EOF'
+diff --git a/index.js b/index.js
+index 79d1f22a8e7a27efb8841bb83cb682ea1ff3a59c..1e33b4cf949b73bde8861ad65de71b4e46360259 100644
+--- a/index.js
++++ b/index.js
+@@ -24,1 +24,2 @@ module.exports = function isOdd(value) {
+ };
++module.exports.patched = 'v1';
+EOF
+	cat >pnpm-lock.yaml <<'EOF'
+lockfileVersion: '9.0'
+patchedDependencies:
+  is-odd@3.0.0: 02efb892c0aa62e77ab535074021159d4eb5764f187cecb6b759227dcc9ebfec
+importers:
+  .:
+    dependencies:
+      is-odd:
+        specifier: 3.0.0
+        version: 3.0.0
+packages:
+  is-odd@3.0.0:
+    resolution: {integrity: sha512-stale}
+snapshots:
+  is-odd@3.0.0: {}
+EOF
+
+	run aube install --no-frozen-lockfile --ignore-scripts
+	assert_success
+	run node -e 'const odd = require("is-odd"); if (!odd.patched) process.exit(1)'
+	assert_success
+	run grep -q 'is-odd@3.0.0' pnpm-lock.yaml
+	assert_failure
+	run grep -q 'is-odd@3.0.1:' pnpm-lock.yaml
+	assert_success
+}


### PR DESCRIPTION
## Summary

- replace stale pnpm lockfile patch metadata with current manifest/workspace declarations after a fresh resolution
- avoid reading deleted patch paths or pnpm 11 hash-only values as files
- add end-to-end coverage for pnpm 10 object-form and pnpm 11 hash-only stale entries

## Root cause

Fresh resolution produced an empty patch map, then `overlay_metadata_from` restored every patch entry from the prior lockfile. Materialization merged those stale entries with current declarations and eagerly read both keys, even when the stale package version was no longer in the resolved graph.

Fixes the bug reported in Discussion #1019.

## Validation

- `mise run test:bats test/patch.bats`
- `cargo fmt --check`
- `cargo clippy -p aube --all-targets -- -D warnings`

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches install graph state for pnpm patch metadata on the re-resolve path; behavior change is intentional but could affect edge cases where users relied on lockfile-only patch entries without manifest declarations.
> 
> **Overview**
> After a **non-frozen** install re-resolves because the lockfile no longer matches the manifest, **`overlay_metadata_from`** could copy **`patchedDependencies`** from the old **`pnpm-lock.yaml`**, so removed or wrong-version patches were still applied and written back.
> 
> For projects that already use a **pnpm** lockfile, the fresh-resolve path now **replaces** `graph.patched_dependencies` with **`read_patched_dependencies`** from the current **`package.json`** / workspace yaml. Materialization and the rewritten lockfile follow **today’s** patch declarations only, and **pnpm 11** hash-only scalars are not treated as patch file paths.
> 
> **Bats** coverage was added for stale lockfile entries (object **`path`** form and hash-only form) while the workspace still declares a patch for the resolved version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 775089fcb73ac8b561eb2f89a24897753d17d44d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->