### PR TITLE
fix(resolver): handle versionless scoped npm aliases

### DIFF
--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -1702,20 +1702,32 @@ impl<'a> ResolveDriver<'a> {
                     changed = true;
                 }
             }
-            if let Some(rest) = task.range.strip_prefix("npm:")
-                && let Some(at_idx) = rest.rfind('@')
-            {
-                let real_name = rest[..at_idx].to_string();
-                let real_range = rest[at_idx + 1..].to_string();
+            if let Some(rest) = task.range.strip_prefix("npm:") {
+                // The separator for a scoped alias is the `@` after
+                // its package name, not the scope sigil. A missing
+                // separator means the alias has no explicit range and
+                // therefore follows npm's `latest` default.
+                let range_separator = if rest.starts_with('@') {
+                    rest.find('/').and_then(|slash_idx| {
+                        rest[slash_idx + 1..]
+                            .find('@')
+                            .map(|at_idx| slash_idx + 1 + at_idx)
+                    })
+                } else {
+                    rest.find('@')
+                };
+                let (real_name, real_range) = match range_separator {
+                    Some(at_idx) => (&rest[..at_idx], &rest[at_idx + 1..]),
+                    None => (rest, "latest"),
+                };
                 // Keep `task.name` as the user-facing alias; stash
                 // the registry name on `real_name`. Only packument /
                 // tarball fetch sites (via `task.registry_name()`)
                 // hit the real package.
-                if task.real_name.as_deref() != Some(real_name.as_str()) || real_range != task.range
-                {
+                if task.real_name.as_deref() != Some(real_name) || real_range != task.range {
                     tracing::trace!("npm alias: {} -> {}@{}", task.name, real_name, real_range);
-                    task.real_name = Some(real_name);
-                    task.range = real_range;
+                    task.real_name = Some(real_name.to_string());
+                    task.range = real_range.to_string();
                     changed = true;
                 }
             }

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -3633,6 +3633,51 @@ async fn fresh_resolve_preserves_npm_alias_as_folder_name() {
     assert_eq!(root[0].dep_path, "odd-alias@3.0.1");
 }
 
+// Catalog expansion happens before npm alias parsing. A versionless
+// scoped alias such as `npm:@popperjs/core` must treat the leading `@`
+// as the scope sigil and default its range to `latest`; otherwise the
+// remainder (`popperjs/core`) is mistaken for GitHub shorthand.
+#[tokio::test]
+async fn fresh_resolve_handles_versionless_scoped_npm_alias_from_catalog() {
+    let popper = make_packument("@popperjs/core", &["2.11.8"], "2.11.8");
+
+    let client = Arc::new(aube_registry::client::RegistryClient::new(
+        "http://127.0.0.1:0",
+    ));
+    let mut catalogs: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
+    catalogs
+        .entry("default".to_string())
+        .or_default()
+        .insert("popper2".to_string(), "npm:@popperjs/core".to_string());
+    let mut resolver = Resolver::new(client).with_catalogs(catalogs);
+    resolver.cache.insert("@popperjs/core".to_string(), popper);
+
+    let mut manifest = PackageJson::default();
+    manifest
+        .dependencies
+        .insert("popper2".to_string(), "catalog:".to_string());
+
+    let graph = resolver
+        .resolve(&manifest, None)
+        .await
+        .expect("versionless scoped catalog alias should resolve from npm");
+
+    let pkg = graph
+        .packages
+        .get("popper2@2.11.8")
+        .expect("catalog alias must retain its user-facing package name");
+    assert_eq!(pkg.name, "popper2");
+    assert_eq!(pkg.version, "2.11.8");
+    assert_eq!(pkg.alias_of.as_deref(), Some("@popperjs/core"));
+    assert_eq!(pkg.registry_name(), "@popperjs/core");
+    assert!(!graph.packages.contains_key("@popperjs/core@2.11.8"));
+
+    let catalog = graph.catalogs.get("default").unwrap();
+    let entry = catalog.get("popper2").unwrap();
+    assert_eq!(entry.specifier, "npm:@popperjs/core");
+    assert_eq!(entry.version, "2.11.8");
+}
+
 // Catalog-aliased dep + selector override targeting the original
 // (alias) name with a bare-range replacement. Reproduces the
 // pnpm/pnpm `js-yaml: npm:@zkochan/js-yaml@0.0.11` + `js-yaml@<3.14.2:


### PR DESCRIPTION
## Summary

- parse scoped `npm:` aliases using the separator after the package name
- default versionless npm aliases to the `latest` dist-tag
- cover fresh catalog resolution for `popper2: npm:@popperjs/core`

## Root cause

The resolver used the last `@` in an npm alias as the name/range separator. For a versionless scoped alias, that selected the scope sigil, stripped it, and left `popperjs/core`, which the source classifier then treated as GitHub shorthand.

## User impact

Fresh installs can now resolve versionless scoped npm aliases from pnpm catalogs through the npm registry while retaining the user-facing alias in the graph and lockfile.

Addresses https://github.com/jdx/aube/discussions/1043

## Validation

- `cargo test -p aube-resolver`
- `cargo clippy -p aube-resolver --all-targets -- -D warnings`
- `cargo fmt --check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core dependency preprocessing for all `npm:` aliases; behavior change is intentional but could affect edge-case alias strings beyond the fixed catalog scenario.
> 
> **Overview**
> Fixes **scoped `npm:` alias parsing** when the catalog or manifest supplies a target with no explicit version (e.g. `npm:@popperjs/core`).
> 
> The resolver no longer treats the **last `@` in the string** as the name/range split. For scoped names it finds the `@` **after** `scope/package`; if there is no range segment it uses npm’s **`latest`** default. That stops the remainder from being misread as GitHub shorthand (`popperjs/core`) after catalog expansion.
> 
> User-facing alias names and lockfile identity stay on the catalog key; registry fetches still use `@popperjs/core`. A fresh-resolve test covers `popper2: catalog:` → `npm:@popperjs/core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c900b06ce81a17b56a0683aa1a9098e785caa75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resolution of scoped npm aliases, including aliases without an explicit version range.
  * Catalog-based dependencies now correctly resolve to the requested package and version while preserving the original alias.
  * Prevented incorrect package names from appearing in resolved dependency results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->