### PR TITLE
fix(ci): skip dependency-less workspace crates in forced release bump

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -320,12 +320,13 @@ jobs:
             `$1${newVersion}$2`,
           );
           for (const name of packages) {
-            let found = false;
+            // Workspace members nobody depends on (aube-node, aube-ffi) have no
+            // [workspace.dependencies] entry; their versions come from
+            // workspace.package, bumped above. Only rewrite lines that exist.
             cargoToml = cargoToml
               .split('\n')
               .map((line) => {
                 if (!line.startsWith(`${name} = {`) || !line.includes('path = ')) return line;
-                found = true;
                 const updated = line.replace(`version = "${oldVersion}"`, `version = "${newVersion}"`);
                 if (updated === line) {
                   throw new Error(`path dependency ${name} did not contain version ${oldVersion}`);
@@ -333,7 +334,6 @@ jobs:
                 return updated;
               })
               .join('\n');
-            if (!found) throw new Error(`path dependency ${name} not found in Cargo.toml`);
           }
           fs.writeFileSync('Cargo.toml', cargoToml);
 


### PR DESCRIPTION
## Summary

The "Force patch bump for repo-only changes" step in `.github/workflows/release-plz.yml` fails on every non-release push to main since `aube-node` and `aube-ffi` merged (#1025, #1046), e.g. this run: https://github.com/jdx/aube/actions/runs/29472202596 — `path dependency aube-ffi not found in Cargo.toml`.

The embedded node script iterates every local workspace package and threw when one had no `name = { path = ..., version = ... }` line in the root `[workspace.dependencies]`. `aube-node` and `aube-ffi` are workspace members that no other crate depends on, so they have no such line.

## Fix

Skip packages without a path-dependency line instead of throwing. Their crate versions are inherited from `workspace.package` version, which the script already bumps separately. The safety check that an *existing* path-dependency line must contain the expected old version (the "did not contain version" throw) is unchanged.

## Verification

Ran the modified script logic against the real root `Cargo.toml` with the full 15-package list from `cargo metadata`: all 13 `[workspace.dependencies]` path entries plus `workspace.package` version were bumped, `aube-node`/`aube-ffi` were skipped without error, and a simulated stale-version line still triggers the "did not contain version" throw.

*This PR was generated by Claude, an AI coding assistant.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow release automation change with no runtime or publish-path impact beyond fixing a false failure on repo-only main pushes.
> 
> **Overview**
> The **Force patch bump for repo-only changes** embedded Node script in `release-plz.yml` no longer fails when a workspace member has no matching `name = { path = ... }` line in root `[workspace.dependencies]`.
> 
> Previously the loop required every local package from `cargo metadata` to appear there and threw `path dependency X not found in Cargo.toml`—which broke after `aube-node` and `aube-ffi` joined the workspace without being path-deps. Those crates still get their version from `[workspace.package]`, which the script bumps first; only crates with an existing path-dependency line get an in-place `version` rewrite. The guard that errors when a found line still has the wrong old version is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ceac70d064cd6955f14416c6780711d01364f74b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release version updates for workspace path dependencies.
  * Unrelated or absent dependency entries no longer cause release processing to fail.
  * Version mismatches on detected dependency entries continue to be reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->