### PR TITLE
fix(soak): match .exe on windows tool-install early-exit

### DIFF
--- a/scripts/soak/external-tools.mts
+++ b/scripts/soak/external-tools.mts
@@ -281,6 +281,13 @@ async function installAssetTool(name: string, pin: ToolPin): Promise<void> {
   let binName = pin.binaryName ?? name
   const destDir = path.join(RACK_DIR, name, pin.version!)
   let destBin = path.join(destDir, binName)
+  // Windows archives land as `<bin>.exe`; resolve the same suffix the
+  // post-extract path does so a second --install is a no-op instead of a
+  // forced re-download (which wedges on a restricted/offline runner).
+  if (!existsSync(destBin) && existsSync(`${destBin}.exe`)) {
+    destBin = `${destBin}.exe`
+    binName = `${binName}.exe`
+  }
   if (existsSync(destBin)) {
     linkHandle(destBin, binName)
     console.log(`[external-tools] ${name}@${pin.version} already installed`)


### PR DESCRIPTION
## What

Follow-up to #1020. The pre-download idempotency guard in `installAssetTool` (`scripts/soak/external-tools.mts`) checked only the suffix-less `destBin`, while the post-extract path resolves `<bin>.exe` for Windows archives. So on Windows a second `aube` dev-tool `--install` always re-downloaded and re-extracted the archive — and on a restricted/offline runner (cached rack, no network) that forced re-download fails outright.

This mirrors the same `.exe` resolution into the early-exit block, so a repeat install is a no-op on Windows as it already is on POSIX.

## Why

Resolves the remaining unresolved greptile P1 on #1020 ("Idempotency check misses `.exe` on Windows", `external-tools.mts:288`). The sibling P1 ("`.zip` handle name doubles the `.exe` extension") was already handled by the merged `linkHandle`, which strips the suffix before building the PATH handle.

## Testing

- `node --test scripts/soak/external-tools.test.mts` — 13/13 pass
- `node scripts/soak/external-tools.mts --check` — clean

A dedicated unit test isn't added: `RACK_DIR`/`BIN_DIR` are frozen from `XDG_DATA_HOME` at import and `installAssetTool` isn't exported, so exercising the guard would need a subprocess + env-override harness disproportionate to a 4-line Windows-only mirror of already-present logic (lines 296–299).

Note: `scripts/soak/` is mirrored into the nub repo (only `paths.mts` differs); this one-liner should be mirrored there too.

*This PR was generated by Claude.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows installation handling for executable archives.
  * Prevented unnecessary re-downloads and installation retries when an executable was already installed with an `.exe` extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->