### PR TITLE
docs(embedding): update overview for shipped Node-API and C ABI adapters

### DIFF
--- a/docs/embedding/ffi.md
+++ b/docs/embedding/ffi.md
@@ -46,9 +46,10 @@ void aube_string_free(char *value);
 run on an internal multi-threaded runtime. `aube_wait` blocks until completion
 and consumes the handle. `aube_cancel` requests cooperative cancellation.
 A callback-driven host should call `aube_wait` after receiving the terminal
-event; it then returns immediately and releases the completed handle.
+event; `aube_wait` then returns immediately and releases the completed handle.
 
-Initialize the host once before starting operations:
+Initialize the host once before starting operations by passing `aube_init` a
+JSON host profile:
 
 ```json
 {
@@ -190,5 +191,4 @@ callback.close()
 library.close()
 ```
 
-Run Deno with `--allow-ffi`. For support, use
-[GitHub Discussions](https://github.com/jdx/aube/discussions).
+Run Deno with `--allow-ffi`.

--- a/docs/embedding/index.md
+++ b/docs/embedding/index.md
@@ -5,27 +5,33 @@ process. Embedding avoids CLI startup and output parsing, gives the host
 structured progress events and stable error codes, and allows cooperative
 cancellation.
 
-The native Rust API is the foundation for all embedding integrations. Runtime
-adapters, such as Node-API bindings, should be thin translations over this API.
+The native Rust API is the foundation for every embedding integration; the
+Node-API and C ABI distributions are thin adapters over it.
 
 ## Supported operations
 
 The stable `aube::embed` facade supports:
 
-- installing a project's declared dependencies;
-- adding packages and installing the resulting dependency graph;
-- per-install structured progress and output events;
-- cooperative cancellation;
-- concurrent operations in unrelated projects; and
-- stable `ERR_AUBE_*` diagnostic codes.
+- installing a project's declared dependencies
+- adding packages and installing the resulting dependency graph
+- per-install structured progress and output events
+- cooperative cancellation
+- concurrent operations in unrelated projects
+- stable `ERR_AUBE_*` diagnostic codes
 
 Operations that target the same workspace are serialized. The project lock
 spans manifest changes, lockfile updates, and linking, so concurrent callers do
 not observe partial state.
 
-See [Embedding in Rust](./rust.md) for the native API. JavaScript adapters
-should translate this facade through Node-API rather than calling Rust through
-a C FFI layer.
+## Choosing an integration
+
+- [Rust](./rust.md) — the native `aube::embed` facade for Rust hosts.
+- [Node-API](./node.md) — `@jdxcode/aube-node` for Node.js, Bun, Electron, and
+  compiled Bun executables. Prefer this for any JavaScript host that supports
+  Node-API.
+- [C ABI](./ffi.md) — `@jdxcode/aube-ffi` for hosts that need a
+  dynamic-library boundary: Deno FFI, Python `ctypes`, and native
+  applications.
 
 ## Compatibility
 

--- a/docs/embedding/node.md
+++ b/docs/embedding/node.md
@@ -113,6 +113,7 @@ Install optional dependencies for every target before a cross-platform build:
 bun install --os="*" --cpu="*" @jdxcode/aube-node
 ```
 
-The addon targets Node-API 8. Package versions track the aube workspace
-version. For support, use
-[GitHub Discussions](https://github.com/jdx/aube/discussions).
+## Compatibility
+
+The addon targets Node-API 8 and supports Node.js 18 and newer. Package
+versions track the aube workspace version.

--- a/docs/embedding/rust.md
+++ b/docs/embedding/rust.md
@@ -48,8 +48,8 @@ embed::initialize(
 
 Initialization is process-global and first-write-wins. Setting defaults have
 the lowest precedence, so users can still override them through normal aube
-configuration sources. Behavior fields on `Host` are fixed by the embedding
-application.
+configuration sources. `Host` fields, by contrast, are decisions of the
+embedding application and are not user-configurable.
 
 ## Install a project
 


### PR DESCRIPTION
## Summary

The embedding overview predated #1025/#1046: it told JavaScript hosts to build their own Node-API translation "rather than calling Rust through a C FFI layer", and its body linked only to the Rust page. Now that official Node-API and C ABI distributions ship, the overview describes them and routes readers to the right page.

- replace the stale adapter-guidance paragraph with a "Choosing an integration" section linking all three pages (Rust / Node-API / C ABI), with the same preference framing ffi.md already uses
- reword the intro to describe the shipped adapters instead of prescribing how hypothetical ones should be written
- node.md: turn the trailing grab-bag paragraph into a Compatibility section and document the Node.js 18+ floor (previously only in the package README)
- ffi.md: name `aube_wait` instead of an ambiguous "it" in the handle-release sentence, and say explicitly that the host JSON is passed to `aube_init`
- rust.md: clarify that `Host` fields are embedder decisions users cannot override, in contrast to setting defaults
- trim boilerplate: drop the per-page "for support, use GitHub Discussions" footers (kept on the overview) and the semicolon-and-"and" bullet punctuation

No code examples were touched — they mirror the CI-tested POCs (`crates/aube-ffi/poc/`), including the `0, 0` vs `null` pointer-arg difference between the Bun and Deno examples.

## Validation

- `mise run docs:build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime, API, or security behavior changes.
> 
> **Overview**
> Updates the **embedding overview** now that official Node-API and C ABI packages ship: the intro describes those adapters instead of telling JS hosts to build their own Node-API layer, and a new **Choosing an integration** section links Rust, Node-API, and C ABI with the same preference framing as the FFI page. Supported-operations bullets are simplified (no semicolon/“and” style).
> 
> **node.md** replaces a trailing mixed paragraph with a **Compatibility** section and documents **Node.js 18+** and Node-API 8. **ffi.md** clarifies that `aube_wait` releases the handle after the terminal event and that host JSON is passed to `aube_init`. **rust.md** contrasts user-overridable setting defaults with non-configurable `Host` fields.
> 
> Per-page **GitHub Discussions** footers are removed from node and ffi (support remains on the overview).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b39866b384d8d1f2d2580ef5936ee18e90017ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->