### PR TITLE
fix: node version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,20 +47,11 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
-]
-
-[[package]]
-name = "alloca"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -91,12 +82,6 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "anes"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -150,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "approx"
@@ -171,9 +156,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.7"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert-json-diff"
@@ -246,7 +231,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "1.25.2"
+version = "1.23.0"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -309,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "aube-codes"
-version = "1.25.2"
+version = "1.23.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -317,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "1.25.2"
+version = "1.23.0"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -343,7 +328,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "1.25.2"
+version = "1.23.0"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -351,9 +336,7 @@ dependencies = [
  "aube-util",
  "base64",
  "blake3",
- "criterion",
  "glob",
- "memchr",
  "miette",
  "node-semver",
  "proptest",
@@ -370,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "1.25.2"
+version = "1.23.0"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -388,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "1.25.2"
+version = "1.23.0"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -419,7 +402,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "1.25.2"
+version = "1.23.0"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -427,7 +410,6 @@ dependencies = [
  "aube-registry",
  "aube-store",
  "aube-util",
- "criterion",
  "flate2",
  "miette",
  "node-semver",
@@ -436,7 +418,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
- "smallvec",
  "sonic-rs",
  "tar",
  "tempfile",
@@ -448,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "aube-runtime"
-version = "1.25.2"
+version = "1.23.0"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -472,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "1.25.2"
+version = "1.23.0"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -490,20 +471,18 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "1.25.2"
+version = "1.23.0"
 dependencies = [
- "aube-codes",
  "aube-manifest",
  "aube-util",
  "serde",
  "toml",
- "tracing",
  "yaml_serde",
 ]
 
 [[package]]
 name = "aube-store"
-version = "1.25.2"
+version = "1.23.0"
 dependencies = [
  "aube-util",
  "base64",
@@ -527,12 +506,12 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "1.25.2"
+version = "1.23.0"
 dependencies = [
  "aube-codes",
  "blake3",
  "bytes",
- "foldhash",
+ "foldhash 0.2.0",
  "libc",
  "reflink-copy",
  "reqwest",
@@ -548,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "1.25.2"
+version = "1.23.0"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -562,15 +541,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -579,15 +558,14 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.42.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
- "pkg-config",
 ]
 
 [[package]]
@@ -643,12 +621,6 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
@@ -680,18 +652,18 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
 ]
 
 [[package]]
 name = "brotli"
-version = "8.0.4"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -700,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.3"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -710,20 +682,20 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.3"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde_core",
+ "serde",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.20.3"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "by_address"
@@ -762,15 +734,9 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
-
-[[package]]
-name = "cast"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "castaway"
@@ -783,9 +749,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -807,9 +773,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -818,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.45"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -856,33 +822,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d502ead02cc105c33a87aa76817cdca915a7576b59caba5eeb4e7abdd633f23"
 dependencies = [
  "envmnt",
-]
-
-[[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
 ]
 
 [[package]]
@@ -1011,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.9.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -1045,9 +984,9 @@ checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "console"
-version = "0.16.4"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -1136,45 +1075,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "criterion"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
-dependencies = [
- "alloca",
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "itertools 0.13.0",
- "num-traits",
- "oorandom",
- "page_size",
- "regex",
- "serde",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
-dependencies = [
- "cast",
- "itertools 0.13.0",
-]
-
-[[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
 name = "crmf"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1184,15 +1084,6 @@ dependencies = [
  "der",
  "spki",
  "x509-cert",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1226,7 +1117,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -1248,12 +1139,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1265,9 +1150,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
 ]
@@ -1307,12 +1192,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
-
-[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1331,38 +1210,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
-name = "defmt"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
-dependencies = [
- "bitflags 1.3.2",
- "defmt-macros",
-]
-
-[[package]]
-name = "defmt-macros"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
-dependencies = [
- "defmt-parser",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "defmt-parser"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
-dependencies = [
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "demand"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,7 +1217,7 @@ checksum = "9e42d12bfa3506597636b814d58b3f540f6ee71aefd795da37892c45759cdbad"
 dependencies = [
  "console",
  "fuzzy-matcher",
- "itertools 0.14.0",
+ "itertools",
  "signal-hook 0.4.4",
  "termcolor",
 ]
@@ -1404,6 +1251,9 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "derive_more"
@@ -1464,16 +1314,16 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.1",
+ "block-buffer 0.12.0",
  "const-oid 0.10.2",
- "crypto-common 0.2.2",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1509,9 +1359,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -1646,6 +1496,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1823,15 +1679,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
  "wasm-bindgen",
 ]
 
@@ -1866,16 +1724,16 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "ignore",
  "walkdir",
 ]
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1891,21 +1749,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "zerocopy",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1915,7 +1771,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1926,7 +1782,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1948,76 +1804,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-net"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "futures-channel",
- "futures-io",
- "futures-util",
- "hickory-proto",
- "idna",
- "ipnet",
- "jni",
- "rand 0.10.1",
- "thiserror 2.0.18",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-proto"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
-dependencies = [
- "data-encoding",
- "idna",
- "ipnet",
- "jni",
- "once_cell",
- "prefix-trie",
- "rand 0.10.1",
- "ring",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-resolver"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-net",
- "hickory-proto",
- "ipconfig",
- "ipnet",
- "jni",
- "moka",
- "ndk-context",
- "once_cell",
- "parking_lot",
- "rand 0.10.1",
- "resolv-conf",
- "smallvec",
- "system-configuration",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "homedir"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2031,9 +1817,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
  "itoa",
@@ -2085,18 +1871,18 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2261,6 +2047,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2289,9 +2081,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.27"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe112b004901c62c2faa11f4f75e9864e0cc5af8da71c9115d184a3aa888749f"
+checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -2348,26 +2140,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipconfig"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
-dependencies = [
- "socket2",
- "widestring",
- "windows-registry",
- "windows-result 0.4.1",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "is-docker"
@@ -2402,15 +2178,6 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2426,25 +2193,24 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.31"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
+checksum = "6835eea34fb6321b9b3aa7b685c2b433948c09447e389dc017fdf687d5d11e65"
 dependencies = [
- "defmt",
  "jiff-static",
  "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-link 0.2.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.31"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
+checksum = "3c22e04db9c58f5136eb1757f3d5c49a7b187f49e52185228cbd2f5acdfcc08c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2527,12 +2293,13 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2586,6 +2353,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2614,9 +2387,9 @@ checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
 
 [[package]]
 name = "libz-ng-sys"
-version = "1.1.29"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879917b256f6317769b9f374b435805a8697013098aacce5a38ac106cd6a9469"
+checksum = "be734b33b7bc6a42d92d23e25e69758f866cf564a88d0bf80866fcf5a52c2255"
 dependencies = [
  "cmake",
  "libc",
@@ -2628,7 +2401,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -2670,9 +2443,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lru"
@@ -2700,15 +2473,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.11"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
 ]
@@ -2776,31 +2549,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "moka"
-version = "0.12.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-epoch",
- "crossbeam-utils",
- "equivalent",
- "parking_lot",
- "portable-atomic",
- "smallvec",
- "tagptr",
- "uuid",
 ]
 
 [[package]]
@@ -2824,18 +2580,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-
-[[package]]
 name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2847,7 +2597,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2941,9 +2691,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -3018,10 +2768,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-dependencies = [
- "critical-section",
- "portable-atomic",
-]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -3030,19 +2776,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "oorandom"
-version = "11.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
 name = "open"
-version = "5.3.6"
+version = "5.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8d3b65c44123a56e0133d2cd06ce4361bd3ca99d41198b2f25e3c3db9b8b4a"
+checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
 dependencies = [
  "is-wsl",
  "libc",
+ "pathdiff",
 ]
 
 [[package]]
@@ -3066,16 +2807,6 @@ name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
-
-[[package]]
-name = "page_size"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
-dependencies = [
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "palette"
@@ -3337,35 +3068,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "prefix-trie"
-version = "0.8.4"
+name = "prettyplease"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
-dependencies = [
- "either",
- "ipnet",
- "num-traits",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
  "syn",
 ]
 
@@ -3386,7 +3094,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.13.0",
+ "bitflags",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -3425,9 +3133,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
-version = "0.11.11"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3445,9 +3153,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -3481,9 +3189,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -3537,7 +3245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom 0.4.3",
+ "getrandom 0.4.2",
  "rand_core 0.10.1",
 ]
 
@@ -3596,9 +3304,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.30.2"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
+checksum = "1695748e3a735b34968c887ceea5a380b43545903868ae8f5b666593100f6b68"
 dependencies = [
  "instability",
  "ratatui-core",
@@ -3609,14 +3317,15 @@ dependencies = [
 
 [[package]]
 name = "ratatui-core"
-version = "0.1.2"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
+checksum = "42d3603f354bba8c595fa47860e60142d7372b7210c27044c6a7d0e1a4336b44"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "compact_str",
  "hashbrown 0.17.1",
- "itertools 0.14.0",
+ "indoc",
+ "itertools",
  "kasuari",
  "lru",
  "palette",
@@ -3630,9 +3339,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-crossterm"
-version = "0.1.2"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
+checksum = "2b2867bedcbd6a690ca4f8672a687b730ec07660c79844517b084311b529980c"
 dependencies = [
  "cfg-if",
  "crossterm",
@@ -3642,15 +3351,15 @@ dependencies = [
 
 [[package]]
 name = "ratatui-widgets"
-version = "0.3.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
+checksum = "7ef4f17dd7ac3abf5adc2b920a03c61eee4bfe6a88fa5191936895525371d79c"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "hashbrown 0.17.1",
  "indoc",
  "instability",
- "itertools 0.14.0",
+ "itertools",
  "line-clipping",
  "ratatui-core",
  "serde",
@@ -3686,7 +3395,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -3711,9 +3420,9 @@ dependencies = [
 
 [[package]]
 name = "reflink-copy"
-version = "0.1.30"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9dd7ab4af0363d5ccfd2838d782a28196cf32a5cc2e4fe3c5dc83f2be588b8b"
+checksum = "13362233b147e57674c37b802d216b7c5e3dcccbed8967c84f0d8d223868ae27"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3771,7 +3480,6 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "hickory-resolver",
  "http",
  "http-body",
  "http-body-util",
@@ -3781,7 +3489,6 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -3804,12 +3511,6 @@ dependencies = [
  "wasm-streams",
  "web-sys",
 ]
-
-[[package]]
-name = "resolv-conf"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "ring"
@@ -3888,7 +3589,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3897,9 +3598,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -3911,9 +3612,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -3923,9 +3624,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4042,7 +3743,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4227,9 +3928,9 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
-version = "2.0.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sigchld"
@@ -4294,15 +3995,16 @@ dependencies = [
 
 [[package]]
 name = "sigstore-bundle"
-version = "0.10.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18b51b097b7e9d898efad51e1031c855ce4008b4866d0c38ac8b0fac5745a84c"
+checksum = "9a86d28a25d9e6107e02ca60fc60dfeb7cdc2b98251950d6fcd055f2afa31acb"
 dependencies = [
  "base64",
  "hex",
  "serde",
  "serde_json",
  "sigstore-crypto",
+ "sigstore-merkle",
  "sigstore-rekor",
  "sigstore-tsa",
  "sigstore-types",
@@ -4311,9 +4013,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-crypto"
-version = "0.10.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1210ea5dd0dd07b1466449a6c5c79000f8ca10ac30b4e8f64031c3bed4c5c662"
+checksum = "9cdc66f1480e176533425cc880bc5f8a8e0d88ae1fe2701e98de4fb68984b71c"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -4333,9 +4035,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-fulcio"
-version = "0.10.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1804a3030159d6c165f7af4fb753a780d4d114b4d16320c0ea2acc1b5af8fea"
+checksum = "78654d1d908925ff3c0634a8bc5199587b6d37ec7b777fedda86687924f088e0"
 dependencies = [
  "base64",
  "reqwest",
@@ -4350,9 +4052,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-merkle"
-version = "0.10.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae98f8a270885497dbe84e6dae10fa29066df0388f62980923728e38d844716"
+checksum = "a4dbea5d8d5f293dfc2ed6abd06dc26a5ef017af126e53e3e36a6b2f7b7dac8c"
 dependencies = [
  "base64",
  "hex",
@@ -4363,9 +4065,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-oidc"
-version = "0.10.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84e65508b946df747b804f770bb83243ecfcfd61150adc9b27c5dca59d74a117"
+checksum = "6e2146f7779690f14313299bc3f2ec87af26cbb96c44a77a4a61dec4422b0007"
 dependencies = [
  "ambient-id",
  "base64",
@@ -4383,9 +4085,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-rekor"
-version = "0.10.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1c153f4f89f7570d0f625f660cadcb1b2fba72583f378d2d2b308c752ac45f"
+checksum = "fbe0bf948de89bed9b3b5c9d62940264a4da60db3518006b952b107d0e71926f"
 dependencies = [
  "base64",
  "hex",
@@ -4401,9 +4103,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-sign"
-version = "0.10.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ec818202811f9440abf6f7714d187b0248268a5472ea481d3c1d33f51f1fd5"
+checksum = "6d21f5037998997f2e79f568efd48fc16649a78580e0eb45390a0b7a6a3871b6"
 dependencies = [
  "base64",
  "serde_json",
@@ -4421,9 +4123,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-trust-root"
-version = "0.10.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded6afc37295a10dba6569e033dd15f85f04f00980bfcf2c64009bc8ed279985"
+checksum = "54fdf65b1207f96d4b1e5b44028fe3e078d40a50f6316715f6ad97ae21b0bfeb"
 dependencies = [
  "base64",
  "hex",
@@ -4432,7 +4134,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sigstore-crypto",
- "sigstore-tuf",
  "sigstore-types",
  "thiserror 2.0.18",
  "x509-cert",
@@ -4440,9 +4141,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore-tsa"
-version = "0.10.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88505b71600a791e52bed3777ed9cfeefd4b03dee6575d38c5542ae80e2bbdc"
+checksum = "860eb6a645e0a22fa316031b06e9e87f9310c21915743bfa83901472dd3e7146"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -4465,32 +4166,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sigstore-tuf"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc7cced094bd306ef561312cfffa3ea05ac7eea4a62cfa81680c07a10addbc0"
-dependencies = [
- "globset",
- "hex",
- "jiff",
- "reqwest",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "sigstore-crypto",
- "sigstore-types",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
 name = "sigstore-types"
-version = "0.10.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f034e86c3b8d91b32608c83f4a18939eed32c6ca08d17d2f52b88be365aac6"
+checksum = "7fb0334b69834c1f29757e57ade7e9bdbc42f5383cc22d003256d4d2df47af13"
 dependencies = [
  "base64",
  "hex",
@@ -4555,9 +4234,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4659,9 +4338,9 @@ dependencies = [
 
 [[package]]
 name = "subfeature"
-version = "1.26.1"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e685ca3f1f2cd09b04ada9642ea26a0dd7bcf52f963ace408b0279f192f7465f"
+checksum = "c7a12b8bd1c18886edb6412ca26de28cf3e44be4ba5aeb41d14fb911ef2dab63"
 dependencies = [
  "memchr",
  "regex",
@@ -4697,9 +4376,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4732,7 +4411,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4746,12 +4425,6 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "tagptr"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tar"
@@ -4771,7 +4444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4891,9 +4564,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "libc",
@@ -4906,9 +4579,9 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.9"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tinystr"
@@ -4918,16 +4591,6 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
-]
-
-[[package]]
-name = "tinytemplate"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -5073,12 +4736,12 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.11"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "async-compression",
- "bitflags 2.13.0",
+ "bitflags",
  "bytes",
  "futures-core",
  "futures-util",
@@ -5182,9 +4845,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.10"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c343ed63e3f5c64d1acdecb5d2c13d4e169cb5fde0052106ebaa6c6f27f9e55"
+checksum = "887bd495d0582c5e3e0d8ece2233666169fa56a9644d172fc22ad179ab2d0538"
 dependencies = [
  "cc",
  "regex",
@@ -5196,9 +4859,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-iter"
-version = "1.26.1"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fa36a1486a196f8de9ded8047a5c6e42d8b9d83a530a67e8316ba8468a325d4"
+checksum = "d9199d1d8f51defb45b2a55af0545460e0a0265dfde45bdf412b33d13e09b923"
 dependencies = [
  "tree-sitter",
 ]
@@ -5233,9 +4896,9 @@ checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
-version = "1.20.1"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -5263,9 +4926,9 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.3"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-truncate"
@@ -5273,7 +4936,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools 0.14.0",
+ "itertools",
  "unicode-segmentation",
  "unicode-width 0.2.2",
 ]
@@ -5289,6 +4952,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -5329,7 +4998,7 @@ dependencies = [
  "clap",
  "heck",
  "indexmap 2.14.0",
- "itertools 0.14.0",
+ "itertools",
  "kdl",
  "log",
  "miette",
@@ -5358,11 +5027,10 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -5385,7 +5053,7 @@ version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80a7e511ce1795821207a837b7b1c8d8aca0c648810966ad200446ae58f6667f"
 dependencies = [
- "itertools 0.14.0",
+ "itertools",
  "nom 8.0.0",
 ]
 
@@ -5425,18 +5093,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5447,9 +5124,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5457,9 +5134,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5467,9 +5144,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5480,11 +5157,33 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -5501,10 +5200,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.103"
+name = "wasmparser"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5522,9 +5233,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5972,9 +5683,97 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.14.0",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -6019,14 +5818,14 @@ dependencies = [
 
 [[package]]
 name = "xx"
-version = "2.6.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aff208388ac09afbb2bd20c3db8f7d253c9fbed7076e3618d598bb3deef2c5"
+checksum = "0f87a0bd775afa76eb9e103d9bd3b9c71560fd6c02b685b3c730d27b613514a3"
 dependencies = [
  "duct",
  "filetime",
  "fslock",
- "getrandom 0.4.3",
+ "getrandom 0.4.2",
  "homedir",
  "libc",
  "log",
@@ -6053,12 +5852,13 @@ dependencies = [
 
 [[package]]
 name = "yamlpatch"
-version = "1.26.1"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919764173d845c2b685a44ca9a028534ef1127bcf713edc6b69787430f18b030"
+checksum = "f5c7aa995e374499b0decb17a2fa138430d6cd4683705e905e1e6619635d5fbd"
 dependencies = [
  "indexmap 2.14.0",
  "line-index",
+ "serde",
  "serde_json",
  "subfeature",
  "thiserror 2.0.18",
@@ -6068,9 +5868,9 @@ dependencies = [
 
 [[package]]
 name = "yamlpath"
-version = "1.26.1"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25eed75b3170866fd4ad5848fb7e19ce9344f3dbc12238d9b175ef0632d27779"
+checksum = "582de007205c6ff9e4c1e57bf23955922e8020dd9fd479146ab2bb45138b44b4"
 dependencies = [
  "line-index",
  "self_cell",
@@ -6083,9 +5883,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.3"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -6106,18 +5906,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6147,18 +5947,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.9.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.5.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6214,9 +6014,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.5"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ clap = { version = "4", features = ["derive"] }
 strum = { version = "0.28", features = ["derive"] }
 
 # HTTP
-reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "rustls", "http2", "charset", "system-proxy", "gzip", "brotli", "zstd", "hickory-dns"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "rustls", "http2", "charset", "system-proxy", "gzip", "brotli", "zstd"] }
 webpki-root-certs = "1"
 
 # Hashing

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,8 +128,11 @@ log = "0.4"
 # yamlpatch, so adding as a direct dep here is free at compile time.
 regex = "1"
 
-# Archive extraction
-flate2 = { version = "1", default-features = false, features = ["zlib-ng"] }
+# Archive extraction. Use the pure-Rust `zlib-rs` backend, not the C `zlib-ng`:
+# the `zip` dep below pulls `flate2/zlib-rs`, and a consumer (Elide) that also
+# selects `zlib-rs` would otherwise link both backends — duplicate `zng_*` /
+# `alloc_deflate` symbols on static targets.
+flate2 = { version = "1", default-features = false, features = ["zlib-rs"] }
 tar = "0.4"
 zstd = { version = "0.13", default-features = false }
 # Zip reader for the OSV advisory mirror — the bulk dump at

--- a/crates/aube-codes/src/errors.rs
+++ b/crates/aube-codes/src/errors.rs
@@ -100,6 +100,7 @@ pub const ERR_AUBE_RUNTIME_EXTRACT_FAILED: &str = "ERR_AUBE_RUNTIME_EXTRACT_FAIL
 #[rustfmt::skip] pub const ERR_AUBE_RUNTIME_MISE_INSTALL_FAILED: &str = "ERR_AUBE_RUNTIME_MISE_INSTALL_FAILED";
 #[rustfmt::skip] pub const ERR_AUBE_RUNTIME_UNSUPPORTED_PLATFORM: &str = "ERR_AUBE_RUNTIME_UNSUPPORTED_PLATFORM";
 pub const ERR_AUBE_RUNTIME_IO: &str = "ERR_AUBE_RUNTIME_IO";
+pub const ERR_AUBE_RUNTIME_NOT_RUNNABLE: &str = "ERR_AUBE_RUNTIME_NOT_RUNNABLE";
 
 // ── misc tracing::error! sites (non-fatal but high-severity) ────────
 pub const ERR_AUBE_PATCHES_TRACKING_WRITE: &str = "ERR_AUBE_PATCHES_TRACKING_WRITE";
@@ -525,6 +526,12 @@ pub const ALL: &[CodeMeta] = &[
         name: ERR_AUBE_RUNTIME_IO,
         category: category::ENGINE_CLI,
         description: "A filesystem operation in the runtime store failed (lock acquisition, staging, or publishing an install). Not a download failure — the message names the failing path.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: ERR_AUBE_RUNTIME_NOT_RUNNABLE,
+        category: category::ENGINE_CLI,
+        description: "A downloaded Node.js binary extracted cleanly but failed a post-install `node --version` check, so the install was discarded instead of published. Typically missing shared libraries — musl builds require the host's libstdc++/libgcc (e.g. `apk add libstdc++`).",
         exit_code: None,
     },
     // Misc / safety

--- a/crates/aube-lockfile/tests/custom_lock_filename.rs
+++ b/crates/aube-lockfile/tests/custom_lock_filename.rs
@@ -13,6 +13,7 @@ use aube_util::Embedder;
 
 static MYTOOL: Embedder = Embedder {
     name: "mytool",
+    command_prefix: &["mytool"],
     display_name: "mytool",
     vendor: None,
     version: "2.1.0",

--- a/crates/aube-lockfile/tests/custom_lock_filename.rs
+++ b/crates/aube-lockfile/tests/custom_lock_filename.rs
@@ -31,6 +31,7 @@ static MYTOOL: Embedder = Embedder {
     runtime_switching: true,
     self_engines_check: true,
     self_update_enabled: true,
+    progress_renderer_enabled: true,
 };
 
 #[test]

--- a/crates/aube-registry/src/client/http.rs
+++ b/crates/aube-registry/src/client/http.rs
@@ -190,11 +190,6 @@ fn build_http_client_inner(
     }
     builder = builder
         .tcp_keepalive(std::time::Duration::from_secs(60))
-        // In-process DNS caching via hickory-dns. The system resolver
-        // does not cache and uses a thread pool for `getaddrinfo`,
-        // which serializes the first cold lookup per origin. hickory
-        // resolves async + caches for the process lifetime.
-        .hickory_dns(true)
         // `strict-ssl=false` disables cert validation entirely. This
         // is a security hole on purpose: corporate registries should
         // prefer per-registry `ca` / `cafile` so validation stays on.

--- a/crates/aube-registry/tests/user_agent_product.rs
+++ b/crates/aube-registry/tests/user_agent_product.rs
@@ -15,6 +15,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 
 static MYTOOL: Embedder = Embedder {
     name: "mytool",
+    command_prefix: &["mytool"],
     display_name: "mytool",
     vendor: None,
     version: "2.1.0",

--- a/crates/aube-registry/tests/user_agent_product.rs
+++ b/crates/aube-registry/tests/user_agent_product.rs
@@ -33,6 +33,7 @@ static MYTOOL: Embedder = Embedder {
     runtime_switching: true,
     self_engines_check: true,
     self_update_enabled: true,
+    progress_renderer_enabled: true,
 };
 
 #[tokio::test]

--- a/crates/aube-resolver/src/platform.rs
+++ b/crates/aube-resolver/src/platform.rs
@@ -101,69 +101,9 @@ pub fn host_triple() -> (&'static str, &'static str, &'static str) {
     // binary built against musl and shipped to glibc users reported
     // libc=musl everywhere, and the glibc-built distro reported
     // glibc everywhere. Wrong prebuilts got installed, runtime
-    // ld.so errors. Probe /lib/ld-musl-* vs /lib*/ld-linux-*.
-    let libc = if std::env::consts::OS == "linux" {
-        detect_linux_libc()
-    } else {
-        ""
-    };
-    (os, cpu, libc)
-}
-
-/// Probe the active dynamic linker to tell musl from glibc at runtime.
-/// Authoritative signal is `/proc/self/maps`: the dynamic linker that
-/// loaded the running aube binary is always mmap'd into the process,
-/// so whichever of `ld-musl-*` or `ld-linux-*` shows up there is the
-/// libc the host actually runs. Cached once via OnceLock.
-///
-/// The previous /lib-scan heuristic broke on Ubuntu glibc hosts that
-/// `apt install musl` for cross-compile tooling: the musl package
-/// drops `/lib/ld-musl-<arch>.so.1` alongside the system glibc loader,
-/// and a first-match scan returned "musl", causing aube to install
-/// `*-linux-x64-musl` native bindings that node (linked against
-/// glibc) cannot load. /proc/self/maps cuts straight to which loader
-/// actually runs and ignores the partial-install noise. The /lib
-/// fallback is kept for non-Linux containers / stripped rootfs that
-/// expose no procfs, but checks glibc *first* so a dual-loader system
-/// still resolves correctly there.
-fn detect_linux_libc() -> &'static str {
-    use std::sync::OnceLock;
-    static CACHE: OnceLock<&'static str> = OnceLock::new();
-    CACHE.get_or_init(|| {
-        if let Ok(maps) = std::fs::read_to_string("/proc/self/maps") {
-            if maps.contains("/ld-musl-") {
-                return "musl";
-            }
-            if maps.contains("/ld-linux") {
-                return "glibc";
-            }
-        }
-        let glibc_dirs = [
-            "/lib",
-            "/lib64",
-            "/lib/x86_64-linux-gnu",
-            "/lib/aarch64-linux-gnu",
-        ];
-        for dir in glibc_dirs {
-            if let Ok(entries) = std::fs::read_dir(dir) {
-                for entry in entries.flatten() {
-                    let name = entry.file_name();
-                    if name.to_string_lossy().starts_with("ld-linux") {
-                        return "glibc";
-                    }
-                }
-            }
-        }
-        if let Ok(entries) = std::fs::read_dir("/lib") {
-            for entry in entries.flatten() {
-                let name = entry.file_name();
-                if name.to_string_lossy().starts_with("ld-musl-") {
-                    return "musl";
-                }
-            }
-        }
-        "glibc"
-    })
+    // ld.so errors. The shared probe reads /proc/self/maps (glibc-first
+    // /lib scan fallback); see `aube_util::libc`.
+    (os, cpu, aube_util::libc::detect_linux_libc())
 }
 
 /// Apply npm's `os`/`cpu`/`libc` rules to a single (pkg_field, host)

--- a/crates/aube-runtime/src/error.rs
+++ b/crates/aube-runtime/src/error.rs
@@ -33,6 +33,15 @@ pub enum Error {
     #[error("failed to extract Node.js archive: {reason}")]
     ExtractFailed { reason: String },
 
+    /// The extracted binary failed its post-install `node --version`
+    /// check; `hint` is empty or a `\n`-prefixed remediation line.
+    #[error("installed Node.js binary at {path} cannot run: {reason}{hint}")]
+    NotRunnable {
+        path: String,
+        reason: String,
+        hint: String,
+    },
+
     /// `version` carries the full tool spec (`node@22.1.0`,
     /// `aube@1.18.2`).
     #[error("mise failed to install {version}: {reason}")]
@@ -63,6 +72,7 @@ impl Error {
             Error::DownloadFailed { .. } => errors::ERR_AUBE_RUNTIME_DOWNLOAD_FAILED,
             Error::ChecksumMismatch { .. } => errors::ERR_AUBE_RUNTIME_CHECKSUM_MISMATCH,
             Error::ExtractFailed { .. } => errors::ERR_AUBE_RUNTIME_EXTRACT_FAILED,
+            Error::NotRunnable { .. } => errors::ERR_AUBE_RUNTIME_NOT_RUNNABLE,
             Error::MiseInstallFailed { .. } => errors::ERR_AUBE_RUNTIME_MISE_INSTALL_FAILED,
             Error::UnsupportedPlatform { .. } => errors::ERR_AUBE_RUNTIME_UNSUPPORTED_PLATFORM,
             Error::Offline { .. } => errors::ERR_AUBE_OFFLINE,

--- a/crates/aube-runtime/src/installer.rs
+++ b/crates/aube-runtime/src/installer.rs
@@ -135,6 +135,23 @@ async fn download_verify_extract(
         return Err(e);
     }
 
+    // Prove the extracted node can actually run on this host before
+    // publishing it; a broken binary (e.g. missing shared libraries)
+    // must fail the install here, not lifecycle scripts later.
+    let staged_node = crate::discover::node_paths_in(&staging).1;
+    let verify_result = tokio::task::spawn_blocking(move || verify_runnable(&staged_node))
+        .await
+        .map_err(|e| {
+            Error::io(
+                "verify installed node",
+                std::io::Error::other(e.to_string()),
+            )
+        })?;
+    if let Err(e) = verify_result {
+        let _ = std::fs::remove_dir_all(&staging);
+        return Err(e);
+    }
+
     match std::fs::rename(&staging, dest) {
         Ok(()) => {}
         Err(rename_err) => {
@@ -160,6 +177,48 @@ async fn download_verify_extract(
             ),
         }
     })
+}
+
+/// Run the freshly extracted `node` once (`node --version`) before
+/// publishing it, so a binary the host cannot execute fails the
+/// install loudly instead of surfacing as loader errors mid-install
+/// later (elide-dev/WHIPLASH#1254: dynamically-linked musl builds
+/// need the host's libstdc++/libgcc).
+///
+/// # Errors
+/// [`Error::NotRunnable`] when the binary cannot be spawned or exits
+/// non-zero; the message carries the loader/stderr output.
+fn verify_runnable(node_bin: &Path) -> Result<(), Error> {
+    let not_runnable = |reason: String| Error::NotRunnable {
+        path: node_bin.display().to_string(),
+        reason,
+        // A musl host that can't run the unofficial musl build is
+        // almost always missing its shared C++ runtime.
+        hint: if aube_util::libc::detect_linux_libc() == "musl" {
+            "\nhint: musl builds of Node.js need the host's libstdc++/libgcc \
+             (e.g. `apk add libstdc++ libgcc`)"
+                .to_string()
+        } else {
+            String::new()
+        },
+    };
+    let output = std::process::Command::new(node_bin)
+        .arg("--version")
+        .output()
+        .map_err(|e| not_runnable(e.to_string()))?;
+    if output.status.success() {
+        return Ok(());
+    }
+    // Loader failures (the interesting case) spam one line per missing
+    // symbol; the first few lines carry the signal.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let excerpt: Vec<&str> = stderr.trim().lines().take(3).collect();
+    let reason = if excerpt.is_empty() {
+        format!("`node --version` exited with {}", output.status)
+    } else {
+        excerpt.join("\n")
+    };
+    Err(not_runnable(reason))
 }
 
 /// Stream `url` to `path`, returning the SHA-256 of the bytes
@@ -236,5 +295,56 @@ fn gc_stale_temp_dirs() {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    fn fake_node(dir: &Path, script: &str) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let path = dir.join("node");
+        std::fs::write(&path, script).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        path
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn verify_runnable_accepts_a_working_node() {
+        let tmp = tempfile::tempdir().unwrap();
+        let node = fake_node(tmp.path(), "#!/bin/sh\necho v25.2.0\n");
+        assert!(verify_runnable(&node).is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn verify_runnable_rejects_a_binary_that_fails_to_start() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Mimics musl's loader on a host missing libstdc++ (WHIPLASH#1254).
+        let node = fake_node(
+            tmp.path(),
+            "#!/bin/sh\necho 'Error loading shared library libstdc++.so.6: No such file or directory' >&2\nexit 127\n",
+        );
+        let err = verify_runnable(&node).unwrap_err();
+        match err {
+            Error::NotRunnable { ref reason, .. } => {
+                assert!(reason.contains("libstdc++"), "reason: {reason}");
+            }
+            other => panic!("expected NotRunnable, got: {other}"),
+        }
+        assert_eq!(
+            err.code(),
+            aube_codes::errors::ERR_AUBE_RUNTIME_NOT_RUNNABLE
+        );
+    }
+
+    #[test]
+    fn verify_runnable_rejects_a_missing_binary() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = verify_runnable(&tmp.path().join("node")).unwrap_err();
+        assert!(matches!(err, Error::NotRunnable { .. }));
     }
 }

--- a/crates/aube-runtime/src/platform.rs
+++ b/crates/aube-runtime/src/platform.rs
@@ -25,9 +25,14 @@ impl Platform {
     ///
     /// musl detection is a *runtime* check: aube ships static-musl
     /// Linux binaries, so `cfg!(target_env = "musl")` is true even on
-    /// glibc hosts and cannot be trusted. The presence of musl's
-    /// dynamic loader (`/lib/ld-musl-<arch>.so.1`) is the signal mise
-    /// uses for the same decision.
+    /// glibc hosts and cannot be trusted. Nor is the mere presence of
+    /// musl's loader on disk a signal — Debian/Ubuntu's `musl` package
+    /// drops `/lib/ld-musl-<arch>.so.1` alongside glibc, and probing
+    /// it here downloaded unrunnable `linux-*-musl` Node builds on
+    /// glibc hosts (elide-dev/WHIPLASH#1254). The shared probe in
+    /// [`aube_util::libc`] reads `/proc/self/maps` with a glibc-first
+    /// loader scan fallback — the same detection the resolver uses for
+    /// native bindings.
     pub fn current() -> Result<Platform, Error> {
         let os = match std::env::consts::OS {
             "macos" => "darwin",
@@ -47,7 +52,7 @@ impl Platform {
             "s390x" => "s390x",
             other => other,
         };
-        let libc = (os == "linux" && detect_musl()).then(|| "musl".to_string());
+        let libc = (aube_util::libc::detect_linux_libc() == "musl").then(|| "musl".to_string());
         Ok(Platform {
             os: os.to_string(),
             cpu: cpu.to_string(),
@@ -100,19 +105,6 @@ impl Platform {
             None => format!("{}-{}", self.os, self.cpu),
         }
     }
-}
-
-#[cfg(target_os = "linux")]
-fn detect_musl() -> bool {
-    // Rust's arch names match musl's loader names for every
-    // architecture Node ships (x86_64, aarch64), so the constant is
-    // used verbatim.
-    std::path::Path::new(&format!("/lib/ld-musl-{}.so.1", std::env::consts::ARCH)).exists()
-}
-
-#[cfg(not(target_os = "linux"))]
-fn detect_musl() -> bool {
-    false
 }
 
 /// The artifact filename for `version` on `platform`:

--- a/crates/aube-scripts/tests/user_agent_product.rs
+++ b/crates/aube-scripts/tests/user_agent_product.rs
@@ -9,6 +9,7 @@ use aube_util::Embedder;
 
 static MYTOOL: Embedder = Embedder {
     name: "mytool",
+    command_prefix: &["mytool"],
     display_name: "mytool",
     vendor: None,
     version: "2.1.0",

--- a/crates/aube-scripts/tests/user_agent_product.rs
+++ b/crates/aube-scripts/tests/user_agent_product.rs
@@ -27,6 +27,7 @@ static MYTOOL: Embedder = Embedder {
     runtime_switching: true,
     self_engines_check: true,
     self_update_enabled: true,
+    progress_renderer_enabled: true,
 };
 
 #[test]

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -807,7 +807,7 @@ directory only works when Node can still find its deps: set
 running node. The inner dir name is what the walk actually hits, so
 it stays fixed.
 """
-sources.cli = []
+sources.cli = ["modulesDir", "modules-dir"]
 sources.env = ["npm_config_modules_dir", "NPM_CONFIG_MODULES_DIR", "AUBE_MODULES_DIR"]
 sources.npmrc = ["modulesDir", "modules-dir"]
 sources.workspaceYaml = ["modulesDir"]

--- a/crates/aube-util/src/identity.rs
+++ b/crates/aube-util/src/identity.rs
@@ -40,12 +40,22 @@ use std::sync::OnceLock;
 #[derive(Clone, Copy, Debug)]
 pub struct Embedder {
     /// Tool name, lowercase (e.g. `"aube"`). The proper noun users type and
-    /// see in output, and the clap command name driving help/usage/errors.
+    /// see in output, and the command-safe slug used for sidecars.
     /// Must be filesystem- and command-safe (no spaces, slashes, or shell
     /// metacharacters); it is used verbatim in on-disk sidecar paths (e.g.
-    /// `.<name>_patch_state.json`, `.<name>-deploy-injected/`) and in command
-    /// invocations, so the embedder is responsible for supplying a safe slug.
+    /// `.<name>_patch_state.json`, `.<name>-deploy-injected/`), so the
+    /// embedder is responsible for supplying a safe slug.
     pub name: &'static str,
+    /// Words a user types to invoke this tool, used in user-facing command
+    /// references and clap usage/error output. Standalone aube uses
+    /// `["aube"]`; an embedded host can use something like
+    /// `["elide", "aube", "--"]` while keeping [`name`](Self::name) as the
+    /// stable slug.
+    ///
+    /// The first word is display-only when aube recursively invokes itself:
+    /// recursive calls run `std::env::current_exe()` and prepend every
+    /// remaining word before the aube subcommand.
+    pub command_prefix: &'static [&'static str],
     /// High-visibility display name shown in the progress banner (e.g.
     /// `"aube"`). Usually equal to [`name`](Self::name); split out so an
     /// embedder can brand the banner independently of the command name.
@@ -146,6 +156,7 @@ pub struct Embedder {
 /// profile is registered.
 pub const AUBE: Embedder = Embedder {
     name: "aube",
+    command_prefix: &["aube"],
     display_name: "aube",
     vendor: Some("by jdx.dev"),
     version: env!("CARGO_PKG_VERSION"),
@@ -187,6 +198,14 @@ static ACTIVE: OnceLock<&'static Embedder> = OnceLock::new();
 /// `debug_assert!` here — at registration, the single choke point — rather than
 /// misbehaving deep inside `io.rs` / `clean.rs` / `pack.rs`.
 pub fn set_embedder(embedder: &'static Embedder) {
+    debug_assert!(
+        !embedder.command_prefix.is_empty(),
+        "embedder command_prefix must include at least the displayed executable name",
+    );
+    debug_assert!(
+        embedder.command_prefix.iter().all(|part| !part.is_empty()),
+        "embedder command_prefix must not contain empty words",
+    );
     debug_assert!(
         embedder.lockfile_basename.contains('.'),
         "embedder lockfile_basename {:?} must contain a `.` (stem/extension split is load-bearing)",
@@ -239,6 +258,25 @@ pub fn prog() -> &'static str {
     embedder().name
 }
 
+/// The active tool's user-facing invocation prefix as words, e.g. `["aube"]`
+/// for standalone aube or `["elide", "aube", "--"]` for an embedded host.
+pub fn command_prefix() -> &'static [&'static str] {
+    embedder().command_prefix
+}
+
+/// The argument prefix to prepend after `std::env::current_exe()` when aube
+/// recursively invokes itself. The executable word in [`command_prefix`] is a
+/// user-facing display token; recursive calls already have the real executable
+/// path from `current_exe()`.
+pub fn recursive_command_args() -> &'static [&'static str] {
+    command_prefix().get(1..).unwrap_or(&[])
+}
+
+/// The active tool's user-facing invocation prefix as one display string.
+pub fn command_prefix_display() -> String {
+    command_prefix().join(" ")
+}
+
 /// A *user-facing* `"{prog} <verb>"` command reference, e.g. `cmd("install")`
 /// renders `"aube install"` under the default profile and `"nub install"` under
 /// a `nub`-branded embedder.
@@ -256,7 +294,7 @@ pub fn prog() -> &'static str {
 /// text is unchanged. Allocates a `String`; for the bare program name with no
 /// verb use [`prog`], which borrows.
 pub fn cmd(verb: &str) -> String {
-    format!("{} {verb}", prog())
+    format!("{} {verb}", command_prefix_display())
 }
 
 #[cfg(test)]
@@ -276,6 +314,7 @@ mod tests {
     fn embedder_unset_is_aube() {
         let id = embedder();
         assert_eq!(id.name, "aube");
+        assert_eq!(id.command_prefix, &["aube"]);
         assert_eq!(id.display_name, "aube");
         assert_eq!(id.vendor, Some("by jdx.dev"));
         assert_eq!(id.version, env!("CARGO_PKG_VERSION"));
@@ -307,6 +346,9 @@ mod tests {
     #[test]
     fn prog_and_cmd_render_aube_under_default_profile() {
         assert_eq!(prog(), "aube");
+        assert_eq!(command_prefix(), &["aube"]);
+        assert_eq!(recursive_command_args(), &[] as &[&str]);
+        assert_eq!(command_prefix_display(), "aube");
         assert_eq!(cmd("install"), "aube install");
         assert_eq!(cmd("patch-commit"), "aube patch-commit");
         assert_eq!(cmd("store prune"), "aube store prune");

--- a/crates/aube-util/src/identity.rs
+++ b/crates/aube-util/src/identity.rs
@@ -149,6 +149,14 @@ pub struct Embedder {
     /// embedder that owns its own upgrade path sets this `false` so those
     /// code paths never run. Embedder-fixed.
     pub self_update_enabled: bool,
+    /// When `true` (aube's default), aube renders its own progress UI.
+    /// Embedders that install a [`crate::progress::ProgressSink`] and render
+    /// all progress through the host set this `false`.
+    pub progress_renderer_enabled: bool,
+    /// Default npm registry URL used by an embedder when the user's config
+    /// still resolves to aube's public npmjs default. `None` preserves
+    /// standalone aube behavior.
+    pub default_registry: Option<&'static str>,
 }
 
 /// Standalone aube's embedder profile. Reproduces every hardcoded branding
@@ -174,6 +182,8 @@ pub const AUBE: Embedder = Embedder {
     runtime_switching: true,
     self_engines_check: true,
     self_update_enabled: true,
+    progress_renderer_enabled: true,
+    default_registry: None,
 };
 
 static ACTIVE: OnceLock<&'static Embedder> = OnceLock::new();

--- a/crates/aube-util/src/lib.rs
+++ b/crates/aube-util/src/lib.rs
@@ -16,6 +16,7 @@ pub mod hash;
 pub mod http;
 pub mod identity;
 pub mod io;
+pub mod progress;
 
 // Convenience re-exports so consumers can reference `aube_util::Embedder`
 // / `aube_util::embedder()` without naming the module.

--- a/crates/aube-util/src/lib.rs
+++ b/crates/aube-util/src/lib.rs
@@ -19,7 +19,10 @@ pub mod io;
 
 // Convenience re-exports so consumers can reference `aube_util::Embedder`
 // / `aube_util::embedder()` without naming the module.
-pub use identity::{AUBE, Embedder, cmd, embedder, prog, set_embedder};
+pub use identity::{
+    AUBE, Embedder, cmd, command_prefix, command_prefix_display, embedder, prog,
+    recursive_command_args, set_embedder,
+};
 pub mod path;
 pub mod pkg;
 pub mod snapshot;

--- a/crates/aube-util/src/lib.rs
+++ b/crates/aube-util/src/lib.rs
@@ -16,6 +16,7 @@ pub mod hash;
 pub mod http;
 pub mod identity;
 pub mod io;
+pub mod libc;
 pub mod progress;
 
 // Convenience re-exports so consumers can reference `aube_util::Embedder`

--- a/crates/aube-util/src/libc.rs
+++ b/crates/aube-util/src/libc.rs
@@ -1,0 +1,153 @@
+//! Host libc detection (glibc vs musl) shared by native-binding
+//! selection (aube-resolver) and Node runtime downloads (aube-runtime).
+//!
+//! Detection is a *runtime* question, not a compile-time one: aube
+//! ships static-musl Linux binaries, so `cfg!(target_env = "musl")`
+//! reflects the toolchain that built aube, never the host. And the
+//! mere *presence* of musl's loader on disk is not a signal either —
+//! Debian/Ubuntu's `musl` package (common for cross-compile dev)
+//! drops `/lib/ld-musl-<arch>.so.1` alongside the system glibc
+//! loader, which historically caused musl false-positives and
+//! unloadable `*-musl` artifacts on glibc hosts.
+
+use std::path::{Path, PathBuf};
+
+/// The host's libc in npm vocabulary: `"glibc"` / `"musl"` on Linux,
+/// `""` elsewhere (npm only sets `libc` on Linux packages).
+///
+/// Authoritative signal is `/proc/self/maps`: the dynamic linker that
+/// loaded the running process is always mmap'd into it, so whichever
+/// of `ld-musl-*` / `ld-linux-*` appears there is the libc the host
+/// actually runs. Static binaries (like aube's own Linux builds) map
+/// no loader, so a directory scan of the standard loader locations is
+/// kept as a fallback — checking glibc *first* so a dual-loader host
+/// still resolves correctly. Cached once per process.
+pub fn detect_linux_libc() -> &'static str {
+    use std::sync::OnceLock;
+    static CACHE: OnceLock<&'static str> = OnceLock::new();
+    CACHE.get_or_init(|| {
+        if std::env::consts::OS != "linux" {
+            return "";
+        }
+        if let Ok(maps) = std::fs::read_to_string("/proc/self/maps")
+            && let Some(libc) = libc_from_maps(&maps)
+        {
+            return libc;
+        }
+        let glibc_dirs = [
+            PathBuf::from("/lib"),
+            PathBuf::from("/lib64"),
+            PathBuf::from("/lib/x86_64-linux-gnu"),
+            PathBuf::from("/lib/aarch64-linux-gnu"),
+        ];
+        libc_from_loader_scan(&glibc_dirs, Path::new("/lib")).unwrap_or("glibc")
+    })
+}
+
+/// Classify libc from the contents of `/proc/self/maps`. `None` when
+/// no dynamic loader is mapped (static binary, stripped rootfs).
+fn libc_from_maps(maps: &str) -> Option<&'static str> {
+    if maps.contains("/ld-musl-") {
+        return Some("musl");
+    }
+    if maps.contains("/ld-linux") {
+        return Some("glibc");
+    }
+    None
+}
+
+/// Fallback loader scan for hosts without procfs evidence. Checks
+/// `glibc_dirs` for `ld-linux*` before checking `musl_dir` for
+/// `ld-musl-*`, so a host with both loaders resolves to glibc.
+/// `None` when neither loader is found.
+fn libc_from_loader_scan(glibc_dirs: &[PathBuf], musl_dir: &Path) -> Option<&'static str> {
+    for dir in glibc_dirs {
+        if dir_has_loader_prefix(dir, "ld-linux") {
+            return Some("glibc");
+        }
+    }
+    if dir_has_loader_prefix(musl_dir, "ld-musl-") {
+        return Some("musl");
+    }
+    None
+}
+
+fn dir_has_loader_prefix(dir: &Path, prefix: &str) -> bool {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    entries
+        .flatten()
+        .any(|e| e.file_name().to_string_lossy().starts_with(prefix))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_with_musl_loader_classifies_musl() {
+        let maps = "7f0000000000-7f0000001000 r-xp 00000000 08:01 42 /lib/ld-musl-x86_64.so.1\n";
+        assert_eq!(libc_from_maps(maps), Some("musl"));
+    }
+
+    #[test]
+    fn maps_with_glibc_loader_classifies_glibc() {
+        let maps =
+            "7f0000000000-7f0000001000 r-xp 00000000 08:01 42 /usr/lib64/ld-linux-x86-64.so.2\n";
+        assert_eq!(libc_from_maps(maps), Some("glibc"));
+    }
+
+    #[test]
+    fn maps_without_any_loader_is_inconclusive() {
+        // A static binary maps no dynamic loader at all.
+        let maps = "7f0000000000-7f0000001000 r-xp 00000000 08:01 42 /usr/bin/aube\n";
+        assert_eq!(libc_from_maps(maps), None);
+    }
+
+    #[test]
+    fn scan_prefers_glibc_when_both_loaders_are_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let glibc_dir = tmp.path().join("glibc");
+        let musl_dir = tmp.path().join("musl");
+        std::fs::create_dir_all(&glibc_dir).unwrap();
+        std::fs::create_dir_all(&musl_dir).unwrap();
+        std::fs::write(glibc_dir.join("ld-linux-x86-64.so.2"), b"").unwrap();
+        std::fs::write(musl_dir.join("ld-musl-x86_64.so.1"), b"").unwrap();
+        assert_eq!(
+            libc_from_loader_scan(&[glibc_dir], &musl_dir),
+            Some("glibc")
+        );
+    }
+
+    #[test]
+    fn scan_reports_musl_when_only_the_musl_loader_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let glibc_dir = tmp.path().join("glibc");
+        let musl_dir = tmp.path().join("musl");
+        std::fs::create_dir_all(&glibc_dir).unwrap();
+        std::fs::create_dir_all(&musl_dir).unwrap();
+        std::fs::write(musl_dir.join("ld-musl-aarch64.so.1"), b"").unwrap();
+        assert_eq!(libc_from_loader_scan(&[glibc_dir], &musl_dir), Some("musl"));
+    }
+
+    #[test]
+    fn scan_with_no_loaders_is_inconclusive() {
+        let tmp = tempfile::tempdir().unwrap();
+        let glibc_dir = tmp.path().join("glibc");
+        let musl_dir = tmp.path().join("musl");
+        std::fs::create_dir_all(&glibc_dir).unwrap();
+        std::fs::create_dir_all(&musl_dir).unwrap();
+        assert_eq!(libc_from_loader_scan(&[glibc_dir], &musl_dir), None);
+    }
+
+    #[test]
+    fn detect_returns_npm_vocabulary_for_this_host() {
+        let libc = detect_linux_libc();
+        if cfg!(target_os = "linux") {
+            assert!(libc == "glibc" || libc == "musl");
+        } else {
+            assert_eq!(libc, "");
+        }
+    }
+}

--- a/crates/aube-util/src/progress.rs
+++ b/crates/aube-util/src/progress.rs
@@ -1,0 +1,81 @@
+use std::sync::{Arc, OnceLock, RwLock};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProgressUnit {
+    None,
+    Count,
+    Bytes,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProgressOutcome {
+    Success,
+    Failure,
+}
+
+pub trait ProgressSink: Send + Sync + 'static {
+    fn start(&self, _message: &str, _total: Option<u64>) {}
+
+    fn update(&self, _position: Option<u64>, _total: Option<u64>, _message: Option<&str>) {}
+
+    fn finish(&self, _outcome: ProgressOutcome, _message: &str) {}
+
+    fn start_task(
+        &self,
+        _id: u64,
+        _parent: Option<u64>,
+        _message: &str,
+        _total: Option<u64>,
+        _unit: ProgressUnit,
+    ) {
+    }
+
+    fn update_task(
+        &self,
+        _id: u64,
+        _position: Option<u64>,
+        _total: Option<u64>,
+        _message: Option<&str>,
+        _detail: Option<&str>,
+    ) {
+    }
+
+    fn finish_task(&self, _id: u64, _outcome: ProgressOutcome, _message: &str) {}
+
+    fn message(&self, _message: &str) {}
+}
+
+static ACTIVE: OnceLock<RwLock<Option<Arc<dyn ProgressSink>>>> = OnceLock::new();
+
+fn active() -> &'static RwLock<Option<Arc<dyn ProgressSink>>> {
+    ACTIVE.get_or_init(|| RwLock::new(None))
+}
+
+pub struct ProgressSinkGuard {
+    previous: Option<Arc<dyn ProgressSink>>,
+}
+
+impl Drop for ProgressSinkGuard {
+    fn drop(&mut self) {
+        if let Ok(mut guard) = active().write() {
+            *guard = self.previous.take();
+        }
+    }
+}
+
+pub fn install_progress_sink(sink: Arc<dyn ProgressSink>) -> ProgressSinkGuard {
+    let previous = active()
+        .write()
+        .ok()
+        .and_then(|mut guard| guard.replace(sink));
+    ProgressSinkGuard { previous }
+}
+
+pub fn has_progress_sink() -> bool {
+    active().read().is_ok_and(|guard| guard.is_some())
+}
+
+pub fn with_progress_sink<R>(f: impl FnOnce(&dyn ProgressSink) -> R) -> Option<R> {
+    let sink = active().read().ok().and_then(|guard| guard.clone())?;
+    Some(f(sink.as_ref()))
+}

--- a/crates/aube-util/tests/embedded_command_prefix.rs
+++ b/crates/aube-util/tests/embedded_command_prefix.rs
@@ -1,0 +1,19 @@
+//! Integration test for an embedder whose public invocation is a host
+//! subcommand rather than a standalone binary.
+
+use aube_util::{AUBE, Embedder, cmd, command_prefix_display, prog, recursive_command_args};
+
+static ELIDELIKE: Embedder = Embedder {
+    command_prefix: &["elide", "aube", "--"],
+    ..AUBE
+};
+
+#[test]
+fn embedded_command_prefix_drives_user_facing_commands_and_recursion() {
+    aube_util::set_embedder(&ELIDELIKE);
+
+    assert_eq!(prog(), "aube");
+    assert_eq!(command_prefix_display(), "elide aube --");
+    assert_eq!(recursive_command_args(), &["aube", "--"]);
+    assert_eq!(cmd("install"), "elide aube -- install");
+}

--- a/crates/aube-util/tests/embedder_env_brand_gate.rs
+++ b/crates/aube-util/tests/embedder_env_brand_gate.rs
@@ -19,6 +19,7 @@ use aube_util::env::{config_env, embedder_env};
 /// brand (`config_env_prefix = Some("NUB")`).
 static NUBLIKE: Embedder = Embedder {
     name: "nublike",
+    command_prefix: &["nublike"],
     display_name: "nublike",
     vendor: None,
     version: "1.0.0",

--- a/crates/aube-util/tests/embedder_env_brand_gate.rs
+++ b/crates/aube-util/tests/embedder_env_brand_gate.rs
@@ -37,6 +37,8 @@ static NUBLIKE: Embedder = Embedder {
     runtime_switching: false,
     self_engines_check: false,
     self_update_enabled: false,
+    progress_renderer_enabled: true,
+    default_registry: None,
 };
 
 /// Restore the previous value of an env var around a closure. Integration-test

--- a/crates/aube-util/tests/source_branding_brand_gate.rs
+++ b/crates/aube-util/tests/source_branding_brand_gate.rs
@@ -36,6 +36,8 @@ static NUBLIKE: Embedder = Embedder {
     runtime_switching: false,
     self_engines_check: false,
     self_update_enabled: false,
+    progress_renderer_enabled: true,
+    default_registry: None,
 };
 
 #[test]

--- a/crates/aube-util/tests/source_branding_brand_gate.rs
+++ b/crates/aube-util/tests/source_branding_brand_gate.rs
@@ -18,6 +18,7 @@ use aube_util::{Embedder, cmd, prog};
 /// helpers.
 static NUBLIKE: Embedder = Embedder {
     name: "nublike",
+    command_prefix: &["nublike"],
     display_name: "nublike",
     vendor: None,
     version: "1.0.0",

--- a/crates/aube/Cargo.toml
+++ b/crates/aube/Cargo.toml
@@ -78,7 +78,7 @@ sigstore-oidc = { workspace = true, optional = true }
 sigstore-types = { workspace = true, optional = true }
 ambient-id = { workspace = true, optional = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
+tracing-subscriber = { workspace = true, optional = true }
 flate2 = { workspace = true }
 glob = { workspace = true }
 ignore = { workspace = true }
@@ -98,7 +98,7 @@ ratatui = { version = "0.30.0", default-features = false, features = ["crossterm
 crossterm = { version = "0.29.0", optional = true }
 
 [features]
-default = ["mimalloc", "config-tui", "publish-provenance", "standalone-usage"]
+default = ["mimalloc", "config-tui", "publish-provenance", "standalone-usage", "install-tracing-subscriber"]
 # Include the interactive `aube config tui` browser. Builds that want the
 # smallest dependency graph can disable default features and omit this.
 config-tui = ["dep:crossterm", "dep:ratatui"]
@@ -119,6 +119,10 @@ publish-provenance = [
 # Include the standalone binary's `aube usage` generator. Embedded builds do
 # not need this command-only dependency chain.
 standalone-usage = ["dep:clap_usage"]
+# Install a global tracing subscriber for the standalone binary. Embedded
+# builds leave this disabled so the host can own the single process-wide
+# subscriber.
+install-tracing-subscriber = ["dep:tracing-subscriber"]
 
 [dev-dependencies]
 clap-sort = "1"

--- a/crates/aube/Cargo.toml
+++ b/crates/aube/Cargo.toml
@@ -74,10 +74,10 @@ sha1 = { workspace = true }
 sha2 = { workspace = true }
 blake3 = { workspace = true }
 hex = { workspace = true }
-sigstore-sign = { workspace = true }
-sigstore-oidc = { workspace = true }
-sigstore-types = { workspace = true }
-ambient-id = { workspace = true }
+sigstore-sign = { workspace = true, optional = true }
+sigstore-oidc = { workspace = true, optional = true }
+sigstore-types = { workspace = true, optional = true }
+ambient-id = { workspace = true, optional = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 flate2 = { workspace = true }
@@ -99,7 +99,7 @@ ratatui = { version = "0.30.0", default-features = false, features = ["crossterm
 crossterm = { version = "0.29.0", optional = true }
 
 [features]
-default = ["mimalloc", "config-tui"]
+default = ["mimalloc", "config-tui", "publish-provenance"]
 # Include the interactive `aube config tui` browser. Builds that want the
 # smallest dependency graph can disable default features and omit this.
 config-tui = ["dep:crossterm", "dep:ratatui"]
@@ -108,6 +108,15 @@ config-tui = ["dep:crossterm", "dep:ratatui"]
 # falls back to the system allocator. Needed for Valgrind, ASAN,
 # Miri, and distros that require libc malloc.
 mimalloc = ["dep:mimalloc"]
+# Include npm trusted publishing / provenance attestation support for
+# `aube publish --provenance`. Embedders that only need install/link/runtime
+# flows can disable default features to avoid the Sigstore/OIDC stack.
+publish-provenance = [
+  "dep:ambient-id",
+  "dep:sigstore-oidc",
+  "dep:sigstore-sign",
+  "dep:sigstore-types",
+]
 
 [dev-dependencies]
 clap-sort = "1"

--- a/crates/aube/Cargo.toml
+++ b/crates/aube/Cargo.toml
@@ -55,10 +55,9 @@ bytes = "1"
 xx = { workspace = true }
 clap = { workspace = true }
 # Only the aube binary (src/main.rs) uses this, for the aube-specific `usage`
-# (usage.jdx.dev KDL) command; the embeddable lib no longer carries it. Cargo
-# can't scope a dependency to bin-only within a crate that also has a lib, so
-# it stays here.
-clap_usage = "2"
+# (usage.jdx.dev KDL) command; embedders that turn default features off do not
+# carry the usage-lib/KDL stack.
+clap_usage = { version = "2", optional = true }
 strum = { workspace = true }
 clx = { workspace = true }
 console = "0.16"
@@ -99,7 +98,7 @@ ratatui = { version = "0.30.0", default-features = false, features = ["crossterm
 crossterm = { version = "0.29.0", optional = true }
 
 [features]
-default = ["mimalloc", "config-tui", "publish-provenance"]
+default = ["mimalloc", "config-tui", "publish-provenance", "standalone-usage"]
 # Include the interactive `aube config tui` browser. Builds that want the
 # smallest dependency graph can disable default features and omit this.
 config-tui = ["dep:crossterm", "dep:ratatui"]
@@ -117,6 +116,9 @@ publish-provenance = [
   "dep:sigstore-sign",
   "dep:sigstore-types",
 ]
+# Include the standalone binary's `aube usage` generator. Embedded builds do
+# not need this command-only dependency chain.
+standalone-usage = ["dep:clap_usage"]
 
 [dev-dependencies]
 clap-sort = "1"

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -2219,10 +2219,10 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     // output across bar frames. Route through safe_eprintln which
     // pauses the bar and holds the terminal lock for atomic output.
     for w in &policy_warnings {
-        crate::progress::safe_eprintln(&format!("warn: {w}"));
+        crate::progress::safe_eprintln(&format!("warning: {w}"));
     }
     for w in &jail_policy_warnings {
-        crate::progress::safe_eprintln(&format!("warn: {w}"));
+        crate::progress::safe_eprintln(&format!("warning: {w}"));
     }
 
     let link::LinkPhaseOutput {

--- a/crates/aube/src/commands/install/node_gyp_bootstrap.rs
+++ b/crates/aube/src/commands/install/node_gyp_bootstrap.rs
@@ -66,6 +66,50 @@ fn primary_binary_name() -> &'static str {
     BINARY_NAMES[0]
 }
 
+fn sh_quote_arg(arg: &str) -> String {
+    let mut out = String::with_capacity(arg.len() + 2);
+    out.push('\'');
+    for ch in arg.chars() {
+        if ch == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(ch);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+fn sh_join_args(args: &[&str]) -> String {
+    args.iter()
+        .map(|arg| sh_quote_arg(arg))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn sh_bootstrap_args() -> String {
+    let mut args = sh_join_args(aube_util::recursive_command_args());
+    if !args.is_empty() {
+        args.push(' ');
+    }
+    args.push_str("__node-gyp-bootstrap");
+    args
+}
+
+#[cfg(windows)]
+fn cmd_bootstrap_args() -> String {
+    let mut args = aube_util::recursive_command_args()
+        .iter()
+        .map(|arg| aube_scripts::shell_quote_arg(arg))
+        .collect::<Vec<_>>()
+        .join(" ");
+    if !args.is_empty() {
+        args.push(' ');
+    }
+    args.push_str("__node-gyp-bootstrap");
+    args
+}
+
 fn tool_root() -> miette::Result<PathBuf> {
     let cache = aube_store::dirs::cache_dir()
         .ok_or_else(|| miette!("could not resolve cache dir for node-gyp bootstrap"))?;
@@ -146,11 +190,14 @@ pub(crate) async fn print_bootstrapped_binary(project_dir: &Path) -> miette::Res
 }
 
 fn write_lazy_shims(shim_dir: &Path) -> miette::Result<()> {
-    let sh = r#"#!/usr/bin/env sh
+    let bootstrap_args = sh_bootstrap_args();
+    let sh = format!(
+        r#"#!/usr/bin/env sh
 set -eu
-real="$("$AUBE_NODE_GYP_EXE" __node-gyp-bootstrap "$AUBE_NODE_GYP_PROJECT_DIR")"
+real="$("$AUBE_NODE_GYP_EXE" {bootstrap_args} "$AUBE_NODE_GYP_PROJECT_DIR")"
 exec "$real" "$@"
-"#;
+"#
+    );
     let sh_path = shim_dir.join("node-gyp");
     aube_util::fs_atomic::atomic_write(&sh_path, sh.as_bytes()).into_diagnostic()?;
     #[cfg(unix)]
@@ -166,6 +213,8 @@ exec "$real" "$@"
     // same way — via the hidden `__node-gyp-bootstrap` subcommand — then
     // forwards argv. Falls back to a `node-gyp` on PATH when aube's env
     // markers are absent (e.g. a script spawned outside aube's wrappers).
+    let js_args = serde_json::to_string(aube_util::recursive_command_args())
+        .expect("recursive command args are static strings");
     let js = r#"#!/usr/bin/env node
 "use strict";
 // aube lazy node-gyp stand-in for npm_config_node_gyp. Resolves (and
@@ -175,11 +224,12 @@ exec "$real" "$@"
 // so the shim runs under any Node the user drives, including pre-16.
 const { execFileSync, spawnSync } = require("child_process");
 const isWin = process.platform === "win32";
+const aubeArgs = __AUBE_RECURSIVE_ARGS__;
 let real;
 const exe = process.env.AUBE_NODE_GYP_EXE;
 if (exe) {
   const dir = process.env.AUBE_NODE_GYP_PROJECT_DIR || process.cwd();
-  real = execFileSync(exe, ["__node-gyp-bootstrap", dir], { encoding: "utf8" }).trim();
+  real = execFileSync(exe, aubeArgs.concat(["__node-gyp-bootstrap", dir]), { encoding: "utf8" }).trim();
 } else {
   real = isWin ? "node-gyp.cmd" : "node-gyp";
 }
@@ -189,7 +239,8 @@ if (result.error) {
   process.exit(1);
 }
 process.exit(result.status === null ? 1 : result.status);
-"#;
+"#
+    .replace("__AUBE_RECURSIVE_ARGS__", &js_args);
     let js_path = shim_dir.join("node-gyp.js");
     aube_util::fs_atomic::atomic_write(&js_path, js.as_bytes()).into_diagnostic()?;
     #[cfg(unix)]
@@ -201,11 +252,14 @@ process.exit(result.status === null ? 1 : result.status);
 
     #[cfg(windows)]
     {
-        let cmd = r#"@echo off
-for /f "usebackq delims=" %%i in (`"%AUBE_NODE_GYP_EXE%" __node-gyp-bootstrap "%AUBE_NODE_GYP_PROJECT_DIR%"`) do set "AUBE_REAL_NODE_GYP=%%i"
+        let bootstrap_args = cmd_bootstrap_args();
+        let cmd = format!(
+            r#"@echo off
+for /f "usebackq delims=" %%i in (`"%AUBE_NODE_GYP_EXE%" {bootstrap_args} "%AUBE_NODE_GYP_PROJECT_DIR%"`) do set "AUBE_REAL_NODE_GYP=%%i"
 if not defined AUBE_REAL_NODE_GYP exit /b 1
 "%AUBE_REAL_NODE_GYP%" %*
-"#;
+"#
+        );
         aube_util::fs_atomic::atomic_write(&shim_dir.join("node-gyp.cmd"), cmd.as_bytes())
             .into_diagnostic()?;
     }
@@ -279,15 +333,15 @@ fn bootstrap_blocking(
         .into_diagnostic()
         .wrap_err("could not locate current aube executable for node-gyp bootstrap")?;
     tracing::info!("bootstrapping node-gyp {SPEC} into {}", tool_dir.display());
-    let status = std::process::Command::new(&exe)
+    let mut command = std::process::Command::new(&exe);
+    command
+        .args(aube_util::recursive_command_args())
         .args(["install", "--ignore-scripts", "--silent"])
-        .current_dir(tool_dir)
-        .status()
-        .into_diagnostic()
-        .wrap_err(format!(
-            "failed to spawn recursive {} for node-gyp bootstrap",
-            aube_util::cmd("install")
-        ))?;
+        .current_dir(tool_dir);
+    let status = command.status().into_diagnostic().wrap_err(format!(
+        "failed to spawn recursive {} for node-gyp bootstrap",
+        aube_util::cmd("install")
+    ))?;
     if !status.success() {
         return Err(miette!(
             "recursive {} failed while bootstrapping node-gyp (exit {:?}) — \

--- a/crates/aube/src/commands/install/startup.rs
+++ b/crates/aube/src/commands/install/startup.rs
@@ -146,11 +146,11 @@ pub(super) fn merge_branch_lockfiles_if_needed(
                 );
                 if !report.conflicts.is_empty() {
                     crate::progress::safe_eprintln(&format!(
-                        "warn: {} conflict(s) resolved during branch-lockfile merge:",
+                        "warning: {} conflict(s) resolved during branch-lockfile merge:",
                         report.conflicts.len()
                     ));
                     for c in &report.conflicts {
-                        crate::progress::safe_eprintln(&format!("warn:   {c}"));
+                        crate::progress::safe_eprintln(&format!("warning:   {c}"));
                     }
                 }
             } else {
@@ -166,13 +166,13 @@ pub(super) fn merge_branch_lockfiles_if_needed(
 
 pub(super) fn warn_accepted_noop_install_settings(settings_ctx: &aube_settings::ResolveCtx<'_>) {
     if super::settings::resolve_use_running_store_server(settings_ctx) {
-        eprintln!(
-            "warning: aube has no store server; useRunningStoreServer=true is accepted but has no effect"
+        crate::progress::safe_eprintln(
+            "warning: aube has no store server; useRunningStoreServer=true is accepted but has no effect",
         );
     }
     if !super::settings::resolve_symlink(settings_ctx) {
-        eprintln!(
-            "warning: aube's isolated layout requires symlinks; symlink=false is accepted but has no effect"
+        crate::progress::safe_eprintln(
+            "warning: aube's isolated layout requires symlinks; symlink=false is accepted but has no effect",
         );
     }
 }

--- a/crates/aube/src/commands/install/summary.rs
+++ b/crates/aube/src/commands/install/summary.rs
@@ -3,17 +3,16 @@ pub(super) fn print_already_up_to_date() {
         return;
     }
     use clx::style;
-    use std::io::Write;
     // Routed through the shared `aube_prefix_line` helper so this
     // site and `print_install_summary`'s no-op branch can't drift —
-    // both produce `aube VERSION by jdx.dev · ✓ Already up to date`.
+    // both produce `✓ Already up to date`.
     let msg = format!(
         "{} {}",
         style::egreen("✓").bold(),
         style::ebold("Already up to date"),
     );
     let line = crate::progress::aube_prefix_line(&msg);
-    let _ = writeln!(std::io::stderr(), "{line}");
+    crate::progress::emit_message(&line);
 }
 
 pub(super) fn print_direct_dependency_summary(
@@ -33,11 +32,11 @@ pub(super) fn print_direct_dependency_summary(
     let show_importer_headers = importers.len() > 1;
     for (idx, (importer, deps)) in importers.iter().enumerate() {
         if idx > 0 {
-            eprintln!();
+            crate::progress::emit_message("");
         }
         if show_importer_headers {
             let label = direct_dependency_importer_label(importer, manifests);
-            eprintln!("{}{}", style::ebold(&label), style::edim(":"));
+            crate::progress::emit_message(&format!("{}{}", style::ebold(&label), style::edim(":")));
         }
         print_direct_dependency_section(
             graph,
@@ -53,7 +52,7 @@ pub(super) fn print_direct_dependency_summary(
         );
         print_direct_dependency_section(graph, deps, aube_lockfile::DepType::Dev, direct_dep_info);
     }
-    eprintln!();
+    crate::progress::emit_message("");
 }
 
 fn direct_dependency_importer_label(
@@ -86,20 +85,20 @@ fn print_direct_dependency_section(
     }
     deps.sort_by(|a, b| a.name.cmp(&b.name));
     let label = aube_lockfile::dep_type_label(dep_type);
-    eprintln!("{}{}", style::ebold(label), style::edim(":"));
+    crate::progress::emit_message(&format!("{}{}", style::ebold(label), style::edim(":")));
     for dep in deps {
         let version = graph
             .get_package(&dep.dep_path)
             .map(|pkg| pkg.version.as_str())
             .unwrap_or("?");
         let badges = render_direct_dep_badges(direct_dep_info.get(&dep.dep_path));
-        eprintln!(
+        crate::progress::emit_message(&format!(
             "{} {}{}{}",
             style::egreen("+").bold(),
             dep.name,
             style::edim(format!("@{version}")),
             badges,
-        );
+        ));
     }
 }
 

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -48,6 +48,7 @@ pub mod patch_remove;
 pub mod peers;
 pub mod prune;
 pub mod publish;
+#[cfg(feature = "publish-provenance")]
 pub mod publish_provenance;
 pub mod query;
 pub mod rebuild;

--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -38,7 +38,9 @@ use aube_registry::config::{NpmConfig, normalize_registry_url_pub};
 use base64::Engine;
 use clap::Args;
 use miette::{Context, IntoDiagnostic, miette};
+#[cfg(feature = "publish-provenance")]
 use reqwest::Url;
+#[cfg(feature = "publish-provenance")]
 use serde::Deserialize;
 use sha2::Digest as _;
 use sha2::Sha512;
@@ -441,6 +443,9 @@ async fn publish_one(
         // Rekor round-trip because (a) we don't want to spam the public
         // tlog with throwaway entries and (b) dry-run should be cheap.
         if args.provenance {
+            #[cfg(not(feature = "publish-provenance"))]
+            return Err(provenance_not_compiled());
+            #[cfg(feature = "publish-provenance")]
             crate::commands::publish_provenance::probe_oidc_available()
                 .await
                 .wrap_err("--dry-run --provenance: OIDC probe failed")?;
@@ -501,7 +506,14 @@ async fn publish_one(
     // (Fulcio + Rekor + optional TSA round-trips), so we do it *before*
     // serializing the publish body rather than after — a signing
     // failure should never leave us with a half-built request.
-    let provenance_bundle = if args.provenance {
+    #[cfg(not(feature = "publish-provenance"))]
+    if args.provenance {
+        return Err(provenance_not_compiled());
+    }
+    let provenance_bundle: Option<String> = if args.provenance {
+        #[cfg(not(feature = "publish-provenance"))]
+        unreachable!("handled above when publish-provenance is disabled");
+        #[cfg(feature = "publish-provenance")]
         Some(
             crate::commands::publish_provenance::generate(
                 &archive.tarball,
@@ -627,16 +639,19 @@ fn normalize_publish_version(version: &str) -> String {
         .unwrap_or_else(|_| version.to_string())
 }
 
+#[cfg(feature = "publish-provenance")]
 #[derive(Debug, Deserialize)]
 struct GitHubOidcResponse {
     value: Option<String>,
 }
 
+#[cfg(feature = "publish-provenance")]
 #[derive(Debug, Deserialize)]
 struct NpmOidcExchangeResponse {
     token: Option<String>,
 }
 
+#[cfg(feature = "publish-provenance")]
 /// Try npm Trusted Publishing before falling back to traditional `.npmrc`
 /// auth. npm's OIDC exchange is publish-specific: the CI-issued ID token must
 /// have audience `npm:<registry-host>`, then the registry returns a short-lived
@@ -652,6 +667,16 @@ async fn trusted_publish_token(
     exchange_npm_oidc_token(client, registry_url, package_name, &id_token).await
 }
 
+#[cfg(not(feature = "publish-provenance"))]
+async fn trusted_publish_token(
+    _client: &RegistryClient,
+    _registry_url: &str,
+    _package_name: &str,
+) -> miette::Result<Option<String>> {
+    Ok(None)
+}
+
+#[cfg(feature = "publish-provenance")]
 async fn npm_oidc_id_token(
     client: &RegistryClient,
     registry_url: &str,
@@ -723,6 +748,7 @@ async fn npm_oidc_id_token(
     Ok(body.value.filter(|token| !token.trim().is_empty()))
 }
 
+#[cfg(feature = "publish-provenance")]
 async fn exchange_npm_oidc_token(
     client: &RegistryClient,
     registry_url: &str,
@@ -754,6 +780,11 @@ async fn exchange_npm_oidc_token(
         .into_diagnostic()
         .wrap_err("failed to parse npm OIDC token exchange response")?;
     Ok(body.token.filter(|token| !token.trim().is_empty()))
+}
+
+#[cfg(not(feature = "publish-provenance"))]
+fn provenance_not_compiled() -> miette::Report {
+    miette!("publish provenance support was not compiled into this aube build")
 }
 
 struct PublishHttpFailure {

--- a/crates/aube/src/commands/settings_context.rs
+++ b/crates/aube/src/commands/settings_context.rs
@@ -8,6 +8,8 @@ use miette::{Context, IntoDiagnostic, miette};
 
 use super::{CatalogMap, config, install};
 
+const PUBLIC_NPM_REGISTRY: &str = "https://registry.npmjs.org/";
+
 /// Process-wide snapshot of the top-level `--frozen-lockfile` /
 /// `--no-frozen-lockfile` / `--prefer-frozen-lockfile` flags. Set once
 /// by `async_main` before any command runs so downstream helpers
@@ -71,6 +73,10 @@ pub(crate) fn registry_override() -> Option<String> {
         .clone()
 }
 
+fn is_public_npm_registry(url: &str) -> bool {
+    aube_registry::config::normalize_registry_url_pub(url) == PUBLIC_NPM_REGISTRY
+}
+
 /// Load an `NpmConfig` for `dir` and then apply the process-wide
 /// `--registry` override, if any. Use this from any command that
 /// needs config but wants the CLI flag to win.
@@ -78,6 +84,10 @@ pub(crate) fn load_npm_config(dir: &std::path::Path) -> NpmConfig {
     let mut config = NpmConfig::load(dir);
     if let Some(url) = registry_override() {
         config.registry = url;
+    } else if let Some(default_registry) = aube_util::embedder().default_registry
+        && is_public_npm_registry(&config.registry)
+    {
+        config.registry = aube_registry::config::normalize_registry_url_pub(default_registry);
     }
     config
 }

--- a/crates/aube/src/deprecations.rs
+++ b/crates/aube/src/deprecations.rs
@@ -14,7 +14,6 @@ use aube_lockfile::LockfileGraph;
 use aube_settings::resolved::DeprecationWarnings;
 use clx::style;
 use std::collections::{BTreeMap, BTreeSet};
-use std::io::Write;
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
@@ -118,12 +117,12 @@ pub fn render_install_warnings(
 fn write_warn_line(r: &DeprecationRecord) {
     let line = format!(
         "{} {}@{}: {}",
-        style::eyellow("WARN deprecated").bold(),
+        style::eyellow("warning: deprecated").bold(),
         r.name,
         r.version,
         r.message
     );
-    let _ = writeln!(std::io::stderr(), "{line}");
+    crate::progress::emit_message(&line);
 }
 
 fn write_transitive_count_line(count: usize) {
@@ -136,7 +135,7 @@ fn write_transitive_count_line(count: usize) {
     let msg = format!(
         "{pkgs} {verb} deprecation warnings. Run `{product} deprecations --transitive` to see them."
     );
-    let _ = writeln!(std::io::stderr(), "{}", style::edim(msg));
+    crate::progress::emit_message(&style::edim(msg).to_string());
 }
 
 fn write_count_line(count: usize, has_transitive: bool) {
@@ -150,5 +149,5 @@ fn write_count_line(count: usize, has_transitive: bool) {
         format!("{product} deprecations")
     };
     let msg = format!("{pkgs} {verb} deprecation warnings. Run `{cmd}` to see them.");
-    let _ = writeln!(std::io::stderr(), "{}", style::edim(msg));
+    crate::progress::emit_message(&style::edim(msg).to_string());
 }

--- a/crates/aube/src/lib.rs
+++ b/crates/aube/src/lib.rs
@@ -217,6 +217,27 @@ pub(crate) struct Cli {
     command: Option<Commands>,
 }
 
+struct CwdRestoreGuard {
+    original: PathBuf,
+}
+
+impl CwdRestoreGuard {
+    fn capture() -> miette::Result<Self> {
+        Ok(Self {
+            original: std::env::current_dir()
+                .into_diagnostic()
+                .wrap_err("failed to read current directory")?,
+        })
+    }
+}
+
+impl Drop for CwdRestoreGuard {
+    fn drop(&mut self) {
+        let _ = std::env::set_current_dir(&self.original);
+        let _ = crate::dirs::set_cwd(&self.original);
+    }
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
 #[clap(rename_all = "lowercase")]
 pub(crate) enum LogLevel {
@@ -824,6 +845,10 @@ async fn async_main(cli: Cli) -> miette::Result<Option<i32>> {
     // progress UI.
     // `--reporter=silent` is equivalent to `--silent`; all other reporter
     // values leave the log level alone and only affect output routing.
+    let _cwd_restore = (cli.dir.is_some() || cli.workspace_root)
+        .then(CwdRestoreGuard::capture)
+        .transpose()?;
+
     if let Some(dir) = &cli.dir {
         let target_dir = if dir.is_absolute() {
             dir.clone()
@@ -980,7 +1005,13 @@ async fn async_main(cli: Cli) -> miette::Result<Option<i32>> {
         Some(Commands::Import(args)) => commands::import::run(args).await?,
         Some(Commands::Init(args)) => commands::init::run(args).await?,
         Some(Commands::Install(args)) => {
-            run_install_command(args, effective_filter.clone(), cli.workspace_root).await?;
+            run_install_command(
+                args,
+                effective_filter.clone(),
+                cli.workspace_root,
+                cli.ignore_workspace,
+            )
+            .await?;
         }
         Some(Commands::InstallTest(args)) => {
             if let Some(code) = commands::install_test::run(args).await? {
@@ -1066,7 +1097,13 @@ async fn async_main(cli: Cli) -> miette::Result<Option<i32>> {
                     }
                 }
                 Some(Commands::Install(args)) => {
-                    run_install_command(args, nested_filter, nested.workspace_root).await?;
+                    run_install_command(
+                        args,
+                        nested_filter,
+                        nested.workspace_root,
+                        nested.ignore_workspace,
+                    )
+                    .await?;
                 }
                 Some(Commands::List(args)) => commands::list::run(args, nested_filter).await?,
                 Some(Commands::La(mut args)) | Some(Commands::Ll(mut args)) => {
@@ -1284,6 +1321,7 @@ async fn run_install_command(
     args: commands::install::InstallArgs,
     filter: aube_workspace::selector::EffectiveFilter,
     workspace_root_already: bool,
+    ignore_workspace: bool,
 ) -> miette::Result<()> {
     // `-w` on install is a short alias for the global
     // `--workspace-root` flag. Handle the chdir here when the global
@@ -1310,7 +1348,11 @@ async fn run_install_command(
     // means `aube install` from inside a member loads `.npmrc` /
     // workspace yaml from the workspace root, not the member; without
     // this the two diverged when both roots existed.
-    let cwd = crate::dirs::workspace_or_project_root()?;
+    let cwd = if ignore_workspace {
+        crate::dirs::project_root_or_cwd()?
+    } else {
+        crate::dirs::workspace_or_project_root()?
+    };
     let files = commands::FileSources::load(&cwd);
     let raw_ws = aube_manifest::workspace::load_raw(&cwd)
         .into_diagnostic()
@@ -1320,6 +1362,9 @@ async fn run_install_command(
     let ctx = files.ctx(&raw_ws, &env, &cli_flags);
     let yaml_prefer_frozen = aube_settings::resolved::prefer_frozen_lockfile(&ctx);
     let mut opts = args.into_options(global_frozen, yaml_prefer_frozen, cli_flags, env);
+    if ignore_workspace {
+        opts.project_dir = Some(cwd);
+    }
     opts.workspace_filter = filter;
     commands::install::run(opts).await?;
     Ok(())

--- a/crates/aube/src/lib.rs
+++ b/crates/aube/src/lib.rs
@@ -822,9 +822,18 @@ async fn async_main(cli: Cli) -> miette::Result<Option<i32>> {
     // `--reporter=silent` is equivalent to `--silent`; all other reporter
     // values leave the log level alone and only affect output routing.
     if let Some(dir) = &cli.dir {
-        std::env::set_current_dir(dir)
+        let target_dir = if dir.is_absolute() {
+            dir.clone()
+        } else {
+            std::env::current_dir()
+                .into_diagnostic()
+                .wrap_err("failed to read current directory")?
+                .join(dir)
+        };
+        std::env::set_current_dir(&target_dir)
             .into_diagnostic()
-            .wrap_err_with(|| format!("failed to change directory to {}", dir.display()))?;
+            .wrap_err_with(|| format!("failed to change directory to {}", target_dir.display()))?;
+        crate::dirs::set_cwd(&target_dir)?;
     }
 
     if should_print_top_level_version(&cli) {

--- a/crates/aube/src/lib.rs
+++ b/crates/aube/src/lib.rs
@@ -642,7 +642,10 @@ where
     match result {
         Ok(code) => code,
         Err(report) => {
-            eprintln!("{report:?}");
+            let rendered = format!("{report:?}");
+            if aube_util::progress::with_progress_sink(|sink| sink.message(&rendered)).is_none() {
+                eprintln!("{rendered}");
+            }
             report_exit_code(&report)
         }
     }

--- a/crates/aube/src/lib.rs
+++ b/crates/aube/src/lib.rs
@@ -656,6 +656,7 @@ fn inner_main() -> miette::Result<i32> {
         use clap::{CommandFactory, FromArgMatches};
         let matches = Cli::command()
             .name(aube_util::embedder().name)
+            .bin_name(aube_util::command_prefix_display())
             .get_matches_from(lift_per_subcommand_flags(rewrite_multicall_argv(argv)));
         Cli::from_arg_matches(&matches).unwrap_or_else(|e| e.exit())
     };

--- a/crates/aube/src/lib.rs
+++ b/crates/aube/src/lib.rs
@@ -574,6 +574,33 @@ pub fn cli_main_with_defaults(
     embedder: &'static aube_util::Embedder,
     defaults: Vec<(String, String)>,
 ) -> i32 {
+    cli_main_with_defaults_from_args(embedder, defaults, std::env::args_os())
+}
+
+/// Run aube with an explicit argv vector.
+///
+/// This is the embedding entry point for hosts that want in-process execution
+/// without temporarily rewriting the process argv or spawning a child process.
+#[must_use]
+pub fn cli_main_from_args<I, T>(embedder: &'static aube_util::Embedder, args: I) -> i32
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString>,
+{
+    cli_main_with_defaults_from_args(embedder, Vec::new(), args)
+}
+
+/// Run aube with explicit argv and embedder-level default settings.
+#[must_use]
+pub fn cli_main_with_defaults_from_args<I, T>(
+    embedder: &'static aube_util::Embedder,
+    defaults: Vec<(String, String)>,
+    args: I,
+) -> i32
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString>,
+{
     // Register the binary's embedder profile before anything reads branding,
     // and its setting defaults before anything resolves settings. Both are
     // idempotent — a no-op if already set (e.g. a test harness that
@@ -597,7 +624,8 @@ pub fn cli_main_with_defaults(
         aube_util::diag::flush();
         prev_hook(info);
     }));
-    let result = inner_main();
+    let argv = args.into_iter().map(Into::into).collect();
+    let result = inner_main_from(argv);
     aube_util::diag::flush();
     // Drain any in-flight slow-metadata group whose debounce window
     // hasn't fired yet. install pipelines also flush at end-of-resolve
@@ -633,8 +661,7 @@ fn report_exit_code(report: &miette::Report) -> i32 {
     aube_codes::exit::EXIT_GENERIC
 }
 
-fn inner_main() -> miette::Result<i32> {
-    let mut argv: Vec<OsString> = std::env::args_os().collect();
+fn inner_main_from(mut argv: Vec<OsString>) -> miette::Result<i32> {
     // pnpm-compat: pull `--config.<key>[=<value>]` out of argv before
     // clap parses it. Stripping here means the rest of the binary sees
     // a clean argv, and the parsed pairs feed every `ResolveCtx::cli`
@@ -654,11 +681,24 @@ fn inner_main() -> miette::Result<i32> {
     // behavior, matching the previous `parse_from`.
     let cli = {
         use clap::{CommandFactory, FromArgMatches};
-        let matches = Cli::command()
+        let command = Cli::command()
             .name(aube_util::embedder().name)
-            .bin_name(aube_util::command_prefix_display())
-            .get_matches_from(lift_per_subcommand_flags(rewrite_multicall_argv(argv)));
-        Cli::from_arg_matches(&matches).unwrap_or_else(|e| e.exit())
+            .bin_name(aube_util::command_prefix_display());
+        let matches = match command
+            .try_get_matches_from(lift_per_subcommand_flags(rewrite_multicall_argv(argv)))
+        {
+            Ok(matches) => matches,
+            Err(err) => {
+                let kind = err.kind();
+                err.print().into_diagnostic()?;
+                return Ok(match kind {
+                    clap::error::ErrorKind::DisplayHelp
+                    | clap::error::ErrorKind::DisplayVersion => 0,
+                    _ => 2,
+                });
+            }
+        };
+        Cli::from_arg_matches(&matches).into_diagnostic()?
     };
 
     // `--color` / `--no-color` take effect before anything else touches

--- a/crates/aube/src/lib.rs
+++ b/crates/aube/src/lib.rs
@@ -1785,6 +1785,28 @@ mod cli_ordering_tests {
     use clap::CommandFactory;
     use std::collections::BTreeMap;
 
+    #[test]
+    fn clap_usage_can_display_embedded_command_prefix() {
+        let matches = Cli::command()
+            .bin_name("elide aube --")
+            .try_get_matches_from(["elide", "install", "--ignore-scripts"]);
+        assert!(matches.is_ok(), "install --ignore-scripts should parse");
+
+        let err = Cli::command()
+            .bin_name("elide aube --")
+            .try_get_matches_from(["elide", "install", "--definitely-not-a-real-flag"])
+            .unwrap_err();
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("Usage: elide aube -- install"),
+            "embedded usage prefix should be rendered, got:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("Usage: elide install"),
+            "argv[0] should not replace the embedded usage prefix, got:\n{rendered}"
+        );
+    }
+
     /// Validate that aube's CLI commands and arguments are ordered:
     /// - Subcommands alphabetical by name
     /// - Short flags alphabetical by short option

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -33,9 +33,17 @@ fn main() {
     // the standalone `aube` invocation reaches it: multicall shims rewrite
     // argv before clap, so their `usage` tokens belong to the wrapped tool.
     if is_usage_invocation() {
-        let mut cmd = aube::command();
-        clap_usage::generate(&mut cmd, embedder.name, &mut std::io::stdout());
-        return;
+        #[cfg(feature = "standalone-usage")]
+        {
+            let mut cmd = aube::command();
+            clap_usage::generate(&mut cmd, embedder.name, &mut std::io::stdout());
+            return;
+        }
+        #[cfg(not(feature = "standalone-usage"))]
+        {
+            eprintln!("`aube usage` was built without the standalone-usage feature");
+            std::process::exit(2);
+        }
     }
 
     // The binary owns the single `std::process::exit`: `cli_main` returns the

--- a/crates/aube/src/progress/mod.rs
+++ b/crates/aube/src/progress/mod.rs
@@ -246,11 +246,11 @@ impl EmbeddedState {
             estimated_bytes: AtomicU64::new(0),
         });
         embedded_progress::with_progress_sink(|sink| {
-            sink.start("Installing npm packages", None);
+            sink.start("Installing NPM packages", None);
             sink.start_task(
                 state.root_task,
                 None,
-                "npm packages",
+                "NPM packages",
                 None,
                 ProgressUnit::Count,
             );
@@ -1098,7 +1098,7 @@ impl InstallProgress {
             Mode::Embedded(s) => {
                 s.phase_num.store(4, Ordering::Relaxed);
                 s.update();
-                s.finish(EmbeddedOutcome::Success, "npm packages installed");
+                s.finish(EmbeddedOutcome::Success, "NPM packages installed");
             }
         }
     }
@@ -1255,7 +1255,7 @@ impl Drop for InstallProgress {
             }
             Mode::Embedded(s) => {
                 if Arc::strong_count(s) == 1 && !s.finished.load(Ordering::Relaxed) {
-                    s.finish(EmbeddedOutcome::Failure, "npm install failed");
+                    s.finish(EmbeddedOutcome::Failure, "NPM install failed");
                 }
             }
         }

--- a/crates/aube/src/progress/mod.rs
+++ b/crates/aube/src/progress/mod.rs
@@ -36,7 +36,7 @@ use clx::progress::{
 };
 use clx::style;
 use std::collections::HashMap;
-use std::io::{IsTerminal, Write};
+use std::io::IsTerminal;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, Weak};
 use std::time::{Duration, Instant};
@@ -130,6 +130,18 @@ fn product_banner(suffix: &str) -> String {
 /// embedders should see the same concise success line as other tools.
 pub(crate) fn aube_prefix_line(msg: &str) -> String {
     msg.to_string()
+}
+
+/// Emit a user-facing install message without racing an active progress UI.
+///
+/// Embedders that install a progress sink own the visible output surface, so
+/// hand the message to them. Standalone aube falls back to a terminal-safe
+/// stderr write.
+pub fn emit_message(msg: &str) {
+    if embedded_progress::with_progress_sink(|sink| sink.message(msg)).is_some() {
+        return;
+    }
+    write_terminal_message(msg);
 }
 
 /// Install-time progress UI. Cheap to clone (internally `Arc`).
@@ -1105,9 +1117,8 @@ impl InstallProgress {
     /// Emit the post-install summary line after the progress display has
     /// been torn down. Two shapes:
     ///
-    /// * `linked > 0` — `aube VERSION by jdx.dev · ✓ installed N packages
-    ///   in Xs`, TTY-only (CI mode prints its own framed `✓` summary
-    ///   from the heartbeat's final tick).
+    /// * `linked > 0` — `✓ installed N packages in Xs`, TTY-only (CI mode
+    ///   prints its own framed `✓` summary from the heartbeat's final tick).
     /// * `linked == 0 && top_level_linked == 0` — `Already up to date`
     ///   (matches pnpm), printed in both TTY and CI modes so cache-only
     ///   runs confirm nothing needed doing. Stays silent in reporter
@@ -1142,12 +1153,12 @@ impl InstallProgress {
             };
             // Only the check mark is green so it stays the visual
             // success cue without the whole message bleeding green.
-            // Same single-line `aube VERSION by jdx.dev · ✓ msg` shape
-            // for both TTY and CI modes; CI mode's heartbeat may have
-            // emitted intermediate progress lines above this.
+            // Same single-line `✓ msg` shape for both TTY and CI modes; CI
+            // mode's heartbeat may have emitted intermediate progress lines
+            // above this.
             let msg = format!("{} {}", style::egreen("✓").bold(), style::ebold(&body));
             let line = aube_prefix_line(&msg);
-            let _ = writeln!(std::io::stderr(), "{line}");
+            emit_message(&line);
             return;
         }
         if linked == 0 {
@@ -1175,7 +1186,7 @@ impl InstallProgress {
             style::edim(format_duration(elapsed)),
         );
         let line = aube_prefix_line(&msg);
-        let _ = writeln!(std::io::stderr(), "{line}");
+        emit_message(&line);
     }
 }
 
@@ -1440,6 +1451,13 @@ impl Drop for FetchRow {
 /// that already hold a bar handle can use ProgressJob::println
 /// instead, but this works without one.
 pub fn safe_eprintln(msg: &str) {
+    if embedded_progress::with_progress_sink(|sink| sink.message(msg)).is_some() {
+        return;
+    }
+    write_terminal_message(msg);
+}
+
+fn write_terminal_message(msg: &str) {
     use std::io::Write;
     let was_paused = clx::progress::is_paused();
     if !was_paused {

--- a/crates/aube/src/progress/mod.rs
+++ b/crates/aube/src/progress/mod.rs
@@ -27,6 +27,9 @@ mod render;
 
 pub(crate) use render::format_bytes;
 
+use aube_util::progress::{
+    self as embedded_progress, ProgressOutcome as EmbeddedOutcome, ProgressUnit,
+};
 use ci::{CiState, format_duration};
 use clx::progress::{
     ProgressJob, ProgressJobBuilder, ProgressJobDoneBehavior, ProgressOutput, ProgressStatus,
@@ -206,12 +209,133 @@ enum Mode {
         fetch_state: Arc<Mutex<FetchState>>,
     },
     Ci(Arc<CiState>),
+    Embedded(Arc<EmbeddedState>),
 }
 
 struct FetchState {
     visible: usize,
     overflow: usize,
     overflow_row: Option<Arc<ProgressJob>>,
+}
+
+struct EmbeddedState {
+    root_task: u64,
+    next_task: AtomicU64,
+    finished: AtomicBool,
+    total: AtomicUsize,
+    target_total: AtomicUsize,
+    reused: AtomicUsize,
+    downloaded: AtomicUsize,
+    phase_num: AtomicUsize,
+    downloaded_bytes: AtomicU64,
+    estimated_bytes: AtomicU64,
+}
+
+impl EmbeddedState {
+    fn new() -> Arc<Self> {
+        let state = Arc::new(Self {
+            root_task: 1,
+            next_task: AtomicU64::new(2),
+            finished: AtomicBool::new(false),
+            total: AtomicUsize::new(0),
+            target_total: AtomicUsize::new(0),
+            reused: AtomicUsize::new(0),
+            downloaded: AtomicUsize::new(0),
+            phase_num: AtomicUsize::new(0),
+            downloaded_bytes: AtomicU64::new(0),
+            estimated_bytes: AtomicU64::new(0),
+        });
+        embedded_progress::with_progress_sink(|sink| {
+            sink.start("Installing npm packages", None);
+            sink.start_task(
+                state.root_task,
+                None,
+                "npm packages",
+                None,
+                ProgressUnit::Count,
+            );
+        });
+        state.update();
+        state
+    }
+
+    fn next_task_id(&self) -> u64 {
+        self.next_task.fetch_add(1, Ordering::Relaxed)
+    }
+
+    fn phase_label(&self) -> &'static str {
+        match self.phase_num.load(Ordering::Relaxed) {
+            1 => "resolving",
+            2 => "fetching",
+            3 => "linking",
+            _ => "installing",
+        }
+    }
+
+    fn display_total(&self) -> usize {
+        let total = self.total.load(Ordering::Relaxed);
+        if total == 0 {
+            self.target_total.load(Ordering::Relaxed)
+        } else {
+            total
+        }
+    }
+
+    fn completed(&self) -> usize {
+        let total = self.display_total();
+        let completed =
+            self.reused.load(Ordering::Relaxed) + self.downloaded.load(Ordering::Relaxed);
+        if total == 0 {
+            completed
+        } else {
+            completed.min(total)
+        }
+    }
+
+    fn message(&self) -> String {
+        let phase = self.phase_label();
+        let completed = self.completed();
+        let total = self.display_total();
+        let mut message = if total > 0 {
+            format!("{phase} {completed}/{total}")
+        } else {
+            format!("{phase} {completed}")
+        };
+
+        let bytes = self.downloaded_bytes.load(Ordering::Relaxed);
+        let estimated = self.estimated_bytes.load(Ordering::Relaxed);
+        if bytes > 0 {
+            message.push_str(&format!(" · {}", render::format_bytes(bytes)));
+            if estimated > bytes {
+                message.push_str(&format!(" / ~{}", render::format_bytes(estimated)));
+            }
+        } else if estimated > 0 && self.phase_num.load(Ordering::Relaxed) == 2 {
+            message.push_str(&format!(" · ~{}", render::format_bytes(estimated)));
+        }
+
+        message
+    }
+
+    fn update(&self) {
+        let completed = self.completed() as u64;
+        let total = self.display_total();
+        let total = (total > 0).then_some(total as u64);
+        let message = self.message();
+        embedded_progress::with_progress_sink(|sink| {
+            sink.update(Some(completed), total, Some(&message));
+            sink.update_task(self.root_task, Some(completed), total, Some(&message), None);
+        });
+    }
+
+    fn finish(&self, outcome: EmbeddedOutcome, message: &str) {
+        if self.finished.swap(true, Ordering::Relaxed) {
+            return;
+        }
+        embedded_progress::with_progress_sink(|sink| {
+            sink.finish_task(self.root_task, outcome, message);
+            sink.finish(outcome, message);
+        });
+    }
 }
 
 impl Clone for InstallProgress {
@@ -235,6 +359,9 @@ impl InstallProgress {
     /// disabled (clx text mode — i.e. `--silent`, `-v`, or a line-oriented
     /// reporter that owns its own output).
     pub fn try_new() -> Option<Self> {
+        if !aube_util::embedder().progress_renderer_enabled {
+            return embedded_progress::has_progress_sink().then(Self::new_embedded);
+        }
         if clx::progress::output() == ProgressOutput::Text {
             return None;
         }
@@ -247,6 +374,13 @@ impl InstallProgress {
             Some(Self::new_tty())
         } else {
             Some(Self::new_ci())
+        }
+    }
+
+    fn new_embedded() -> Self {
+        Self {
+            mode: Mode::Embedded(EmbeddedState::new()),
+            unpacked_sizes: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -340,6 +474,10 @@ impl InstallProgress {
             Mode::Ci(s) => {
                 s.target_total.fetch_max(n, Ordering::Relaxed);
             }
+            Mode::Embedded(s) => {
+                s.target_total.fetch_max(n, Ordering::Relaxed);
+                s.update();
+            }
         }
     }
 
@@ -375,6 +513,11 @@ impl InstallProgress {
                 s.resolved.store(total, Ordering::Relaxed);
                 clamp_reused_to(&s.reused, &s.downloaded, total);
             }
+            Mode::Embedded(s) => {
+                s.total.store(total, Ordering::Relaxed);
+                clamp_reused_to(&s.reused, &s.downloaded, total);
+                s.update();
+            }
         }
     }
 
@@ -388,6 +531,10 @@ impl InstallProgress {
             }
             Mode::Ci(s) => {
                 s.resolved.fetch_add(n, Ordering::Relaxed);
+            }
+            Mode::Embedded(s) => {
+                s.total.fetch_add(n, Ordering::Relaxed);
+                s.update();
             }
         }
     }
@@ -435,6 +582,13 @@ impl InstallProgress {
                 }
                 s.estimated_bytes.fetch_add(bytes, Ordering::Relaxed);
             }
+            Mode::Embedded(s) => {
+                if prior > 0 {
+                    s.estimated_bytes.fetch_sub(prior, Ordering::Relaxed);
+                }
+                s.estimated_bytes.fetch_add(bytes, Ordering::Relaxed);
+                s.update();
+            }
         }
     }
 
@@ -466,6 +620,10 @@ impl InstallProgress {
             }
             Mode::Ci(s) => {
                 s.estimated_bytes.store(sum, Ordering::Relaxed);
+            }
+            Mode::Embedded(s) => {
+                s.estimated_bytes.store(sum, Ordering::Relaxed);
+                s.update();
             }
         }
     }
@@ -539,6 +697,16 @@ impl InstallProgress {
                 self.refresh_tty_bar();
             }
             Mode::Ci(s) => s.set_phase(phase),
+            Mode::Embedded(s) => {
+                let n = match phase {
+                    "resolving" => 1,
+                    "fetching" => 2,
+                    "linking" => 3,
+                    _ => 0,
+                };
+                s.phase_num.store(n, Ordering::Relaxed);
+                s.update();
+            }
         }
     }
 
@@ -554,6 +722,10 @@ impl InstallProgress {
             }
             Mode::Ci(s) => {
                 s.reused.fetch_add(n, Ordering::Relaxed);
+            }
+            Mode::Embedded(s) => {
+                s.reused.fetch_add(n, Ordering::Relaxed);
+                s.update();
             }
         }
     }
@@ -584,6 +756,10 @@ impl InstallProgress {
             }
             Mode::Ci(s) => {
                 s.downloaded_bytes.fetch_add(bytes, Ordering::Relaxed);
+            }
+            Mode::Embedded(s) => {
+                s.downloaded_bytes.fetch_add(bytes, Ordering::Relaxed);
+                s.update();
             }
         }
     }
@@ -851,6 +1027,25 @@ impl InstallProgress {
                 inner: FetchRowInner::Ci(Arc::downgrade(s)),
                 completed: false,
             },
+            Mode::Embedded(s) => {
+                let id = s.next_task_id();
+                embedded_progress::with_progress_sink(|sink| {
+                    sink.start_task(
+                        id,
+                        Some(s.root_task),
+                        &format!("{name}@{version}"),
+                        None,
+                        ProgressUnit::Bytes,
+                    );
+                });
+                FetchRow {
+                    inner: FetchRowInner::Embedded {
+                        id,
+                        state: Arc::downgrade(s),
+                    },
+                    completed: false,
+                }
+            }
         }
     }
 
@@ -900,6 +1095,11 @@ impl InstallProgress {
                 clx::progress::stop();
             }
             Mode::Ci(s) => s.stop(print_ci_summary),
+            Mode::Embedded(s) => {
+                s.phase_num.store(4, Ordering::Relaxed);
+                s.update();
+                s.finish(EmbeddedOutcome::Success, "npm packages installed");
+            }
         }
     }
 
@@ -962,6 +1162,7 @@ impl InstallProgress {
         let needs_summary = match &self.mode {
             Mode::Tty { .. } => true,
             Mode::Ci(s) => !s.shown.load(Ordering::Relaxed),
+            Mode::Embedded(_) => false,
         };
         if !needs_summary {
             return;
@@ -1052,6 +1253,11 @@ impl Drop for InstallProgress {
                     s.stop(false);
                 }
             }
+            Mode::Embedded(s) => {
+                if Arc::strong_count(s) == 1 && !s.finished.load(Ordering::Relaxed) {
+                    s.finish(EmbeddedOutcome::Failure, "npm install failed");
+                }
+            }
         }
     }
 }
@@ -1094,6 +1300,10 @@ enum FetchRowInner {
     /// rows shouldn't prevent `CiState` from being dropped after the
     /// last `InstallProgress` clone is gone.
     Ci(Weak<CiState>),
+    Embedded {
+        id: u64,
+        state: Weak<EmbeddedState>,
+    },
 }
 
 impl FetchRow {
@@ -1178,6 +1388,15 @@ impl FetchRow {
                     s.downloaded.fetch_add(1, Ordering::Relaxed);
                 }
             }
+            FetchRowInner::Embedded { id, state } => {
+                if let Some(s) = state.upgrade() {
+                    s.downloaded.fetch_add(1, Ordering::Relaxed);
+                    s.update();
+                    embedded_progress::with_progress_sink(|sink| {
+                        sink.finish_task(*id, EmbeddedOutcome::Success, "fetched");
+                    });
+                }
+            }
         }
     }
 }
@@ -1237,9 +1456,11 @@ pub fn safe_eprintln(msg: &str) {
     }
 }
 
+#[cfg(feature = "install-tracing-subscriber")]
 #[derive(Clone, Copy, Default)]
 pub struct PausingWriter;
 
+#[cfg(feature = "install-tracing-subscriber")]
 impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for PausingWriter {
     type Writer = PausingWriterGuard;
 
@@ -1251,10 +1472,12 @@ impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for PausingWriter {
 /// Per-event writer guard returned by [`PausingWriter::make_writer`].
 /// Accumulates into `buf` and flushes once on drop. See `PausingWriter`
 /// for the full pause/write/resume protocol.
+#[cfg(feature = "install-tracing-subscriber")]
 pub struct PausingWriterGuard {
     buf: Vec<u8>,
 }
 
+#[cfg(feature = "install-tracing-subscriber")]
 impl Write for PausingWriterGuard {
     fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
         self.buf.extend_from_slice(data);
@@ -1266,6 +1489,7 @@ impl Write for PausingWriterGuard {
     }
 }
 
+#[cfg(feature = "install-tracing-subscriber")]
 impl Drop for PausingWriterGuard {
     fn drop(&mut self) {
         if self.buf.is_empty() {

--- a/crates/aube/src/progress/mod.rs
+++ b/crates/aube/src/progress/mod.rs
@@ -125,12 +125,11 @@ fn product_banner(suffix: &str) -> String {
     }
 }
 
-/// Build the standard `<product banner> · <msg>` one-line header used
-/// by the no-op and fast-mode summaries. Centralizes the header shape
-/// so the install-finished, already-up-to-date, and fast-mode-summary
-/// paths all read consistently.
+/// Build the one-line install summary used by no-op and fast-mode
+/// completions. The progress header already identifies standalone aube;
+/// embedders should see the same concise success line as other tools.
 pub(crate) fn aube_prefix_line(msg: &str) -> String {
-    product_banner(&format!(" {} {msg}", style::edim("·")))
+    msg.to_string()
 }
 
 /// Install-time progress UI. Cheap to clone (internally `Arc`).

--- a/crates/aube/src/startup.rs
+++ b/crates/aube/src/startup.rs
@@ -1,6 +1,7 @@
 use super::{Cli, Commands, LogLevel, ReporterType};
 use miette::{Context, IntoDiagnostic, miette};
 use std::path::PathBuf;
+#[cfg(feature = "install-tracing-subscriber")]
 use tracing_subscriber::prelude::*;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -272,41 +273,45 @@ pub(crate) fn diag_config_from_flag(cli: &Cli) -> Option<Option<aube_util::diag:
 }
 
 pub(crate) fn init_logging(cli: &Cli, effective_level: LogLevel) {
-    let log_level = effective_level.filter();
-    let env_filter = tracing_subscriber::EnvFilter::try_from_env("AUBE_LOG").unwrap_or_else(|_| {
-        format!(
-            "aube={log_level},aube_cli={log_level},aube_registry={log_level},\
+    #[cfg(feature = "install-tracing-subscriber")]
+    {
+        let log_level = effective_level.filter();
+        let env_filter =
+            tracing_subscriber::EnvFilter::try_from_env("AUBE_LOG").unwrap_or_else(|_| {
+                format!(
+                    "aube={log_level},aube_cli={log_level},aube_registry={log_level},\
              aube_resolver={log_level},aube_lockfile={log_level},aube_store={log_level},\
              aube_linker={log_level},aube_manifest={log_level},aube_scripts={log_level},\
              aube_workspace={log_level},aube_settings={log_level},aube_util={log_level}"
-        )
-        .into()
-    });
+                )
+                .into()
+            });
 
-    let drop_timestamp = !matches!(effective_level, LogLevel::Debug | LogLevel::Trace);
-    let registry = tracing_subscriber::registry().with(env_filter);
-    if matches!(cli.reporter, Some(ReporterType::Ndjson)) {
-        crate::pnpmfile::set_ndjson_reporter(true);
-        registry
-            .with(
-                tracing_subscriber::fmt::layer()
-                    .json()
-                    .flatten_event(true)
-                    .with_writer(crate::progress::PausingWriter),
-            )
-            .init();
-    } else if drop_timestamp {
-        registry
-            .with(
-                tracing_subscriber::fmt::layer()
-                    .without_time()
-                    .with_writer(crate::progress::PausingWriter),
-            )
-            .init();
-    } else {
-        registry
-            .with(tracing_subscriber::fmt::layer().with_writer(crate::progress::PausingWriter))
-            .init();
+        let drop_timestamp = !matches!(effective_level, LogLevel::Debug | LogLevel::Trace);
+        let registry = tracing_subscriber::registry().with(env_filter);
+        if matches!(cli.reporter, Some(ReporterType::Ndjson)) {
+            crate::pnpmfile::set_ndjson_reporter(true);
+            let _ = registry
+                .with(
+                    tracing_subscriber::fmt::layer()
+                        .json()
+                        .flatten_event(true)
+                        .with_writer(crate::progress::PausingWriter),
+                )
+                .try_init();
+        } else if drop_timestamp {
+            let _ = registry
+                .with(
+                    tracing_subscriber::fmt::layer()
+                        .without_time()
+                        .with_writer(crate::progress::PausingWriter),
+                )
+                .try_init();
+        } else {
+            let _ = registry
+                .with(tracing_subscriber::fmt::layer().with_writer(crate::progress::PausingWriter))
+                .try_init();
+        }
     }
 
     let force_text = matches!(
@@ -315,7 +320,7 @@ pub(crate) fn init_logging(cli: &Cli, effective_level: LogLevel) {
     ) || matches!(
         cli.reporter,
         Some(ReporterType::AppendOnly) | Some(ReporterType::Ndjson)
-    );
+    ) || !aube_util::embedder().progress_renderer_enabled;
     if force_text {
         clx::progress::set_output(clx::progress::ProgressOutput::Text);
     }

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -391,6 +391,12 @@
       "exit_code": null
     },
     {
+      "name": "ERR_AUBE_RUNTIME_NOT_RUNNABLE",
+      "category": "Engine / CLI",
+      "description": "A downloaded Node.js binary extracted cleanly but failed a post-install `node --version` check, so the install was discarded instead of published. Typically missing shared libraries — musl builds require the host's libstdc++/libgcc (e.g. `apk add libstdc++`).",
+      "exit_code": null
+    },
+    {
       "name": "ERR_AUBE_UNSAFE_INDEX_KEY",
       "category": "Misc / safety",
       "description": "A package index key tried to escape its directory (path traversal defense in depth).",


### PR DESCRIPTION
Fixes broken Node.js installs on glibc hosts (elide-dev/WHIPLASH#1254). Two parts.

**musl false-positive in `aube-runtime`.** `Platform::current()` decided glibc vs musl by probing for `/lib/ld-musl-<arch>.so.1` on disk. Debian/Ubuntu's `musl` package drops that file on glibc hosts, so aube downloaded the musl Node build from unofficial-builds, which is dynamically linked against musl libstdc++/libgcc and can't run there (`Error loading shared library libstdc++.so.6`). The sibling `aube-resolver` already fixed this exact bug for npm native binaries (#398: read `/proc/self/maps` to see which loader is actually mapped, falling back to a glibc-first loader scan for static binaries) but the port never reached the runtime crate. Hoisted that detection into a shared `aube_util::libc::detect_linux_libc()` and pointed both crates at it.

**No post-install sanity check.** `validate_install` only checked the exec bit, so a broken binary was published and failed later with an opaque loader error. The installer now runs `node --version` on the staged binary before the rename; failure removes the staging dir and raises a new `ERR_AUBE_RUNTIME_NOT_RUNNABLE` with the loader's stderr and, on musl hosts, an `apk add libstdc++ libgcc` hint.

Verified in containers with the real `libc.rs` compiled into a harness: Debian + `musl` package flips musl→glibc (dynamic and static/fallback-scan paths); Alpine still detects musl. 382 tests pass; clippy/fmt clean.

Fixes elide-dev/WHIPLASH#1254

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Installations now verify that downloaded Node.js binaries can run before publishing them.
  * Added clearer diagnostics and guidance when a runtime is not runnable.
  * Added embedded progress rendering for integrations.
  * Embedder command prefixes now appear consistently in commands and help output.
  * Added support for both `modulesDir` and `modules-dir` CLI forms.
  * Added CLI entry points that accept explicit argument lists.

* **Bug Fixes**
  * Improved libc detection across Linux environments.
  * Fixed recursive `node-gyp` invocations for custom command prefixes.
  * Improved registry and workspace handling during installation.
  * Standardized warning and progress output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->