### PR TITLE
feat(install): add embedder control hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,7 @@ dependencies = [
  "tar",
  "tempfile",
  "tokio",
+ "tokio-util",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -5019,6 +5020,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", features = ["rt"] }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/crates/aube-codes/src/errors.rs
+++ b/crates/aube-codes/src/errors.rs
@@ -103,7 +103,8 @@ pub const ERR_AUBE_RUNTIME_EXTRACT_FAILED: &str = "ERR_AUBE_RUNTIME_EXTRACT_FAIL
 #[rustfmt::skip] pub const ERR_AUBE_RUNTIME_UNSUPPORTED_PLATFORM: &str = "ERR_AUBE_RUNTIME_UNSUPPORTED_PLATFORM";
 pub const ERR_AUBE_RUNTIME_IO: &str = "ERR_AUBE_RUNTIME_IO";
 
-// ── misc tracing::error! sites (non-fatal but high-severity) ────────
+// ── misc / safety ──────────────────────────────────────────────────
+pub const ERR_AUBE_INSTALL_CANCELLED: &str = "ERR_AUBE_INSTALL_CANCELLED";
 pub const ERR_AUBE_PATCHES_TRACKING_WRITE: &str = "ERR_AUBE_PATCHES_TRACKING_WRITE";
 pub const ERR_AUBE_UNSAFE_SHEBANG_INTERPRETER: &str = "ERR_AUBE_UNSAFE_SHEBANG_INTERPRETER";
 
@@ -542,6 +543,12 @@ pub const ALL: &[CodeMeta] = &[
         exit_code: None,
     },
     // Misc / safety
+    CodeMeta {
+        name: ERR_AUBE_INSTALL_CANCELLED,
+        category: category::MISC_SAFETY,
+        description: "An in-process install was cooperatively cancelled by its embedding host. Cancellation is observed at safe install boundaries so an in-flight filesystem phase is not abandoned mid-mutation.",
+        exit_code: None,
+    },
     CodeMeta {
         name: ERR_AUBE_UNSAFE_INDEX_KEY,
         category: category::MISC_SAFETY,

--- a/crates/aube/Cargo.toml
+++ b/crates/aube/Cargo.toml
@@ -65,6 +65,7 @@ console = "0.16"
 demand = "2"
 reqwest = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 miette = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/aube/src/commands/ci.rs
+++ b/crates/aube/src/commands/ci.rs
@@ -63,6 +63,7 @@ pub async fn run(args: CiArgs) -> miette::Result<()> {
     // Strict frozen install. Any drift is an error, no lockfile is an error.
     // Propagate --ignore-scripts so root lifecycle hooks are skipped.
     let opts = install::InstallOptions {
+        control: install::InstallControl::default(),
         project_dir: None,
         mode: install::FrozenMode::Frozen,
         dep_selection: install::DepSelection::from_flags(false, false, no_optional),

--- a/crates/aube/src/commands/deploy/mod.rs
+++ b/crates/aube/src/commands/deploy/mod.rs
@@ -314,6 +314,7 @@ pub async fn run(
             aube_registry::NetworkMode::Online
         };
         let opts = InstallOptions {
+            control: install::InstallControl::default(),
             project_dir: Some(s.target.clone()),
             mode,
             dep_selection: dep_selection_for_args(&args),

--- a/crates/aube/src/commands/install/args.rs
+++ b/crates/aube/src/commands/install/args.rs
@@ -308,6 +308,7 @@ impl InstallArgs {
             // `advisoryCheckEveryInstall` setting flips it on for
             // every install — neither needs the caller to opt in.
             osv_transitive_check: false,
+            control: super::InstallControl::default(),
         }
     }
 }
@@ -438,6 +439,11 @@ pub struct InstallOptions {
     /// picked a `(name, version)` pair the lockfile didn't
     /// already pin.
     pub osv_transitive_check: bool,
+    /// Invocation-scoped output, progress reporting, and cooperative
+    /// cancellation. Standalone CLI callers use the default human output;
+    /// embedders can select structured events or silence independently for
+    /// each concurrent install.
+    pub control: super::InstallControl,
 }
 
 impl InstallOptions {
@@ -481,6 +487,7 @@ impl InstallOptions {
             // routing (fresh-resolution detection / mirror
             // fallback) instead of an unconditional API hit.
             osv_transitive_check: false,
+            control: super::InstallControl::default(),
         }
     }
 }

--- a/crates/aube/src/commands/install/control.rs
+++ b/crates/aube/src/commands/install/control.rs
@@ -150,7 +150,7 @@ impl InstallControl {
             InstallOutputMode::Human => {
                 let message = match level {
                     InstallOutputLevel::Info => message,
-                    InstallOutputLevel::Warning => format!("warning: {message}"),
+                    InstallOutputLevel::Warning => format!("warn: {message}"),
                     InstallOutputLevel::Error => format!("error: {message}"),
                 };
                 crate::progress::safe_eprintln(&message);

--- a/crates/aube/src/commands/install/control.rs
+++ b/crates/aube/src/commands/install/control.rs
@@ -232,19 +232,6 @@ mod tests {
         }
     }
 
-    #[derive(Default)]
-    struct CancelOnOutputReporter(Mutex<Option<InstallControl>>);
-
-    impl InstallReporter for CancelOnOutputReporter {
-        fn report(&self, event: InstallEvent) {
-            if matches!(event, InstallEvent::Output { .. })
-                && let Some(control) = self.0.lock().unwrap().as_ref()
-            {
-                control.cancel();
-            }
-        }
-    }
-
     #[test]
     fn cloned_controls_share_cancellation_without_leaking_to_other_invocations() {
         let first = InstallControl::silent();
@@ -365,9 +352,18 @@ mod tests {
         initial.control = InstallControl::silent();
         super::super::run(initial).await.unwrap();
 
-        let cancelling_reporter = Arc::new(CancelOnOutputReporter::default());
+        let state_path = project.path().join("node_modules/.aube-state/state.json");
+        let mut state: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&state_path).unwrap()).unwrap();
+        state
+            .as_object_mut()
+            .unwrap()
+            .remove("package_content_hashes");
+        std::fs::write(&state_path, serde_json::to_vec(&state).unwrap()).unwrap();
+
+        let cancelling_reporter = Arc::new(RecordingReporter::default());
         let cancelling_control = InstallControl::events(cancelling_reporter.clone());
-        *cancelling_reporter.0.lock().unwrap() = Some(cancelling_control.clone());
+        cancelling_control.cancel();
         let mut cancelled =
             super::super::InstallOptions::with_mode(super::super::FrozenMode::Prefer);
         cancelled.project_dir = Some(project.path().to_path_buf());
@@ -379,6 +375,7 @@ mod tests {
             error.code().map(|code| code.to_string()).as_deref(),
             Some(aube_codes::errors::ERR_AUBE_INSTALL_CANCELLED)
         );
+        assert!(cancelling_reporter.0.lock().unwrap().is_empty());
 
         let reporter = Arc::new(RecordingReporter::default());
         let mut completed =

--- a/crates/aube/src/commands/install/control.rs
+++ b/crates/aube/src/commands/install/control.rs
@@ -147,7 +147,14 @@ impl InstallControl {
     ) {
         let message = message.into();
         match self.output {
-            InstallOutputMode::Human => crate::progress::safe_eprintln(&message),
+            InstallOutputMode::Human => {
+                let message = match level {
+                    InstallOutputLevel::Info => message,
+                    InstallOutputLevel::Warning => format!("warning: {message}"),
+                    InstallOutputLevel::Error => format!("error: {message}"),
+                };
+                crate::progress::safe_eprintln(&message);
+            }
             InstallOutputMode::Events => self.report(InstallEvent::Output {
                 level,
                 code: code.map(str::to_owned),
@@ -155,6 +162,22 @@ impl InstallControl {
             }),
             InstallOutputMode::Silent => {}
         }
+    }
+
+    fn complete(&self) {
+        if self.output != InstallOutputMode::Events {
+            return;
+        }
+        self.report(InstallEvent::Phase(InstallPhase::Complete));
+        self.report(InstallEvent::Progress(InstallProgressSnapshot {
+            phase: Some(InstallPhase::Complete),
+            resolved: 0,
+            total: 0,
+            reused: 0,
+            downloaded: 0,
+            downloaded_bytes: 0,
+            estimated_bytes: 0,
+        }));
     }
 }
 
@@ -178,6 +201,10 @@ pub(crate) fn output(level: InstallOutputLevel, code: Option<&str>, message: imp
     current().output(level, code, message);
 }
 
+pub(crate) fn complete() {
+    current().complete();
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -198,6 +225,19 @@ mod tests {
     impl InstallReporter for CancelOnResolvingReporter {
         fn report(&self, event: InstallEvent) {
             if event == InstallEvent::Phase(InstallPhase::Resolving)
+                && let Some(control) = self.0.lock().unwrap().as_ref()
+            {
+                control.cancel();
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct CancelOnOutputReporter(Mutex<Option<InstallControl>>);
+
+    impl InstallReporter for CancelOnOutputReporter {
+        fn report(&self, event: InstallEvent) {
+            if matches!(event, InstallEvent::Output { .. })
                 && let Some(control) = self.0.lock().unwrap().as_ref()
             {
                 control.cancel();
@@ -249,6 +289,11 @@ mod tests {
             InstallEvent::Output { message, .. } if message == "first"
         ));
         assert!(matches!(
+            &first_events[1],
+            InstallEvent::Output { level: InstallOutputLevel::Warning, message, .. }
+                if message == "first warning"
+        ));
+        assert!(matches!(
             &second_events[0],
             InstallEvent::Output { message, .. } if message == "second"
         ));
@@ -297,5 +342,52 @@ mod tests {
             Some(aube_codes::errors::ERR_AUBE_INSTALL_CANCELLED)
         );
         assert!(!project.path().join("node_modules").exists());
+    }
+
+    #[tokio::test]
+    async fn warm_path_reports_cancellation_or_completion() {
+        let project = tempfile::tempdir().unwrap();
+        std::fs::write(
+            project.path().join("package.json"),
+            r#"{"name":"warm-test","version":"1.0.0"}"#,
+        )
+        .unwrap();
+
+        let mut initial = super::super::InstallOptions::with_mode(super::super::FrozenMode::No);
+        initial.project_dir = Some(project.path().to_path_buf());
+        initial.network_mode = aube_registry::NetworkMode::Offline;
+        initial.control = InstallControl::silent();
+        super::super::run(initial).await.unwrap();
+
+        let cancelling_reporter = Arc::new(CancelOnOutputReporter::default());
+        let cancelling_control = InstallControl::events(cancelling_reporter.clone());
+        *cancelling_reporter.0.lock().unwrap() = Some(cancelling_control.clone());
+        let mut cancelled =
+            super::super::InstallOptions::with_mode(super::super::FrozenMode::Prefer);
+        cancelled.project_dir = Some(project.path().to_path_buf());
+        cancelled.network_mode = aube_registry::NetworkMode::Offline;
+        cancelled.control = cancelling_control;
+
+        let error = super::super::run(cancelled).await.unwrap_err();
+        assert_eq!(
+            error.code().map(|code| code.to_string()).as_deref(),
+            Some(aube_codes::errors::ERR_AUBE_INSTALL_CANCELLED)
+        );
+
+        let reporter = Arc::new(RecordingReporter::default());
+        let mut completed =
+            super::super::InstallOptions::with_mode(super::super::FrozenMode::Prefer);
+        completed.project_dir = Some(project.path().to_path_buf());
+        completed.network_mode = aube_registry::NetworkMode::Offline;
+        completed.control = InstallControl::events(reporter.clone());
+        super::super::run(completed).await.unwrap();
+
+        let events = reporter.0.lock().unwrap();
+        assert!(events.contains(&InstallEvent::Phase(InstallPhase::Complete)));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            InstallEvent::Progress(snapshot)
+                if snapshot.phase == Some(InstallPhase::Complete)
+        )));
     }
 }

--- a/crates/aube/src/commands/install/control.rs
+++ b/crates/aube/src/commands/install/control.rs
@@ -164,16 +164,16 @@ impl InstallControl {
         }
     }
 
-    fn complete(&self) {
+    fn complete(&self, total: usize) {
         if self.output != InstallOutputMode::Events {
             return;
         }
         self.report(InstallEvent::Phase(InstallPhase::Complete));
         self.report(InstallEvent::Progress(InstallProgressSnapshot {
             phase: Some(InstallPhase::Complete),
-            resolved: 0,
-            total: 0,
-            reused: 0,
+            resolved: total,
+            total,
+            reused: total,
             downloaded: 0,
             downloaded_bytes: 0,
             estimated_bytes: 0,
@@ -201,8 +201,8 @@ pub(crate) fn output(level: InstallOutputLevel, code: Option<&str>, message: imp
     current().output(level, code, message);
 }
 
-pub(crate) fn complete() {
-    current().complete();
+pub(crate) fn complete(total: usize) {
+    current().complete(total);
 }
 
 #[cfg(test)]
@@ -349,7 +349,13 @@ mod tests {
         let project = tempfile::tempdir().unwrap();
         std::fs::write(
             project.path().join("package.json"),
-            r#"{"name":"warm-test","version":"1.0.0"}"#,
+            r#"{"name":"warm-test","version":"1.0.0","dependencies":{"dep":"file:./dep"}}"#,
+        )
+        .unwrap();
+        std::fs::create_dir(project.path().join("dep")).unwrap();
+        std::fs::write(
+            project.path().join("dep/package.json"),
+            r#"{"name":"dep","version":"1.0.0"}"#,
         )
         .unwrap();
 
@@ -388,6 +394,9 @@ mod tests {
             event,
             InstallEvent::Progress(snapshot)
                 if snapshot.phase == Some(InstallPhase::Complete)
+                    && snapshot.resolved == 1
+                    && snapshot.total == 1
+                    && snapshot.reused == 1
         )));
     }
 }

--- a/crates/aube/src/commands/install/control.rs
+++ b/crates/aube/src/commands/install/control.rs
@@ -1,0 +1,301 @@
+use std::future::Future;
+use std::sync::Arc;
+
+use miette::miette;
+
+/// How an install presents user-facing output.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum InstallOutputMode {
+    /// Render the normal CLI progress display and human-readable summaries.
+    #[default]
+    Human,
+    /// Suppress direct output and deliver structured events to the reporter.
+    Events,
+    /// Suppress both direct output and structured output events.
+    Silent,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstallPhase {
+    Resolving,
+    Fetching,
+    Linking,
+    Complete,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstallOutputLevel {
+    Info,
+    Warning,
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstallProgressSnapshot {
+    pub phase: Option<InstallPhase>,
+    pub resolved: usize,
+    pub total: usize,
+    pub reused: usize,
+    pub downloaded: usize,
+    pub downloaded_bytes: u64,
+    pub estimated_bytes: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InstallEvent {
+    Phase(InstallPhase),
+    Progress(InstallProgressSnapshot),
+    Output {
+        level: InstallOutputLevel,
+        code: Option<String>,
+        message: String,
+    },
+}
+
+/// Non-blocking destination for structured install events.
+///
+/// Implementations that cross a runtime boundary should enqueue and return;
+/// they must not wait for the consumer while holding an install worker.
+pub trait InstallReporter: Send + Sync + 'static {
+    fn report(&self, event: InstallEvent);
+}
+
+#[derive(Clone)]
+pub struct InstallControl {
+    output: InstallOutputMode,
+    reporter: Option<Arc<dyn InstallReporter>>,
+    cancellation: tokio_util::sync::CancellationToken,
+}
+
+impl std::fmt::Debug for InstallControl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InstallControl")
+            .field("output", &self.output)
+            .field("has_reporter", &self.reporter.is_some())
+            .field("cancelled", &self.is_cancelled())
+            .finish()
+    }
+}
+
+impl Default for InstallControl {
+    fn default() -> Self {
+        Self {
+            output: InstallOutputMode::Human,
+            reporter: None,
+            cancellation: tokio_util::sync::CancellationToken::new(),
+        }
+    }
+}
+
+impl InstallControl {
+    pub fn events(reporter: Arc<dyn InstallReporter>) -> Self {
+        Self {
+            output: InstallOutputMode::Events,
+            reporter: Some(reporter),
+            cancellation: tokio_util::sync::CancellationToken::new(),
+        }
+    }
+
+    pub fn silent() -> Self {
+        Self {
+            output: InstallOutputMode::Silent,
+            ..Self::default()
+        }
+    }
+
+    pub fn output_mode(&self) -> InstallOutputMode {
+        self.output
+    }
+
+    pub fn cancel(&self) {
+        self.cancellation.cancel();
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.cancellation.is_cancelled()
+    }
+
+    pub async fn cancelled(&self) {
+        self.cancellation.cancelled().await;
+    }
+
+    pub(crate) fn reporter(&self) -> Option<Arc<dyn InstallReporter>> {
+        self.reporter.clone()
+    }
+
+    pub(crate) fn check_cancelled(&self) -> miette::Result<()> {
+        if self.is_cancelled() {
+            return Err(miette!(
+                code = aube_codes::errors::ERR_AUBE_INSTALL_CANCELLED,
+                "install cancelled"
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn report(&self, event: InstallEvent) {
+        if let Some(reporter) = &self.reporter {
+            reporter.report(event);
+        }
+    }
+
+    pub(crate) fn output(
+        &self,
+        level: InstallOutputLevel,
+        code: Option<&str>,
+        message: impl Into<String>,
+    ) {
+        let message = message.into();
+        match self.output {
+            InstallOutputMode::Human => crate::progress::safe_eprintln(&message),
+            InstallOutputMode::Events => self.report(InstallEvent::Output {
+                level,
+                code: code.map(str::to_owned),
+                message,
+            }),
+            InstallOutputMode::Silent => {}
+        }
+    }
+}
+
+tokio::task_local! {
+    static ACTIVE: InstallControl;
+}
+
+pub(crate) async fn scope<F: Future>(control: InstallControl, future: F) -> F::Output {
+    ACTIVE.scope(control, future).await
+}
+
+pub(crate) fn current() -> InstallControl {
+    ACTIVE.try_with(Clone::clone).unwrap_or_default()
+}
+
+pub(crate) fn check_cancelled() -> miette::Result<()> {
+    current().check_cancelled()
+}
+
+pub(crate) fn output(level: InstallOutputLevel, code: Option<&str>, message: impl Into<String>) {
+    current().output(level, code, message);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct RecordingReporter(Mutex<Vec<InstallEvent>>);
+
+    impl InstallReporter for RecordingReporter {
+        fn report(&self, event: InstallEvent) {
+            self.0.lock().unwrap().push(event);
+        }
+    }
+
+    #[derive(Default)]
+    struct CancelOnResolvingReporter(Mutex<Option<InstallControl>>);
+
+    impl InstallReporter for CancelOnResolvingReporter {
+        fn report(&self, event: InstallEvent) {
+            if event == InstallEvent::Phase(InstallPhase::Resolving)
+                && let Some(control) = self.0.lock().unwrap().as_ref()
+            {
+                control.cancel();
+            }
+        }
+    }
+
+    #[test]
+    fn cloned_controls_share_cancellation_without_leaking_to_other_invocations() {
+        let first = InstallControl::silent();
+        let first_clone = first.clone();
+        let second = InstallControl::silent();
+
+        first.cancel();
+
+        assert!(first_clone.is_cancelled());
+        assert!(!second.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn task_local_output_is_isolated_between_parallel_invocations() {
+        let first = Arc::new(RecordingReporter::default());
+        let second = Arc::new(RecordingReporter::default());
+        let first_control = InstallControl::events(first.clone());
+        let second_control = InstallControl::events(second.clone());
+
+        let ((), ()) = tokio::join!(
+            scope(first_control, async {
+                output(InstallOutputLevel::Info, None, "first");
+                tokio::task::yield_now().await;
+                output(
+                    InstallOutputLevel::Warning,
+                    Some("WARN_FIRST"),
+                    "first warning",
+                );
+            }),
+            scope(second_control, async {
+                tokio::task::yield_now().await;
+                output(InstallOutputLevel::Info, None, "second");
+            }),
+        );
+
+        let first_events = first.0.lock().unwrap();
+        let second_events = second.0.lock().unwrap();
+        assert_eq!(first_events.len(), 2);
+        assert_eq!(second_events.len(), 1);
+        assert!(matches!(
+            &first_events[0],
+            InstallEvent::Output { message, .. } if message == "first"
+        ));
+        assert!(matches!(
+            &second_events[0],
+            InstallEvent::Output { message, .. } if message == "second"
+        ));
+    }
+
+    #[test]
+    fn cancelled_control_returns_stable_error_code() {
+        let control = InstallControl::silent();
+        control.cancel();
+        let error = control.check_cancelled().unwrap_err();
+
+        assert_eq!(
+            error.code().map(|code| code.to_string()).as_deref(),
+            Some(aube_codes::errors::ERR_AUBE_INSTALL_CANCELLED)
+        );
+    }
+
+    #[tokio::test]
+    async fn reporter_can_cancel_an_install_before_resolution_work_starts() {
+        let project = tempfile::tempdir().unwrap();
+        std::fs::write(
+            project.path().join("package.json"),
+            r#"{"name":"cancel-test","version":"1.0.0","dependencies":{"dep":"file:./dep"}}"#,
+        )
+        .unwrap();
+        std::fs::create_dir(project.path().join("dep")).unwrap();
+        std::fs::write(
+            project.path().join("dep/package.json"),
+            r#"{"name":"dep","version":"1.0.0"}"#,
+        )
+        .unwrap();
+
+        let reporter = Arc::new(CancelOnResolvingReporter::default());
+        let control = InstallControl::events(reporter.clone());
+        *reporter.0.lock().unwrap() = Some(control.clone());
+        let mut options = super::super::InstallOptions::with_mode(super::super::FrozenMode::No);
+        options.project_dir = Some(project.path().to_path_buf());
+        options.dry_run = true;
+        options.network_mode = aube_registry::NetworkMode::Offline;
+        options.control = control;
+
+        let error = super::super::run(options).await.unwrap_err();
+
+        assert_eq!(
+            error.code().map(|code| code.to_string()).as_deref(),
+            Some(aube_codes::errors::ERR_AUBE_INSTALL_CANCELLED)
+        );
+        assert!(!project.path().join("node_modules").exists());
+    }
+}

--- a/crates/aube/src/commands/install/link.rs
+++ b/crates/aube/src/commands/install/link.rs
@@ -78,11 +78,11 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
     // diagnostic). Settings-file values flow through the generated typed
     // accessor, which collapses unknown values to `None` so they behave
     // like an absent setting.
+    super::control::check_cancelled()?;
     let strategy = resolve_link_strategy(cwd, settings_ctx, planned_gvs)?;
     if let Some(p) = prog_ref {
         p.set_phase("linking");
     }
-    super::control::check_cancelled()?;
     tracing::debug!("Link strategy: {strategy:?}");
 
     let shamefully_hoist = aube_settings::resolved::shamefully_hoist(settings_ctx);

--- a/crates/aube/src/commands/install/link.rs
+++ b/crates/aube/src/commands/install/link.rs
@@ -82,6 +82,7 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
     if let Some(p) = prog_ref {
         p.set_phase("linking");
     }
+    super::control::check_cancelled()?;
     tracing::debug!("Link strategy: {strategy:?}");
 
     let shamefully_hoist = aube_settings::resolved::shamefully_hoist(settings_ctx);

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -544,9 +544,8 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     }
     if !opts.dry_run
         && let Some(total) =
-            try_install_fast_path(&cwd, &opts, mode, modules_cache_sweep_is_default(&cwd))
+            try_install_fast_path(&cwd, &opts, mode, modules_cache_sweep_is_default(&cwd))?
     {
-        control::check_cancelled()?;
         control::complete(total);
         return Ok(());
     }

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1055,11 +1055,11 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
 
             // Lockfile path: the total is known upfront, so seed the overall
             // bar with the full package count and enter the fetch phase.
+            control::check_cancelled()?;
             if let Some(p) = prog_ref {
                 p.set_total(graph.packages.len());
                 p.set_phase("fetching");
             }
-            control::check_cancelled()?;
             // Seed the chain index for diagnostic enrichment on the
             // lockfile fast path. Same effect as the resolve-fresh
             // branch above — error wrappers in `dep_chain` now know
@@ -1177,6 +1177,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
         {
             // No lockfile — resolve + fetch tarballs concurrently
             tracing::debug!("No lockfile found, resolving dependencies for {project_name}...");
+            control::check_cancelled()?;
             if let Some(p) = prog_ref {
                 // Seed the resolving-phase denominator floor from any
                 // existing lockfile on disk. In FrozenMode::Fix /
@@ -1204,7 +1205,6 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
                 }
                 p.set_phase("resolving");
             }
-            control::check_cancelled()?;
             // Resolve node version + build policy up front so the
             // GVS-prewarm materializer (spawned below the resolver
             // await) can compute the same graph hashes the link phase
@@ -1872,10 +1872,10 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
                 super::security_scanner::run_scanner(&scanner, &cwd, &scanner_packages).await?;
             }
 
+            control::check_cancelled()?;
             if let Some(p) = prog_ref {
                 p.set_phase("fetching");
             }
-            control::check_cancelled()?;
             tracing::debug!("phase:resolve (fresh) {:.1?}", phase_start.elapsed());
             phase_timings.record("resolve", phase_start.elapsed());
             drop(_diag_resolve);

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -7,6 +7,7 @@ use std::io::Write;
 mod advisory;
 mod args;
 mod bin_linking;
+pub(crate) mod control;
 mod critical_path;
 mod delta;
 mod dep_selection;
@@ -34,6 +35,10 @@ mod workspace;
 use advisory::resolve_osv_routing_settings;
 pub use args::{InstallArgs, InstallOptions};
 pub(crate) use bin_linking::{PkgJsonCache, link_dep_bins, materialized_pkg_dir};
+pub use control::{
+    InstallControl, InstallEvent, InstallOutputLevel, InstallOutputMode, InstallPhase,
+    InstallProgressSnapshot, InstallReporter,
+};
 pub use dep_selection::DepSelection;
 pub(super) use fetch::fetch_packages;
 use fetch::{
@@ -513,14 +518,20 @@ pub(crate) async fn run_with_project_lock(
 }
 
 async fn run_scoped(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Result<()> {
+    let control = opts.control.clone();
     // Box the large install state machine before stacking task-local scopes.
     // Keeping it inline overflowed a Tokio worker stack in the parallel-install
     // regression test once runtime and script-settings scopes were added.
     let install = Box::pin(run_inner(opts, cwd));
-    crate::runtime::scope(aube_scripts::scope(crate::dep_chain::scope(install))).await
+    control::scope(
+        control,
+        crate::runtime::scope(aube_scripts::scope(crate::dep_chain::scope(install))),
+    )
+    .await
 }
 
 async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Result<()> {
+    opts.control.check_cancelled()?;
     let mode = opts.mode;
     let start = std::time::Instant::now();
     let mut phase_timings = InstallPhaseTimings::from_env();
@@ -737,6 +748,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     // *no* output other than the bar itself — everything else is tracing at
     // debug level, visible with `aube -v install`. Must be constructed after
     // any lifecycle script that writes to stderr.
+    control::check_cancelled()?;
     let prog = InstallProgress::try_new();
     let prog_ref = prog.as_ref();
 
@@ -1026,6 +1038,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
             )?;
             validate_lockfile_trust_policy(&cwd, &graph, opts.network_mode, &dependency_policy)
                 .await?;
+            control::check_cancelled()?;
             let source_label = resolve::lockfile_source_label(kind);
             tracing::debug!(
                 "{source_label}: {} packages for {project_name}",
@@ -1043,6 +1056,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
                 p.set_total(graph.packages.len());
                 p.set_phase("fetching");
             }
+            control::check_cancelled()?;
             // Seed the chain index for diagnostic enrichment on the
             // lockfile fast path. Same effect as the resolve-fresh
             // branch above — error wrappers in `dep_chain` now know
@@ -1187,6 +1201,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
                 }
                 p.set_phase("resolving");
             }
+            control::check_cancelled()?;
             // Resolve node version + build policy up front so the
             // GVS-prewarm materializer (spawned below the resolver
             // await) can compute the same graph hashes the link phase
@@ -1247,6 +1262,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
             };
             super::run_pnpmfile_pre_resolution(&pnpmfile_paths, &cwd, existing_for_resolver)
                 .await?;
+            control::check_cancelled()?;
             let (read_package_host, read_package_forwarders) =
                 match crate::pnpmfile::ReadPackageHostChain::spawn(&pnpmfile_paths, &cwd)
                     .await
@@ -1836,6 +1852,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
                 osv_settings.advisory_check_every_install,
             )
             .await?;
+            control::check_cancelled()?;
 
             // Bun-compatible security scanner runs against the
             // *resolved* graph — full transitive set with concrete
@@ -1855,6 +1872,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
             if let Some(p) = prog_ref {
                 p.set_phase("fetching");
             }
+            control::check_cancelled()?;
             tracing::debug!("phase:resolve (fresh) {:.1?}", phase_start.elapsed());
             phase_timings.record("resolve", phase_start.elapsed());
             drop(_diag_resolve);
@@ -2341,10 +2359,10 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     // output across bar frames. Route through safe_eprintln which
     // pauses the bar and holds the terminal lock for atomic output.
     for w in &policy_warnings {
-        crate::progress::safe_eprintln(&format!("warn: {w}"));
+        control::output(InstallOutputLevel::Warning, None, format!("warn: {w}"));
     }
     for w in &jail_policy_warnings {
-        crate::progress::safe_eprintln(&format!("warn: {w}"));
+        control::output(InstallOutputLevel::Warning, None, format!("warn: {w}"));
     }
 
     let link::LinkPhaseOutput {
@@ -2379,6 +2397,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
         prog_ref,
         phase_timings: &mut phase_timings,
     })?;
+    control::check_cancelled()?;
     // Join the overlapped lockfile write before finalize re-reads the
     // graph. The write ran concurrently with the link phase above; a write
     // error surfaces here (it is not dropped). `None` on every inline-write
@@ -2386,6 +2405,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     if let Some(handle) = lockfile_write_handle.take() {
         lockfile_write_overlap::join(handle).await?;
     }
+    control::check_cancelled()?;
     finalize::run_finalize_phase(finalize::FinalizePhaseInput {
         cwd: &cwd,
         settings_ctx: &settings_ctx,
@@ -2423,6 +2443,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
         phase_timings: &mut phase_timings,
     })
     .await?;
+    control::check_cancelled()?;
     // A fresh resolve enforces trustPolicy=no-downgrade while picking
     // versions from packuments. If an existing lockfile fed the resolver,
     // `try_lockfile_reuse` may carry locked packages forward without

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -543,10 +543,11 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
         apply_force_state_reset(&cwd, &opts)?;
     }
     if !opts.dry_run
-        && try_install_fast_path(&cwd, &opts, mode, modules_cache_sweep_is_default(&cwd))
+        && let Some(total) =
+            try_install_fast_path(&cwd, &opts, mode, modules_cache_sweep_is_default(&cwd))
     {
         control::check_cancelled()?;
-        control::complete();
+        control::complete(total);
         return Ok(());
     }
 

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -545,6 +545,8 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     if !opts.dry_run
         && try_install_fast_path(&cwd, &opts, mode, modules_cache_sweep_is_default(&cwd))
     {
+        control::check_cancelled()?;
+        control::complete();
         return Ok(());
     }
 
@@ -2359,10 +2361,10 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     // output across bar frames. Route through safe_eprintln which
     // pauses the bar and holds the terminal lock for atomic output.
     for w in &policy_warnings {
-        control::output(InstallOutputLevel::Warning, None, format!("warn: {w}"));
+        control::output(InstallOutputLevel::Warning, None, w.to_string());
     }
     for w in &jail_policy_warnings {
-        control::output(InstallOutputLevel::Warning, None, format!("warn: {w}"));
+        control::output(InstallOutputLevel::Warning, None, w.to_string());
     }
 
     let link::LinkPhaseOutput {

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -2399,7 +2399,6 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
         prog_ref,
         phase_timings: &mut phase_timings,
     })?;
-    control::check_cancelled()?;
     // Join the overlapped lockfile write before finalize re-reads the
     // graph. The write ran concurrently with the link phase above; a write
     // error surfaces here (it is not dropped). `None` on every inline-write
@@ -2407,7 +2406,6 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     if let Some(handle) = lockfile_write_handle.take() {
         lockfile_write_overlap::join(handle).await?;
     }
-    control::check_cancelled()?;
     finalize::run_finalize_phase(finalize::FinalizePhaseInput {
         cwd: &cwd,
         settings_ctx: &settings_ctx,
@@ -2445,7 +2443,6 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
         phase_timings: &mut phase_timings,
     })
     .await?;
-    control::check_cancelled()?;
     // A fresh resolve enforces trustPolicy=no-downgrade while picking
     // versions from packuments. If an existing lockfile fed the resolver,
     // `try_lockfile_reuse` may carry locked packages forward without

--- a/crates/aube/src/commands/install/resolve.rs
+++ b/crates/aube/src/commands/install/resolve.rs
@@ -192,17 +192,24 @@ pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::R
             p.finish(true);
         }
         if !write_lockfile {
-            eprintln!(
-                "Dry run: lockfile is up to date; fetch/link steps were not run and node_modules were not modified"
+            super::control::output(
+                super::InstallOutputLevel::Info,
+                None,
+                "Dry run: lockfile is up to date; fetch/link steps were not run and node_modules were not modified",
             );
             return Ok(());
         }
-        eprintln!("Lockfile is up to date, resolution step is skipped");
+        super::control::output(
+            super::InstallOutputLevel::Info,
+            None,
+            "Lockfile is up to date, resolution step is skipped",
+        );
         return Ok(());
     }
     if let Some(p) = prog_ref {
         p.set_phase("resolving");
     }
+    super::control::check_cancelled()?;
     let client =
         std::sync::Arc::new(crate::commands::make_client(cwd).with_network_mode(network_mode));
     let pnpmfile_paths = if ignore_pnpmfile {
@@ -215,6 +222,7 @@ pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::R
     };
     crate::commands::run_pnpmfile_pre_resolution(&pnpmfile_paths, cwd, existing_for_resolver)
         .await?;
+    super::control::check_cancelled()?;
     let (read_package_host, read_package_forwarders) =
         match crate::pnpmfile::ReadPackageHostChain::spawn(&pnpmfile_paths, cwd)
             .await
@@ -319,9 +327,13 @@ pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::R
         if let Some(p) = prog_ref {
             p.finish(true);
         }
-        eprintln!(
-            "Dry run: resolved {} package(s); lockfile and node_modules were not modified",
-            graph.packages.len()
+        super::control::output(
+            super::InstallOutputLevel::Info,
+            None,
+            format!(
+                "Dry run: resolved {} package(s); lockfile and node_modules were not modified",
+                graph.packages.len()
+            ),
         );
         return Ok(());
     }
@@ -359,9 +371,13 @@ pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::R
     if let Some(p) = prog_ref {
         p.finish(true);
     }
-    eprintln!(
-        "Lockfile written ({} packages); skipped node_modules linking",
-        graph.packages.len()
+    super::control::output(
+        super::InstallOutputLevel::Info,
+        None,
+        format!(
+            "Lockfile written ({} packages); skipped node_modules linking",
+            graph.packages.len()
+        ),
     );
     Ok(())
 }

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -993,10 +993,11 @@ pub(super) fn check_unmet_peers(
     if unmet.is_empty() {
         return Ok(());
     }
-    // Called from install flow after resolver, before linker phase.
-    // Progress bar is active at this point. Raw eprintln smears
-    // across bar frames. Route through safe_eprintln.
-    crate::progress::safe_eprintln("error: Issues with peer dependencies found");
+    super::control::output(
+        super::InstallOutputLevel::Error,
+        None,
+        "error: Issues with peer dependencies found",
+    );
     for u in &unmet {
         let from_ver = version_from_dep_path(&u.from_dep_path, &u.from_name);
         let msg = match &u.found {
@@ -1009,7 +1010,7 @@ pub(super) fn check_unmet_peers(
                 u.from_name, u.peer_name, u.declared,
             ),
         };
-        crate::progress::safe_eprintln(&msg);
+        super::control::output(super::InstallOutputLevel::Error, None, msg);
     }
     Err(miette!(
         "{} unmet peer dependenc{} (strict-peer-dependencies is enabled)\n  \

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -996,17 +996,17 @@ pub(super) fn check_unmet_peers(
     super::control::output(
         super::InstallOutputLevel::Error,
         None,
-        "error: Issues with peer dependencies found",
+        "Issues with peer dependencies found",
     );
     for u in &unmet {
         let from_ver = version_from_dep_path(&u.from_dep_path, &u.from_name);
         let msg = match &u.found {
             Some(found) => format!(
-                "error:   {}@{from_ver}: expected peer {}@{}, found {found}",
+                "  {}@{from_ver}: expected peer {}@{}, found {found}",
                 u.from_name, u.peer_name, u.declared,
             ),
             None => format!(
-                "error:   {}@{from_ver}: missing required peer {}@{}",
+                "  {}@{from_ver}: missing required peer {}@{}",
                 u.from_name, u.peer_name, u.declared,
             ),
         };

--- a/crates/aube/src/commands/install/startup.rs
+++ b/crates/aube/src/commands/install/startup.rs
@@ -33,7 +33,7 @@ pub(super) fn try_install_fast_path(
     opts: &InstallOptions,
     mode: FrozenMode,
     modules_cache_sweep_default: bool,
-) -> bool {
+) -> Option<usize> {
     let dangerously_allow_all_builds = resolve_dangerously_allow_all_builds(cwd, opts);
     if !install_fast_path_eligible(
         cwd,
@@ -42,10 +42,14 @@ pub(super) fn try_install_fast_path(
         modules_cache_sweep_default,
         dangerously_allow_all_builds,
     ) {
-        return false;
+        return None;
     }
     emit_up_to_date(cwd);
-    true
+    Some(
+        state::read_state_package_content_hashes(cwd)
+            .map(|packages| packages.len())
+            .unwrap_or_default(),
+    )
 }
 
 fn resolve_dangerously_allow_all_builds(cwd: &Path, opts: &InstallOptions) -> bool {

--- a/crates/aube/src/commands/install/startup.rs
+++ b/crates/aube/src/commands/install/startup.rs
@@ -149,7 +149,7 @@ pub(super) fn merge_branch_lockfiles_if_needed(
                         super::InstallOutputLevel::Warning,
                         None,
                         format!(
-                            "warn: {} conflict(s) resolved during branch-lockfile merge:",
+                            "{} conflict(s) resolved during branch-lockfile merge:",
                             report.conflicts.len()
                         ),
                     );
@@ -157,7 +157,7 @@ pub(super) fn merge_branch_lockfiles_if_needed(
                         super::control::output(
                             super::InstallOutputLevel::Warning,
                             None,
-                            format!("warn:   {c}"),
+                            format!("  {c}"),
                         );
                     }
                 }
@@ -177,14 +177,14 @@ pub(super) fn warn_accepted_noop_install_settings(settings_ctx: &aube_settings::
         super::control::output(
             super::InstallOutputLevel::Warning,
             None,
-            "warning: aube has no store server; useRunningStoreServer=true is accepted but has no effect",
+            "aube has no store server; useRunningStoreServer=true is accepted but has no effect",
         );
     }
     if !super::settings::resolve_symlink(settings_ctx) {
         super::control::output(
             super::InstallOutputLevel::Warning,
             None,
-            "warning: aube's isolated layout requires symlinks; symlink=false is accepted but has no effect",
+            "aube's isolated layout requires symlinks; symlink=false is accepted but has no effect",
         );
     }
 }

--- a/crates/aube/src/commands/install/startup.rs
+++ b/crates/aube/src/commands/install/startup.rs
@@ -33,7 +33,7 @@ pub(super) fn try_install_fast_path(
     opts: &InstallOptions,
     mode: FrozenMode,
     modules_cache_sweep_default: bool,
-) -> Option<usize> {
+) -> miette::Result<Option<usize>> {
     let dangerously_allow_all_builds = resolve_dangerously_allow_all_builds(cwd, opts);
     if !install_fast_path_eligible(
         cwd,
@@ -42,14 +42,20 @@ pub(super) fn try_install_fast_path(
         modules_cache_sweep_default,
         dangerously_allow_all_builds,
     ) {
-        return None;
+        return Ok(None);
     }
+    opts.control.check_cancelled()?;
     emit_up_to_date(cwd);
-    Some(
-        state::read_state_package_content_hashes(cwd)
-            .map(|packages| packages.len())
-            .unwrap_or_default(),
-    )
+    let total = state::read_state_package_content_hashes(cwd)
+        .map(|packages| packages.len())
+        .or_else(|| {
+            let manifest = super::super::load_manifest_or_default(cwd).ok()?;
+            aube_lockfile::parse_lockfile_with_kind(cwd, &manifest)
+                .ok()
+                .map(|(graph, _)| graph.packages.len())
+        })
+        .unwrap_or_default();
+    Ok(Some(total))
 }
 
 fn resolve_dangerously_allow_all_builds(cwd: &Path, opts: &InstallOptions) -> bool {

--- a/crates/aube/src/commands/install/startup.rs
+++ b/crates/aube/src/commands/install/startup.rs
@@ -145,12 +145,20 @@ pub(super) fn merge_branch_lockfiles_if_needed(
                     filenames.join(", ")
                 );
                 if !report.conflicts.is_empty() {
-                    crate::progress::safe_eprintln(&format!(
-                        "warn: {} conflict(s) resolved during branch-lockfile merge:",
-                        report.conflicts.len()
-                    ));
+                    super::control::output(
+                        super::InstallOutputLevel::Warning,
+                        None,
+                        format!(
+                            "warn: {} conflict(s) resolved during branch-lockfile merge:",
+                            report.conflicts.len()
+                        ),
+                    );
                     for c in &report.conflicts {
-                        crate::progress::safe_eprintln(&format!("warn:   {c}"));
+                        super::control::output(
+                            super::InstallOutputLevel::Warning,
+                            None,
+                            format!("warn:   {c}"),
+                        );
                     }
                 }
             } else {
@@ -166,13 +174,17 @@ pub(super) fn merge_branch_lockfiles_if_needed(
 
 pub(super) fn warn_accepted_noop_install_settings(settings_ctx: &aube_settings::ResolveCtx<'_>) {
     if super::settings::resolve_use_running_store_server(settings_ctx) {
-        eprintln!(
-            "warning: aube has no store server; useRunningStoreServer=true is accepted but has no effect"
+        super::control::output(
+            super::InstallOutputLevel::Warning,
+            None,
+            "warning: aube has no store server; useRunningStoreServer=true is accepted but has no effect",
         );
     }
     if !super::settings::resolve_symlink(settings_ctx) {
-        eprintln!(
-            "warning: aube's isolated layout requires symlinks; symlink=false is accepted but has no effect"
+        super::control::output(
+            super::InstallOutputLevel::Warning,
+            None,
+            "warning: aube's isolated layout requires symlinks; symlink=false is accepted but has no effect",
         );
     }
 }

--- a/crates/aube/src/commands/install/summary.rs
+++ b/crates/aube/src/commands/install/summary.rs
@@ -1,4 +1,12 @@
 pub(super) fn print_already_up_to_date() {
+    match super::control::current().output_mode() {
+        super::InstallOutputMode::Events => {
+            super::control::output(super::InstallOutputLevel::Info, None, "Already up to date");
+            return;
+        }
+        super::InstallOutputMode::Silent => return,
+        super::InstallOutputMode::Human => {}
+    }
     if clx::progress::output() == clx::progress::ProgressOutput::Text {
         return;
     }
@@ -69,7 +77,9 @@ fn direct_dependency_importer_label(
 
 pub(super) fn should_print_human_install_summary() -> bool {
     let flags = super::super::global_output_flags();
-    !flags.silent && !flags.ndjson
+    super::control::current().output_mode() == super::InstallOutputMode::Human
+        && !flags.silent
+        && !flags.ndjson
 }
 
 fn print_direct_dependency_section(

--- a/crates/aube/src/progress/mod.rs
+++ b/crates/aube/src/progress/mod.rs
@@ -461,8 +461,8 @@ impl InstallProgress {
                 s.resolved.fetch_add(n, Ordering::Relaxed);
             }
             Mode::Events(s) => {
-                s.resolved.fetch_add(n, Ordering::Relaxed);
-                s.total.fetch_add(n, Ordering::Relaxed);
+                let resolved = s.resolved.fetch_add(n, Ordering::Relaxed) + n;
+                s.total.fetch_max(resolved, Ordering::Relaxed);
                 s.report_progress();
             }
         }
@@ -1465,6 +1465,8 @@ mod tests {
             let progress = InstallProgress::try_new().unwrap();
             progress.set_phase("resolving");
             progress.set_total_floor(3);
+            progress.inc_total(1);
+            progress.inc_total(1);
             progress.set_total(2);
             progress.inc_reused(1);
             progress.set_phase("fetching");
@@ -1479,6 +1481,13 @@ mod tests {
         assert!(events.contains(&InstallEvent::Phase(InstallPhase::Resolving)));
         assert!(events.contains(&InstallEvent::Phase(InstallPhase::Fetching)));
         assert!(events.contains(&InstallEvent::Phase(InstallPhase::Complete)));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            InstallEvent::Progress(snapshot)
+                if snapshot.phase == Some(InstallPhase::Resolving)
+                    && snapshot.resolved == 2
+                    && snapshot.total == 3
+        )));
         assert!(events.iter().any(|event| matches!(
             event,
             InstallEvent::Progress(snapshot)

--- a/crates/aube/src/progress/mod.rs
+++ b/crates/aube/src/progress/mod.rs
@@ -628,15 +628,18 @@ impl InstallProgress {
             Mode::Ci(s) => s.set_phase(phase),
             Mode::Events(s) => {
                 let (n, phase) = match phase {
-                    "resolving" => (1, Some(InstallPhase::Resolving)),
-                    "fetching" => (2, Some(InstallPhase::Fetching)),
-                    "linking" => (3, Some(InstallPhase::Linking)),
-                    _ => (0, None),
+                    "resolving" => (1, InstallPhase::Resolving),
+                    "fetching" => (2, InstallPhase::Fetching),
+                    "linking" => (3, InstallPhase::Linking),
+                    "" => {
+                        s.phase.store(0, Ordering::Relaxed);
+                        s.report_progress();
+                        return;
+                    }
+                    _ => return,
                 };
                 s.phase.store(n, Ordering::Relaxed);
-                if let Some(phase) = phase {
-                    s.reporter.report(InstallEvent::Phase(phase));
-                }
+                s.reporter.report(InstallEvent::Phase(phase));
                 s.report_progress();
             }
         }
@@ -1465,6 +1468,7 @@ mod tests {
             progress.set_total(2);
             progress.inc_reused(1);
             progress.set_phase("fetching");
+            progress.set_phase("future-phase");
             progress.inc_downloaded_bytes(512);
             drop(progress.start_fetch("dep", "1.0.0"));
             progress.finish(false);
@@ -1475,6 +1479,12 @@ mod tests {
         assert!(events.contains(&InstallEvent::Phase(InstallPhase::Resolving)));
         assert!(events.contains(&InstallEvent::Phase(InstallPhase::Fetching)));
         assert!(events.contains(&InstallEvent::Phase(InstallPhase::Complete)));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            InstallEvent::Progress(snapshot)
+                if snapshot.phase == Some(InstallPhase::Fetching)
+                    && snapshot.downloaded_bytes == 512
+        )));
         assert!(events.iter().any(|event| matches!(
             event,
             InstallEvent::Progress(snapshot)

--- a/crates/aube/src/progress/mod.rs
+++ b/crates/aube/src/progress/mod.rs
@@ -27,6 +27,9 @@ mod render;
 
 pub(crate) use render::format_bytes;
 
+use crate::commands::install::{
+    InstallEvent, InstallOutputMode, InstallPhase, InstallProgressSnapshot, InstallReporter,
+};
 use ci::{CiState, format_duration};
 use clx::progress::{
     ProgressJob, ProgressJobBuilder, ProgressJobDoneBehavior, ProgressOutput, ProgressStatus,
@@ -206,6 +209,43 @@ enum Mode {
         fetch_state: Arc<Mutex<FetchState>>,
     },
     Ci(Arc<CiState>),
+    Events(Arc<EventState>),
+}
+
+struct EventState {
+    reporter: Arc<dyn InstallReporter>,
+    phase: AtomicUsize,
+    resolved: AtomicUsize,
+    total: AtomicUsize,
+    reused: AtomicUsize,
+    downloaded: AtomicUsize,
+    downloaded_bytes: AtomicU64,
+    estimated_bytes: AtomicU64,
+}
+
+impl EventState {
+    fn phase(&self) -> Option<InstallPhase> {
+        match self.phase.load(Ordering::Relaxed) {
+            1 => Some(InstallPhase::Resolving),
+            2 => Some(InstallPhase::Fetching),
+            3 => Some(InstallPhase::Linking),
+            4 => Some(InstallPhase::Complete),
+            _ => None,
+        }
+    }
+
+    fn report_progress(&self) {
+        self.reporter
+            .report(InstallEvent::Progress(InstallProgressSnapshot {
+                phase: self.phase(),
+                resolved: self.resolved.load(Ordering::Relaxed),
+                total: self.total.load(Ordering::Relaxed),
+                reused: self.reused.load(Ordering::Relaxed),
+                downloaded: self.downloaded.load(Ordering::Relaxed),
+                downloaded_bytes: self.downloaded_bytes.load(Ordering::Relaxed),
+                estimated_bytes: self.estimated_bytes.load(Ordering::Relaxed),
+            }));
+    }
 }
 
 struct FetchState {
@@ -235,6 +275,27 @@ impl InstallProgress {
     /// disabled (clx text mode — i.e. `--silent`, `-v`, or a line-oriented
     /// reporter that owns its own output).
     pub fn try_new() -> Option<Self> {
+        let control = crate::commands::install::control::current();
+        match control.output_mode() {
+            InstallOutputMode::Events => {
+                let reporter = control.reporter()?;
+                return Some(Self {
+                    mode: Mode::Events(Arc::new(EventState {
+                        reporter,
+                        phase: AtomicUsize::new(0),
+                        resolved: AtomicUsize::new(0),
+                        total: AtomicUsize::new(0),
+                        reused: AtomicUsize::new(0),
+                        downloaded: AtomicUsize::new(0),
+                        downloaded_bytes: AtomicU64::new(0),
+                        estimated_bytes: AtomicU64::new(0),
+                    })),
+                    unpacked_sizes: Arc::new(Mutex::new(HashMap::new())),
+                });
+            }
+            InstallOutputMode::Silent => return None,
+            InstallOutputMode::Human => {}
+        }
         if clx::progress::output() == ProgressOutput::Text {
             return None;
         }
@@ -340,6 +401,10 @@ impl InstallProgress {
             Mode::Ci(s) => {
                 s.target_total.fetch_max(n, Ordering::Relaxed);
             }
+            Mode::Events(s) => {
+                s.total.fetch_max(n, Ordering::Relaxed);
+                s.report_progress();
+            }
         }
     }
 
@@ -375,6 +440,12 @@ impl InstallProgress {
                 s.resolved.store(total, Ordering::Relaxed);
                 clamp_reused_to(&s.reused, &s.downloaded, total);
             }
+            Mode::Events(s) => {
+                s.resolved.store(total, Ordering::Relaxed);
+                s.total.store(total, Ordering::Relaxed);
+                clamp_reused_to(&s.reused, &s.downloaded, total);
+                s.report_progress();
+            }
         }
     }
 
@@ -388,6 +459,11 @@ impl InstallProgress {
             }
             Mode::Ci(s) => {
                 s.resolved.fetch_add(n, Ordering::Relaxed);
+            }
+            Mode::Events(s) => {
+                s.resolved.fetch_add(n, Ordering::Relaxed);
+                s.total.fetch_add(n, Ordering::Relaxed);
+                s.report_progress();
             }
         }
     }
@@ -435,6 +511,13 @@ impl InstallProgress {
                 }
                 s.estimated_bytes.fetch_add(bytes, Ordering::Relaxed);
             }
+            Mode::Events(s) => {
+                if prior > 0 {
+                    s.estimated_bytes.fetch_sub(prior, Ordering::Relaxed);
+                }
+                s.estimated_bytes.fetch_add(bytes, Ordering::Relaxed);
+                s.report_progress();
+            }
         }
     }
 
@@ -466,6 +549,10 @@ impl InstallProgress {
             }
             Mode::Ci(s) => {
                 s.estimated_bytes.store(sum, Ordering::Relaxed);
+            }
+            Mode::Events(s) => {
+                s.estimated_bytes.store(sum, Ordering::Relaxed);
+                s.report_progress();
             }
         }
     }
@@ -539,6 +626,19 @@ impl InstallProgress {
                 self.refresh_tty_bar();
             }
             Mode::Ci(s) => s.set_phase(phase),
+            Mode::Events(s) => {
+                let (n, phase) = match phase {
+                    "resolving" => (1, Some(InstallPhase::Resolving)),
+                    "fetching" => (2, Some(InstallPhase::Fetching)),
+                    "linking" => (3, Some(InstallPhase::Linking)),
+                    _ => (0, None),
+                };
+                s.phase.store(n, Ordering::Relaxed);
+                if let Some(phase) = phase {
+                    s.reporter.report(InstallEvent::Phase(phase));
+                }
+                s.report_progress();
+            }
         }
     }
 
@@ -554,6 +654,10 @@ impl InstallProgress {
             }
             Mode::Ci(s) => {
                 s.reused.fetch_add(n, Ordering::Relaxed);
+            }
+            Mode::Events(s) => {
+                s.reused.fetch_add(n, Ordering::Relaxed);
+                s.report_progress();
             }
         }
     }
@@ -584,6 +688,10 @@ impl InstallProgress {
             }
             Mode::Ci(s) => {
                 s.downloaded_bytes.fetch_add(bytes, Ordering::Relaxed);
+            }
+            Mode::Events(s) => {
+                s.downloaded_bytes.fetch_add(bytes, Ordering::Relaxed);
+                s.report_progress();
             }
         }
     }
@@ -851,6 +959,10 @@ impl InstallProgress {
                 inner: FetchRowInner::Ci(Arc::downgrade(s)),
                 completed: false,
             },
+            Mode::Events(s) => FetchRow {
+                inner: FetchRowInner::Events(Arc::downgrade(s)),
+                completed: false,
+            },
         }
     }
 
@@ -900,6 +1012,13 @@ impl InstallProgress {
                 clx::progress::stop();
             }
             Mode::Ci(s) => s.stop(print_ci_summary),
+            Mode::Events(s) => {
+                if s.phase.swap(4, Ordering::Relaxed) != 4 {
+                    s.reporter
+                        .report(InstallEvent::Phase(InstallPhase::Complete));
+                    s.report_progress();
+                }
+            }
         }
     }
 
@@ -932,6 +1051,9 @@ impl InstallProgress {
         total_packages: usize,
         elapsed: Duration,
     ) {
+        if matches!(self.mode, Mode::Events(_)) {
+            return;
+        }
         if linked == 0 && top_level_linked == 0 {
             let body = if total_packages == 0 {
                 "Already up to date".to_string()
@@ -962,6 +1084,7 @@ impl InstallProgress {
         let needs_summary = match &self.mode {
             Mode::Tty { .. } => true,
             Mode::Ci(s) => !s.shown.load(Ordering::Relaxed),
+            Mode::Events(_) => false,
         };
         if !needs_summary {
             return;
@@ -1052,6 +1175,7 @@ impl Drop for InstallProgress {
                     s.stop(false);
                 }
             }
+            Mode::Events(_) => {}
         }
     }
 }
@@ -1094,6 +1218,7 @@ enum FetchRowInner {
     /// rows shouldn't prevent `CiState` from being dropped after the
     /// last `InstallProgress` clone is gone.
     Ci(Weak<CiState>),
+    Events(Weak<EventState>),
 }
 
 impl FetchRow {
@@ -1176,6 +1301,12 @@ impl FetchRow {
             FetchRowInner::Ci(weak) => {
                 if let Some(s) = weak.upgrade() {
                     s.downloaded.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+            FetchRowInner::Events(weak) => {
+                if let Some(s) = weak.upgrade() {
+                    s.downloaded.fetch_add(1, Ordering::Relaxed);
+                    s.report_progress();
                 }
             }
         }
@@ -1311,6 +1442,49 @@ impl Drop for PausingWriterGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct RecordingReporter(Mutex<Vec<InstallEvent>>);
+
+    impl InstallReporter for RecordingReporter {
+        fn report(&self, event: InstallEvent) {
+            self.0.lock().unwrap().push(event);
+        }
+    }
+
+    #[tokio::test]
+    async fn event_mode_reports_phase_progress_and_completion() {
+        let reporter = Arc::new(RecordingReporter::default());
+        let control = crate::commands::install::InstallControl::events(reporter.clone());
+
+        crate::commands::install::control::scope(control, async {
+            let progress = InstallProgress::try_new().unwrap();
+            progress.set_phase("resolving");
+            progress.set_total_floor(3);
+            progress.set_total(2);
+            progress.inc_reused(1);
+            progress.set_phase("fetching");
+            progress.inc_downloaded_bytes(512);
+            drop(progress.start_fetch("dep", "1.0.0"));
+            progress.finish(false);
+        })
+        .await;
+
+        let events = reporter.0.lock().unwrap();
+        assert!(events.contains(&InstallEvent::Phase(InstallPhase::Resolving)));
+        assert!(events.contains(&InstallEvent::Phase(InstallPhase::Fetching)));
+        assert!(events.contains(&InstallEvent::Phase(InstallPhase::Complete)));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            InstallEvent::Progress(snapshot)
+                if snapshot.phase == Some(InstallPhase::Complete)
+                    && snapshot.resolved == 2
+                    && snapshot.reused == 1
+                    && snapshot.downloaded == 1
+                    && snapshot.downloaded_bytes == 512
+        )));
+    }
 
     #[test]
     fn overflow_fetch_label_pluralizes_count() {

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -403,6 +403,12 @@
       "exit_code": null
     },
     {
+      "name": "ERR_AUBE_INSTALL_CANCELLED",
+      "category": "Misc / safety",
+      "description": "An in-process install was cooperatively cancelled by its embedding host. Cancellation is observed at safe install boundaries so an in-flight filesystem phase is not abandoned mid-mutation.",
+      "exit_code": null
+    },
+    {
       "name": "ERR_AUBE_UNSAFE_INDEX_KEY",
       "category": "Misc / safety",
       "description": "A package index key tried to escape its directory (path traversal defense in depth).",


### PR DESCRIPTION
## Summary

- add invocation-scoped install controls with human, structured-event, and silent output modes
- expose structured phase, progress, and output events through a non-blocking reporter trait
- add cooperative cancellation with the stable `ERR_AUBE_INSTALL_CANCELLED` diagnostic
- route install-owned direct output through the invocation control while preserving the standalone CLI default
- keep concurrent installs isolated through Tokio task-local control state

## Cancellation semantics

Cancellation is observed at safe install boundaries. Aube does not abandon a filesystem phase mid-mutation; an already-running phase reaches its safe boundary before the install returns `ERR_AUBE_INSTALL_CANCELLED`. This gives embedders abort propagation without releasing the project lock while install work may still be mutating the tree.

## Follow-up

This is a prerequisite for #1025. That PR will adapt the reporter to N-API thread-safe callbacks, map `AbortSignal` to `InstallControl::cancel`, and expose the structured events to JavaScript.

## Validation

- `mise run lint`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core install orchestration path and filesystem-adjacent cancellation boundaries; default CLI behavior is preserved but embedder-facing install semantics change.
> 
> **Overview**
> Introduces **`InstallControl`** on **`InstallOptions`**, scoped per install via a Tokio task-local so concurrent in-process installs stay isolated. Embedders can choose **human** (CLI default), **events** (structured reporter), or **silent** output.
> 
> **`InstallReporter`** receives non-blocking **phase**, **progress**, and **output** events; **`InstallProgress`** gains an Events mode that mirrors TTY/CI counters instead of drawing a bar. Direct install messages (warnings, peer errors, lockfile-only text, “already up to date”) route through **`control::output`** so they respect the selected mode.
> 
> **Cooperative cancellation** uses **`tokio_util::CancellationToken`**; **`check_cancelled`** runs at safe boundaries (start, before resolve/fetch/link, fast path). Cancelled installs return **`ERR_AUBE_INSTALL_CANCELLED`** (new stable code + docs). The warm fast path reports **Complete** progress in event mode when the tree is already fresh.
> 
> CLI entry points (`ci`, `deploy`, `InstallArgs`) wire **`InstallControl::default()`**; no behavior change for standalone **`aube install`** unless a custom control is passed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ad20fca517b9f1cc811dcef7b099469ad7f8b2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->