### PR TITLE
fix(install): refresh changed file directory dependencies

### DIFF
--- a/crates/aube-linker/src/link.rs
+++ b/crates/aube-linker/src/link.rs
@@ -185,6 +185,16 @@ impl Linker {
                 continue;
             };
             let aube_entry = aube_dir.join(dep_path);
+            // `file:` directories and portals are mutable while their
+            // dep_path is intentionally stable (it identifies the source
+            // path, not one generation of its contents). A full install has
+            // just re-imported the current tree, so replace the existing
+            // materialization instead of treating the path-keyed entry as a
+            // cache hit. The install-state warm path prevents this work when
+            // the source fingerprint is unchanged.
+            if matches!(local, LocalSource::Directory(_) | LocalSource::Portal(_)) {
+                try_remove_entry(&aube_entry);
+            }
             if !aube_entry.exists() {
                 self.materialize_into(
                     &aube_dir,

--- a/crates/aube-linker/src/link.rs
+++ b/crates/aube-linker/src/link.rs
@@ -757,6 +757,9 @@ impl Linker {
                 continue;
             };
             let aube_entry = aube_dir.join(self.aube_dir_entry_name(dep_path));
+            if matches!(local, LocalSource::Directory(_) | LocalSource::Portal(_)) {
+                try_remove_entry(&aube_entry);
+            }
             if aube_entry.exists() {
                 stats.packages_cached += 1;
                 continue;

--- a/crates/aube-linker/src/link.rs
+++ b/crates/aube-linker/src/link.rs
@@ -194,6 +194,14 @@ impl Linker {
             // the source fingerprint is unchanged.
             if matches!(local, LocalSource::Directory(_) | LocalSource::Portal(_)) {
                 try_remove_entry(&aube_entry);
+                if aube_entry.exists() {
+                    return Err(Error::Io(
+                        aube_entry,
+                        std::io::Error::other(
+                            "failed to remove stale local dependency materialization",
+                        ),
+                    ));
+                }
             }
             if !aube_entry.exists() {
                 self.materialize_into(
@@ -759,6 +767,14 @@ impl Linker {
             let aube_entry = aube_dir.join(self.aube_dir_entry_name(dep_path));
             if matches!(local, LocalSource::Directory(_) | LocalSource::Portal(_)) {
                 try_remove_entry(&aube_entry);
+                if aube_entry.exists() {
+                    return Err(Error::Io(
+                        aube_entry,
+                        std::io::Error::other(
+                            "failed to remove stale local dependency materialization",
+                        ),
+                    ));
+                }
             }
             if aube_entry.exists() {
                 stats.packages_cached += 1;

--- a/crates/aube-linker/src/link.rs
+++ b/crates/aube-linker/src/link.rs
@@ -184,7 +184,7 @@ impl Linker {
             let Some(index) = package_indices.get(dep_path) else {
                 continue;
             };
-            let aube_entry = aube_dir.join(dep_path);
+            let aube_entry = aube_dir.join(self.aube_dir_entry_name(dep_path));
             // `file:` directories and portals are mutable while their
             // dep_path is intentionally stable (it identifies the source
             // path, not one generation of its contents). A full install has

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -30,6 +30,7 @@ pub use integrity::{
     shasum_to_sri, validate_and_encode_name, validate_pkg_content, validate_version,
     verify_integrity, verify_precomputed_sha512,
 };
+pub use tarball::directory_content_fingerprint;
 #[cfg(test)]
 pub(crate) use tarball::normalize_tar_entry_path;
 pub(crate) use tarball::{

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -30,11 +30,13 @@ pub use integrity::{
     shasum_to_sri, validate_and_encode_name, validate_pkg_content, validate_version,
     verify_integrity, verify_precomputed_sha512,
 };
-pub use tarball::directory_content_fingerprint;
 #[cfg(test)]
 pub(crate) use tarball::normalize_tar_entry_path;
 pub(crate) use tarball::{
     CappedReader, MAX_TARBALL_DECOMPRESSED_BYTES, MAX_TARBALL_ENTRIES, MAX_TARBALL_ENTRY_BYTES,
+};
+pub use tarball::{
+    directory_content_fingerprint, directory_fingerprints, directory_metadata_fingerprint,
 };
 
 #[cfg(test)]

--- a/crates/aube-store/src/tarball.rs
+++ b/crates/aube-store/src/tarball.rs
@@ -1,6 +1,73 @@
 use crate::{Error, PackageIndex, Store, StoredFile};
 use std::path::Path;
 
+/// Deterministic fingerprint of a directory imported as a `file:` package.
+///
+/// This deliberately mirrors [`Store::import_directory`]: `.git` and
+/// `node_modules` directories are skipped, non-files are ignored, and each
+/// relative path, content hash, and executable bit contributes to the result.
+/// The install freshness check uses it without writing the files to the CAS.
+pub fn directory_content_fingerprint(dir: &Path) -> Result<String, Error> {
+    let mut entries = Vec::new();
+    fingerprint_directory_recursive(dir, dir, &mut entries)?;
+    entries.sort_unstable();
+    let mut hasher = blake3::Hasher::new();
+    for (path, hex_hash, executable) in entries {
+        hasher.update(path.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(hex_hash.as_bytes());
+        hasher.update(if executable { b"\x01" } else { b"\x00" });
+    }
+    Ok(hasher.finalize().to_hex().to_string())
+}
+
+fn fingerprint_directory_recursive(
+    base: &Path,
+    current: &Path,
+    entries: &mut Vec<(String, String, bool)>,
+) -> Result<(), Error> {
+    let dir_entries = std::fs::read_dir(current)
+        .map_err(|e| Error::Tar(format!("read_dir {}: {e}", current.display())))?;
+    for entry in dir_entries {
+        let entry = entry.map_err(|e| Error::Tar(format!("read_dir entry: {e}")))?;
+        let file_type = entry
+            .file_type()
+            .map_err(|e| Error::Tar(format!("file_type: {e}")))?;
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if matches!(name.as_ref(), ".git" | "node_modules") {
+            continue;
+        }
+        let path = entry.path();
+        if file_type.is_dir() {
+            fingerprint_directory_recursive(base, &path, entries)?;
+            continue;
+        }
+        if !file_type.is_file() {
+            continue;
+        }
+        let content = std::fs::read(&path)
+            .map_err(|e| Error::Tar(format!("read {}: {e}", path.display())))?;
+        #[cfg(unix)]
+        let executable = {
+            use std::os::unix::fs::PermissionsExt;
+            let meta = entry
+                .metadata()
+                .map_err(|e| Error::Tar(format!("metadata: {e}")))?;
+            meta.permissions().mode() & 0o111 != 0
+        };
+        #[cfg(not(unix))]
+        let executable = false;
+        let rel = path
+            .strip_prefix(base)
+            .map_err(|e| Error::Tar(format!("strip_prefix: {e}")))?
+            .to_string_lossy()
+            .replace('\\', "/");
+        entries.push((rel, blake3::hash(&content).to_hex().to_string(), executable));
+    }
+    Ok(())
+}
+
 impl Store {
     /// Import every file under a directory into the store, producing a
     /// `PackageIndex` keyed by paths relative to `dir`. Used by `file:`
@@ -606,3 +673,31 @@ pub(crate) const MAX_TARBALL_ENTRY_BYTES: u64 = 1 << 20;
 pub(crate) const MAX_TARBALL_ENTRIES: usize = 200_000;
 #[cfg(test)]
 pub(crate) const MAX_TARBALL_ENTRIES: usize = 64;
+
+#[cfg(test)]
+mod directory_fingerprint_tests {
+    use super::*;
+
+    #[test]
+    fn directory_fingerprint_matches_imported_index() {
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().join("source");
+        std::fs::create_dir_all(source.join("lib")).unwrap();
+        std::fs::create_dir_all(source.join("node_modules/ignored")).unwrap();
+        std::fs::write(source.join("package.json"), br#"{"name":"local"}"#).unwrap();
+        std::fs::write(source.join("lib/index.js"), b"module.exports = 'v1';\n").unwrap();
+        std::fs::write(source.join("node_modules/ignored/index.js"), b"ignored\n").unwrap();
+
+        let store = Store::at(temp.path().join("store"));
+        let index = store.import_directory(&source).unwrap();
+        assert_eq!(
+            directory_content_fingerprint(&source).unwrap(),
+            crate::index_content_fingerprint(&index)
+        );
+
+        let before = directory_content_fingerprint(&source).unwrap();
+        std::fs::write(source.join("lib/index.js"), b"module.exports = 'v2';\n").unwrap();
+        let after = directory_content_fingerprint(&source).unwrap();
+        assert_ne!(before, after);
+    }
+}

--- a/crates/aube-store/src/tarball.rs
+++ b/crates/aube-store/src/tarball.rs
@@ -8,8 +8,52 @@ use std::path::Path;
 /// relative path, content hash, and executable bit contributes to the result.
 /// The install freshness check uses it without writing the files to the CAS.
 pub fn directory_content_fingerprint(dir: &Path) -> Result<String, Error> {
-    let mut entries = Vec::new();
-    fingerprint_directory_recursive(dir, dir, &mut entries)?;
+    let entries = collect_directory_fingerprints(dir, true)?;
+    Ok(content_fingerprint(&entries))
+}
+
+/// Metadata-only fingerprint for the same tree as
+/// [`directory_content_fingerprint`]. This stats every included file but does
+/// not read its contents, letting warm install checks avoid unbounded file I/O
+/// when the source tree is unchanged.
+pub fn directory_metadata_fingerprint(dir: &Path) -> Result<String, Error> {
+    let entries = collect_directory_fingerprints(dir, false)?;
+    Ok(metadata_fingerprint(&entries))
+}
+
+/// Compute content and metadata fingerprints in one directory walk.
+///
+/// State writes need both values. Combining them avoids a second traversal
+/// after reading the source files for the authoritative content fingerprint.
+pub fn directory_fingerprints(dir: &Path) -> Result<(String, String), Error> {
+    let entries = collect_directory_fingerprints(dir, true)?;
+    Ok((
+        content_fingerprint(&entries),
+        metadata_fingerprint(&entries),
+    ))
+}
+
+#[derive(Debug)]
+struct DirectoryFileFingerprint {
+    path: String,
+    content_hash: Option<String>,
+    executable: bool,
+    size: u64,
+    mtime_secs: i64,
+    mtime_nanos: u32,
+}
+
+fn content_fingerprint(entries: &[DirectoryFileFingerprint]) -> String {
+    let mut entries: Vec<(&str, &str, bool)> = entries
+        .iter()
+        .filter_map(|entry| {
+            Some((
+                entry.path.as_str(),
+                entry.content_hash.as_deref()?,
+                entry.executable,
+            ))
+        })
+        .collect();
     entries.sort_unstable();
     let mut hasher = blake3::Hasher::new();
     for (path, hex_hash, executable) in entries {
@@ -18,13 +62,38 @@ pub fn directory_content_fingerprint(dir: &Path) -> Result<String, Error> {
         hasher.update(hex_hash.as_bytes());
         hasher.update(if executable { b"\x01" } else { b"\x00" });
     }
-    Ok(hasher.finalize().to_hex().to_string())
+    hasher.finalize().to_hex().to_string()
 }
 
-fn fingerprint_directory_recursive(
+fn metadata_fingerprint(entries: &[DirectoryFileFingerprint]) -> String {
+    let mut entries: Vec<&DirectoryFileFingerprint> = entries.iter().collect();
+    entries.sort_unstable_by(|a, b| a.path.cmp(&b.path));
+    let mut hasher = blake3::Hasher::new();
+    for entry in entries {
+        hasher.update(entry.path.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(&entry.size.to_le_bytes());
+        hasher.update(&entry.mtime_secs.to_le_bytes());
+        hasher.update(&entry.mtime_nanos.to_le_bytes());
+        hasher.update(if entry.executable { b"\x01" } else { b"\x00" });
+    }
+    hasher.finalize().to_hex().to_string()
+}
+
+fn collect_directory_fingerprints(
+    dir: &Path,
+    hash_content: bool,
+) -> Result<Vec<DirectoryFileFingerprint>, Error> {
+    let mut entries = Vec::new();
+    collect_directory_fingerprints_recursive(dir, dir, hash_content, &mut entries)?;
+    Ok(entries)
+}
+
+fn collect_directory_fingerprints_recursive(
     base: &Path,
     current: &Path,
-    entries: &mut Vec<(String, String, bool)>,
+    hash_content: bool,
+    entries: &mut Vec<DirectoryFileFingerprint>,
 ) -> Result<(), Error> {
     let dir_entries = std::fs::read_dir(current)
         .map_err(|e| Error::Tar(format!("read_dir {}: {e}", current.display())))?;
@@ -40,21 +109,26 @@ fn fingerprint_directory_recursive(
         }
         let path = entry.path();
         if file_type.is_dir() {
-            fingerprint_directory_recursive(base, &path, entries)?;
+            collect_directory_fingerprints_recursive(base, &path, hash_content, entries)?;
             continue;
         }
         if !file_type.is_file() {
             continue;
         }
-        let content = std::fs::read(&path)
-            .map_err(|e| Error::Tar(format!("read {}: {e}", path.display())))?;
+        let metadata = entry
+            .metadata()
+            .map_err(|e| Error::Tar(format!("metadata {}: {e}", path.display())))?;
+        let content_hash = if hash_content {
+            let content = std::fs::read(&path)
+                .map_err(|e| Error::Tar(format!("read {}: {e}", path.display())))?;
+            Some(blake3::hash(&content).to_hex().to_string())
+        } else {
+            None
+        };
         #[cfg(unix)]
         let executable = {
             use std::os::unix::fs::PermissionsExt;
-            let meta = entry
-                .metadata()
-                .map_err(|e| Error::Tar(format!("metadata: {e}")))?;
-            meta.permissions().mode() & 0o111 != 0
+            metadata.permissions().mode() & 0o111 != 0
         };
         #[cfg(not(unix))]
         let executable = false;
@@ -63,7 +137,21 @@ fn fingerprint_directory_recursive(
             .map_err(|e| Error::Tar(format!("strip_prefix: {e}")))?
             .to_string_lossy()
             .replace('\\', "/");
-        entries.push((rel, blake3::hash(&content).to_hex().to_string(), executable));
+        let modified = metadata
+            .modified()
+            .ok()
+            .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok());
+        let (mtime_secs, mtime_nanos) = modified
+            .map(|duration| (duration.as_secs() as i64, duration.subsec_nanos()))
+            .unwrap_or((0, 0));
+        entries.push(DirectoryFileFingerprint {
+            path: rel,
+            content_hash,
+            executable,
+            size: metadata.len(),
+            mtime_secs,
+            mtime_nanos,
+        });
     }
     Ok(())
 }
@@ -690,14 +778,22 @@ mod directory_fingerprint_tests {
 
         let store = Store::at(temp.path().join("store"));
         let index = store.import_directory(&source).unwrap();
+        let (content_hash, metadata_hash) = directory_fingerprints(&source).unwrap();
+        assert_eq!(content_hash, crate::index_content_fingerprint(&index));
         assert_eq!(
-            directory_content_fingerprint(&source).unwrap(),
-            crate::index_content_fingerprint(&index)
+            metadata_hash,
+            directory_metadata_fingerprint(&source).unwrap()
         );
 
-        let before = directory_content_fingerprint(&source).unwrap();
+        let before_content = content_hash;
         std::fs::write(source.join("lib/index.js"), b"module.exports = 'v2';\n").unwrap();
-        let after = directory_content_fingerprint(&source).unwrap();
-        assert_ne!(before, after);
+        let after_content = directory_content_fingerprint(&source).unwrap();
+        assert_ne!(before_content, after_content);
+
+        std::fs::write(source.join("lib/added.js"), b"added\n").unwrap();
+        assert_ne!(
+            metadata_hash,
+            directory_metadata_fingerprint(&source).unwrap()
+        );
     }
 }

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -78,6 +78,11 @@ pub struct InstallState {
     /// there for the freshness-check fast-path semantics.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub package_json_meta: BTreeMap<String, FileMeta>,
+    /// Content fingerprints for copied local directory dependencies, keyed by
+    /// their project-relative source path. `None` means the state predates
+    /// local-source freshness tracking and must miss the warm path once.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local_directory_hashes: Option<BTreeMap<String, String>>,
     pub aube_version: String,
     #[serde(default, rename = "prod")]
     pub section_filtered: bool,
@@ -145,6 +150,8 @@ struct FreshnessState {
     /// existing hash path, so older state files stay valid.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     package_json_meta: BTreeMap<String, FileMeta>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    local_directory_hashes: Option<BTreeMap<String, String>>,
     #[serde(default, rename = "prod")]
     section_filtered: bool,
     #[serde(default)]
@@ -208,6 +215,7 @@ impl From<&InstallState> for FreshnessState {
             member_lockfile_meta: state.member_lockfile_meta.clone(),
             package_json_hashes: state.package_json_hashes.clone(),
             package_json_meta: state.package_json_meta.clone(),
+            local_directory_hashes: state.local_directory_hashes.clone(),
             section_filtered: state.section_filtered,
             settings_hash: state.settings_hash.clone(),
             package_json_shape_digests: state.package_json_shape_digests.clone(),
@@ -398,6 +406,18 @@ fn check_needs_install_compute(
     // --node-linker=hoisted` writes a hash with cli_flags set, then
     // bare `aube run` reads without the flag, mismatches, and triggers
     // a spurious auto-install.
+    let Some(local_directory_hashes) = state.local_directory_hashes.as_ref() else {
+        return Some("local dependency fingerprints not recorded".to_string());
+    };
+    for (rel, stored_hash) in local_directory_hashes {
+        let path = project_dir.join(rel);
+        match aube_store::directory_content_fingerprint(&path) {
+            Ok(current_hash) if current_hash == *stored_hash => {}
+            Ok(_) => return Some(format!("local dependency {rel} has changed")),
+            Err(_) => return Some(format!("local dependency {rel} is unreadable")),
+        }
+    }
+
     if lockfile_missing {
         return Some("no lockfile found".into());
     }
@@ -629,6 +649,7 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
     // Fingerprint each member's lockfile so the warm path has something
     // to verify; empty for the default shared layout.
     let (member_lockfile_hashes, member_lockfile_meta) = collect_member_lockfile_state(project_dir);
+    let local_directory_hashes = collect_local_directory_hashes(project_dir, layout.graph)?;
 
     let state = InstallState {
         lockfile_hash,
@@ -637,6 +658,7 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
         member_lockfile_meta,
         package_json_hashes,
         package_json_meta,
+        local_directory_hashes: Some(local_directory_hashes),
         aube_version: env!("CARGO_PKG_VERSION").to_string(),
         section_filtered,
         settings_hash,
@@ -654,6 +676,28 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
     write_fresh_state(&state_path, &fresh_state)?;
 
     Ok(())
+}
+
+fn collect_local_directory_hashes(
+    project_dir: &Path,
+    graph: &aube_lockfile::LockfileGraph,
+) -> Result<BTreeMap<String, String>, std::io::Error> {
+    let mut hashes = BTreeMap::new();
+    for pkg in graph.packages.values() {
+        let rel = match pkg.local_source.as_ref() {
+            Some(aube_lockfile::LocalSource::Directory(rel))
+            | Some(aube_lockfile::LocalSource::Portal(rel)) => rel,
+            _ => continue,
+        };
+        let key = rel.to_string_lossy().replace('\\', "/");
+        if hashes.contains_key(&key) {
+            continue;
+        }
+        let hash = aube_store::directory_content_fingerprint(&project_dir.join(rel))
+            .map_err(std::io::Error::other)?;
+        hashes.insert(key, hash);
+    }
+    Ok(hashes)
 }
 
 fn snapshot_active_lockfile(
@@ -1287,6 +1331,7 @@ mod tests {
             member_lockfile_meta: BTreeMap::new(),
             package_json_hashes: BTreeMap::new(),
             package_json_meta: BTreeMap::new(),
+            local_directory_hashes: Some(BTreeMap::new()),
             aube_version: String::new(),
             section_filtered: false,
             settings_hash: String::new(),
@@ -1467,6 +1512,7 @@ mod tests {
             member_lockfile_meta: BTreeMap::new(),
             package_json_hashes: BTreeMap::from([(".".to_string(), "blake3:pkg".to_string())]),
             package_json_meta: BTreeMap::new(),
+            local_directory_hashes: Some(BTreeMap::new()),
             aube_version: env!("CARGO_PKG_VERSION").to_string(),
             section_filtered: false,
             settings_hash: "blake3:settings".to_string(),
@@ -1522,6 +1568,7 @@ mod tests {
             member_lockfile_meta: BTreeMap::new(),
             package_json_hashes: BTreeMap::new(),
             package_json_meta: BTreeMap::new(),
+            local_directory_hashes: Some(BTreeMap::new()),
             aube_version: env!("CARGO_PKG_VERSION").to_string(),
             section_filtered: false,
             settings_hash: String::new(),
@@ -1621,6 +1668,7 @@ mod tests {
             member_lockfile_meta: BTreeMap::new(),
             package_json_hashes: pjh,
             package_json_meta: BTreeMap::new(),
+            local_directory_hashes: Some(BTreeMap::new()),
             aube_version: env!("CARGO_PKG_VERSION").to_string(),
             section_filtered: false,
             settings_hash: String::new(),
@@ -1685,6 +1733,7 @@ mod tests {
             member_lockfile_meta: BTreeMap::new(),
             package_json_hashes: BTreeMap::new(),
             package_json_meta: BTreeMap::new(),
+            local_directory_hashes: Some(BTreeMap::new()),
             section_filtered: false,
             settings_hash: String::new(),
             package_json_shape_digests: BTreeMap::new(),

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -82,7 +82,7 @@ pub struct InstallState {
     /// their project-relative source path. `None` means the state predates
     /// local-source freshness tracking and must miss the warm path once.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub local_directory_hashes: Option<BTreeMap<String, String>>,
+    pub local_directory_hashes: Option<BTreeMap<String, LocalDirectoryFingerprint>>,
     pub aube_version: String,
     #[serde(default, rename = "prod")]
     pub section_filtered: bool,
@@ -151,7 +151,7 @@ struct FreshnessState {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     package_json_meta: BTreeMap<String, FileMeta>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    local_directory_hashes: Option<BTreeMap<String, String>>,
+    local_directory_hashes: Option<BTreeMap<String, LocalDirectoryFingerprint>>,
     #[serde(default, rename = "prod")]
     section_filtered: bool,
     #[serde(default)]
@@ -185,6 +185,12 @@ pub struct FileMeta {
     pub mtime_secs: i64,
     #[serde(default)]
     pub mtime_nanos: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LocalDirectoryFingerprint {
+    pub content_hash: String,
+    pub metadata_hash: String,
 }
 
 impl FileMeta {
@@ -310,7 +316,7 @@ fn check_needs_install_compute(
     // No state directory = never installed (or `rm -rf <modulesDir>` wiped it).
     let _diag_read =
         aube_util::diag::Span::new(aube_util::diag::Category::Frozen, "read_state_file");
-    let state = match read_or_migrate_fresh_state(&state_path) {
+    let mut state = match read_or_migrate_fresh_state(&state_path) {
         Some(s) => s,
         None => return Some("install state not found".into()),
     };
@@ -406,20 +412,50 @@ fn check_needs_install_compute(
     // --node-linker=hoisted` writes a hash with cli_flags set, then
     // bare `aube run` reads without the flag, mismatches, and triggers
     // a spurious auto-install.
-    let Some(local_directory_hashes) = state.local_directory_hashes.as_ref() else {
-        return Some("local dependency fingerprints not recorded".to_string());
-    };
-    for (rel, stored_hash) in local_directory_hashes {
-        let path = project_dir.join(rel);
-        match aube_store::directory_content_fingerprint(&path) {
-            Ok(current_hash) if current_hash == *stored_hash => {}
-            Ok(_) => return Some(format!("local dependency {rel} has changed")),
-            Err(_) => return Some(format!("local dependency {rel} is unreadable")),
-        }
-    }
-
     if lockfile_missing {
         return Some("no lockfile found".into());
+    }
+
+    let Some(local_directory_hashes) = state.local_directory_hashes.as_mut() else {
+        return Some("local dependency fingerprints not recorded".to_string());
+    };
+    let mut refreshed_metadata = false;
+    for (rel, stored) in local_directory_hashes {
+        let path = project_dir.join(rel);
+        let current_metadata = match aube_store::directory_metadata_fingerprint(&path) {
+            Ok(current) if current == stored.metadata_hash => continue,
+            Ok(current) => current,
+            Err(err) => {
+                tracing::debug!(
+                    path = %path.display(),
+                    error = %err,
+                    "local dependency metadata fingerprint failed"
+                );
+                return Some(format!("local dependency {rel} is unreadable"));
+            }
+        };
+        match aube_store::directory_content_fingerprint(&path) {
+            Ok(current_hash) if current_hash == stored.content_hash => {
+                stored.metadata_hash = current_metadata;
+                refreshed_metadata = true;
+            }
+            Ok(_) => return Some(format!("local dependency {rel} has changed")),
+            Err(err) => {
+                tracing::debug!(
+                    path = %path.display(),
+                    error = %err,
+                    "local dependency content fingerprint failed"
+                );
+                return Some(format!("local dependency {rel} is unreadable"));
+            }
+        }
+    }
+    if refreshed_metadata && let Err(err) = write_fresh_state(&state_path, &state) {
+        tracing::debug!(
+            path = %fresh_state_file(&state_path).display(),
+            error = %err,
+            "refresh local dependency metadata state failed"
+        );
     }
     None
 }
@@ -681,7 +717,7 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
 fn collect_local_directory_hashes(
     project_dir: &Path,
     graph: &aube_lockfile::LockfileGraph,
-) -> Result<BTreeMap<String, String>, std::io::Error> {
+) -> Result<BTreeMap<String, LocalDirectoryFingerprint>, std::io::Error> {
     let mut hashes = BTreeMap::new();
     for pkg in graph.packages.values() {
         let rel = match pkg.local_source.as_ref() {
@@ -693,9 +729,16 @@ fn collect_local_directory_hashes(
         if hashes.contains_key(&key) {
             continue;
         }
-        let hash = aube_store::directory_content_fingerprint(&project_dir.join(rel))
-            .map_err(std::io::Error::other)?;
-        hashes.insert(key, hash);
+        let (content_hash, metadata_hash) =
+            aube_store::directory_fingerprints(&project_dir.join(rel))
+                .map_err(std::io::Error::other)?;
+        hashes.insert(
+            key,
+            LocalDirectoryFingerprint {
+                content_hash,
+                metadata_hash,
+            },
+        );
     }
     Ok(hashes)
 }

--- a/test/local_deps.bats
+++ b/test/local_deps.bats
@@ -182,6 +182,7 @@ EOF
 	# packages the app depends on via file: / link:.
 	_make_local_pkg vendor-dir vendor-dir 9.9.9
 	_make_local_pkg vendor-link vendor-link 9.9.9
+	printf 'module.exports = "v1";\n' >vendor-dir/index.js
 
 	cat >package.json <<'EOF'
 {"name":"ws-root","version":"0.0.0","private":true}
@@ -195,8 +196,13 @@ EOF
 {"name":"app","version":"0.0.0","dependencies":{"vendor-dir":"file:../../vendor-dir","vendor-link":"link:../../vendor-link"}}
 EOF
 
-	run aube install
+	run aube install --offline
 	assert_success
+	run aube install --offline
+	assert_success
+	run aube install --offline
+	assert_success
+	assert_output --partial "Already up to date"
 
 	assert_file_exists packages/app/node_modules/vendor-dir/package.json
 	run cat packages/app/node_modules/vendor-dir/package.json
@@ -208,6 +214,13 @@ EOF
 	assert_file_exists packages/app/node_modules/vendor-link/package.json
 	run cat packages/app/node_modules/vendor-link/package.json
 	assert_output --partial '"version":"9.9.9"'
+
+	printf 'module.exports = "v2";\n' >vendor-dir/index.js
+	run aube install --offline
+	assert_success
+	refute_output --partial "Already up to date"
+	run cat packages/app/node_modules/vendor-dir/index.js
+	assert_output 'module.exports = "v2";'
 }
 
 @test "aube install preserves pnpm workspace link targets relative to importer" {

--- a/test/local_deps.bats
+++ b/test/local_deps.bats
@@ -46,6 +46,7 @@ EOF
 @test "aube install refreshes a settled file: directory dep after its contents change" {
 	_make_local_pkg vendor-dir vendor-dir 1.2.3
 	printf 'module.exports = "v1";\n' >vendor-dir/index.js
+	printf 'obsolete\n' >vendor-dir/obsolete.txt
 
 	mkdir -p app
 	cd app
@@ -63,11 +64,13 @@ EOF
 
 	# Keep the same byte length so freshness cannot rely on file size.
 	printf 'module.exports = "v2";\n' >../vendor-dir/index.js
+	rm ../vendor-dir/obsolete.txt
 	run env CI=1 aube install --offline
 	assert_success
 	refute_output --partial "Already up to date"
 	run cat node_modules/vendor-dir/index.js
 	assert_output 'module.exports = "v2";'
+	assert_file_not_exists node_modules/vendor-dir/obsolete.txt
 }
 
 @test "aube install handles link: symlink dep" {

--- a/test/local_deps.bats
+++ b/test/local_deps.bats
@@ -43,6 +43,33 @@ EOF
 	assert_output --partial 'vendor-dir@file:../vendor-dir'
 }
 
+@test "aube install refreshes a settled file: directory dep after its contents change" {
+	_make_local_pkg vendor-dir vendor-dir 1.2.3
+	printf 'module.exports = "v1";\n' >vendor-dir/index.js
+
+	mkdir -p app
+	cd app
+	cat >package.json <<'EOF'
+{"name":"app","version":"0.0.0","dependencies":{"vendor-dir":"file:../vendor-dir"}}
+EOF
+
+	run env CI=1 aube install --offline
+	assert_success
+	run env CI=1 aube install --offline
+	assert_success
+	run env CI=1 aube install --offline
+	assert_success
+	assert_output --partial "Already up to date"
+
+	# Keep the same byte length so freshness cannot rely on file size.
+	printf 'module.exports = "v2";\n' >../vendor-dir/index.js
+	run env CI=1 aube install --offline
+	assert_success
+	refute_output --partial "Already up to date"
+	run cat node_modules/vendor-dir/index.js
+	assert_output 'module.exports = "v2";'
+}
+
 @test "aube install handles link: symlink dep" {
 	_make_local_pkg vendor-link vendor-link 2.0.0
 


### PR DESCRIPTION
## Summary

- fingerprint copied `file:` directory and `portal:` sources in install state
- invalidate the warm install path when local source contents change
- rematerialize mutable local directory entries during the ensuing full install
- add unit and BATS coverage for equal-size content changes

## Root cause

Local directory dependency identities are intentionally keyed by source path. The install freshness state did not separately track the source tree contents, so a content-only edit could take the `Already up to date` path. Even when the full pipeline ran, the linker treated the existing path-keyed `.aube` entry as cached.

The dependency identity remains path-based; this change adds a deterministic materialization fingerprint covering relative paths, file contents, and executable bits while matching `import_directory` exclusions.

Discussion: https://github.com/jdx/aube/discussions/1030

## Validation

- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `mise run test:bats test/local_deps.bats` (14/14)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches install warm-path correctness and linker materialization for local deps; wrong fingerprint logic could cause spurious full installs or, conversely, leave stale trees if checks are bypassed.
> 
> **Overview**
> Fixes stale **`file:`** and **`portal:`** installs when the source tree changes but the lockfile and dep path stay the same.
> 
> **Install freshness** now records per-source **content** and **metadata** fingerprints (BLAKE3, aligned with `import_directory` skips for `.git` / `node_modules`). The warm path compares metadata first, then content on mismatch; missing legacy state forces a reinstall once. Fingerprints are written at install completion.
> 
> **Linker** removes existing path-keyed `.aube` materializations for directory/portal locals before re-import so an existing entry is not treated as a cache hit during a full install.
> 
> **Store** exposes `directory_content_fingerprint`, `directory_metadata_fingerprint`, and `directory_fingerprints` for the state layer.
> 
> **Tests:** unit coverage for fingerprint vs imported index; BATS for repeated offline installs staying fresh until equal-size content edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a001202a3916ec1947ec8d0c60374357579e4be0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Local `file:` directory and portal dependencies are now correctly re-materialized when their directory contents change, avoiding stale installed outputs.
  - Offline installs now detect updates reliably (including cases where file size is unchanged) and stop incorrectly reporting “Already up to date.”
  - Updated freshness handling can refresh stored metadata when only non-content details change.

- **Tests**
  - Added Bats coverage for offline refresh after changing a local directory dependency’s files.
  - Extended workspace importer coverage to confirm repeated offline installs remain stable until the source changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->