### PR TITLE
refactor(install): make explicit installs reentrant

### DIFF
--- a/crates/aube/src/commands/add/filtered.rs
+++ b/crates/aube/src/commands/add/filtered.rs
@@ -21,7 +21,7 @@ pub(super) async fn run(
     // walks up) mutate the real root lockfile and then silently skip
     // the restore under `--no-save`.
     let (root, matched) = crate::commands::select_workspace_packages(&cwd, filter, "add")?;
-    let _lock = crate::commands::take_project_lock(&root)?;
+    let lock = crate::commands::take_project_lock(&root)?;
 
     // CLI build review flags write against the workspace root (where
     // `allowBuilds` lives) — same as the non-filtered path. Run before
@@ -78,7 +78,7 @@ pub(super) async fn run(
         // See the sibling `aube add` codepath for why this flag is set:
         // live OSV API on the resolved transitives.
         install_opts.osv_transitive_check = true;
-        install::run(install_opts).await?;
+        install::run_with_project_lock(install_opts, &lock).await?;
         Ok(())
     }
     .await;

--- a/crates/aube/src/commands/add/mod.rs
+++ b/crates/aube/src/commands/add/mod.rs
@@ -325,7 +325,7 @@ pub async fn run(
         }
     }
 
-    let _lock = super::take_project_lock(&cwd)?;
+    let lock = super::take_project_lock(&cwd)?;
     let manifest_path = cwd.join("package.json");
 
     // 1. Read existing package.json. Snapshot the raw bytes when
@@ -411,7 +411,8 @@ pub async fn run(
         install::InstallOptions::with_mode(super::chained_frozen_mode(install::FrozenMode::Fix));
     apply_dangerously_allow_all_builds(&mut install_opts, dangerously_allow_all_builds);
     install_opts.osv_transitive_check = true;
-    let pipeline_result: miette::Result<()> = install::run(install_opts).await;
+    let pipeline_result: miette::Result<()> =
+        install::run_with_project_lock(install_opts, &lock).await;
 
     // 5. Under `--no-save`, restore the snapshotted `package.json` and
     // lockfile so neither shows up in `git status`. The user's

--- a/crates/aube/src/commands/add/mod.rs
+++ b/crates/aube/src/commands/add/mod.rs
@@ -325,7 +325,7 @@ pub async fn run(
         }
     }
 
-    let lock = super::take_project_lock(&cwd)?;
+    let lock = super::take_install_project_lock(&cwd)?;
     let manifest_path = cwd.join("package.json");
 
     // 1. Read existing package.json. Snapshot the raw bytes when

--- a/crates/aube/src/commands/ci.rs
+++ b/crates/aube/src/commands/ci.rs
@@ -46,7 +46,7 @@ pub async fn run(args: CiArgs) -> miette::Result<()> {
         network: _,
         virtual_store: _,
     } = args;
-    let cwd = crate::dirs::project_root()?;
+    let cwd = crate::dirs::workspace_or_project_root()?;
     let lock = super::take_project_lock(&cwd)?;
 
     let nm = super::project_modules_dir(&cwd);

--- a/crates/aube/src/commands/ci.rs
+++ b/crates/aube/src/commands/ci.rs
@@ -47,7 +47,7 @@ pub async fn run(args: CiArgs) -> miette::Result<()> {
         virtual_store: _,
     } = args;
     let cwd = crate::dirs::project_root()?;
-    let _lock = super::take_project_lock(&cwd)?;
+    let lock = super::take_project_lock(&cwd)?;
 
     let nm = super::project_modules_dir(&cwd);
     // `symlink_metadata` instead of `exists` so we notice (and delete) a
@@ -94,5 +94,5 @@ pub async fn run(args: CiArgs) -> miette::Result<()> {
         // `advisoryCheckEveryInstall` setting still apply.
         osv_transitive_check: false,
     };
-    install::run(opts).await
+    install::run_with_project_lock(opts, &lock).await
 }

