### PR TITLE
fix(release): allow fresh workspace crates during publish

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -44,6 +44,10 @@ jobs:
         with:
           command: release
         env:
+          # Workspace crates are published in dependency order during one
+          # release, so their freshly published internal dependencies must
+          # bypass the repository-wide 7-day dependency soak.
+          CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE: allow
           GITHUB_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}
       # The `releases` output is an array of every crate that was
       # published, in dependency order. Since aube depends on all


### PR DESCRIPTION
## Summary

- allow newly published workspace crates during the release-plz publish step
- retain the repository-wide 7-day minimum publish age for all other Cargo resolution

## Root cause

The v1.27.0 release published `aube-codes` first, then Cargo rejected it while packaging dependent workspace crate `aube-util` because the global 7-day minimum publish age also applied inside the sequential release operation.

## Validation

- `mise exec actionlint -- actionlint .github/workflows/release-plz.yml`
- `git diff --check`

*This pull request was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the release-plz GitHub Actions job; it only relaxes publish-age checks during automated releases, not general dependency resolution.
> 
> **Overview**
> Fixes **release-plz** publish failures when workspace crates are published in dependency order in a single run.
> 
> The `release-plz release` step now sets **`CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow`** so Cargo can resolve **just-published** internal crates (e.g. `aube-codes` → `aube-util`) without hitting the repo’s **7-day minimum publish age**. That soak policy stays in effect everywhere else; only this release job opts out for same-release internal deps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4625148ac5789c8560818337b4f70dbe2c52aa3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process to allow newly published internal packages to be released in dependency order without waiting for the standard publish-age period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->