### PR TITLE
feat(packaging): add C ABI embedding distribution

### DIFF
--- a/.github/workflows/ffi.yml
+++ b/.github/workflows/ffi.yml
@@ -4,13 +4,29 @@ on:
   pull_request:
     paths:
       - "crates/aube-ffi/**"
+      - "crates/aube-codes/**"
+      - "crates/aube/src/lib.rs"
       - "crates/aube/src/embed.rs"
+      - "crates/aube/src/commands/add/mod.rs"
+      - "crates/aube/src/commands/install/control.rs"
+      - "crates/aube/src/commands/install/dep_selection.rs"
+      - "crates/aube/src/commands/install/frozen.rs"
+      - "crates/aube-util/src/identity.rs"
+      - "crates/aube-util/src/lib.rs"
       - ".github/workflows/ffi.yml"
   push:
     branches: [main]
     paths:
       - "crates/aube-ffi/**"
+      - "crates/aube-codes/**"
+      - "crates/aube/src/lib.rs"
       - "crates/aube/src/embed.rs"
+      - "crates/aube/src/commands/add/mod.rs"
+      - "crates/aube/src/commands/install/control.rs"
+      - "crates/aube/src/commands/install/dep_selection.rs"
+      - "crates/aube/src/commands/install/frozen.rs"
+      - "crates/aube-util/src/identity.rs"
+      - "crates/aube-util/src/lib.rs"
       - ".github/workflows/ffi.yml"
   release:
     types: [published]

--- a/.github/workflows/ffi.yml
+++ b/.github/workflows/ffi.yml
@@ -2,9 +2,16 @@ name: ffi
 
 on:
   pull_request:
-    paths: ["crates/aube-ffi/**", "crates/aube/**", "crates/aube-*/**", "Cargo.toml", "Cargo.lock", ".github/workflows/ffi.yml"]
+    paths:
+      - "crates/aube-ffi/**"
+      - "crates/aube/src/embed.rs"
+      - ".github/workflows/ffi.yml"
   push:
     branches: [main]