--- a/crates/aube/src/commands/dedupe.rs
+++ b/crates/aube/src/commands/dedupe.rs
@@ -30,7 +30,7 @@ pub async fn run(args: DedupeArgs) -> miette::Result<()> {
     args.lockfile.install_overrides();
     args.virtual_store.install_overrides();
     let cwd = crate::dirs::project_root()?;
-    let _lock = super::take_project_lock(&cwd)?;
+    let lock = super::take_project_lock(&cwd)?;
 
     let manifest = super::load_manifest(&cwd.join("package.json"))?;
 
@@ -114,9 +114,10 @@ pub async fn run(args: DedupeArgs) -> miette::Result<()> {
     super::write_and_log_lockfile(&cwd, &graph, &manifest)?;
 
     // Resync node_modules against the new lockfile.
-    install::run(install::InstallOptions::with_mode(
-        super::chained_frozen_mode(install::FrozenMode::Prefer),
-    ))
+    install::run_with_project_lock(
+        install::InstallOptions::with_mode(super::chained_frozen_mode(install::FrozenMode::Prefer)),
+        &lock,
+    )
     .await?;
 
     Ok(())

--- a/crates/aube/src/commands/dedupe.rs
+++ b/crates/aube/src/commands/dedupe.rs
@@ -29,7 +29,7 @@ pub async fn run(args: DedupeArgs) -> miette::Result<()> {
     args.network.install_overrides();
     args.lockfile.install_overrides();
     args.virtual_store.install_overrides();
-    let cwd = crate::dirs::project_root()?;
+    let cwd = crate::dirs::workspace_or_project_root()?;
     let lock = super::take_project_lock(&cwd)?;
 
     let manifest = super::load_manifest(&cwd.join("package.json"))?;

--- a/crates/aube/src/commands/install/fetch.rs
+++ b/crates/aube/src/commands/install/fetch.rs
@@ -787,7 +787,7 @@ where
             let row = progress.map(|p| p.start_fetch(&display_name, &version));
             let bytes_progress = progress.cloned();
 
-            handles.spawn(async move {
+            handles.spawn(crate::dep_chain::scope_current(async move {
                 let _row = row;
                 let task_start = std::time::Instant::now();
                 let permit = sem.acquire().await;
@@ -962,7 +962,7 @@ where
                 );
 
                 Ok::<_, miette::Report>((dep_path, index, computed_integrity))
-            });
+            }));
         }
 
         while let Some(joined) = handles.join_next().await {

--- a/crates/aube/src/commands/install/lifecycle.rs
+++ b/crates/aube/src/commands/install/lifecycle.rs
@@ -570,7 +570,7 @@ pub(crate) async fn run_dep_lifecycle_scripts(
         let modules_dir_name = modules_dir_name.clone();
         let node_gyp_bin_dir = node_gyp_bin_dir.clone();
         let jail_policy = jail_policy.clone();
-        set.spawn(async move {
+        set.spawn(crate::dep_chain::scope_current(async move {
             let _permit = sem.acquire().await.unwrap();
             if should_restore_side_effects_cache && let Some(cache_entry) = job.cache_entry.clone()
             {
@@ -665,7 +665,7 @@ pub(crate) async fn run_dep_lifecycle_scripts(
                 }
             }
             Ok(ran_here)
-        });
+        }));
     }
 
     let mut ran = 0usize;

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -80,6 +80,38 @@ const TRUST_POLICY_VALIDATION_CACHE_DIR: &str = "trust-policy-v1";
 const TRUST_POLICY_VALIDATION_CACHE_TTL: std::time::Duration =
     std::time::Duration::from_secs(5 * 60);
 
+#[cfg(test)]
+mod reentrancy_tests {
+    use super::*;
+
+    fn explicit_options(project_dir: &std::path::Path) -> InstallOptions {
+        let mut options = InstallOptions::with_mode(FrozenMode::Prefer);
+        options.project_dir = Some(project_dir.to_path_buf());
+        options.ignore_scripts = true;
+        options.skip_root_lifecycle = true;
+        options.network_mode = aube_registry::NetworkMode::Offline;
+        options
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn explicit_directory_installs_can_run_concurrently() {
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+        std::fs::write(first.path().join("package.json"), "{}\n").unwrap();
+        std::fs::write(second.path().join("package.json"), "{}\n").unwrap();
+
+        let (first_result, second_result) = tokio::join!(
+            run(explicit_options(first.path())),
+            run(explicit_options(second.path())),
+        );
+
+        first_result.unwrap();
+        second_result.unwrap();
+        assert!(first.path().join("aube-lock.yaml").is_file());
+        assert!(second.path().join("aube-lock.yaml").is_file());
+    }
+}
+
 pub(crate) fn package_build_is_allowed(
     policy: &aube_scripts::BuildPolicy,
     pkg: &aube_lockfile::LockedPackage,
@@ -440,9 +472,26 @@ fn reachable_package_dep_paths(
 }
 
 pub async fn run(opts: InstallOptions) -> miette::Result<()> {
-    let mode = opts.mode;
     let cwd = resolve_project_cwd(&opts)?;
     let _lock = super::take_project_lock(&cwd)?;
+    crate::dep_chain::scope(run_inner(opts, cwd)).await
+}
+
+/// Run install while reusing a project lock owned by an outer command.
+///
+/// The guard reference makes lock reentrancy invocation-scoped: only the
+/// command that owns this lock can bypass acquisition. Concurrent installs
+/// for unrelated projects always acquire their own filesystem lock.
+pub(crate) async fn run_with_project_lock(
+    opts: InstallOptions,
+    _lock: &super::project_lock::ProjectLock,
+) -> miette::Result<()> {
+    let cwd = resolve_project_cwd(&opts)?;
+    crate::dep_chain::scope(run_inner(opts, cwd)).await
+}
+
+async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Result<()> {
+    let mode = opts.mode;
     let start = std::time::Instant::now();
     let mut phase_timings = InstallPhaseTimings::from_env();
     aube_util::diag::spawn_concurrency_sampler();
@@ -512,7 +561,9 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
         )
         .await?;
     }
-    super::configure_script_settings(&settings_ctx, Some("install"));
+    if !opts.ignore_scripts {
+        super::configure_script_settings(&settings_ctx, Some("install"));
+    }
 
     let layout::InstallLayoutConfig {
         lockfile_dir,
@@ -1463,7 +1514,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                         .map(|p| p.start_fetch(&pkg.name, &pkg.version));
                     let bytes_progress = fetch_progress.clone();
 
-                    handles.spawn(async move {
+                    handles.spawn(crate::dep_chain::scope_current(async move {
                         let _row = row;
                         let _diag_tar = aube_util::diag::Span::new(aube_util::diag::Category::Fetch, "tarball")
                             .with_meta_fn(|| format!(r#"{{"name":{},"version":{}}}"#,
@@ -1620,7 +1671,7 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
                         }
 
                         Ok::<_, miette::Report>((dep_path, index, computed_integrity))
-                    });
+                    }));
                 }
 
                 // Collect all fetch results via JoinSet. Drop on

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -110,6 +110,26 @@ mod reentrancy_tests {
         assert!(first.path().join("aube-lock.yaml").is_file());
         assert!(second.path().join("aube-lock.yaml").is_file());
     }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn guarded_installs_can_run_concurrently() {
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+        std::fs::write(first.path().join("package.json"), "{}\n").unwrap();
+        std::fs::write(second.path().join("package.json"), "{}\n").unwrap();
+        let first_lock = super::super::take_project_lock(first.path()).unwrap();
+        let second_lock = super::super::take_project_lock(second.path()).unwrap();
+
+        let (first_result, second_result) = tokio::join!(
+            run_with_project_lock(explicit_options(first.path()), &first_lock),
+            run_with_project_lock(explicit_options(second.path()), &second_lock),
+        );
+
+        first_result.unwrap();
+        second_result.unwrap();
+        assert!(first.path().join("aube-lock.yaml").is_file());
+        assert!(second.path().join("aube-lock.yaml").is_file());
+    }
 }
 
 pub(crate) fn package_build_is_allowed(
@@ -479,14 +499,16 @@ pub async fn run(opts: InstallOptions) -> miette::Result<()> {
 
 /// Run install while reusing a project lock owned by an outer command.
 ///
-/// The guard reference makes lock reentrancy invocation-scoped: only the
-/// command that owns this lock can bypass acquisition. Concurrent installs
-/// for unrelated projects always acquire their own filesystem lock.
+/// The guard determines the project directory, making lock reentrancy
+/// invocation-scoped: only the command that owns this project's lock can
+/// bypass acquisition. Concurrent installs for unrelated projects always
+/// acquire their own filesystem lock.
 pub(crate) async fn run_with_project_lock(
-    opts: InstallOptions,
-    _lock: &super::project_lock::ProjectLock,
+    mut opts: InstallOptions,
+    lock: &super::project_lock::ProjectLock,
 ) -> miette::Result<()> {
-    let cwd = resolve_project_cwd(&opts)?;
+    let cwd = lock.project_dir().to_path_buf();
+    opts.project_dir = Some(cwd.clone());
     crate::dep_chain::scope(run_inner(opts, cwd)).await
 }
 

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -109,6 +109,7 @@ pub(crate) use manifest_io::{
 pub(crate) use package_spec::{
     encode_package_name, max_satisfying_version, resolve_version, split_name_spec,
 };
+pub(crate) use project_lock::take_install_project_lock;
 pub(crate) use project_lock::take_project_lock;
 pub(crate) use script_settings::{configure_script_settings, configure_script_settings_for_cwd};
 pub(crate) use settings_context::{

--- a/crates/aube/src/commands/project_lock.rs
+++ b/crates/aube/src/commands/project_lock.rs
@@ -1,12 +1,6 @@
 use std::any::Any;
-use std::sync::atomic::{AtomicBool, Ordering};
 
 use miette::miette;
-
-/// Process-wide guard: `true` while a project lock is held by this process.
-/// Nested commands (e.g. `add` calling `install`) observe this and skip
-/// re-acquiring so they don't deadlock against themselves.
-static LOCK_HELD: AtomicBool = AtomicBool::new(false);
 
 /// Whether the project-level advisory lock is disabled. Resolves the
 /// `aubeNoLock` setting through the full file-source chain so
@@ -17,25 +11,16 @@ fn aube_no_lock_enabled(cwd: &std::path::Path) -> bool {
     super::with_settings_ctx(cwd, aube_settings::resolved::aube_no_lock)
 }
 
-/// Opaque guard holding a project-level advisory lock. Dropping it releases
-/// the lock and clears the process-wide `LOCK_HELD` flag. Commands bind
-/// this to a `_lock` variable at the top of `run` so the lock is held for
-/// the duration of the command.
+/// Opaque guard holding a project-level advisory lock. Commands bind this to a
+/// local variable for the duration of the operation. Commands that chain into
+/// install pass a reference to the guard explicitly, so unrelated concurrent
+/// operations never mistake another project's lock for their own.
 ///
 /// The `_inner` field holds an erased `fslock::LockFile` (via `dyn Any`)
 /// so callers don't have to take a direct dep on `fslock` to name the
 /// type — the lock is released on drop regardless.
 pub(crate) struct ProjectLock {
     _inner: Option<Box<dyn Any + Send>>,
-    owns_flag: bool,
-}
-
-impl Drop for ProjectLock {
-    fn drop(&mut self) {
-        if self.owns_flag {
-            LOCK_HELD.store(false, Ordering::Release);
-        }
-    }
 }
 
 /// Take an advisory lock on the current project's `node_modules/`.
@@ -45,26 +30,18 @@ impl Drop for ProjectLock {
 /// project — even via different relative paths or symlinks — serialize
 /// correctly.
 ///
-/// Returns a no-op guard when `AUBE_NO_LOCK` is active or when this
-/// process already holds the project lock (re-entrant case for
-/// `add` → `install`), so callers don't need to special-case.
+/// Returns a no-op guard when `AUBE_NO_LOCK` is active. Nested commands must
+/// pass the returned guard into the inner operation rather than attempting to
+/// acquire the same filesystem lock again.
 pub(crate) fn take_project_lock(cwd: &std::path::Path) -> miette::Result<ProjectLock> {
     if aube_no_lock_enabled(cwd) {
-        return Ok(ProjectLock {
-            _inner: None,
-            owns_flag: false,
-        });
+        return Ok(ProjectLock { _inner: None });
     }
 
-    // Re-entrant: if this process already holds the lock (outer command
-    // chained into an inner one like add → install), skip re-acquisition.
-    if LOCK_HELD.load(Ordering::Acquire) {
-        return Ok(ProjectLock {
-            _inner: None,
-            owns_flag: false,
-        });
-    }
+    take_project_lock_enabled(cwd)
+}
 
+fn take_project_lock_enabled(cwd: &std::path::Path) -> miette::Result<ProjectLock> {
     let nm_path = super::project_modules_dir(cwd);
     let lock = xx::fslock::FSLock::new(&nm_path)
         .with_callback(|_| {
@@ -79,13 +56,24 @@ pub(crate) fn take_project_lock(cwd: &std::path::Path) -> miette::Result<Project
         .lock()
         .map_err(|e| miette!("failed to acquire project lock: {e}"))?;
 
-    // Only mark the flag as held AFTER the OS lock is in hand, so a nested
-    // call can't observe `LOCK_HELD = true` and get a no-op guard before
-    // this process actually owns the underlying advisory lock.
-    LOCK_HELD.store(true, Ordering::Release);
-
     Ok(ProjectLock {
         _inner: Some(Box::new(lock)),
-        owns_flag: true,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn different_projects_hold_independent_process_locks() {
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+
+        let first_lock = take_project_lock_enabled(first.path()).unwrap();
+        let second_lock = take_project_lock_enabled(second.path()).unwrap();
+
+        assert!(first_lock._inner.is_some());
+        assert!(second_lock._inner.is_some());
+    }
 }

--- a/crates/aube/src/commands/project_lock.rs
+++ b/crates/aube/src/commands/project_lock.rs
@@ -55,6 +55,17 @@ pub(crate) fn take_project_lock(cwd: &std::path::Path) -> miette::Result<Project
     take_project_lock_enabled(cwd, project_dir)
 }
 
+/// Lock the directory that a chained install will operate on. Outer commands
+/// may mutate a workspace member manifest, but the install itself owns the
+/// workspace-root lockfile and virtual store.
+pub(crate) fn take_install_project_lock(
+    project_dir: &std::path::Path,
+) -> miette::Result<ProjectLock> {
+    let install_dir =
+        crate::dirs::find_workspace_root(project_dir).unwrap_or_else(|| project_dir.to_path_buf());
+    take_project_lock(&install_dir)
+}
+
 fn take_project_lock_enabled(
     cwd: &std::path::Path,
     project_dir: std::path::PathBuf,
@@ -97,5 +108,22 @@ mod tests {
         assert!(second_lock._inner.is_some());
         assert_eq!(first_lock.project_dir(), first.path());
         assert_eq!(second_lock.project_dir(), second.path());
+    }
+
+    #[test]
+    fn chained_install_lock_targets_workspace_root() {
+        let workspace = tempfile::tempdir().unwrap();
+        let member = workspace.path().join("packages/app");
+        std::fs::create_dir_all(&member).unwrap();
+        std::fs::write(
+            workspace.path().join("package.json"),
+            "{\"workspaces\":[\"packages/*\"]}\n",
+        )
+        .unwrap();
+        std::fs::write(member.join("package.json"), "{}\n").unwrap();
+
+        let lock = take_install_project_lock(&member).unwrap();
+
+        assert_eq!(lock.project_dir(), workspace.path().canonicalize().unwrap());
     }
 }

--- a/crates/aube/src/commands/project_lock.rs
+++ b/crates/aube/src/commands/project_lock.rs
@@ -20,7 +20,14 @@ fn aube_no_lock_enabled(cwd: &std::path::Path) -> bool {
 /// so callers don't have to take a direct dep on `fslock` to name the
 /// type — the lock is released on drop regardless.
 pub(crate) struct ProjectLock {
+    project_dir: std::path::PathBuf,
     _inner: Option<Box<dyn Any + Send>>,
+}
+
+impl ProjectLock {
+    pub(crate) fn project_dir(&self) -> &std::path::Path {
+        &self.project_dir
+    }
 }
 
 /// Take an advisory lock on the current project's `node_modules/`.
@@ -34,14 +41,24 @@ pub(crate) struct ProjectLock {
 /// pass the returned guard into the inner operation rather than attempting to
 /// acquire the same filesystem lock again.
 pub(crate) fn take_project_lock(cwd: &std::path::Path) -> miette::Result<ProjectLock> {
+    let project_dir = cwd
+        .canonicalize()
+        .or_else(|_| std::path::absolute(cwd))
+        .unwrap_or_else(|_| cwd.to_path_buf());
     if aube_no_lock_enabled(cwd) {
-        return Ok(ProjectLock { _inner: None });
+        return Ok(ProjectLock {
+            project_dir,
+            _inner: None,
+        });
     }
 
-    take_project_lock_enabled(cwd)
+    take_project_lock_enabled(cwd, project_dir)
 }
 
-fn take_project_lock_enabled(cwd: &std::path::Path) -> miette::Result<ProjectLock> {
+fn take_project_lock_enabled(
+    cwd: &std::path::Path,
+    project_dir: std::path::PathBuf,
+) -> miette::Result<ProjectLock> {
     let nm_path = super::project_modules_dir(cwd);
     let lock = xx::fslock::FSLock::new(&nm_path)
         .with_callback(|_| {
@@ -57,6 +74,7 @@ fn take_project_lock_enabled(cwd: &std::path::Path) -> miette::Result<ProjectLoc
         .map_err(|e| miette!("failed to acquire project lock: {e}"))?;
 
     Ok(ProjectLock {
+        project_dir,
         _inner: Some(Box::new(lock)),
     })
 }
@@ -70,10 +88,14 @@ mod tests {
         let first = tempfile::tempdir().unwrap();
         let second = tempfile::tempdir().unwrap();
 
-        let first_lock = take_project_lock_enabled(first.path()).unwrap();
-        let second_lock = take_project_lock_enabled(second.path()).unwrap();
+        let first_lock =
+            take_project_lock_enabled(first.path(), first.path().to_path_buf()).unwrap();
+        let second_lock =
+            take_project_lock_enabled(second.path(), second.path().to_path_buf()).unwrap();
 
         assert!(first_lock._inner.is_some());
         assert!(second_lock._inner.is_some());
+        assert_eq!(first_lock.project_dir(), first.path());
+        assert_eq!(second_lock.project_dir(), second.path());
     }
 }

--- a/crates/aube/src/commands/remove.rs
+++ b/crates/aube/src/commands/remove.rs
@@ -68,7 +68,7 @@ pub async fn run(
     }
 
     let cwd = crate::dirs::project_root()?;
-    let _lock = super::take_project_lock(&cwd)?;
+    let lock = super::take_project_lock(&cwd)?;
     let manifest_path = cwd.join("package.json");
 
     let mut manifest = super::load_manifest(&manifest_path)?;
@@ -174,7 +174,7 @@ pub async fn run(
     let mut opts =
         install::InstallOptions::with_mode(super::chained_frozen_mode(install::FrozenMode::Prefer));
     opts.ignore_scripts = args.ignore_scripts;
-    install::run(opts).await?;
+    install::run_with_project_lock(opts, &lock).await?;
 
     Ok(())
 }

--- a/crates/aube/src/commands/remove.rs
+++ b/crates/aube/src/commands/remove.rs
@@ -68,7 +68,7 @@ pub async fn run(
     }
 
     let cwd = crate::dirs::project_root()?;
-    let lock = super::take_project_lock(&cwd)?;
+    let lock = super::take_install_project_lock(&cwd)?;
     let manifest_path = cwd.join("package.json");
 
     let mut manifest = super::load_manifest(&manifest_path)?;

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -179,7 +179,7 @@ pub async fn run(
     {
         cwd = root;
     }
-    let _lock = super::take_project_lock(&cwd)?;
+    let lock = super::take_project_lock(&cwd)?;
     let manifest_path = cwd.join("package.json");
 
     let mut manifest = aube_manifest::PackageJson::from_path(&manifest_path)
@@ -789,7 +789,7 @@ pub async fn run(
     // tree stays as-is. Mirrors `aube install --lockfile-only` and
     // closes the gap with `npm update --package-lock-only`.
     chained.lockfile_only = args.lockfile_only;
-    install::run(chained).await?;
+    install::run_with_project_lock(chained, &lock).await?;
 
     Ok(None)
 }

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -179,7 +179,7 @@ pub async fn run(
     {
         cwd = root;
     }
-    let lock = super::take_project_lock(&cwd)?;
+    let lock = super::take_install_project_lock(&cwd)?;
     let manifest_path = cwd.join("package.json");
 
     let mut manifest = aube_manifest::PackageJson::from_path(&manifest_path)

--- a/crates/aube/src/dep_chain.rs
+++ b/crates/aube/src/dep_chain.rs
@@ -9,10 +9,9 @@
 //! `(name, version)` pairs and doesn't know which importer is
 //! responsible for each entry.
 //!
-//! This module bridges the gap. After the resolver finishes — when a
-//! `LockfileGraph` is available — call [`set_active`] to seed a
-//! process-global chain index. Subsequent error wrappers consult it
-//! via [`format_chain_for`] and embed a chain string in the message.
+//! This module bridges the gap. Each install runs inside [`scope`]. After the
+//! resolver finishes, [`set_active`] seeds that install's chain index;
+//! subsequent error wrappers consult it through [`format_chain_for`].
 //!
 //! The index is computed once via BFS from importer roots, recording
 //! the *shortest* path back to an importer for each `(name, version)`
@@ -21,15 +20,34 @@
 //! transitive pulls. Multi-parent disambiguation isn't tracked; the
 //! goal is "tell the user where this came from", not full ancestry.
 //!
-//! Storage is a `OnceLock<Mutex<Option<Arc<ChainIndex>>>>`. A single
-//! install run sets it once; recursive installs (workspace fan-out)
-//! reset it per-package. Outside an install, `format_chain_for` is a
-//! no-op and returns an empty string, so error messages remain
-//! stable when no install is active (e.g. during `aube view`).
+//! Storage is Tokio task-local and shared with child tasks through
+//! [`scope_current`]. Parallel installs therefore cannot replace one another's
+//! diagnostic graph. Outside an install, `format_chain_for` remains a no-op.
 
 use aube_lockfile::LockfileGraph;
 use std::collections::{BTreeMap, HashMap, VecDeque};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::future::Future;
+use std::sync::{Arc, RwLock};
+
+type ActiveIndex = Arc<RwLock<Option<Arc<ChainIndex>>>>;
+
+tokio::task_local! {
+    static ACTIVE: ActiveIndex;
+}
+
+/// Run an install with an isolated dependency-chain slot.
+pub async fn scope<F: Future>(future: F) -> F::Output {
+    ACTIVE.scope(Arc::new(RwLock::new(None)), future).await
+}
+
+/// Propagate the current install's dependency-chain slot into a spawned task.
+/// Out-of-band callers get an empty slot, preserving the no-context behavior.
+pub fn scope_current<F: Future>(future: F) -> impl Future<Output = F::Output> {
+    let active = ACTIVE
+        .try_with(Arc::clone)
+        .unwrap_or_else(|_| Arc::new(RwLock::new(None)));
+    ACTIVE.scope(active, future)
+}
 
 /// Maps `(name, version)` → shortest ancestor chain back to an
 /// importer. Empty chain = direct importer dep (no ancestors above
@@ -139,19 +157,13 @@ pub fn format_chain(ancestors: &[(String, String)], leaf_name: &str, leaf_versio
     s
 }
 
-/// Process-global active index. Set after the resolver finishes;
-/// consulted by error wrappers in the install pipeline.
-fn slot() -> &'static Mutex<Option<Arc<ChainIndex>>> {
-    static SLOT: OnceLock<Mutex<Option<Arc<ChainIndex>>>> = OnceLock::new();
-    SLOT.get_or_init(|| Mutex::new(None))
-}
-
-/// Set the active chain index. Call once per install run, after
-/// resolution settles. Idempotent — replacing an existing index is
-/// fine (recursive installs reset between workspace packages).
+/// Set the current install's chain index after resolution settles.
 pub fn set_active(graph: &LockfileGraph) {
     let idx = Arc::new(ChainIndex::from_graph(graph));
-    *slot().lock().expect("chain index slot poisoned") = Some(idx);
+    let _ = ACTIVE.try_with(|active| match active.write() {
+        Ok(mut slot) => *slot = Some(idx),
+        Err(poisoned) => *poisoned.into_inner() = Some(idx),
+    });
 }
 
 /// Lookup the chain for `(name, version)` against the active index
@@ -159,22 +171,20 @@ pub fn set_active(graph: &LockfileGraph) {
 /// the package isn't present — callers concatenate the result, so
 /// the empty case must not insert separator characters.
 pub fn format_chain_for(name: &str, version: &str) -> String {
-    let guard = match slot().lock() {
-        Ok(g) => g,
-        Err(_) => return String::new(),
-    };
-    let Some(idx) = guard.as_ref() else {
-        return String::new();
-    };
-    match idx.lookup(name, version) {
-        Some(chain) if !chain.is_empty() => {
-            // Prefix newline so the chain appears on its own line in
-            // miette's rendered output. Empty-chain case (direct
-            // importer dep) returns "" so nothing is appended.
-            format!("\n{}", format_chain(chain, name, version))
-        }
-        _ => String::new(),
-    }
+    ACTIVE
+        .try_with(|active| {
+            let guard = match active.read() {
+                Ok(guard) => guard,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            match guard.as_ref().and_then(|idx| idx.lookup(name, version)) {
+                Some(chain) if !chain.is_empty() => {
+                    format!("\n{}", format_chain(chain, name, version))
+                }
+                _ => String::new(),
+            }
+        })
+        .unwrap_or_default()
 }
 
 #[cfg(test)]
@@ -289,5 +299,51 @@ mod tests {
         let idx = ChainIndex::from_graph(&graph);
         assert_eq!(idx.lookup("h3-v2", "2.0.0"), Some(&[][..]));
         assert_eq!(idx.lookup("h3", "2.0.0"), Some(&[][..]));
+    }
+
+    fn graph_with_ancestor(ancestor: &str) -> LockfileGraph {
+        let mut graph = LockfileGraph::default();
+        graph
+            .importers
+            .insert(".".to_string(), vec![direct(ancestor, "1")]);
+        graph
+            .packages
+            .extend([pkg(ancestor, "1", &[("leaf", "1")]), pkg("leaf", "1", &[])]);
+        graph
+    }
+
+    #[tokio::test]
+    async fn parallel_scopes_keep_their_own_chain_index() {
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+        let first_barrier = Arc::clone(&barrier);
+        let second_barrier = Arc::clone(&barrier);
+
+        let first = scope(async move {
+            set_active(&graph_with_ancestor("first"));
+            first_barrier.wait().await;
+            format_chain_for("leaf", "1")
+        });
+        let second = scope(async move {
+            set_active(&graph_with_ancestor("second"));
+            second_barrier.wait().await;
+            format_chain_for("leaf", "1")
+        });
+
+        let (first, second) = tokio::join!(first, second);
+        assert_eq!(first, "\nchain: first@1 > leaf@1");
+        assert_eq!(second, "\nchain: second@1 > leaf@1");
+    }
+
+    #[tokio::test]
+    async fn scope_current_propagates_chain_index_to_spawned_tasks() {
+        let chain = scope(async {
+            set_active(&graph_with_ancestor("parent"));
+            tokio::spawn(scope_current(async { format_chain_for("leaf", "1") }))
+                .await
+                .unwrap()
+        })
+        .await;
+
+        assert_eq!(chain, "\nchain: parent@1 > leaf@1");
     }
 }


### PR DESCRIPTION
## Summary

- replace the process-wide project-lock reentrancy flag with explicit lock-guard reuse for commands that chain into install
- scope dependency-chain diagnostics to each install and propagate that state into spawned fetch and lifecycle tasks
- avoid mutating process-global script configuration when scripts are disabled
- add regression coverage for concurrent explicit-directory installs, independent project locks, and isolated diagnostic chains

## Why

The process-wide lock flag could let an install for project B skip its filesystem lock merely because project A was already installing in the same process. The process-wide dependency-chain index could also be overwritten by a concurrent install.

This is prerequisite groundwork for #1025. Once merged, that PR can rebase onto this API and remove its addon-wide serialization mutex. The supported embedding profile remains intentionally constrained: explicit project directories, scripts disabled, and runtime management owned by the embedder. Broader concurrent lifecycle-script and runtime-switching support remains follow-up work.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches install locking, workspace root resolution for ci/dedupe, and global script configuration gating—core concurrency paths where mistakes could cause deadlocks, cross-project lock skips, or wrong diagnostic context.
> 
> **Overview**
> Replaces the **process-wide project lock reentrancy flag** with **explicit `ProjectLock` guards**: commands that chain into install (`add`, `remove`, `update`, filtered add, `ci`, `dedupe`) keep the guard and call **`install::run_with_project_lock`** instead of relying on a nested `install::run` to skip locking. **`take_install_project_lock`** locks the workspace root when manifests are edited under a member but install owns the root lockfile; **`ci`** / **`dedupe`** resolve **`workspace_or_project_root`** before locking.
> 
> **`install::run`** still acquires a lock for standalone installs but runs the pipeline inside **`dep_chain::scope`**. Dependency-chain diagnostics move from a global mutex to **Tokio task-local state**, with **`scope_current`** on fetch and lifecycle **spawned tasks** so parallel installs do not clobber each other's transitive error chains.
> 
> **`configure_script_settings`** runs only when scripts are not disabled (`!ignore_scripts`). Adds regression tests for concurrent installs, independent per-project locks, workspace-root install locks, and isolated dep-chain scopes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c2f880ccefd26912413353d969bd017a1def1e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->