### PR TITLE
fix(resolver): handle versionless scoped npm: alias on fresh resolve

### DIFF
--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -1702,11 +1702,8 @@ impl<'a> ResolveDriver<'a> {
                     changed = true;
                 }
             }
-            if let Some(rest) = task.range.strip_prefix("npm:")
-                && let Some(at_idx) = rest.rfind('@')
-            {
-                let real_name = rest[..at_idx].to_string();
-                let real_range = rest[at_idx + 1..].to_string();
+            if let Some(rest) = task.range.strip_prefix("npm:") {
+                let (real_name, real_range) = split_npm_alias(rest);
                 // Keep `task.name` as the user-facing alias; stash
                 // the registry name on `real_name`. Only packument /
                 // tarball fetch sites (via `task.registry_name()`)
@@ -2082,6 +2079,24 @@ impl<'a> ResolveDriver<'a> {
     }
 }
 
+/// Split the body of an `npm:<name>[@<range>]` alias into its
+/// registry name and version range. `rest` is the spec with the
+/// `npm:` prefix already stripped.
+///
+/// Delegates the name/version split to [`aube_util::pkg::split_name_spec`]
+/// so a scoped name's leading `@` (`@popperjs/core`) is never mistaken
+/// for a version separator — the bug that let a version-less scoped
+/// alias fall through to the bare `owner/repo` git-shorthand parser.
+/// A missing range defaults to `latest`, matching pnpm.
+fn split_npm_alias(rest: &str) -> (String, String) {
+    let (name, range) = aube_util::pkg::split_name_spec(rest);
+    let range = match range {
+        Some(r) if !r.is_empty() => r,
+        _ => "latest",
+    };
+    (name.to_string(), range.to_string())
+}
+
 fn attach_integrity_to_git_source(local: &mut LocalSource, integrity: Option<&str>) {
     if let LocalSource::Git(git) = local
         && git.integrity.is_none()
@@ -2094,6 +2109,22 @@ fn attach_integrity_to_git_source(local: &mut LocalSource, integrity: Option<&st
 mod tests {
     use super::*;
     use aube_lockfile::GitSource;
+
+    // The name/version split itself is `split_name_spec`'s job (tested
+    // in aube-util). What's unique here is the wrapper's default: an
+    // alias with no version tail — scoped or plain — falls back to the
+    // `latest` dist-tag rather than an empty range.
+    #[test]
+    fn split_npm_alias_defaults_missing_range_to_latest() {
+        assert_eq!(
+            split_npm_alias("@popperjs/core"),
+            ("@popperjs/core".to_string(), "latest".to_string())
+        );
+        assert_eq!(
+            split_npm_alias("lodash"),
+            ("lodash".to_string(), "latest".to_string())
+        );
+    }
 
     #[test]
     fn attach_integrity_to_git_source_fills_missing_git_integrity() {

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -3633,6 +3633,52 @@ async fn fresh_resolve_preserves_npm_alias_as_folder_name() {
     assert_eq!(root[0].dep_path, "odd-alias@3.0.1");
 }
 
+// Catalog expansion happens before npm alias parsing. A versionless
+// scoped alias such as `npm:@popperjs/core` must treat the leading `@`
+// as the scope sigil and default its range to `latest`; otherwise the
+// remainder (`popperjs/core`) is mistaken for GitHub shorthand and the
+// resolve falls through to `git ls-remote`.
+#[tokio::test]
+async fn fresh_resolve_handles_versionless_scoped_npm_alias_from_catalog() {
+    let popper = make_packument("@popperjs/core", &["2.11.8"], "2.11.8");
+
+    let client = Arc::new(aube_registry::client::RegistryClient::new(
+        "http://127.0.0.1:0",
+    ));
+    let mut catalogs: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
+    catalogs
+        .entry("default".to_string())
+        .or_default()
+        .insert("popper2".to_string(), "npm:@popperjs/core".to_string());
+    let mut resolver = Resolver::new(client).with_catalogs(catalogs);
+    resolver.cache.insert("@popperjs/core".to_string(), popper);
+
+    let mut manifest = PackageJson::default();
+    manifest
+        .dependencies
+        .insert("popper2".to_string(), "catalog:".to_string());
+
+    let graph = resolver
+        .resolve(&manifest, None)
+        .await
+        .expect("versionless scoped catalog alias should resolve from npm");
+
+    let pkg = graph
+        .packages
+        .get("popper2@2.11.8")
+        .expect("catalog alias must retain its user-facing package name");
+    assert_eq!(pkg.name, "popper2");
+    assert_eq!(pkg.version, "2.11.8");
+    assert_eq!(pkg.alias_of.as_deref(), Some("@popperjs/core"));
+    assert_eq!(pkg.registry_name(), "@popperjs/core");
+    assert!(!graph.packages.contains_key("@popperjs/core@2.11.8"));
+
+    let catalog = graph.catalogs.get("default").unwrap();
+    let entry = catalog.get("popper2").unwrap();
+    assert_eq!(entry.specifier, "npm:@popperjs/core");
+    assert_eq!(entry.version, "2.11.8");
+}
+
 // Catalog-aliased dep + selector override targeting the original
 // (alias) name with a bare-range replacement. Reproduces the
 // pnpm/pnpm `js-yaml: npm:@zkochan/js-yaml@0.0.11` + `js-yaml@<3.14.2:

--- a/test/catalogs.bats
+++ b/test/catalogs.bats
@@ -264,6 +264,35 @@ _setup_catalog_workspace() {
 	assert_output --partial "catalog:"
 }
 
+@test "aube install: plain npm: alias dep with no version resolves to the registry" {
+	# Regression: a version-less `npm:` alias used to be skipped by the
+	# resolver entirely (the rewrite required a trailing `@version`).
+	# The versionless scoped form of the same bug — `npm:@popperjs/core`
+	# via a catalog, whose scope `@` got mistaken for a version
+	# separator and fell through to the git `owner/repo` parser — is
+	# covered hermetically by
+	# `fresh_resolve_handles_versionless_scoped_npm_alias_from_catalog`
+	# in aube-resolver (the offline fixture set has no scoped package
+	# whose `latest` tarball is committed).
+	cat >package.json <<-'EOF'
+		{
+		  "name": "aube-test-alias",
+		  "version": "0.0.0",
+		  "private": true,
+		  "dependencies": {
+		    "alias-odd": "npm:is-odd"
+		  }
+		}
+	EOF
+
+	run aube install
+	assert_success
+
+	assert_dir_exists node_modules/alias-odd
+	run grep "aliasOf: is-odd" aube-lock.yaml
+	assert_success
+}
+
 @test "aube install: unknown catalog reference fails fast" {
 	mkdir -p packages/lib
 	cat >pnpm-workspace.yaml <<-'EOF'


### PR DESCRIPTION
## Summary

- parse `npm:` aliases via `split_name_spec` so a scoped name's leading `@`
  is never taken for the name/range separator
- default a versionless `npm:` alias to the `latest` dist-tag
- add a hermetic resolver-level regression test for fresh catalog
  resolution of `popper2: npm:@popperjs/core`

## Root cause

`preprocess_task` split an `npm:` alias with `rest.rfind('@')`. For a
versionless scoped alias (`npm:@popperjs/core`) the only `@` is the scope
sigil, so it was taken as the name/range separator — leaving an empty
registry name and `popperjs/core` as the "range". The source classifier
then read `popperjs/core` as bare `owner/repo` GitHub shorthand and the
resolve fell through to `git ls-remote https://github.com/popperjs/core.git`
instead of the npm registry.

Fresh resolve only: with a pnpm-generated lockfile already present the
lockfile reader handled it fine.

## Fix

Delegate the name/range split to `aube_util::pkg::split_name_spec` (which
already handles the scope sigil correctly and is unit-tested in
`aube-util`) and default a missing range to `latest`, matching pnpm and
mirroring the adjacent `jsr:` branch. The user-facing alias stays on
`task.name`; only registry IO uses the real name.

## Validation

- `cargo test -p aube-resolver -p aube-util`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `hk check --all --slow`
- `test/catalogs.bats` (offline Verdaccio)
- manual repro from the discussion now resolves `popper2 -> @popperjs/core@2.11.8`

Addresses https://github.com/jdx/aube/discussions/1043

Note: #1044 fixes the same bug with the same diagnosis via an inline
separator scan. This PR is an alternative that reuses the existing
`split_name_spec` helper instead of adding a third hand-rolled scope
parser, and adopts #1044's hermetic resolver-level test. Happy to defer to
whichever you prefer.

*This PR was generated by Claude.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of scoped npm aliases, such as `@popperjs/core`.
  * Versionless npm aliases now correctly default to the `latest` version.
  * Catalog dependencies preserve their declared package names and alias mappings during resolution.
  * Fixed installation and lockfile recording for aliased npm packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->