### PR TITLE
fix(deploy): dedupe injected workspace dependencies

### DIFF
--- a/crates/aube-lockfile/src/source.rs
+++ b/crates/aube-lockfile/src/source.rs
@@ -173,14 +173,17 @@ impl LocalSource {
     /// Internal FS-safe dep_path used as the key in
     /// `LockfileGraph.packages` and as the `.aube/` subdir name.
     ///
-    /// Distinct paths must map to distinct keys (otherwise the
+    /// Distinct normalized paths must map to distinct keys (otherwise the
     /// linker would silently mix files between two local packages),
     /// and the result must be a single filesystem component — no
     /// `/`, `\`, `:`, or `..`. Ad-hoc character substitution trips
     /// over cases like `../vendor` vs `__/vendor` or `a.b` vs `a_b`
-    /// collapsing to the same string, so we hash the raw path bytes
-    /// and suffix the first 16 hex chars (64 bits — more than enough
-    /// to avoid collisions inside a single project).
+    /// collapsing to the same string, so we hash the lexically normalized
+    /// path bytes and suffix the first 16 hex chars (64 bits — more than
+    /// enough to avoid collisions inside a single project). Normalization
+    /// also makes equivalent spellings such as `./vendor` and `vendor`
+    /// share one package identity without changing their serialized
+    /// specifiers.
     ///
     /// The hash input is the POSIX-form path string so a checked-in
     /// lockfile resolves to the same key regardless of which
@@ -201,7 +204,15 @@ impl LocalSource {
             LocalSource::RemoteTarball(t) => {
                 hasher.update(t.url.as_bytes());
             }
-            _ => hasher.update(self.path_posix().as_bytes()),
+            LocalSource::Directory(path)
+            | LocalSource::Tarball(path)
+            | LocalSource::Link(path)
+            | LocalSource::Portal(path)
+            | LocalSource::Exec(path) => {
+                let normalized = aube_util::path::normalize_lexical(path);
+                let posix = normalized.to_string_lossy().replace('\\', "/");
+                hasher.update(posix.as_bytes());
+            }
         }
         let digest = hasher.finalize();
         let short: String = digest.iter().take(8).map(|b| format!("{b:02x}")).collect();
@@ -1123,6 +1134,15 @@ mod tests {
             subpath: Some("packages/b".to_string()),
         });
         assert_ne!(a.dep_path("dep"), b.dep_path("dep"));
+    }
+
+    #[test]
+    fn dep_path_normalizes_equivalent_local_paths() {
+        let root = LocalSource::Directory(PathBuf::from("./injected/lib-b"));
+        let transitive = LocalSource::Directory(PathBuf::from("injected/lib-a/../lib-b"));
+
+        assert_eq!(root.dep_path("lib-b"), transitive.dep_path("lib-b"));
+        assert_eq!(root.specifier(), "file:./injected/lib-b");
     }
 
     const SHARED_SHA: &str = "0123456789abcdef0123456789abcdef01234567";

--- a/test/deploy.bats
+++ b/test/deploy.bats
@@ -417,6 +417,50 @@ EOF
 	assert_output "file:../@test_core"
 }
 
+@test "aube deploy: dedupes a workspace sibling reached directly and transitively" {
+	mkdir -p packages/app packages/lib-a packages/lib-b
+	cat >package.json <<'EOF'
+{ "name": "deploy-dedupe-root", "private": true }
+EOF
+	cat >aube-workspace.yaml <<'EOF'
+packages:
+  - packages/*
+EOF
+	cat >packages/lib-b/package.json <<'EOF'
+{ "name": "lib-b", "version": "1.0.0", "type": "module", "main": "index.js" }
+EOF
+	cat >packages/lib-b/index.js <<'EOF'
+globalThis.__libBLoads = (globalThis.__libBLoads ?? 0) + 1;
+export const loads = () => globalThis.__libBLoads;
+export const registry = new Map();
+EOF
+	cat >packages/lib-a/package.json <<'EOF'
+{ "name": "lib-a", "version": "1.0.0", "type": "module", "main": "index.js", "dependencies": { "lib-b": "workspace:" } }
+EOF
+	cat >packages/lib-a/index.js <<'EOF'
+export * as libB from "lib-b";
+EOF
+	cat >packages/app/package.json <<'EOF'
+{ "name": "app", "version": "1.0.0", "type": "module", "main": "index.js", "dependencies": { "lib-a": "workspace:", "lib-b": "workspace:" } }
+EOF
+	cat >packages/app/index.js <<'EOF'
+import { registry, loads } from "lib-b";
+import { libB } from "lib-a";
+registry.set("from-app", true);
+console.log(registry === libB.registry, loads());
+EOF
+
+	run aube deploy --filter app --prod ./out
+	assert_success
+
+	run bash -c "find out/node_modules/.aube -maxdepth 1 -type d -name 'lib-b@file+*' | wc -l | tr -d ' '"
+	assert_success
+	assert_output "1"
+	run node out/index.js
+	assert_success
+	assert_output "true 1"
+}
+
 @test "aube deploy: deploy-all-files=true copies symlinked files via their target" {
 	# Regression: `DirEntry::file_type()` uses lstat, so without
 	# following file symlinks the walk would silently drop them —


### PR DESCRIPTION
## Summary

- normalize path-backed local-source identities before deriving virtual-store keys
- preserve the original `file:` spelling used for lockfile serialization
- cover a deployed workspace dependency reached both directly and transitively

## Root cause

`aube deploy` rewrites the root reference as `file:./.aube-deploy-injected/lib-b` and the transitive reference as `file:../lib-b`. Resolution rebases the transitive path to `.aube-deploy-injected/lib-b`, while the root fast path preserves its leading `./`. `LocalSource::dep_path` hashed those equivalent strings independently, creating two virtual-store entries and two Node module instances.

Lexically normalizing only the identity hash makes equivalent paths converge without changing serialized manifest or lockfile specifiers.

Fixes the behavior reported in [Discussion #1037](https://github.com/jdx/aube/discussions/1037).

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `mise run test:bats test/deploy.bats`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing `dep_path` hashing affects all path-backed local packages in the lockfile graph and virtual store; equivalent paths converge (intended) but any tooling that assumed distinct keys for different spellings of the same path could see different layout after upgrade.
> 
> **Overview**
> **`LocalSource::dep_path`** now hashes **lexically normalized** POSIX paths for directory/tarball/link/portal/exec sources (via `aube_util::path::normalize_lexical`) instead of the raw stored path string. Equivalent targets such as `./injected/lib-b` and `injected/lib-a/../lib-b` therefore get the **same** virtual-store key and `.aube/` subdir, while **`specifier()`** still serializes the original `file:` spelling for lockfiles and manifests.
> 
> This fixes **`aube deploy`** creating **two** `lib-b@file+*` entries when the same workspace package is referenced directly and transitively with different relative `file:` paths after injection—Node would load two module instances and break shared singleton state.
> 
> Adds a **unit test** for equivalent-path `dep_path` equality and a **bats** deploy scenario asserting a single virtual-store dir and one shared `lib-b` registry at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec76232440d54ddba30ec28b221ea0c90582dc2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->