+    paths:
+      - "crates/aube-ffi/**"
+      - "crates/aube/src/embed.rs"
+      - ".github/workflows/ffi.yml"
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/ffi.yml
+++ b/.github/workflows/ffi.yml
@@ -1,0 +1,193 @@
+name: ffi
+
+on:
+  pull_request:
+    paths: ["crates/aube-ffi/**", "crates/aube/**", "crates/aube-*/**", "Cargo.toml", "Cargo.lock", ".github/workflows/ffi.yml"]
+  push:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+concurrency:
+  group: ffi-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'release' }}
+
+permissions: {}
+
+jobs:
+  build:
+    name: ${{ matrix.package }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { runner: macos-15, target: aarch64-apple-darwin, os: darwin, cpu: arm64, package: darwin-arm64, binary: libaube_ffi.dylib, ext: dylib }
+          - { runner: macos-15-intel, target: x86_64-apple-darwin, os: darwin, cpu: x64, package: darwin-x64, binary: libaube_ffi.dylib, ext: dylib }
+          - { runner: ubuntu-24.04-arm, target: aarch64-unknown-linux-gnu, os: linux, cpu: arm64, package: linux-arm64, binary: libaube_ffi.so, ext: so }
+          - { runner: ubuntu-latest, target: x86_64-unknown-linux-gnu, os: linux, cpu: x64, package: linux-x64, binary: libaube_ffi.so, ext: so }
+          - { runner: ubuntu-24.04-arm, target: aarch64-unknown-linux-musl, os: linux, cpu: arm64, libc: musl, package: linux-arm64-musl, binary: libaube_ffi.so, ext: so }
+          - { runner: ubuntu-latest, target: x86_64-unknown-linux-musl, os: linux, cpu: x64, libc: musl, package: linux-x64-musl, binary: libaube_ffi.so, ext: so }
+          - { runner: windows-latest, target: aarch64-pc-windows-msvc, os: win32, cpu: arm64, package: win32-arm64, binary: aube_ffi.dll, ext: dll }
+          - { runner: windows-latest, target: x86_64-pc-windows-msvc, os: win32, cpu: x64, package: win32-x64, binary: aube_ffi.dll, ext: dll }
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    permissions: { contents: read }
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with: { persist-credentials: false }
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with: { node-version: "24", package-manager-cache: false }
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 # zizmor: ignore[cache-poisoning] PRs are read-only
+        with:
+          shared-key: ffi-${{ matrix.target }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Install Rust target
+        shell: bash
+        run: rustup target add '${{ matrix.target }}'
+      - name: Install musl compiler
+        if: matrix.libc == 'musl'
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+      - name: Build C ABI library
+        shell: bash
+        run: |
+          if [[ '${{ matrix.libc }}' == musl ]]; then
+            export RUSTFLAGS='-C target-feature=-crt-static'
+          fi
+          cargo build --locked --profile ffi -p aube-ffi --target '${{ matrix.target }}'
+      - name: Import macOS signing certificate
+        if: github.event_name == 'release' && matrix.os == 'darwin'
+        uses: apple-actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7.0.0
+        with:
+          p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
+          p12-password: ${{ secrets.CERTIFICATES_P12_PASS }}
+      - name: Sign macOS library
+        if: github.event_name == 'release' && matrix.os == 'darwin'
+        shell: bash
+        run: |
+          codesign --force --sign 'Developer ID Application: Jeffrey Dickey (4993Y37DX6)' \
+            --options runtime --timestamp \
+            'target/${{ matrix.target }}/ffi/${{ matrix.binary }}'
+      - name: Set package version
+        id: version
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [[ "$EVENT_NAME" == release ]]; then version=${RELEASE_TAG#v}; else version="0.0.0-smoke.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"; fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Stage library and platform package
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          OUT_DIR: ${{ runner.temp }}/ffi
+          AUBE_FFI_BINARY: target/${{ matrix.target }}/ffi/${{ matrix.binary }}
+          AUBE_FFI_OS: ${{ matrix.os }}
+          AUBE_FFI_CPU: ${{ matrix.cpu }}
+          AUBE_FFI_LIBC: ${{ matrix.libc }}
+          AUBE_FFI_TARGET: ${{ matrix.target }}
+        run: |
+          mkdir -p "$OUT_DIR"
+          cp "$AUBE_FFI_BINARY" "$OUT_DIR/libaube-${AUBE_FFI_TARGET}.${{ matrix.ext }}"
+          node crates/aube-ffi/npm/package.mjs
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: aube-ffi-${{ matrix.package }}
+          path: ${{ runner.temp }}/ffi/*
+          if-no-files-found: error
+
+  packages:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions: { contents: read, id-token: write, attestations: write }
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with: { persist-credentials: false }
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with: { node-version: "24", package-manager-cache: false }
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          tool_versions: |
+            bun 1.3.11
+            deno 2.9.2
+          install_args: bun deno
+          cache: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with: { pattern: aube-ffi-*, path: packages, merge-multiple: true }
+      - name: Pack root npm package
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [[ "$EVENT_NAME" == release ]]; then VERSION=${RELEASE_TAG#v}; else VERSION="0.0.0-smoke.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"; fi
+          VERSION="$VERSION" OUT_DIR="$PWD/packages" node crates/aube-ffi/npm/package.mjs
+          cp crates/aube-ffi/include/aube.h packages/aube.h
+          test "$(find packages -maxdepth 1 -name '*.tgz' -print | wc -l)" -eq 9
+      - name: Smoke-test raw library with Bun and Deno
+        shell: bash
+        env:
+          AUBE_FFI_LIBRARY: ${{ github.workspace }}/packages/libaube-x86_64-unknown-linux-gnu.so
+        run: |
+          bun run crates/aube-ffi/poc/bun.ts
+          deno run --allow-env=AUBE_FFI_LIBRARY --allow-ffi --allow-read --allow-write crates/aube-ffi/poc/deno.ts
+      - name: Smoke-test npm packages and declarations
+        shell: bash
+        run: | # zizmor: ignore[adhoc-packages] installs only tarballs built by required matrix jobs
+          mkdir npm-smoke
+          cd npm-smoke
+          npm init --yes >/dev/null
+          npm install --force --ignore-scripts --no-package-lock ../packages/*.tgz
+          node -e "const ffi=require('@jdxcode/aube-ffi'); require('fs').accessSync(ffi.libraryPath); require('fs').accessSync(ffi.headerPath)"
+          cp "$GITHUB_WORKSPACE/crates/aube-ffi/npm/typecheck.ts" .
+          npx --yes --package=typescript@5.9.3 tsc --strict --noEmit \
+            --lib ES2022,DOM --module NodeNext --moduleResolution NodeNext typecheck.ts
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: aube-ffi-distribution
+          path: |
+            packages/*.tgz
+            packages/libaube-*
+            packages/aube.h
+          if-no-files-found: error
+      - uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        if: github.event_name == 'release'
+        with:
+          subject-path: |
+            packages/*.tgz
+            packages/libaube-*
+            packages/aube.h
+      - name: Publish platform and root packages
+        if: github.event_name == 'release'
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          version=${RELEASE_TAG#v}; tag=latest; [[ "$version" == *-* ]] && tag=next
+          publish_package() {
+            local package=$1 name
+            name=$(tar -xOf "$package" package/package.json | jq -r .name)
+            if npm view "${name}@${version}" version >/dev/null 2>&1; then
+              echo "${name}@${version} is already published"
+              return
+            fi
+            npm publish "$package" --access public --provenance --tag "$tag"
+          }
+          for package in packages/*-darwin-*.tgz packages/*-linux-*.tgz packages/*-win32-*.tgz; do publish_package "$package"; done
+          publish_package "packages/jdxcode-aube-ffi-${version}.tgz"
+
+  release-assets:
+    if: github.event_name == 'release'
+    needs: packages
+    runs-on: ubuntu-latest
+    permissions: { contents: write }
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with: { name: aube-ffi-distribution, path: packages }
+      - name: Attach C ABI assets to release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: gh release upload "$RELEASE_TAG" packages/libaube-* packages/aube.h --clobber

--- a/.github/workflows/node-addon.yml
+++ b/.github/workflows/node-addon.yml
@@ -2,9 +2,16 @@ name: node-addon
 
 on:
   pull_request:
-    paths: ["crates/aube-node/**", "crates/aube/**", "crates/aube-*/**", "Cargo.toml", "Cargo.lock", ".github/workflows/node-addon.yml"]
+    paths:
+      - "crates/aube-node/**"
+      - "crates/aube/src/embed.rs"
+      - ".github/workflows/node-addon.yml"
   push:
     branches: [main]
+    paths:
+      - "crates/aube-node/**"
+      - "crates/aube/src/embed.rs"
+      - ".github/workflows/node-addon.yml"
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/node-addon.yml
+++ b/.github/workflows/node-addon.yml
@@ -4,13 +4,33 @@ on:
   pull_request:
     paths:
       - "crates/aube-node/**"
+      - "crates/aube-codes/**"
+      - "crates/aube-registry/src/config/**"
+      - "crates/aube-registry/src/lib.rs"
+      - "crates/aube/src/lib.rs"
       - "crates/aube/src/embed.rs"
+      - "crates/aube/src/commands/add/mod.rs"
+      - "crates/aube/src/commands/install/control.rs"
+      - "crates/aube/src/commands/install/dep_selection.rs"
+      - "crates/aube/src/commands/install/frozen.rs"
+      - "crates/aube-util/src/identity.rs"
+      - "crates/aube-util/src/lib.rs"
       - ".github/workflows/node-addon.yml"
   push:
     branches: [main]
     paths:
       - "crates/aube-node/**"
+      - "crates/aube-codes/**"
+      - "crates/aube-registry/src/config/**"
+      - "crates/aube-registry/src/lib.rs"
+      - "crates/aube/src/lib.rs"
       - "crates/aube/src/embed.rs"
+      - "crates/aube/src/commands/add/mod.rs"
+      - "crates/aube/src/commands/install/control.rs"
+      - "crates/aube/src/commands/install/dep_selection.rs"
+      - "crates/aube/src/commands/install/frozen.rs"
+      - "crates/aube-util/src/identity.rs"
+      - "crates/aube-util/src/lib.rs"
       - ".github/workflows/node-addon.yml"
   release:
     types: [published]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,6 +317,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "aube-ffi"
+version = "1.27.0"
+dependencies = [
+ "aube",
+ "aube-codes",
+ "miette",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "aube-linker"
 version = "1.27.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,13 @@ codegen-units = 1
 inherits = "release"
 panic = "unwind"
 
+# C ABI calls execute inside the host process and catch every panic at the
+# extern boundary. The workspace release profile's panic=abort would bypass
+# those guards and terminate the host.
+[profile.ffi]
+inherits = "release"
+panic = "unwind"
+
 [workspace.package]
 version = "1.27.0"
 edition = "2024"

--- a/crates/aube-codes/src/errors.rs
+++ b/crates/aube-codes/src/errors.rs
@@ -109,6 +109,10 @@ pub const ERR_AUBE_PATCHES_TRACKING_WRITE: &str = "ERR_AUBE_PATCHES_TRACKING_WRI
 pub const ERR_AUBE_UNSAFE_SHEBANG_INTERPRETER: &str = "ERR_AUBE_UNSAFE_SHEBANG_INTERPRETER";
 pub const ERR_AUBE_EMBED_INVALID_PROJECT: &str = "ERR_AUBE_EMBED_INVALID_PROJECT";
 pub const ERR_AUBE_EMBED_INSTALL_FAILED: &str = "ERR_AUBE_EMBED_INSTALL_FAILED";
+pub const ERR_AUBE_FFI_INVALID_ARGUMENT: &str = "ERR_AUBE_FFI_INVALID_ARGUMENT";
+pub const ERR_AUBE_FFI_UNKNOWN_HANDLE: &str = "ERR_AUBE_FFI_UNKNOWN_HANDLE";
+pub const ERR_AUBE_FFI_RUNTIME: &str = "ERR_AUBE_FFI_RUNTIME";
+pub const ERR_AUBE_FFI_PANIC: &str = "ERR_AUBE_FFI_PANIC";
 
 /// Stable category labels that group codes in the generated docs and
 /// in `EXIT_TABLE`'s 10-wide allocation ranges. Public so the docs
@@ -573,6 +577,30 @@ pub const ALL: &[CodeMeta] = &[
         name: ERR_AUBE_EMBED_INSTALL_FAILED,
         category: category::MISC_SAFETY,
         description: "An in-process embedder could not initialize its host callback or received an install failure without a more specific stable code.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: ERR_AUBE_FFI_INVALID_ARGUMENT,
+        category: category::MISC_SAFETY,
+        description: "A C ABI call received a null pointer, invalid UTF-8, malformed JSON, or an unsupported option value.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: ERR_AUBE_FFI_UNKNOWN_HANDLE,
+        category: category::MISC_SAFETY,
+        description: "A C ABI wait or cancellation call referenced an unknown or already-consumed operation handle.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: ERR_AUBE_FFI_RUNTIME,
+        category: category::MISC_SAFETY,
+        description: "The C ABI could not initialize or use its internal asynchronous runtime.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: ERR_AUBE_FFI_PANIC,
+        category: category::MISC_SAFETY,
+        description: "A panic was caught at the C ABI boundary before it could cross into the host process.",
         exit_code: None,
     },
     CodeMeta {

--- a/crates/aube-ffi/Cargo.toml
+++ b/crates/aube-ffi/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "aube-ffi"
+description = "C ABI bindings for embedding aube"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+aube = { workspace = true }
+aube-codes = { workspace = true }
+miette = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/aube-ffi/README.md
+++ b/crates/aube-ffi/README.md
@@ -1,0 +1,25 @@
+# aube C ABI
+
+`@jdxcode/aube-ffi` distributes aube's C ABI for Bun FFI, Deno FFI,
+Node.js FFI loaders, Python `ctypes`, and native applications. The root npm
+package selects one of eight platform packages and exports `libraryPath`,
+`headerPath`, and `target`.
+
+```sh
+npm install @jdxcode/aube-ffi
+```
+
+The same libraries and `aube.h` are attached to GitHub releases for hosts that
+do not consume npm packages.
+
+The ABI uses asynchronous operation handles. `aube_install` and `aube_add`
+return immediately; `aube_cancel` requests cooperative cancellation and
+`aube_wait` blocks until the result is available. Event callbacks run on
+aube-managed threads and must be thread-safe. Strings returned by the library
+must be released with `aube_string_free`.
+A callback-driven host should call `aube_wait` after its terminal event to
+release the completed operation handle without blocking.
+
+See the [C ABI embedding guide](https://aube.jdx.dev/embedding/ffi) for schemas,
+ownership rules, and examples. For support, use
+[GitHub Discussions](https://github.com/jdx/aube/discussions).

--- a/crates/aube-ffi/include/aube.h
+++ b/crates/aube-ffi/include/aube.h
@@ -1,0 +1,57 @@
+#ifndef AUBE_H
+#define AUBE_H
+
+#include <stdint.h>
+
+#if defined(_WIN32)
+#define AUBE_API __declspec(dllimport)
+#else
+#define AUBE_API
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Called from aube-managed threads. The callback and ctx must remain valid and
+ * thread-safe until aube_wait returns for the operation. event_json is borrowed
+ * and valid only for the duration of the callback. */
+typedef void (*aube_event_cb)(const char *event_json, void *ctx);
+
+/* host_json: {"name":"host","version":"1.0.0","defaults":{...}}
+ * Returns 0 on success, -1 for invalid input, and -2 when a panic is caught. */
+AUBE_API int32_t aube_init(const char *host_json);
+
+/* options_json must contain projectDir. Returns immediately with an operation
+ * handle. Inputs are copied before return. A zero handle indicates a caught
+ * boundary failure. */
+AUBE_API uint64_t aube_install(
+    const char *options_json,
+    aube_event_cb callback,
+    void *ctx);
+
+/* packages_json is a JSON array of package specifier strings. */
+AUBE_API uint64_t aube_add(
+    const char *project_dir,
+    const char *packages_json,
+    const char *options_json,
+    aube_event_cb callback,
+    void *ctx);
+
+/* Blocks until completion and consumes the handle. Returns owned UTF-8 JSON:
+ * {"ok":true} or {"ok":false,"code":"ERR_AUBE_*","message":"..."}.
+ * Free the returned string with aube_string_free. */
+AUBE_API char *aube_wait(uint64_t handle);
+
+/* Returns 0 when cancellation was requested, -1 for an unknown handle, and -2
+ * when a panic is caught. */
+AUBE_API int32_t aube_cancel(uint64_t handle);
+
+/* Frees any string returned by this library. Null is accepted. */
+AUBE_API void aube_string_free(char *value);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/crates/aube-ffi/include/aube.h
+++ b/crates/aube-ffi/include/aube.h
@@ -21,7 +21,9 @@ extern "C" {
 typedef void (*aube_event_cb)(const char *event_json, void *ctx);
 
 /* host_json: {"name":"host","version":"1.0.0","defaults":{...}}
- * Returns 0 on success, -1 for invalid input, and -2 when a panic is caught. */
+ * Call before starting operations. The first operation seals standalone host
+ * defaults when init has not run. Returns 0 on success, -1 for invalid input,
+ * and -2 when a panic is caught. */
 AUBE_API int32_t aube_init(const char *host_json);
 
 /* options_json must contain projectDir. Returns immediately with an operation

--- a/crates/aube-ffi/include/aube.h
+++ b/crates/aube-ffi/include/aube.h
@@ -15,7 +15,9 @@ extern "C" {
 
 /* Called from aube-managed threads. The callback and ctx must remain valid and
  * thread-safe until aube_wait returns for the operation. event_json is borrowed
- * and valid only for the duration of the callback. */
+ * and valid only for the duration of the callback. The callback must return
+ * normally: it must not throw, panic, or unwind across this C boundary, and it
+ * must not call aube_wait for its active operation. */
 typedef void (*aube_event_cb)(const char *event_json, void *ctx);
 
 /* host_json: {"name":"host","version":"1.0.0","defaults":{...}}
@@ -23,14 +25,15 @@ typedef void (*aube_event_cb)(const char *event_json, void *ctx);
 AUBE_API int32_t aube_init(const char *host_json);
 
 /* options_json must contain projectDir. Returns immediately with an operation
- * handle. Inputs are copied before return. A zero handle indicates a caught
- * boundary failure. */
+ * handle. Inputs are copied before return. Boundary failures are represented
+ * by a completed handle; call aube_wait to retrieve the structured error. */
 AUBE_API uint64_t aube_install(
     const char *options_json,
     aube_event_cb callback,
     void *ctx);
 
-/* packages_json is a JSON array of package specifier strings. */
+/* packages_json is a JSON array of package specifier strings. Returns a
+ * completed handle containing a structured error for boundary failures. */
 AUBE_API uint64_t aube_add(
     const char *project_dir,
     const char *packages_json,

--- a/crates/aube-ffi/include/aube.h
+++ b/crates/aube-ffi/include/aube.h
@@ -40,7 +40,9 @@ AUBE_API uint64_t aube_add(
 
 /* Blocks until completion and consumes the handle. Returns owned UTF-8 JSON:
  * {"ok":true} or {"ok":false,"code":"ERR_AUBE_*","message":"..."}.
- * Free the returned string with aube_string_free. */
+ * Returns NULL only if an internal result cannot be represented as a C string;
+ * treat that as ERR_AUBE_FFI_RUNTIME. Free a non-null result with
+ * aube_string_free. */
 AUBE_API char *aube_wait(uint64_t handle);
 
 /* Returns 0 when cancellation was requested, -1 for an unknown handle, and -2

--- a/crates/aube-ffi/npm/index.d.ts
+++ b/crates/aube-ffi/npm/index.d.ts
@@ -1,0 +1,20 @@
+export type InstallEvent =
+  | { kind: "phase"; phase: "resolving" | "fetching" | "linking" | "complete" }
+  | {
+      kind: "progress"
+      resolved: number
+      total: number
+      reused: number
+      downloaded: number
+      downloadedBytes: number
+      estimatedBytes?: number
+    }
+  | { kind: "output"; level: "info" | "warning" | "error"; code?: string; message: string }
+
+export type AubeResult =
+  | { ok: true }
+  | { ok: false; code: `ERR_AUBE_${string}`; message: string }
+
+export const libraryPath: string
+export const headerPath: string
+export const target: string

--- a/crates/aube-ffi/npm/index.js
+++ b/crates/aube-ffi/npm/index.js
@@ -1,0 +1,34 @@
+const fs = require("node:fs")
+const path = require("node:path")
+const childProcess = require("node:child_process")
+
+function isMusl() {
+  if (fs.existsSync("/etc/alpine-release")) return true
+  try {
+    if (process.report.getReport().header.glibcVersionRuntime) return false
+  } catch (_) {}
+  try {
+    return childProcess.execFileSync("ldd", ["--version"], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] })
+      .toLowerCase().includes("musl")
+  } catch (error) {
+    return `${error.stdout || ""}\n${error.stderr || ""}`.toLowerCase().includes("musl")
+  }
+}
+
+function platformPackage() {
+  const key = `${process.platform}-${process.arch}`
+  if (key === "darwin-arm64") return "@jdxcode/aube-ffi-darwin-arm64"
+  if (key === "darwin-x64") return "@jdxcode/aube-ffi-darwin-x64"
+  if (key === "win32-arm64") return "@jdxcode/aube-ffi-win32-arm64"
+  if (key === "win32-x64") return "@jdxcode/aube-ffi-win32-x64"
+  if (key === "linux-arm64" && isMusl()) return "@jdxcode/aube-ffi-linux-arm64-musl"
+  if (key === "linux-arm64") return "@jdxcode/aube-ffi-linux-arm64"
+  if (key === "linux-x64" && isMusl()) return "@jdxcode/aube-ffi-linux-x64-musl"
+  if (key === "linux-x64") return "@jdxcode/aube-ffi-linux-x64"
+  throw new Error(`Unsupported aube FFI platform: ${key}`)
+}
+
+const platform = require(platformPackage())
+exports.libraryPath = platform.libraryPath
+exports.headerPath = path.join(__dirname, "aube.h")
+exports.target = platform.target

--- a/crates/aube-ffi/npm/package.json
+++ b/crates/aube-ffi/npm/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@jdxcode/aube-ffi",
+  "version": "0.0.0-placeholder",
+  "description": "C ABI bindings for embedding the aube package manager",
+  "license": "MIT",
+  "repository": "https://github.com/jdx/aube",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": { "types": "./index.d.ts", "default": "./index.js" },
+    "./aube.h": "./aube.h"
+  },
+  "files": ["index.js", "index.d.ts", "aube.h", "README.md"],
+  "preferUnplugged": true,
+  "engines": { "node": ">=18" }
+}

--- a/crates/aube-ffi/npm/package.mjs
+++ b/crates/aube-ffi/npm/package.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+import { cpSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { spawnSync } from "node:child_process"
+
+const here = dirname(fileURLToPath(import.meta.url))
+const version = process.env.VERSION
+const out = resolve(process.env.OUT_DIR || resolve(here, "dist"))
+const targets = [
+  ["darwin", "arm64"], ["darwin", "x64"],
+  ["linux", "arm64"], ["linux", "x64"],
+  ["linux", "arm64", "musl"], ["linux", "x64", "musl"],
+  ["win32", "arm64"], ["win32", "x64"],
+]
+if (!version || !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) throw new Error("VERSION must be SemVer")
+mkdirSync(out, { recursive: true })
+
+function name(os, cpu, libc) {
+  return `@jdxcode/aube-ffi-${os}-${cpu}${libc ? `-${libc}` : ""}`
+}
+function libraryName(os) {
+  if (os === "darwin") return "libaube.dylib"
+  if (os === "win32") return "aube.dll"
+  return "libaube.so"
+}
+function pack(dir) {
+  const args = ["pack", "--pack-destination", out]
+  const npm = process.platform === "win32"
+    ? resolve(dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js")
+    : "npm"
+  if (process.platform === "win32") args.unshift(npm)
+  const result = spawnSync(process.platform === "win32" ? process.execPath : npm, args, {
+    cwd: dir,
+    stdio: "inherit",
+  })
+  if (result.status !== 0) throw new Error(`npm pack failed: ${result.error?.message ?? result.status}`)
+}
+
+if (process.env.AUBE_FFI_BINARY) {
+  const os = process.env.AUBE_FFI_OS
+  const cpu = process.env.AUBE_FFI_CPU
+  const libc = process.env.AUBE_FFI_LIBC || undefined
+  const target = process.env.AUBE_FFI_TARGET
+  if (!targets.some((item) => item[0] === os && item[1] === cpu && item[2] === libc)) throw new Error("invalid target")
+  if (!target) throw new Error("AUBE_FFI_TARGET is required")
+  const stage = resolve(out, "stage-platform")
+  const library = libraryName(os)
+  rmSync(stage, { recursive: true, force: true })
+  mkdirSync(stage, { recursive: true })
+  cpSync(process.env.AUBE_FFI_BINARY, resolve(stage, library))
+  cpSync(resolve(here, "../README.md"), resolve(stage, "README.md"))
+  writeFileSync(resolve(stage, "index.js"), [
+    'const path = require("node:path")',
+    `exports.libraryPath = path.join(__dirname, ${JSON.stringify(library)})`,
+    `exports.target = ${JSON.stringify(target)}`,
+    "",
+  ].join("\n"))
+  writeFileSync(resolve(stage, "package.json"), JSON.stringify({
+    name: name(os, cpu, libc), version,
+    description: "Platform library for @jdxcode/aube-ffi; install the root package instead",
+    license: "MIT", repository: "https://github.com/jdx/aube", main: "index.js",
+    files: ["index.js", library, "README.md"], preferUnplugged: true,
+    os: [os], cpu: [cpu], ...(libc ? { libc: [libc] } : {}),
+  }, null, 2) + "\n")
+  pack(stage)
+} else {
+  const stage = resolve(out, "stage-root")
+  rmSync(stage, { recursive: true, force: true })
+  mkdirSync(stage, { recursive: true })
+  cpSync(resolve(here, "index.js"), resolve(stage, "index.js"))
+  cpSync(resolve(here, "index.d.ts"), resolve(stage, "index.d.ts"))
+  cpSync(resolve(here, "../include/aube.h"), resolve(stage, "aube.h"))
+  cpSync(resolve(here, "../README.md"), resolve(stage, "README.md"))
+  const manifest = JSON.parse(readFileSync(resolve(here, "package.json"), "utf8"))
+  manifest.version = version
+  manifest.optionalDependencies = Object.fromEntries(targets.map((target) => [name(...target), version]))
+  writeFileSync(resolve(stage, "package.json"), JSON.stringify(manifest, null, 2) + "\n")
+  pack(stage)
+}

--- a/crates/aube-ffi/npm/typecheck.ts
+++ b/crates/aube-ffi/npm/typecheck.ts
@@ -1,0 +1,26 @@
+import {
+  headerPath,
+  libraryPath,
+  target,
+  type AubeResult,
+  type InstallEvent,
+} from "@jdxcode/aube-ffi"
+
+function handleEvent(event: InstallEvent) {
+  switch (event.kind) {
+    case "phase":
+      return event.phase
+    case "progress":
+      return event.resolved + event.downloadedBytes
+    case "output":
+      return `${event.level}:${event.message}`
+    default: {
+      const exhaustive: never = event
+      return exhaustive
+    }
+  }
+}
+
+const paths: string[] = [libraryPath, headerPath, target]
+const result: AubeResult = { ok: true }
+void [paths, result, handleEvent]

--- a/crates/aube-ffi/poc/bun.ts
+++ b/crates/aube-ffi/poc/bun.ts
@@ -1,0 +1,138 @@
+import { CString, dlopen, ptr } from "bun:ffi"
+import { createHash } from "node:crypto"
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+
+const libraryPath = process.env.AUBE_FFI_LIBRARY
+if (!libraryPath) throw new Error("AUBE_FFI_LIBRARY is required")
+
+const library = dlopen(libraryPath, {
+  aube_init: { args: ["ptr"], returns: "i32" },
+  aube_install: { args: ["ptr", "ptr", "ptr"], returns: "u64" },
+  aube_add: { args: ["ptr", "ptr", "ptr", "ptr", "ptr"], returns: "u64" },
+  aube_wait: { args: ["u64"], returns: "ptr" },
+  aube_cancel: { args: ["u64"], returns: "i32" },
+  aube_string_free: { args: ["ptr"], returns: "void" },
+})
+
+function cstring(value: string) {
+  return Buffer.from(`${value}\0`, "utf8")
+}
+
+function wait(handle: bigint) {
+  const resultPointer = library.symbols.aube_wait(handle)
+  if (!resultPointer) throw new Error("aube_wait returned null")
+  const result = JSON.parse(new CString(resultPointer).toString()) as {
+    ok: boolean
+    code?: string
+    message?: string
+  }
+  library.symbols.aube_string_free(resultPointer)
+  return result
+}
+
+const host = cstring(JSON.stringify({ name: "aube-ffi-bun", version: "1.0.0" }))
+if (library.symbols.aube_init(ptr(host)) !== 0) throw new Error("aube_init failed")
+
+const project = await mkdtemp(path.join(tmpdir(), "aube-ffi-bun-"))
+const seedProject = await mkdtemp(path.join(tmpdir(), "aube-ffi-bun-seed-"))
+const offlineProject = await mkdtemp(path.join(tmpdir(), "aube-ffi-bun-offline-"))
+const registryDir = await mkdtemp(path.join(tmpdir(), "aube-ffi-bun-registry-"))
+const cacheDir = await mkdtemp(path.join(tmpdir(), "aube-ffi-bun-cache-"))
+let registry: ReturnType<typeof Bun.spawn> | undefined
+try {
+  const dependency = path.join(project, "local-dependency")
+  await mkdir(dependency)
+  await Promise.all([
+    writeFile(path.join(dependency, "package.json"), JSON.stringify({ name: "local-dependency", version: "1.0.0" })),
+    writeFile(path.join(project, "package.json"), JSON.stringify({ dependencies: { "local-dependency": "file:./local-dependency" } })),
+  ])
+
+  const installOptions = cstring(JSON.stringify({ projectDir: project, offline: true, ignoreScripts: true }))
+  const installResult = wait(library.symbols.aube_install(ptr(installOptions), 0, 0))
+  if (!installResult.ok) throw new Error(`offline install failed: ${JSON.stringify(installResult)}`)
+  await access(path.join(project, "node_modules", "local-dependency"))
+
+  const malformed = cstring("{")
+  const malformedResult = wait(library.symbols.aube_install(ptr(malformed), 0, 0))
+  if (malformedResult.code !== "ERR_AUBE_FFI_INVALID_ARGUMENT") {
+    throw new Error(`missing structured FFI code: ${JSON.stringify(malformedResult)}`)
+  }
+
+  const packageDir = path.join(registryDir, "package")
+  await mkdir(packageDir)
+  await writeFile(
+    path.join(packageDir, "package.json"),
+    JSON.stringify({ name: "aube-ffi-cached-package", version: "1.0.0" }),
+  )
+  const packed = Bun.spawnSync(
+    ["npm", "pack", "--pack-destination", registryDir],
+    { cwd: packageDir, stdout: "pipe", stderr: "pipe" },
+  )
+  if (packed.exitCode !== 0) throw new Error(packed.stderr.toString())
+  const tarballName = packed.stdout.toString().trim().split("\n").at(-1)
+  if (!tarballName) throw new Error("npm pack did not return a tarball name")
+  const tarballPath = path.join(registryDir, tarballName)
+  const tarball = await readFile(tarballPath)
+  const integrity = `sha512-${createHash("sha512").update(tarball).digest("base64")}`
+  registry = Bun.spawn(["node", path.join(import.meta.dir, "registry.mjs")], {
+    env: {
+      ...process.env,
+      AUBE_FFI_TARBALL: tarballPath,
+      AUBE_FFI_INTEGRITY: integrity,
+    },
+    stdout: "pipe",
+    stderr: "inherit",
+  })
+  const reader = registry.stdout.getReader()
+  const portChunk = await reader.read()
+  const port = new TextDecoder().decode(portChunk.value).trim()
+  if (!port) throw new Error("registry fixture did not report a port")
+  const npmrc = `registry=http://127.0.0.1:${port}/\ncache-dir=${cacheDir}\nminimum-release-age=0\n`
+  await Promise.all([
+    writeFile(path.join(seedProject, "package.json"), "{}\n"),
+    writeFile(path.join(seedProject, ".npmrc"), npmrc),
+    writeFile(path.join(offlineProject, "package.json"), "{}\n"),
+    writeFile(path.join(offlineProject, ".npmrc"), npmrc),
+  ])
+  const packageList = cstring(JSON.stringify(["aube-ffi-cached-package@1.0.0"]))
+  const exactAdd = cstring(JSON.stringify({ saveExact: true }))
+  const seedProjectString = cstring(seedProject)
+  const seedResult = wait(
+    library.symbols.aube_add(ptr(seedProjectString), ptr(packageList), ptr(exactAdd), 0, 0),
+  )
+  if (!seedResult.ok) throw new Error(`cache seed failed: ${JSON.stringify(seedResult)}`)
+  registry.kill()
+  await registry.exited
+  registry = undefined
+
+  const offlineProjectString = cstring(offlineProject)
+  const offlineAdd = cstring(JSON.stringify({ saveExact: true, offline: true }))
+  const cachedResult = wait(
+    library.symbols.aube_add(ptr(offlineProjectString), ptr(packageList), ptr(offlineAdd), 0, 0),
+  )
+  if (!cachedResult.ok) throw new Error(`cached offline add failed: ${JSON.stringify(cachedResult)}`)
+  await access(path.join(offlineProject, "node_modules", "aube-ffi-cached-package"))
+
+  await writeFile(path.join(project, ".npmrc"), "registry=http://10.255.255.1/\nfetch-timeout=60000\n")
+  const projectString = cstring(project)
+  const packages = cstring(JSON.stringify(["aube-ffi-bun-cancel-test"]))
+  const addOptions = cstring("{}")
+  const handle = library.symbols.aube_add(ptr(projectString), ptr(packages), ptr(addOptions), 0, 0)
+  if (library.symbols.aube_cancel(handle) !== 0) throw new Error("aube_cancel failed")
+  const cancelled = wait(handle)
+  if (cancelled.code !== "ERR_AUBE_INSTALL_CANCELLED") {
+    throw new Error(`unexpected cancellation result: ${JSON.stringify(cancelled)}`)
+  }
+
+  console.log("Bun FFI smoke passed")
+} finally {
+  registry?.kill()
+  library.close()
+  await Promise.all(
+    [project, seedProject, offlineProject, registryDir, cacheDir].map((directory) =>
+      rm(directory, { recursive: true, force: true }),
+    ),
+  )
+}

--- a/crates/aube-ffi/poc/deno.ts
+++ b/crates/aube-ffi/poc/deno.ts
@@ -1,0 +1,77 @@
+const libraryPath = Deno.env.get("AUBE_FFI_LIBRARY")
+if (!libraryPath) throw new Error("AUBE_FFI_LIBRARY is required")
+
+const library = Deno.dlopen(libraryPath, {
+  aube_init: { parameters: ["buffer"], result: "i32" },
+  aube_install: { parameters: ["buffer", "function", "pointer"], result: "u64" },
+  aube_add: { parameters: ["buffer", "buffer", "buffer", "function", "pointer"], result: "u64" },
+  aube_wait: { parameters: ["u64"], result: "pointer", nonblocking: true },
+  aube_cancel: { parameters: ["u64"], result: "i32" },
+  aube_string_free: { parameters: ["pointer"], result: "void" },
+} as const)
+
+const encoder = new TextEncoder()
+function cstring(value: string) {
+  return encoder.encode(`${value}\0`)
+}
+
+async function wait(handle: bigint) {
+  const resultPointer = await library.symbols.aube_wait(handle)
+  if (!resultPointer) throw new Error("aube_wait returned null")
+  const result = JSON.parse(new Deno.UnsafePointerView(resultPointer).getCString()) as {
+    ok: boolean
+    code?: string
+    message?: string
+  }
+  library.symbols.aube_string_free(resultPointer)
+  return result
+}
+
+const host = cstring(JSON.stringify({ name: "aube-ffi-deno", version: "1.0.0" }))
+if (library.symbols.aube_init(host) !== 0) throw new Error("aube_init failed")
+
+const project = await Deno.makeTempDir({ prefix: "aube-ffi-deno-" })
+const events: unknown[] = []
+const callback = Deno.UnsafeCallback.threadSafe(
+  { parameters: ["pointer", "pointer"], result: "void" } as const,
+  (event) => {
+    if (event) events.push(JSON.parse(new Deno.UnsafePointerView(event).getCString()))
+  },
+)
+
+try {
+  const dependency = `${project}/local-dependency`
+  await Deno.mkdir(dependency)
+  await Promise.all([
+    Deno.writeTextFile(`${dependency}/package.json`, JSON.stringify({ name: "local-dependency", version: "1.0.0" })),
+    Deno.writeTextFile(`${project}/package.json`, JSON.stringify({ dependencies: { "local-dependency": "file:./local-dependency" } })),
+  ])
+
+  const installOptions = cstring(JSON.stringify({ projectDir: project, offline: true, ignoreScripts: true }))
+  const installResult = await wait(library.symbols.aube_install(installOptions, callback.pointer, null))
+  if (!installResult.ok) throw new Error(`offline install failed: ${JSON.stringify(installResult)}`)
+  await Deno.stat(`${project}/node_modules/local-dependency`)
+  if (!events.some((event) => (event as { kind?: string; phase?: string }).kind === "phase" && (event as { phase?: string }).phase === "complete")) {
+    throw new Error(`completion event missing: ${JSON.stringify(events)}`)
+  }
+
+  await Deno.writeTextFile(`${project}/.npmrc`, "registry=http://10.255.255.1/\nfetch-timeout=60000\n")
+  const handle = library.symbols.aube_add(
+    cstring(project),
+    cstring(JSON.stringify(["aube-ffi-deno-cancel-test"])),
+    cstring("{}"),
+    null,
+    null,
+  )
+  if (library.symbols.aube_cancel(handle) !== 0) throw new Error("aube_cancel failed")
+  const cancelled = await wait(handle)
+  if (cancelled.code !== "ERR_AUBE_INSTALL_CANCELLED") {
+    throw new Error(`unexpected cancellation result: ${JSON.stringify(cancelled)}`)
+  }
+
+  console.log("Deno FFI smoke passed")
+} finally {
+  callback.close()
+  library.close()
+  await Deno.remove(project, { recursive: true })
+}

--- a/crates/aube-ffi/poc/registry.mjs
+++ b/crates/aube-ffi/poc/registry.mjs
@@ -1,0 +1,46 @@
+import { createServer } from "node:http"
+import { readFileSync } from "node:fs"
+
+const tarballPath = process.env.AUBE_FFI_TARBALL
+const integrity = process.env.AUBE_FFI_INTEGRITY
+if (!tarballPath || !integrity) throw new Error("registry fixture environment is incomplete")
+const tarball = readFileSync(tarballPath)
+const tarballName = tarballPath.split(/[\\/]/).at(-1)
+
+const server = createServer((request, response) => {
+  if (request.url?.endsWith(".tgz")) {
+    response.writeHead(200, { "content-type": "application/octet-stream" })
+    response.end(tarball)
+    return
+  }
+  if (request.url === "/aube-ffi-cached-package") {
+    const address = server.address()
+    if (!address || typeof address === "string") throw new Error("registry address unavailable")
+    response.writeHead(200, { "content-type": "application/json" })
+    response.end(JSON.stringify({
+      name: "aube-ffi-cached-package",
+      "dist-tags": { latest: "1.0.0" },
+      versions: {
+        "1.0.0": {
+          name: "aube-ffi-cached-package",
+          version: "1.0.0",
+          dist: {
+            tarball: `http://127.0.0.1:${address.port}/${tarballName}`,
+            integrity,
+          },
+        },
+      },
+    }))
+    return
+  }
+  response.writeHead(404)
+  response.end("not found")
+})
+
+server.listen(0, "127.0.0.1", () => {
+  const address = server.address()
+  if (!address || typeof address === "string") throw new Error("registry address unavailable")
+  process.stdout.write(`${address.port}\n`)
+})
+
+process.on("SIGTERM", () => server.close(() => process.exit(0)))

--- a/crates/aube-ffi/poc/run.sh
+++ b/crates/aube-ffi/poc/run.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+profile_dir="$repo_root/target/ffi"
+
+cd "$repo_root"
+cargo build --profile ffi -p aube-ffi
+
+case "$(uname -s)" in
+Darwin) library="$profile_dir/libaube_ffi.dylib" ;;
+Linux) library="$profile_dir/libaube_ffi.so" ;;
+MINGW* | MSYS* | CYGWIN*) library="$profile_dir/aube_ffi.dll" ;;
+*)
+	echo "unsupported FFI smoke host: $(uname -s)" >&2
+	exit 1
+	;;
+esac
+
+AUBE_FFI_LIBRARY="$library" mise x bun@1.3.11 -- bun run crates/aube-ffi/poc/bun.ts
+AUBE_FFI_LIBRARY="$library" mise x deno@2.9.2 -- deno run \
+	--allow-env=AUBE_FFI_LIBRARY --allow-ffi --allow-read --allow-write \
+	crates/aube-ffi/poc/deno.ts

--- a/crates/aube-ffi/src/lib.rs
+++ b/crates/aube-ffi/src/lib.rs
@@ -1,0 +1,736 @@
+//! C ABI surface for embedding aube through dynamic FFI loaders.
+
+use aube::embed::{
+    self, AddToProjectOptions, DepSelection, FrozenMode, InstallControl, InstallEvent,
+    InstallOutputLevel, InstallPhase, InstallReporter, NetworkMode,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, HashMap};
+use std::ffi::{CStr, CString, c_char, c_void};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
+
+pub type AubeEventCallback = unsafe extern "C" fn(*const c_char, *mut c_void);
+
+const STATUS_OK: i32 = 0;
+const STATUS_INVALID: i32 = -1;
+const STATUS_PANIC: i32 = -2;
+
+static NEXT_HANDLE: AtomicU64 = AtomicU64::new(1);
+static JOBS: OnceLock<Mutex<HashMap<u64, Arc<Job>>>> = OnceLock::new();
+static RUNTIME: OnceLock<Result<tokio::runtime::Runtime, String>> = OnceLock::new();
+static HOST_INITIALIZED: OnceLock<()> = OnceLock::new();
+
+#[derive(Debug)]
+struct Failure {
+    code: String,
+    message: String,
+}
+
+impl Failure {
+    fn new(code: &str, message: impl Into<String>) -> Self {
+        Self {
+            code: code.to_string(),
+            message: message.into(),
+        }
+    }
+
+    fn invalid(message: impl Into<String>) -> Self {
+        Self::new(aube_codes::errors::ERR_AUBE_FFI_INVALID_ARGUMENT, message)
+    }
+
+    fn panic() -> Self {
+        Self::new(
+            aube_codes::errors::ERR_AUBE_FFI_PANIC,
+            "a panic was caught at the aube C ABI boundary",
+        )
+    }
+}
+
+struct Job {
+    control: InstallControl,
+    callback: CallbackReporter,
+    result: Mutex<Option<String>>,
+    ready: Condvar,
+}
+
+impl Job {
+    fn new(control: InstallControl, callback: CallbackReporter) -> Self {
+        Self {
+            control,
+            callback,
+            result: Mutex::new(None),
+            ready: Condvar::new(),
+        }
+    }
+
+    fn finish(&self, result: Result<(), Failure>) {
+        if let Err(error) = &result {
+            self.callback.report_payload(&EventPayload::Output {
+                level: "error",
+                code: Some(error.code.clone()),
+                message: error.message.clone(),
+            });
+        }
+        let json = result_json(result);
+        let mut slot = self
+            .result
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *slot = Some(json);
+        self.ready.notify_all();
+    }
+
+    fn wait(&self) -> String {
+        let mut slot = self
+            .result
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        while slot.is_none() {
+            slot = self
+                .ready
+                .wait(slot)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+        slot.clone().unwrap_or_else(|| {
+            result_json(Err(Failure::new(
+                aube_codes::errors::ERR_AUBE_FFI_RUNTIME,
+                "operation completed without a result",
+            )))
+        })
+    }
+}
+
+#[derive(Clone)]
+struct CallbackReporter {
+    callback: Option<AubeEventCallback>,
+    context: usize,
+}
+
+impl CallbackReporter {
+    fn report_payload(&self, event: &EventPayload) {
+        let Some(callback) = self.callback else {
+            return;
+        };
+        let Ok(json) = serde_json::to_string(event) else {
+            return;
+        };
+        let Ok(json) = CString::new(json) else {
+            return;
+        };
+        // SAFETY: The host promises that callback and context remain valid and
+        // thread-safe until aube_wait returns. The CString lives through the call.
+        unsafe { callback(json.as_ptr(), self.context as *mut c_void) };
+    }
+}
+
+impl InstallReporter for CallbackReporter {
+    fn report(&self, event: InstallEvent) {
+        self.report_payload(&EventPayload::from(event));
+    }
+}
+
+#[derive(Serialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+enum EventPayload {
+    Phase {
+        phase: &'static str,
+    },
+    Progress {
+        resolved: u64,
+        total: u64,
+        reused: u64,
+        downloaded: u64,
+        #[serde(rename = "downloadedBytes")]
+        downloaded_bytes: u64,
+        #[serde(rename = "estimatedBytes", skip_serializing_if = "Option::is_none")]
+        estimated_bytes: Option<u64>,
+    },
+    Output {
+        level: &'static str,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        code: Option<String>,
+        message: String,
+    },
+}
+
+impl From<InstallEvent> for EventPayload {
+    fn from(event: InstallEvent) -> Self {
+        match event {
+            InstallEvent::Phase(phase) => Self::Phase {
+                phase: match phase {
+                    InstallPhase::Resolving => "resolving",
+                    InstallPhase::Fetching => "fetching",
+                    InstallPhase::Linking => "linking",
+                    InstallPhase::Complete => "complete",
+                },
+            },
+            InstallEvent::Progress(progress) => Self::Progress {
+                resolved: progress.resolved as u64,
+                total: progress.total as u64,
+                reused: progress.reused as u64,
+                downloaded: progress.downloaded as u64,
+                downloaded_bytes: progress.downloaded_bytes,
+                estimated_bytes: (progress.estimated_bytes > 0).then_some(progress.estimated_bytes),
+            },
+            InstallEvent::Output {
+                level,
+                code,
+                message,
+            } => Self::Output {
+                level: match level {
+                    InstallOutputLevel::Info => "info",
+                    InstallOutputLevel::Warning => "warning",
+                    InstallOutputLevel::Error => "error",
+                },
+                code,
+                message,
+            },
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct HostInput {
+    name: String,
+    version: String,
+    #[serde(default)]
+    defaults: BTreeMap<String, String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct InstallInput {
+    project_dir: PathBuf,
+    #[serde(default)]
+    frozen_mode: FrozenInput,
+    #[serde(default)]
+    prod_only: bool,
+    #[serde(default)]
+    dev_only: bool,
+    #[serde(default)]
+    omit_optional: bool,
+    #[serde(default)]
+    ignore_scripts: bool,
+    #[serde(default = "default_true")]
+    run_root_lifecycle: bool,
+    #[serde(default)]
+    dry_run: bool,
+    #[serde(default)]
+    lockfile_only: bool,
+    #[serde(default)]
+    force: bool,
+    #[serde(default)]
+    offline: bool,
+    #[serde(default)]
+    strict_no_lockfile: bool,
+    #[serde(default)]
+    dangerously_allow_all_builds: bool,
+    #[serde(default)]
+    osv_transitive_check: bool,
+}
+
+#[derive(Clone, Copy, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum FrozenInput {
+    Frozen,
+    #[default]
+    Prefer,
+    No,
+    Fix,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+struct AddInput {
+    save_dev: bool,
+    save_exact: bool,
+    save_optional: bool,
+    save_peer: bool,
+    ignore_scripts: bool,
+    force: bool,
+    dangerously_allow_all_builds: bool,
+    offline: bool,
+    prod_only: bool,
+    dev_only: bool,
+    omit_optional: bool,
+    osv_transitive_check: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// Initialize the process-global embedding host.
+#[unsafe(no_mangle)]
+pub extern "C" fn aube_init(host_json: *const c_char) -> i32 {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| init_impl(host_json))) {
+        Ok(Ok(())) => STATUS_OK,
+        Ok(Err(_)) => STATUS_INVALID,
+        Err(_) => STATUS_PANIC,
+    }
+}
+
+/// Start an asynchronous install and return its operation handle.
+#[unsafe(no_mangle)]
+pub extern "C" fn aube_install(
+    options_json: *const c_char,
+    callback: Option<AubeEventCallback>,
+    context: *mut c_void,
+) -> u64 {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        install_impl(options_json, callback, context)
+    })) {
+        Ok(Ok(handle)) => handle,
+        Ok(Err(error)) => completed_failure(error),
+        Err(_) => completed_failure(Failure::panic()),
+    }
+}
+
+/// Start an asynchronous package add and return its operation handle.
+#[unsafe(no_mangle)]
+pub extern "C" fn aube_add(
+    project_dir: *const c_char,
+    packages_json: *const c_char,
+    options_json: *const c_char,
+    callback: Option<AubeEventCallback>,
+    context: *mut c_void,
+) -> u64 {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        add_impl(project_dir, packages_json, options_json, callback, context)
+    })) {
+        Ok(Ok(handle)) => handle,
+        Ok(Err(error)) => completed_failure(error),
+        Err(_) => completed_failure(Failure::panic()),
+    }
+}
+
+/// Block until an operation completes and return owned result JSON.
+#[unsafe(no_mangle)]
+pub extern "C" fn aube_wait(handle: u64) -> *mut c_char {
+    let json = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| wait_impl(handle))) {
+        Ok(result) => result,
+        Err(_) => result_json(Err(Failure::panic())),
+    };
+    owned_c_string(json)
+}
+
+/// Request cooperative cancellation for an operation.
+#[unsafe(no_mangle)]
+pub extern "C" fn aube_cancel(handle: u64) -> i32 {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| cancel_impl(handle))) {
+        Ok(true) => STATUS_OK,
+        Ok(false) => STATUS_INVALID,
+        Err(_) => STATUS_PANIC,
+    }
+}
+
+/// Free a string returned by this library.
+///
+/// # Safety
+///
+/// `value` must be null or an owned pointer returned by [`aube_wait`] that has
+/// not previously been freed.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn aube_string_free(value: *mut c_char) {
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        if !value.is_null() {
+            // SAFETY: The API contract requires a pointer returned by aube_wait
+            // and permits exactly one call to aube_string_free for that pointer.
+            unsafe { drop(CString::from_raw(value)) };
+        }
+    }));
+}
+
+fn init_impl(host_json: *const c_char) -> Result<(), Failure> {
+    let input: HostInput = parse_json(host_json, "host_json")?;
+    if input.name.is_empty()
+        || !input.name.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'-' | b'_')
+        })
+    {
+        return Err(Failure::invalid(
+            "host name must contain only lowercase ASCII letters, digits, '-' or '_'",
+        ));
+    }
+    if input.version.is_empty() {
+        return Err(Failure::invalid("host version must not be empty"));
+    }
+    if HOST_INITIALIZED.get().is_some() {
+        return Ok(());
+    }
+
+    let name = leak_string(input.name);
+    let version = leak_string(input.version);
+    let user_agent = leak_string(format!("{name}/{version}"));
+    let self_names = Box::leak(vec![name].into_boxed_slice());
+    let host = Box::leak(Box::new(embed::Host {
+        name,
+        display_name: name,
+        vendor: None,
+        version,
+        user_agent,
+        self_names,
+        compatible_names: &["npm", "pnpm", "bun", "yarn"],
+        lockfile_basename: "aube-lock.yaml",
+        workspace_yaml: None,
+        manifest_namespace: "",
+        env_prefix: None,
+        config_env_prefix: None,
+        cache_namespace: name,
+        data_namespace: name,
+        canonical_lockfile_always_wins: false,
+        runtime_switching: false,
+        self_engines_check: false,
+        self_update_enabled: false,
+    }));
+    embed::initialize(host, input.defaults.into_iter().collect());
+    let _ = HOST_INITIALIZED.set(());
+    Ok(())
+}
+
+fn install_impl(
+    options_json: *const c_char,
+    callback: Option<AubeEventCallback>,
+    context: *mut c_void,
+) -> Result<u64, Failure> {
+    let input: InstallInput = parse_json(options_json, "options_json")?;
+    if input.prod_only && input.dev_only {
+        return Err(Failure::invalid("prodOnly and devOnly cannot both be true"));
+    }
+    let reporter = CallbackReporter {
+        callback,
+        context: context as usize,
+    };
+    let control = InstallControl::events(Arc::new(reporter.clone()));
+    let (handle, job) = register_job(control.clone(), reporter);
+    runtime()?.spawn(async move {
+        let mut options = embed::InstallOptions::new(input.project_dir);
+        options.frozen_mode = match input.frozen_mode {
+            FrozenInput::Frozen => FrozenMode::Frozen,
+            FrozenInput::Prefer => FrozenMode::Prefer,
+            FrozenInput::No => FrozenMode::No,
+            FrozenInput::Fix => FrozenMode::Fix,
+        };
+        options.dep_selection =
+            DepSelection::from_flags(input.prod_only, input.dev_only, input.omit_optional);
+        options.ignore_scripts = input.ignore_scripts;
+        options.run_root_lifecycle = input.run_root_lifecycle;
+        options.dry_run = input.dry_run;
+        options.lockfile_only = input.lockfile_only;
+        options.force = input.force;
+        options.network_mode = if input.offline {
+            NetworkMode::Offline
+        } else {
+            NetworkMode::Online
+        };
+        options.strict_no_lockfile = input.strict_no_lockfile;
+        options.dangerously_allow_all_builds = input.dangerously_allow_all_builds;
+        options.osv_transitive_check = input.osv_transitive_check && !input.offline;
+        options.control = control;
+        job.finish(embed::install(options).await.map_err(embed_failure));
+    });
+    Ok(handle)
+}
+
+fn add_impl(
+    project_dir: *const c_char,
+    packages_json: *const c_char,
+    options_json: *const c_char,
+    callback: Option<AubeEventCallback>,
+    context: *mut c_void,
+) -> Result<u64, Failure> {
+    let project_dir = PathBuf::from(borrowed_string(project_dir, "project_dir")?);
+    let packages: Vec<String> = parse_json(packages_json, "packages_json")?;
+    let input: AddInput = parse_json(options_json, "options_json")?;
+    if input.prod_only && input.dev_only {
+        return Err(Failure::invalid("prodOnly and devOnly cannot both be true"));
+    }
+    let reporter = CallbackReporter {
+        callback,
+        context: context as usize,
+    };
+    let control = InstallControl::events(Arc::new(reporter.clone()));
+    let (handle, job) = register_job(control.clone(), reporter);
+    runtime()?.spawn(async move {
+        let options = AddToProjectOptions {
+            save_dev: input.save_dev,
+            save_exact: input.save_exact,
+            save_optional: input.save_optional,
+            save_peer: input.save_peer,
+            ignore_scripts: input.ignore_scripts,
+            force: input.force,
+            dangerously_allow_all_builds: input.dangerously_allow_all_builds,
+            offline: input.offline,
+            dep_selection: DepSelection::from_flags(
+                input.prod_only,
+                input.dev_only,
+                input.omit_optional,
+            ),
+            osv_transitive_check: input.osv_transitive_check && !input.offline,
+            control,
+        };
+        job.finish(
+            embed::add(&project_dir, &packages, options)
+                .await
+                .map_err(embed_failure),
+        );
+    });
+    Ok(handle)
+}
+
+fn register_job(control: InstallControl, callback: CallbackReporter) -> (u64, Arc<Job>) {
+    let handle = NEXT_HANDLE.fetch_add(1, Ordering::Relaxed);
+    let job = Arc::new(Job::new(control, callback));
+    jobs()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .insert(handle, Arc::clone(&job));
+    (handle, job)
+}
+
+fn completed_failure(error: Failure) -> u64 {
+    let reporter = CallbackReporter {
+        callback: None,
+        context: 0,
+    };
+    let (handle, job) = register_job(InstallControl::silent(), reporter);
+    job.finish(Err(error));
+    handle
+}
+
+fn wait_impl(handle: u64) -> String {
+    let job = jobs()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .get(&handle)
+        .cloned();
+    let Some(job) = job else {
+        return result_json(Err(Failure::new(
+            aube_codes::errors::ERR_AUBE_FFI_UNKNOWN_HANDLE,
+            format!("unknown or already-consumed operation handle {handle}"),
+        )));
+    };
+    let result = job.wait();
+    jobs()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .remove(&handle);
+    result
+}
+
+fn cancel_impl(handle: u64) -> bool {
+    let control = jobs()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .get(&handle)
+        .map(|job| job.control.clone());
+    if let Some(control) = control {
+        control.cancel();
+        true
+    } else {
+        false
+    }
+}
+
+fn jobs() -> &'static Mutex<HashMap<u64, Arc<Job>>> {
+    JOBS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn runtime() -> Result<&'static tokio::runtime::Runtime, Failure> {
+    RUNTIME
+        .get_or_init(|| {
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .thread_name("aube-ffi")
+                .build()
+                .map_err(|error| error.to_string())
+        })
+        .as_ref()
+        .map_err(|message| {
+            Failure::new(
+                aube_codes::errors::ERR_AUBE_FFI_RUNTIME,
+                format!("failed to initialize the aube FFI runtime: {message}"),
+            )
+        })
+}
+
+fn embed_failure(error: miette::Report) -> Failure {
+    Failure {
+        code: embed::error_code(&error)
+            .unwrap_or_else(|| aube_codes::errors::ERR_AUBE_EMBED_INSTALL_FAILED.to_string()),
+        message: error.to_string(),
+    }
+}
+
+fn result_json(result: Result<(), Failure>) -> String {
+    #[derive(Serialize)]
+    struct ResultPayload<'a> {
+        ok: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        code: Option<&'a str>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        message: Option<&'a str>,
+    }
+    let payload = match &result {
+        Ok(()) => ResultPayload {
+            ok: true,
+            code: None,
+            message: None,
+        },
+        Err(error) => ResultPayload {
+            ok: false,
+            code: Some(&error.code),
+            message: Some(&error.message),
+        },
+    };
+    serde_json::to_string(&payload).unwrap_or_else(|_| {
+        format!(
+            r#"{{"ok":false,"code":"{}","message":"failed to serialize operation result"}}"#,
+            aube_codes::errors::ERR_AUBE_FFI_RUNTIME
+        )
+    })
+}
+
+fn parse_json<T: for<'de> Deserialize<'de>>(
+    value: *const c_char,
+    label: &str,
+) -> Result<T, Failure> {
+    let value = borrowed_string(value, label)?;
+    serde_json::from_str(&value)
+        .map_err(|error| Failure::invalid(format!("invalid {label}: {error}")))
+}
+
+fn borrowed_string(value: *const c_char, label: &str) -> Result<String, Failure> {
+    if value.is_null() {
+        return Err(Failure::invalid(format!("{label} must not be null")));
+    }
+    // SAFETY: The API requires a NUL-terminated pointer valid for the duration
+    // of this call. The returned owned String copies the input before return.
+    let value = unsafe { CStr::from_ptr(value) };
+    value
+        .to_str()
+        .map(str::to_owned)
+        .map_err(|error| Failure::invalid(format!("{label} must be valid UTF-8: {error}")))
+}
+
+fn owned_c_string(value: String) -> *mut c_char {
+    CString::new(value)
+        .map(CString::into_raw)
+        .unwrap_or(std::ptr::null_mut())
+}
+
+fn leak_string(value: String) -> &'static str {
+    Box::leak(value.into_boxed_str())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn c(value: impl AsRef<str>) -> CString {
+        CString::new(value.as_ref()).unwrap()
+    }
+
+    fn wait(handle: u64) -> serde_json::Value {
+        let value = aube_wait(handle);
+        assert!(!value.is_null());
+        // SAFETY: aube_wait returned an owned NUL-terminated string.
+        let json = unsafe { CStr::from_ptr(value) }
+            .to_str()
+            .unwrap()
+            .to_string();
+        // SAFETY: value was returned by aube_wait and has not been freed.
+        unsafe { aube_string_free(value) };
+        serde_json::from_str(&json).unwrap()
+    }
+
+    #[test]
+    fn installs_offline_and_reports_events() {
+        let project = tempfile::tempdir().unwrap();
+        fs::write(project.path().join("package.json"), "{}\n").unwrap();
+        let options = c(serde_json::json!({
+            "projectDir": project.path(),
+            "offline": true,
+            "ignoreScripts": true
+        })
+        .to_string());
+        let events = Mutex::new(Vec::<String>::new());
+        unsafe extern "C" fn callback(event: *const c_char, context: *mut c_void) {
+            // SAFETY: The test passes a live Mutex as context and the event
+            // pointer is valid for the duration of this callback.
+            let (events, event) = unsafe {
+                (
+                    &*(context.cast::<Mutex<Vec<String>>>()),
+                    CStr::from_ptr(event).to_string_lossy().into_owned(),
+                )
+            };
+            events
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(event);
+        }
+        let handle = aube_install(
+            options.as_ptr(),
+            Some(callback),
+            (&events as *const Mutex<Vec<String>>).cast_mut().cast(),
+        );
+        assert_eq!(wait(handle)["ok"], true);
+        assert!(
+            events
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .iter()
+                .any(|event| event.contains(r#""phase":"complete""#))
+        );
+    }
+
+    #[test]
+    fn returns_structured_boundary_and_project_errors() {
+        let malformed = c("{");
+        let malformed_result = wait(aube_install(malformed.as_ptr(), None, std::ptr::null_mut()));
+        assert_eq!(
+            malformed_result["code"],
+            aube_codes::errors::ERR_AUBE_FFI_INVALID_ARGUMENT
+        );
+
+        let project = tempfile::tempdir().unwrap();
+        let parent = project.path().join("file");
+        fs::write(&parent, "not a directory").unwrap();
+        let options = c(serde_json::json!({ "projectDir": parent.join("child") }).to_string());
+        let project_result = wait(aube_install(options.as_ptr(), None, std::ptr::null_mut()));
+        assert_eq!(
+            project_result["code"],
+            aube_codes::errors::ERR_AUBE_EMBED_INSTALL_FAILED
+        );
+    }
+
+    #[test]
+    fn cancels_an_in_flight_add() {
+        let project = tempfile::tempdir().unwrap();
+        fs::write(project.path().join("package.json"), "{}\n").unwrap();
+        fs::write(
+            project.path().join(".npmrc"),
+            "registry=http://10.255.255.1/\nfetch-timeout=60000\n",
+        )
+        .unwrap();
+        let project_dir = c(project.path().to_string_lossy());
+        let packages = c(r#"["aube-ffi-cancel-test"]"#);
+        let options = c("{}");
+        let handle = aube_add(
+            project_dir.as_ptr(),
+            packages.as_ptr(),
+            options.as_ptr(),
+            None,
+            std::ptr::null_mut(),
+        );
+        assert_eq!(aube_cancel(handle), STATUS_OK);
+        assert_eq!(
+            wait(handle)["code"],
+            aube_codes::errors::ERR_AUBE_INSTALL_CANCELLED
+        );
+    }
+}

--- a/crates/aube-ffi/src/lib.rs
+++ b/crates/aube-ffi/src/lib.rs
@@ -130,7 +130,9 @@ impl CallbackReporter {
             return;
         };
         // SAFETY: The host promises that callback and context remain valid and
-        // thread-safe until aube_wait returns. The CString lives through the call.
+        // thread-safe until aube_wait returns. The callback contract also
+        // forbids waiting on this operation or unwinding across the boundary.
+        // The CString lives through the call.
         unsafe { callback(json.as_ptr(), self.context as *mut c_void) };
     }
 }
@@ -407,6 +409,19 @@ fn init_impl(host_json: *const c_char) -> Result<(), Failure> {
     Ok(())
 }
 
+fn seal_host_initialization() {
+    if HOST_INITIALIZED.get().is_some() {
+        return;
+    }
+    let _guard = HOST_INIT_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if HOST_INITIALIZED.get().is_none() {
+        embed::initialize(&embed::AUBE, Vec::new());
+        let _ = HOST_INITIALIZED.set(());
+    }
+}
+
 fn install_impl(
     options_json: *const c_char,
     callback: Option<AubeEventCallback>,
@@ -416,6 +431,7 @@ fn install_impl(
     if input.prod_only && input.dev_only {
         return Err(Failure::invalid("prodOnly and devOnly cannot both be true"));
     }
+    seal_host_initialization();
     let reporter = CallbackReporter {
         callback,
         context: context as usize,
@@ -465,6 +481,7 @@ fn add_impl(
     if input.prod_only && input.dev_only {
         return Err(Failure::invalid("prodOnly and devOnly cannot both be true"));
     }
+    seal_host_initialization();
     let reporter = CallbackReporter {
         callback,
         context: context as usize,

--- a/crates/aube-ffi/src/lib.rs
+++ b/crates/aube-ffi/src/lib.rs
@@ -9,7 +9,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::ffi::{CStr, CString, c_char, c_void};
 use std::future::Future;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex, OnceLock};
 
 pub type AubeEventCallback = unsafe extern "C" fn(*const c_char, *mut c_void);
@@ -53,6 +53,7 @@ impl Failure {
 struct Job {
     control: InstallControl,
     callback: CallbackReporter,
+    wait_claimed: AtomicBool,
     result: Mutex<Option<String>>,
     ready: Condvar,
 }
@@ -62,6 +63,7 @@ impl Job {
         Self {
             control,
             callback,
+            wait_claimed: AtomicBool::new(false),
             result: Mutex::new(None),
             ready: Condvar::new(),
         }
@@ -101,6 +103,12 @@ impl Job {
                 "operation completed without a result",
             )))
         })
+    }
+
+    fn claim_wait(&self) -> bool {
+        self.wait_claimed
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
     }
 }
 
@@ -544,6 +552,12 @@ fn wait_impl(handle: u64) -> String {
             format!("unknown or already-consumed operation handle {handle}"),
         )));
     };
+    if !job.claim_wait() {
+        return result_json(Err(Failure::new(
+            aube_codes::errors::ERR_AUBE_FFI_UNKNOWN_HANDLE,
+            format!("operation handle {handle} is already being consumed"),
+        )));
+    }
     let result = job.wait();
     jobs()
         .lock()
@@ -661,9 +675,16 @@ fn leak_string(value: String) -> &'static str {
 mod tests {
     use super::*;
     use std::fs;
+    use std::sync::mpsc;
+    use std::time::Duration;
 
     fn c(value: impl AsRef<str>) -> CString {
         CString::new(value.as_ref()).unwrap()
+    }
+
+    fn initialize() {
+        let host = c(r#"{"name":"ffi-test","version":"1.0.0"}"#);
+        assert_eq!(aube_init(host.as_ptr()), STATUS_OK);
     }
 
     fn wait(handle: u64) -> serde_json::Value {
@@ -683,13 +704,9 @@ mod tests {
     fn initialization_is_concurrent_and_idempotent() {
         std::thread::scope(|scope| {
             let threads = (0..8)
-                .map(|index| {
-                    scope.spawn(move || {
-                        let host = c(serde_json::json!({
-                            "name": format!("ffi-host-{index}"),
-                            "version": "1.0.0"
-                        })
-                        .to_string());
+                .map(|_| {
+                    scope.spawn(|| {
+                        let host = c(r#"{"name":"ffi-test","version":"1.0.0"}"#);
                         aube_init(host.as_ptr())
                     })
                 })
@@ -698,7 +715,7 @@ mod tests {
                 assert_eq!(thread.join().unwrap(), STATUS_OK);
             }
         });
-        assert!(embed::host().name.starts_with("ffi-host-"));
+        assert_eq!(embed::host().name, "ffi-test");
 
         let malformed = c("{");
         assert_eq!(aube_init(malformed.as_ptr()), STATUS_OK);
@@ -707,6 +724,7 @@ mod tests {
 
     #[test]
     fn task_panics_complete_the_job() {
+        initialize();
         let reporter = CallbackReporter {
             callback: None,
             context: 0,
@@ -719,7 +737,35 @@ mod tests {
     }
 
     #[test]
+    fn concurrent_wait_has_a_single_consumer() {
+        initialize();
+        let reporter = CallbackReporter {
+            callback: None,
+            context: 0,
+        };
+        let (handle, job) = register_job(InstallControl::silent(), reporter);
+        let (sender, receiver) = mpsc::channel();
+        std::thread::scope(|scope| {
+            for _ in 0..2 {
+                let sender = sender.clone();
+                scope.spawn(move || sender.send(wait(handle)).unwrap());
+            }
+            let rejected = receiver.recv_timeout(Duration::from_secs(1)).unwrap();
+            assert_eq!(
+                rejected["code"],
+                aube_codes::errors::ERR_AUBE_FFI_UNKNOWN_HANDLE
+            );
+            job.finish(Ok(()));
+            assert_eq!(
+                receiver.recv_timeout(Duration::from_secs(1)).unwrap()["ok"],
+                true
+            );
+        });
+    }
+
+    #[test]
     fn installs_offline_and_reports_events() {
+        initialize();
         let project = tempfile::tempdir().unwrap();
         fs::write(project.path().join("package.json"), "{}\n").unwrap();
         let options = c(serde_json::json!({
@@ -760,6 +806,7 @@ mod tests {
 
     #[test]
     fn returns_structured_boundary_and_project_errors() {
+        initialize();
         let malformed = c("{");
         let malformed_result = wait(aube_install(malformed.as_ptr(), None, std::ptr::null_mut()));
         assert_eq!(
@@ -780,6 +827,7 @@ mod tests {
 
     #[test]
     fn cancels_an_in_flight_add() {
+        initialize();
         let project = tempfile::tempdir().unwrap();
         fs::write(project.path().join("package.json"), "{}\n").unwrap();
         fs::write(

--- a/crates/aube-ffi/src/lib.rs
+++ b/crates/aube-ffi/src/lib.rs
@@ -7,6 +7,7 @@ use aube::embed::{
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::ffi::{CStr, CString, c_char, c_void};
+use std::future::Future;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex, OnceLock};
@@ -21,6 +22,7 @@ static NEXT_HANDLE: AtomicU64 = AtomicU64::new(1);
 static JOBS: OnceLock<Mutex<HashMap<u64, Arc<Job>>>> = OnceLock::new();
 static RUNTIME: OnceLock<Result<tokio::runtime::Runtime, String>> = OnceLock::new();
 static HOST_INITIALIZED: OnceLock<()> = OnceLock::new();
+static HOST_INIT_LOCK: Mutex<()> = Mutex::new(());
 
 #[derive(Debug)]
 struct Failure {
@@ -345,6 +347,16 @@ pub unsafe extern "C" fn aube_string_free(value: *mut c_char) {
 }
 
 fn init_impl(host_json: *const c_char) -> Result<(), Failure> {
+    if HOST_INITIALIZED.get().is_some() {
+        return Ok(());
+    }
+    let _guard = HOST_INIT_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if HOST_INITIALIZED.get().is_some() {
+        return Ok(());
+    }
+
     let input: HostInput = parse_json(host_json, "host_json")?;
     if input.name.is_empty()
         || !input.name.bytes().all(|byte| {
@@ -358,10 +370,6 @@ fn init_impl(host_json: *const c_char) -> Result<(), Failure> {
     if input.version.is_empty() {
         return Err(Failure::invalid("host version must not be empty"));
     }
-    if HOST_INITIALIZED.get().is_some() {
-        return Ok(());
-    }
-
     let name = leak_string(input.name);
     let version = leak_string(input.version);
     let user_agent = leak_string(format!("{name}/{version}"));
@@ -404,9 +412,10 @@ fn install_impl(
         callback,
         context: context as usize,
     };
+    let runtime = runtime()?;
     let control = InstallControl::events(Arc::new(reporter.clone()));
     let (handle, job) = register_job(control.clone(), reporter);
-    runtime()?.spawn(async move {
+    spawn_job(runtime, job, async move {
         let mut options = embed::InstallOptions::new(input.project_dir);
         options.frozen_mode = match input.frozen_mode {
             FrozenInput::Frozen => FrozenMode::Frozen,
@@ -430,7 +439,7 @@ fn install_impl(
         options.dangerously_allow_all_builds = input.dangerously_allow_all_builds;
         options.osv_transitive_check = input.osv_transitive_check && !input.offline;
         options.control = control;
-        job.finish(embed::install(options).await.map_err(embed_failure));
+        embed::install(options).await.map_err(embed_failure)
     });
     Ok(handle)
 }
@@ -452,9 +461,10 @@ fn add_impl(
         callback,
         context: context as usize,
     };
+    let runtime = runtime()?;
     let control = InstallControl::events(Arc::new(reporter.clone()));
     let (handle, job) = register_job(control.clone(), reporter);
-    runtime()?.spawn(async move {
+    spawn_job(runtime, job, async move {
         let options = AddToProjectOptions {
             save_dev: input.save_dev,
             save_exact: input.save_exact,
@@ -472,11 +482,9 @@ fn add_impl(
             osv_transitive_check: input.osv_transitive_check && !input.offline,
             control,
         };
-        job.finish(
-            embed::add(&project_dir, &packages, options)
-                .await
-                .map_err(embed_failure),
-        );
+        embed::add(&project_dir, &packages, options)
+            .await
+            .map_err(embed_failure)
     });
     Ok(handle)
 }
@@ -489,6 +497,29 @@ fn register_job(control: InstallControl, callback: CallbackReporter) -> (u64, Ar
         .unwrap_or_else(std::sync::PoisonError::into_inner)
         .insert(handle, Arc::clone(&job));
     (handle, job)
+}
+
+fn spawn_job<F>(runtime: &'static tokio::runtime::Runtime, job: Arc<Job>, operation: F)
+where
+    F: Future<Output = Result<(), Failure>> + Send + 'static,
+{
+    let worker_job = Arc::clone(&job);
+    let worker = runtime.spawn(async move {
+        worker_job.finish(operation.await);
+    });
+    runtime.spawn(async move {
+        if let Err(error) = worker.await {
+            let failure = if error.is_panic() {
+                Failure::panic()
+            } else {
+                Failure::new(
+                    aube_codes::errors::ERR_AUBE_FFI_RUNTIME,
+                    format!("aube FFI operation task failed: {error}"),
+                )
+            };
+            job.finish(Err(failure));
+        }
+    });
 }
 
 fn completed_failure(error: Failure) -> u64 {
@@ -646,6 +677,45 @@ mod tests {
         // SAFETY: value was returned by aube_wait and has not been freed.
         unsafe { aube_string_free(value) };
         serde_json::from_str(&json).unwrap()
+    }
+
+    #[test]
+    fn initialization_is_concurrent_and_idempotent() {
+        std::thread::scope(|scope| {
+            let threads = (0..8)
+                .map(|index| {
+                    scope.spawn(move || {
+                        let host = c(serde_json::json!({
+                            "name": format!("ffi-host-{index}"),
+                            "version": "1.0.0"
+                        })
+                        .to_string());
+                        aube_init(host.as_ptr())
+                    })
+                })
+                .collect::<Vec<_>>();
+            for thread in threads {
+                assert_eq!(thread.join().unwrap(), STATUS_OK);
+            }
+        });
+        assert!(embed::host().name.starts_with("ffi-host-"));
+
+        let malformed = c("{");
+        assert_eq!(aube_init(malformed.as_ptr()), STATUS_OK);
+        assert_eq!(aube_init(std::ptr::null()), STATUS_OK);
+    }
+
+    #[test]
+    fn task_panics_complete_the_job() {
+        let reporter = CallbackReporter {
+            callback: None,
+            context: 0,
+        };
+        let (handle, job) = register_job(InstallControl::silent(), reporter);
+        spawn_job(runtime().unwrap(), job, async {
+            panic!("simulated operation panic");
+        });
+        assert_eq!(wait(handle)["code"], aube_codes::errors::ERR_AUBE_FFI_PANIC);
     }
 
     #[test]

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -131,6 +131,7 @@ export default defineConfig({
           { text: "Overview", link: "/embedding/" },
           { text: "Rust", link: "/embedding/rust" },
           { text: "Node-API", link: "/embedding/node" },
+          { text: "C ABI", link: "/embedding/ffi" },
         ],
       },
       {

--- a/docs/embedding/ffi.md
+++ b/docs/embedding/ffi.md
@@ -79,6 +79,10 @@ of package specifier strings.
 - Event strings are borrowed and valid only during the callback.
 - Callbacks run on aube-managed threads. The callback and its context must be
   thread-safe and remain valid until `aube_wait` returns.
+- Callbacks must return normally without throwing, panicking, or unwinding
+  across the C boundary. A callback must not call `aube_wait` for its active
+  operation; signal another host thread to wait or wait after the callback
+  returns.
 - Every exported function catches Rust panics. Release FFI libraries use an
   unwind-enabled profile so a panic cannot cross the C boundary or abort the
   host process.

--- a/docs/embedding/ffi.md
+++ b/docs/embedding/ffi.md
@@ -1,0 +1,186 @@
+# C ABI
+
+`@jdxcode/aube-ffi` exposes aube through a stable C ABI for Bun FFI, Deno FFI,
+Node.js FFI loaders, Python `ctypes`, and native applications. JavaScript hosts
+that support Node-API should generally use [`@jdxcode/aube-node`](/embedding/node);
+the C ABI is intended for hosts that need a universal dynamic-library boundary.
+
+## Distribution
+
+```sh
+npm install @jdxcode/aube-ffi
+```
+
+The root package selects the matching macOS, Windows, glibc Linux, or musl
+Linux platform package and exports:
+
+```ts
+import { headerPath, libraryPath, target } from "@jdxcode/aube-ffi"
+```
+
+The same target-named libraries and `aube.h` are attached to GitHub releases
+for non-npm consumers. Package versions track the aube workspace version.
+
+## Header and operation model
+
+The hand-written [`aube.h`](https://github.com/jdx/aube/blob/main/crates/aube-ffi/include/aube.h)
+declares these operations:
+
+```c
+typedef void (*aube_event_cb)(const char *event_json, void *ctx);
+
+int32_t aube_init(const char *host_json);
+uint64_t aube_install(const char *options_json, aube_event_cb cb, void *ctx);
+uint64_t aube_add(
+    const char *project_dir,
+    const char *packages_json,
+    const char *options_json,
+    aube_event_cb cb,
+    void *ctx);
+char *aube_wait(uint64_t handle);
+int32_t aube_cancel(uint64_t handle);
+void aube_string_free(char *value);
+```
+
+`aube_install` and `aube_add` copy their input strings, return immediately, and
+run on an internal multi-threaded runtime. `aube_wait` blocks until completion
+and consumes the handle. `aube_cancel` requests cooperative cancellation.
+A callback-driven host should call `aube_wait` after receiving the terminal
+event; it then returns immediately and releases the completed handle.
+
+Initialize the host once before starting operations:
+
+```json
+{
+  "name": "my-host",
+  "version": "1.0.0",
+  "defaults": {
+    "minimumReleaseAge": "0"
+  }
+}
+```
+
+Install options require `projectDir` and may include `frozenMode`, `prodOnly`,
+`devOnly`, `omitOptional`, `ignoreScripts`, `runRootLifecycle`, `dryRun`,
+`lockfileOnly`, `force`, `offline`, `strictNoLockfile`,
+`dangerouslyAllowAllBuilds`, and `osvTransitiveCheck`.
+
+Add options may include `saveDev`, `saveExact`, `saveOptional`, `savePeer`,
+`ignoreScripts`, `force`, `dangerouslyAllowAllBuilds`, `offline`, `prodOnly`,
+`devOnly`, `omitOptional`, and `osvTransitiveCheck`. `packages_json` is an array
+of package specifier strings.
+
+## Ownership and threading
+
+- Inputs are UTF-8, NUL-terminated, borrowed only for the duration of the call,
+  and copied before an asynchronous start function returns.
+- The string returned by `aube_wait` belongs to aube and must be passed exactly
+  once to `aube_string_free`.
+- Event strings are borrowed and valid only during the callback.
+- Callbacks run on aube-managed threads. The callback and its context must be
+  thread-safe and remain valid until `aube_wait` returns.
+- Every exported function catches Rust panics. Release FFI libraries use an
+  unwind-enabled profile so a panic cannot cross the C boundary or abort the
+  host process.
+
+## Events and results
+
+Both Node-API and C ABI transports use the same event JSON schema:
+
+```ts
+type InstallEvent =
+  | { kind: "phase"; phase: "resolving" | "fetching" | "linking" | "complete" }
+  | {
+      kind: "progress"
+      resolved: number
+      total: number
+      reused: number
+      downloaded: number
+      downloadedBytes: number
+      estimatedBytes?: number
+    }
+  | {
+      kind: "output"
+      level: "info" | "warning" | "error"
+      code?: string
+      message: string
+    }
+```
+
+`aube_wait` returns one of:
+
+```json
+{ "ok": true }
+```
+
+```json
+{
+  "ok": false,
+  "code": "ERR_AUBE_INSTALL_CANCELLED",
+  "message": "install cancelled"
+}
+```
+
+Codes follow the published [error-code stability policy](/error-codes).
+
+## Bun FFI
+
+```ts
+import { libraryPath } from "@jdxcode/aube-ffi"
+import { CString, dlopen, ptr } from "bun:ffi"
+
+const library = dlopen(libraryPath, {
+  aube_init: { args: ["ptr"], returns: "i32" },
+  aube_install: { args: ["ptr", "ptr", "ptr"], returns: "u64" },
+  aube_wait: { args: ["u64"], returns: "ptr" },
+  aube_cancel: { args: ["u64"], returns: "i32" },
+  aube_string_free: { args: ["ptr"], returns: "void" },
+})
+
+const c = (value: string) => Buffer.from(`${value}\0`)
+library.symbols.aube_init(ptr(c(JSON.stringify({ name: "my-host", version: "1.0.0" }))))
+
+const handle = library.symbols.aube_install(
+  ptr(c(JSON.stringify({ projectDir: ".", offline: true }))),
+  0,
+  0,
+)
+const resultPointer = library.symbols.aube_wait(handle)
+const result = JSON.parse(new CString(resultPointer).toString())
+library.symbols.aube_string_free(resultPointer)
+library.close()
+```
+
+Bun's FFI and arbitrary-thread JavaScript callbacks remain experimental. Use
+the Node-API package when a JavaScript event callback is required in Bun.
+
+## Deno FFI
+
+```ts
+import { libraryPath } from "npm:@jdxcode/aube-ffi"
+
+const library = Deno.dlopen(libraryPath, {
+  aube_install: { parameters: ["buffer", "function", "pointer"], result: "u64" },
+  aube_wait: { parameters: ["u64"], result: "pointer", nonblocking: true },
+  aube_string_free: { parameters: ["pointer"], result: "void" },
+} as const)
+
+const events: unknown[] = []
+const callback = Deno.UnsafeCallback.threadSafe(
+  { parameters: ["pointer", "pointer"], result: "void" } as const,
+  (event) => {
+    if (event) events.push(JSON.parse(new Deno.UnsafePointerView(event).getCString()))
+  },
+)
+const input = new TextEncoder().encode(`${JSON.stringify({ projectDir: "." })}\0`)
+const handle = library.symbols.aube_install(input, callback.pointer, null)
+const resultPointer = await library.symbols.aube_wait(handle)
+if (!resultPointer) throw new Error("aube_wait returned null")
+const result = JSON.parse(new Deno.UnsafePointerView(resultPointer).getCString())
+library.symbols.aube_string_free(resultPointer)
+callback.close()
+library.close()
+```
+
+Run Deno with `--allow-ffi`. For support, use
+[GitHub Discussions](https://github.com/jdx/aube/discussions).

--- a/docs/embedding/ffi.md
+++ b/docs/embedding/ffi.md
@@ -60,6 +60,10 @@ Initialize the host once before starting operations:
 }
 ```
 
+Initialization and operation start are synchronized. If an operation starts
+before `aube_init`, aube permanently selects its standalone host defaults for
+the process and later initialization calls are no-ops.
+
 Install options require `projectDir` and may include `frozenMode`, `prodOnly`,
 `devOnly`, `omitOptional`, `ignoreScripts`, `runRootLifecycle`, `dryRun`,
 `lockfileOnly`, `force`, `offline`, `strictNoLockfile`,

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -433,6 +433,30 @@
       "exit_code": null
     },
     {
+      "name": "ERR_AUBE_FFI_INVALID_ARGUMENT",
+      "category": "Misc / safety",
+      "description": "A C ABI call received a null pointer, invalid UTF-8, malformed JSON, or an unsupported option value.",
+      "exit_code": null
+    },
+    {
+      "name": "ERR_AUBE_FFI_UNKNOWN_HANDLE",
+      "category": "Misc / safety",
+      "description": "A C ABI wait or cancellation call referenced an unknown or already-consumed operation handle.",
+      "exit_code": null
+    },
+    {
+      "name": "ERR_AUBE_FFI_RUNTIME",
+      "category": "Misc / safety",
+      "description": "The C ABI could not initialize or use its internal asynchronous runtime.",
+      "exit_code": null
+    },
+    {
+      "name": "ERR_AUBE_FFI_PANIC",
+      "category": "Misc / safety",
+      "description": "A panic was caught at the C ABI boundary before it could cross into the host process.",
+      "exit_code": null
+    },
+    {
       "name": "ERR_AUBE_UNSAFE_PACKAGE_NAME",
       "category": "Misc / safety",
       "description": "A package/dependency alias would escape its `node_modules` slot if linked.",


### PR DESCRIPTION
## Summary

- add a panic-safe, asynchronous C ABI for install, add, progress events, cancellation, and structured errors
- publish `@jdxcode/aube-ffi` with eight optional platform packages while attaching the same libraries and header to GitHub releases
- add generic C ABI documentation plus real Bun and Deno FFI smoke tests
- build, sign, attest, package, and publish the full macOS, Linux glibc/musl, and Windows target matrix

## Stack

This is a follow-up to #1025 and targets its branch. The C ABI is implemented on top of the stable embedding facade introduced there.

## Validation

- `cargo test --locked`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `mise run lint`
- `mise run docs:build`
- `crates/aube-ffi/poc/run.sh`
- local npm platform/root package installation and TypeScript declaration smoke test

## Release setup

The npm publishing job uses trusted publishing and provenance. Before the first release, the new `@jdxcode/aube-ffi*` package names need trusted-publisher configuration for `.github/workflows/ffi.yml` in the `jdx/aube` repository.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new native boundary and release pipeline (signing, npm publish, host-process panics); core install/add behavior is delegated to the existing embed layer rather than rewritten.
> 
> **Overview**
> Adds a new **`aube-ffi`** `cdylib` and **`profile.ffi`** (`panic = "unwind"`) so panics are caught at the C boundary instead of aborting the host process.
> 
> The C API in **`aube.h`** exposes **`aube_init`**, async **`aube_install`** / **`aube_add`** (operation handles), JSON progress callbacks, **`aube_wait`** / **`aube_cancel`**, and **`aube_string_free`**, backed by the existing embed install/add paths and new **`ERR_AUBE_FFI_*`** stable codes.
> 
> **`@jdxcode/aube-ffi`** ships via eight optional platform npm packages plus a root selector (`libraryPath`, `headerPath`, `target`); **`ffi.yml`** builds the full macOS/Linux glibc/musl/Windows matrix, runs Bun/Deno/npm smoke tests, publishes with provenance on release, signs macOS binaries, and uploads **`libaube-*`** and **`aube.h`** to GitHub releases. **`node-addon.yml`** path filters are tightened to match shared embed-related crates.
> 
> Docs add **`/embedding/ffi`**; POC scripts under **`crates/aube-ffi/poc/`** exercise offline install, cached add, cancellation, and malformed-input errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faea7e72df91e7d8e77c8c42bbba4fea5cff7782. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a stable C ABI for embedding Aube in Bun, Deno, Node.js, Python (ctypes), and native applications.
  * Added async install/add operations with event callbacks, JSON results, cancellation, and handle-based waiting.
  * Added new published platform npm packages and release-distributed libraries plus `aube.h`.
  * Introduced new C ABI error codes for invalid arguments, unknown/consumed handles, runtime failures, and panics.
* **Documentation**
  * Added C ABI documentation with headers, JSON/ownership rules, and Bun/Deno usage examples.
* **Tests**
  * Added automated release smoke checks (Bun/Deno) and TypeScript type validation for the npm surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->