### PR TITLE
refactor(install): isolate runtime and script state

### DIFF
--- a/crates/aube-scripts/src/lib.rs
+++ b/crates/aube-scripts/src/lib.rs
@@ -136,14 +136,51 @@ impl Drop for ScriptJailHomeCleanup {
 static SCRIPT_SETTINGS: std::sync::OnceLock<std::sync::RwLock<ScriptSettings>> =
     std::sync::OnceLock::new();
 
+type ScriptSettingsSlot = std::sync::Arc<std::sync::RwLock<ScriptSettings>>;
+
+tokio::task_local! {
+    static INSTALL_SCRIPT_SETTINGS: ScriptSettingsSlot;
+}
+
+/// Run an install with an isolated script-settings snapshot.
+pub async fn scope<F: std::future::Future>(future: F) -> F::Output {
+    INSTALL_SCRIPT_SETTINGS
+        .scope(
+            std::sync::Arc::new(std::sync::RwLock::new(ScriptSettings::default())),
+            future,
+        )
+        .await
+}
+
+/// Propagate the current install's script settings into a spawned task.
+pub fn scope_current<F: std::future::Future>(
+    future: F,
+) -> impl std::future::Future<Output = F::Output> {
+    let settings = INSTALL_SCRIPT_SETTINGS.try_with(std::sync::Arc::clone).ok();
+    async move {
+        match settings {
+            Some(settings) => INSTALL_SCRIPT_SETTINGS.scope(settings, future).await,
+            None => future.await,
+        }
+    }
+}
+
 fn script_settings_lock() -> &'static std::sync::RwLock<ScriptSettings> {
     SCRIPT_SETTINGS.get_or_init(|| std::sync::RwLock::new(ScriptSettings::default()))
 }
 
-/// Replace the process-wide script settings snapshot. CLI commands call
-/// this after resolving `.npmrc` / workspace settings for the active
-/// project.
+/// Replace the current install's script settings snapshot, or the process-wide
+/// fallback when called outside an install scope.
 pub fn set_script_settings(settings: ScriptSettings) {
+    if INSTALL_SCRIPT_SETTINGS
+        .try_with(|slot| match slot.write() {
+            Ok(mut guard) => *guard = settings.clone(),
+            Err(poisoned) => *poisoned.into_inner() = settings.clone(),
+        })
+        .is_ok()
+    {
+        return;
+    }
     match script_settings_lock().write() {
         Ok(mut guard) => *guard = settings,
         Err(poisoned) => *poisoned.into_inner() = settings,
@@ -151,9 +188,52 @@ pub fn set_script_settings(settings: ScriptSettings) {
 }
 
 fn script_settings() -> ScriptSettings {
+    if let Ok(settings) = INSTALL_SCRIPT_SETTINGS.try_with(|slot| match slot.read() {
+        Ok(guard) => guard.clone(),
+        Err(poisoned) => poisoned.into_inner().clone(),
+    }) {
+        return settings;
+    }
     match script_settings_lock().read() {
         Ok(guard) => guard.clone(),
         Err(poisoned) => poisoned.into_inner().clone(),
+    }
+}
+
+#[cfg(test)]
+mod scoped_settings_tests {
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn install_script_settings_are_isolated_and_propagated() {
+        let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+        let first_barrier = std::sync::Arc::clone(&barrier);
+        let second_barrier = std::sync::Arc::clone(&barrier);
+
+        let first = scope(async move {
+            set_script_settings(ScriptSettings {
+                command: Some("first".to_string()),
+                ..ScriptSettings::default()
+            });
+            first_barrier.wait().await;
+            tokio::spawn(scope_current(async { script_settings().command }))
+                .await
+                .unwrap()
+        });
+        let second = scope(async move {
+            set_script_settings(ScriptSettings {
+                command: Some("second".to_string()),
+                ..ScriptSettings::default()
+            });
+            second_barrier.wait().await;
+            tokio::spawn(scope_current(async { script_settings().command }))
+                .await
+                .unwrap()
+        });
+
+        let (first, second) = tokio::join!(first, second);
+        assert_eq!(first.as_deref(), Some("first"));
+        assert_eq!(second.as_deref(), Some("second"));
     }
 }
 

--- a/crates/aube/src/commands/install/lifecycle.rs
+++ b/crates/aube/src/commands/install/lifecycle.rs
@@ -570,7 +570,7 @@ pub(crate) async fn run_dep_lifecycle_scripts(
         let modules_dir_name = modules_dir_name.clone();
         let node_gyp_bin_dir = node_gyp_bin_dir.clone();
         let jail_policy = jail_policy.clone();
-        set.spawn(crate::dep_chain::scope_current(async move {
+        let task = crate::dep_chain::scope_current(async move {
             let _permit = sem.acquire().await.unwrap();
             if should_restore_side_effects_cache && let Some(cache_entry) = job.cache_entry.clone()
             {
@@ -665,7 +665,10 @@ pub(crate) async fn run_dep_lifecycle_scripts(
                 }
             }
             Ok(ran_here)
-        }));
+        });
+        let task = crate::runtime::scope_current(task);
+        let task = aube_scripts::scope_current(task);
+        set.spawn(task);
     }
 
     let mut ran = 0usize;

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -494,7 +494,8 @@ fn reachable_package_dep_paths(
 pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     let cwd = resolve_project_cwd(&opts)?;
     let _lock = super::take_project_lock(&cwd)?;
-    crate::dep_chain::scope(run_inner(opts, cwd)).await
+    let install = Box::pin(run_inner(opts, cwd));
+    crate::runtime::scope(aube_scripts::scope(crate::dep_chain::scope(install))).await
 }
 
 /// Run install while reusing a project lock owned by an outer command.
@@ -509,7 +510,8 @@ pub(crate) async fn run_with_project_lock(
 ) -> miette::Result<()> {
     let cwd = lock.project_dir().to_path_buf();
     opts.project_dir = Some(cwd.clone());
-    crate::dep_chain::scope(run_inner(opts, cwd)).await
+    let install = Box::pin(run_inner(opts, cwd));
+    crate::runtime::scope(aube_scripts::scope(crate::dep_chain::scope(install))).await
 }
 
 async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Result<()> {
@@ -1326,7 +1328,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
             // spawned task. The install command reads it back after
             // `filter_graph` prunes the post-resolve graph.
             let fetch_deprecations_tx = deprecations.clone();
-            let fetch_handle = tokio::spawn(async move {
+            let fetch_handle = tokio::spawn(crate::runtime::scope_current(async move {
                 /*
                  * Adaptive tarball concurrency. Loaded from the
                  * cross run persistent store when available so the
@@ -1720,7 +1722,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
                     semaphore_for_persist.persist(state, "tarball:default");
                 }
                 Ok::<_, miette::Report>((indices, cached_count, fetch_count, computed_integrities))
-            });
+            }));
 
             // Run resolution (this streams packages to the fetch coordinator).
             // `existing_for_resolver` is `Some` when Fix / Prefer parsed a

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -494,8 +494,7 @@ fn reachable_package_dep_paths(
 pub async fn run(opts: InstallOptions) -> miette::Result<()> {
     let cwd = resolve_project_cwd(&opts)?;
     let _lock = super::take_project_lock(&cwd)?;
-    let install = Box::pin(run_inner(opts, cwd));
-    crate::runtime::scope(aube_scripts::scope(crate::dep_chain::scope(install))).await
+    run_scoped(opts, cwd).await
 }
 
 /// Run install while reusing a project lock owned by an outer command.
@@ -510,6 +509,13 @@ pub(crate) async fn run_with_project_lock(
 ) -> miette::Result<()> {
     let cwd = lock.project_dir().to_path_buf();
     opts.project_dir = Some(cwd.clone());
+    run_scoped(opts, cwd).await
+}
+
+async fn run_scoped(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Result<()> {
+    // Box the large install state machine before stacking task-local scopes.
+    // Keeping it inline overflowed a Tokio worker stack in the parallel-install
+    // regression test once runtime and script-settings scopes were added.
     let install = Box::pin(run_inner(opts, cwd));
     crate::runtime::scope(aube_scripts::scope(crate::dep_chain::scope(install))).await
 }
@@ -1328,7 +1334,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
             // spawned task. The install command reads it back after
             // `filter_graph` prunes the post-resolve graph.
             let fetch_deprecations_tx = deprecations.clone();
-            let fetch_handle = tokio::spawn(crate::runtime::scope_current(async move {
+            let fetch = Box::pin(async move {
                 /*
                  * Adaptive tarball concurrency. Loaded from the
                  * cross run persistent store when available so the
@@ -1722,7 +1728,10 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
                     semaphore_for_persist.persist(state, "tarball:default");
                 }
                 Ok::<_, miette::Report>((indices, cached_count, fetch_count, computed_integrities))
-            }));
+            });
+            let fetch = crate::runtime::scope_current(fetch);
+            let fetch = aube_scripts::scope_current(fetch);
+            let fetch_handle = tokio::spawn(fetch);
 
             // Run resolution (this streams packages to the fetch coordinator).
             // `existing_for_resolver` is `Some` when Fix / Prefer parsed a

--- a/crates/aube/src/commands/runtime.rs
+++ b/crates/aube/src/commands/runtime.rs
@@ -128,10 +128,20 @@ async fn run_set(args: RuntimeSetArgs) -> miette::Result<()> {
         install::InstallOptions::with_mode(super::chained_frozen_mode(install::FrozenMode::Prefer));
     install::run(opts).await?;
 
-    let ctx = crate::runtime::current();
-    if let Some(ctx) = ctx
-        && let Some(version) = &ctx.version
-    {
+    // Install runtime state is invocation-scoped so concurrent projects cannot
+    // replace one another. Re-read the manifest rather than using the process
+    // cache, which may still contain the pre-edit package.json, then resolve the
+    // now-installed, lockfile-pinned runtime for the follow-up status message.
+    let manifest = aube_manifest::PackageJson::from_path(&manifest_path)
+        .map_err(miette::Report::new)
+        .wrap_err("failed to read updated package.json")?;
+    let parse_options = super::with_settings_ctx(&project_dir, |ctx| aube_lockfile::ParseOptions {
+        strict_store_integrity: aube_settings::resolved::strict_store_integrity(ctx)
+            || aube_settings::resolved::paranoid(ctx),
+    });
+    let pin = crate::runtime::lockfile_node_pin(&project_dir, &manifest, parse_options);
+    let ctx = crate::runtime::ensure(&project_dir, Some(&manifest), settings, pin.as_ref()).await?;
+    if let Some(version) = &ctx.version {
         println!("node {version} ready ({})", ctx.provenance.label());
     }
     Ok(())

--- a/crates/aube/src/commands/script_settings.rs
+++ b/crates/aube/src/commands/script_settings.rs
@@ -37,8 +37,9 @@ pub(crate) fn configure_script_settings(
         script_shell,
         unsafe_perm,
         shell_emulator,
-        node_bin_dir: runtime.and_then(|r| r.bin_dir.clone()),
+        node_bin_dir: runtime.as_ref().and_then(|r| r.bin_dir.clone()),
         node_exe: runtime
+            .as_ref()
             .and_then(|r| r.node_bin.clone())
             .or_else(aube_runtime::node_on_path),
         command: command.map(str::to_string),

--- a/crates/aube/src/runtime.rs
+++ b/crates/aube/src/runtime.rs
@@ -1,16 +1,19 @@
-//! Process-global Node runtime context: which node this aube process
-//! should put on PATH for scripts, exec, dlx, and lifecycle hooks.
+//! Node runtime context: which node aube should put on PATH for scripts,
+//! exec, dlx, and lifecycle hooks.
 //!
-//! Resolution happens once per process via [`ensure`]; every spawn
-//! site reads the snapshot through [`current`] / [`path_entries`] /
+//! Explicit installs resolve once per invocation inside [`scope`], so parallel
+//! projects cannot replace one another's selected runtime. Other CLI commands
+//! retain the process-wide fallback resolved through [`ensure`]. Every spawn
+//! site reads the active snapshot through [`current`] / [`path_entries`] /
 //! [`node_program`] / [`apply_child_env`]. A project with no runtime
-//! configuration resolves to a pass-through context — PATH untouched,
-//! behavior identical to aube before runtime switching existed.
+//! configuration resolves to a pass-through context — PATH untouched.
 
 use aube_manifest::PackageJson;
 use aube_settings::ResolveCtx;
 use miette::miette;
+use std::future::Future;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 /// Where the version requirement came from.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -89,11 +92,39 @@ impl RuntimeContext {
     }
 }
 
-static RUNTIME: tokio::sync::OnceCell<RuntimeContext> = tokio::sync::OnceCell::const_new();
+static RUNTIME: tokio::sync::OnceCell<Arc<RuntimeContext>> = tokio::sync::OnceCell::const_new();
+
+type RuntimeSlot = Arc<tokio::sync::OnceCell<Arc<RuntimeContext>>>;
+
+tokio::task_local! {
+    static INSTALL_RUNTIME: RuntimeSlot;
+}
+
+/// Run an install with an isolated runtime slot. Standalone commands outside
+/// this scope retain the process-wide runtime selected by the CLI.
+pub async fn scope<F: Future>(future: F) -> F::Output {
+    INSTALL_RUNTIME
+        .scope(Arc::new(tokio::sync::OnceCell::new()), future)
+        .await
+}
+
+/// Propagate the current install's runtime slot into a spawned task.
+pub fn scope_current<F: Future>(future: F) -> impl Future<Output = F::Output> {
+    let runtime = INSTALL_RUNTIME.try_with(Arc::clone).ok();
+    async move {
+        match runtime {
+            Some(runtime) => INSTALL_RUNTIME.scope(runtime, future).await,
+            None => future.await,
+        }
+    }
+}
 
 /// The resolved context, if [`ensure`] has run.
-pub fn current() -> Option<&'static RuntimeContext> {
-    RUNTIME.get()
+pub fn current() -> Option<Arc<RuntimeContext>> {
+    match INSTALL_RUNTIME.try_with(|runtime| runtime.get().map(Arc::clone)) {
+        Ok(runtime) => runtime,
+        Err(_) => RUNTIME.get().map(Arc::clone),
+    }
 }
 
 /// The node executable spawn sites should use: the switched runtime's
@@ -212,7 +243,7 @@ pub(crate) fn lockfile_node_pin(
 /// [`ensure`] for commands that haven't loaded settings/manifests yet
 /// (dlx, run/exec warm paths): loads the settings for `cwd`'s project
 /// root, reads the lockfile pin, and resolves from there.
-pub async fn ensure_for_cwd(cwd: &Path) -> miette::Result<&'static RuntimeContext> {
+pub async fn ensure_for_cwd(cwd: &Path) -> miette::Result<Arc<RuntimeContext>> {
     if let Some(ctx) = current() {
         return Ok(ctx);
     }
@@ -242,13 +273,28 @@ pub async fn ensure(
     manifest: Option<&PackageJson>,
     settings: RuntimeSettings,
     lock_pin: Option<&aube_lockfile::RuntimePin>,
-) -> miette::Result<&'static RuntimeContext> {
+) -> miette::Result<Arc<RuntimeContext>> {
     let lock_pin = lock_pin.cloned();
     let project_dir = project_dir.to_path_buf();
     let manifest = manifest.cloned();
+    if let Ok(runtime) = INSTALL_RUNTIME.try_with(Arc::clone) {
+        return runtime
+            .get_or_try_init(|| async {
+                resolve_context(project_dir, manifest, settings, lock_pin)
+                    .await
+                    .map(Arc::new)
+            })
+            .await
+            .map(Arc::clone);
+    }
     RUNTIME
-        .get_or_try_init(|| resolve_context(project_dir, manifest, settings, lock_pin))
+        .get_or_try_init(|| async {
+            resolve_context(project_dir, manifest, settings, lock_pin)
+                .await
+                .map(Arc::new)
+        })
         .await
+        .map(Arc::clone)
 }
 
 async fn resolve_context(
@@ -700,6 +746,42 @@ impl aube_runtime::DownloadProgress for CliProgress {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_context(requested: &str) -> RuntimeContext {
+        let mut context = RuntimeContext::path_fallback();
+        context.requested = Some(requested.to_string());
+        context
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn install_runtime_is_isolated_and_propagated() {
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+        let first_barrier = Arc::clone(&barrier);
+        let second_barrier = Arc::clone(&barrier);
+
+        let first = scope(async move {
+            INSTALL_RUNTIME.with(|runtime| runtime.set(Arc::new(test_context("first"))).unwrap());
+            first_barrier.wait().await;
+            tokio::spawn(scope_current(async {
+                current().and_then(|runtime| runtime.requested.clone())
+            }))
+            .await
+            .unwrap()
+        });
+        let second = scope(async move {
+            INSTALL_RUNTIME.with(|runtime| runtime.set(Arc::new(test_context("second"))).unwrap());
+            second_barrier.wait().await;
+            tokio::spawn(scope_current(async {
+                current().and_then(|runtime| runtime.requested.clone())
+            }))
+            .await
+            .unwrap()
+        });
+
+        let (first, second) = tokio::join!(first, second);
+        assert_eq!(first.as_deref(), Some("first"));
+        assert_eq!(second.as_deref(), Some("second"));
+    }
 
     #[test]
     fn lockfile_pin_round_trip_shapes() {

--- a/test/runtime_download.bats
+++ b/test/runtime_download.bats
@@ -175,6 +175,7 @@ _dev_engines_project() {
 	echo "runtime-installer=aube" >>.npmrc
 	run aube runtime set node 0.95
 	assert_success
+	assert_output --partial "node 0.95.2 ready (aube)"
 	run cat package.json
 	assert_output --partial '"name": "node"'
 	assert_output --partial '"version": "^0.95.2"'


### PR DESCRIPTION
## Summary

- scope Node runtime selection to each explicit install invocation
- scope lifecycle-script settings to each install instead of replacing the process-wide fallback
- propagate both contexts into spawned fetch and dependency-lifecycle tasks
- retain process-wide runtime and script settings for non-install CLI commands

## Why

OpenCode starts package installations for independent directories concurrently. PR #1026 made explicit-directory installs and their project locks reentrant, but the install pipeline could still share the selected Node runtime and lifecycle-script settings between projects.

This change removes those remaining mutable snapshots from the concurrent install path. Each install receives its own task-local runtime cell and script-settings slot. Spawned work explicitly inherits the owning install's context, while unrelated installs cannot observe or replace it.

This is a prerequisite for #1025. Once merged, the Node-API addon can remove its addon-wide install mutex and allow independent OpenCode installs to execute in parallel.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- parallel runtime and script-context isolation tests
- parallel explicit-directory and guarded-install tests
- `mise run test:bats test/runtime.bats` (23 tests)
- `mise run test:bats test/lifecycle_scripts.bats` (42 tests)
- `mise run test:bats test/pnpm_install_hooks.bats` (21 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches install orchestration, runtime resolution, and script env for all lifecycle/fetch spawns; behavior change is intentional for concurrency but regressions could affect wrong Node binary or script settings under parallel installs.
> 
> **Overview**
> **Parallel installs** no longer share a single process-wide **Node runtime** or **lifecycle script settings**. Each install runs inside nested task-local scopes (`runtime`, `aube_scripts`, existing `dep_chain`), with **`scope_current`** on spawned **fetch** and **dependency lifecycle** tasks so children inherit the owning install’s context. Non-install CLI commands still use the process-wide fallbacks.
> 
> The install entry path is **`run_scoped`**, which nests those scopes and **`Box::pin`s** `run_inner` to avoid Tokio worker stack overflow when scopes stack. **`aube runtime set`** re-reads `package.json` and resolves the lockfile-pinned runtime for its status line instead of trusting a possibly stale process cache. **`RuntimeContext`** is now returned as **`Arc`** from **`current`** / **`ensure`**. Isolation is covered by new multi-thread tests; bats expects **`node … ready (aube)`** after **`aube runtime set`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06641d9db44845ceeeb052e19f72855afe1295d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->