### PR TITLE
fix(ci): publish npm tarballs by local path and allow dispatch publishes

### DIFF
--- a/.github/workflows/ffi.yml
+++ b/.github/workflows/ffi.yml
@@ -38,7 +38,7 @@ on:
         default: ""
 
 concurrency:
-  group: ffi-${{ github.ref }}
+  group: ffi-${{ inputs.tag || github.ref }}
   cancel-in-progress: ${{ github.event_name != 'release' && inputs.tag == '' }}
 
 permissions: {}
@@ -63,7 +63,7 @@ jobs:
     permissions: { contents: read }
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with: { persist-credentials: false }
+        with: { persist-credentials: false, ref: "${{ inputs.tag || github.ref }}" }
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with: { node-version: "24", package-manager-cache: false }
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 # zizmor: ignore[cache-poisoning] PRs are read-only
@@ -130,7 +130,7 @@ jobs:
     permissions: { contents: read, id-token: write, attestations: write }
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with: { persist-credentials: false }
+        with: { persist-credentials: false, ref: "${{ inputs.tag || github.ref }}" }
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with: { node-version: "24", package-manager-cache: false }
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0

--- a/.github/workflows/ffi.yml
+++ b/.github/workflows/ffi.yml
@@ -31,10 +31,15 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag (e.g. v1.28.0) to publish packages for. Empty runs a smoke build."
+        required: false
+        default: ""
 
 concurrency:
   group: ffi-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'release' }}
+  cancel-in-progress: ${{ github.event_name != 'release' && inputs.tag == '' }}
 
 permissions: {}
 
@@ -79,13 +84,13 @@ jobs:
           fi
           cargo build --locked --profile ffi -p aube-ffi --target '${{ matrix.target }}'
       - name: Import macOS signing certificate
-        if: github.event_name == 'release' && matrix.os == 'darwin'
+        if: (github.event_name == 'release' || inputs.tag != '') && matrix.os == 'darwin'
         uses: apple-actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7.0.0
         with:
           p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
           p12-password: ${{ secrets.CERTIFICATES_P12_PASS }}
       - name: Sign macOS library
-        if: github.event_name == 'release' && matrix.os == 'darwin'
+        if: (github.event_name == 'release' || inputs.tag != '') && matrix.os == 'darwin'
         shell: bash
         run: |
           codesign --force --sign 'Developer ID Application: Jeffrey Dickey (4993Y37DX6)' \
@@ -95,10 +100,9 @@ jobs:
         id: version
         shell: bash
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: |
-          if [[ "$EVENT_NAME" == release ]]; then version=${RELEASE_TAG#v}; else version="0.0.0-smoke.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"; fi
+          if [[ -n "$RELEASE_TAG" ]]; then version=${RELEASE_TAG#v}; else version="0.0.0-smoke.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"; fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
       - name: Stage library and platform package
         shell: bash
@@ -141,10 +145,9 @@ jobs:
       - name: Pack root npm package
         shell: bash
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: |
-          if [[ "$EVENT_NAME" == release ]]; then VERSION=${RELEASE_TAG#v}; else VERSION="0.0.0-smoke.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"; fi
+          if [[ -n "$RELEASE_TAG" ]]; then VERSION=${RELEASE_TAG#v}; else VERSION="0.0.0-smoke.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"; fi
           VERSION="$VERSION" OUT_DIR="$PWD/packages" node crates/aube-ffi/npm/package.mjs
           cp crates/aube-ffi/include/aube.h packages/aube.h
           test "$(find packages -maxdepth 1 -name '*.tgz' -print | wc -l)" -eq 9
@@ -175,17 +178,17 @@ jobs:
             packages/aube.h
           if-no-files-found: error
       - uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || inputs.tag != ''
         with:
           subject-path: |
             packages/*.tgz
             packages/libaube-*
             packages/aube.h
       - name: Publish platform and root packages
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || inputs.tag != ''
         shell: bash
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: |
           version=${RELEASE_TAG#v}; tag=latest; [[ "$version" == *-* ]] && tag=next
           publish_package() {
@@ -197,11 +200,13 @@ jobs:
             fi
             npm publish "$package" --access public --provenance --tag "$tag"
           }
-          for package in packages/*-darwin-*.tgz packages/*-linux-*.tgz packages/*-win32-*.tgz; do publish_package "$package"; done
-          publish_package "packages/jdxcode-aube-ffi-${version}.tgz"
+          # Relative paths need the ./ prefix or npm parses them as
+          # hosted-git owner/repo shorthands instead of local tarballs.
+          for package in ./packages/*-darwin-*.tgz ./packages/*-linux-*.tgz ./packages/*-win32-*.tgz; do publish_package "$package"; done
+          publish_package "./packages/jdxcode-aube-ffi-${version}.tgz"
 
   release-assets:
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || inputs.tag != ''
     needs: packages
     runs-on: ubuntu-latest
     permissions: { contents: write }
@@ -212,5 +217,5 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: gh release upload "$RELEASE_TAG" packages/libaube-* packages/aube.h --clobber

--- a/.github/workflows/node-addon.yml
+++ b/.github/workflows/node-addon.yml
@@ -42,7 +42,7 @@ on:
         default: ""
 
 concurrency:
-  group: node-addon-${{ github.ref }}
+  group: node-addon-${{ inputs.tag || github.ref }}
   cancel-in-progress: ${{ github.event_name != 'release' && inputs.tag == '' }}
 
 permissions: {}
@@ -67,7 +67,7 @@ jobs:
     permissions: { contents: read }
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with: { persist-credentials: false }
+        with: { persist-credentials: false, ref: "${{ inputs.tag || github.ref }}" }
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with: { node-version: "24", package-manager-cache: false }
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 # zizmor: ignore[cache-poisoning] PRs are read-only
@@ -138,7 +138,7 @@ jobs:
     permissions: { contents: read, id-token: write, attestations: write }
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with: { persist-credentials: false }
+        with: { persist-credentials: false, ref: "${{ inputs.tag || github.ref }}" }
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with: { node-version: "24", package-manager-cache: false }
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0

--- a/.github/workflows/node-addon.yml
+++ b/.github/workflows/node-addon.yml
@@ -35,10 +35,15 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag (e.g. v1.28.0) to publish packages for. Empty runs a smoke build."
+        required: false
+        default: ""
 
 concurrency:
   group: node-addon-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'release' }}
+  cancel-in-progress: ${{ github.event_name != 'release' && inputs.tag == '' }}
 
 permissions: {}
 
@@ -83,13 +88,13 @@ jobs:
           fi
           cargo build --locked --profile napi -p aube-node --target '${{ matrix.target }}'
       - name: Import macOS signing certificate
-        if: github.event_name == 'release' && matrix.os == 'darwin'
+        if: (github.event_name == 'release' || inputs.tag != '') && matrix.os == 'darwin'
         uses: apple-actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7.0.0
         with:
           p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
           p12-password: ${{ secrets.CERTIFICATES_P12_PASS }}
       - name: Sign macOS addon
-        if: github.event_name == 'release' && matrix.os == 'darwin'
+        if: (github.event_name == 'release' || inputs.tag != '') && matrix.os == 'darwin'
         shell: bash
         run: |
           codesign --force --sign 'Developer ID Application: Jeffrey Dickey (4993Y37DX6)' \
@@ -99,10 +104,9 @@ jobs:
         id: version
         shell: bash
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: |
-          if [[ "$EVENT_NAME" == release ]]; then version=${RELEASE_TAG#v}; else version="0.0.0-smoke.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"; fi
+          if [[ -n "$RELEASE_TAG" ]]; then version=${RELEASE_TAG#v}; else version="0.0.0-smoke.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"; fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
       - name: Pack platform package
         shell: bash
@@ -147,10 +151,9 @@ jobs:
       - name: Pack root package
         shell: bash
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: |
-          if [[ "$EVENT_NAME" == release ]]; then VERSION=${RELEASE_TAG#v}; else VERSION="0.0.0-smoke.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"; fi
+          if [[ -n "$RELEASE_TAG" ]]; then VERSION=${RELEASE_TAG#v}; else VERSION="0.0.0-smoke.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"; fi
           VERSION="$VERSION" OUT_DIR="$PWD/packages" node crates/aube-node/npm/package.mjs
           test "$(find packages -maxdepth 1 -name '*.tgz' -print | wc -l)" -eq 9
       - name: Smoke-test installed packages with Node and Bun
@@ -180,13 +183,13 @@ jobs:
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with: { name: aube-node-npm-packages, path: "packages/*.tgz", if-no-files-found: error }
       - uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || inputs.tag != ''
         with: { subject-path: "packages/*.tgz" }
       - name: Publish platform and root packages
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || inputs.tag != ''
         shell: bash
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: |
           version=${RELEASE_TAG#v}; tag=latest; [[ "$version" == *-* ]] && tag=next
           publish_package() {
@@ -198,5 +201,7 @@ jobs:
             fi
             npm publish "$package" --access public --provenance --tag "$tag"
           }
-          for package in packages/*-darwin-*.tgz packages/*-linux-*.tgz packages/*-win32-*.tgz; do publish_package "$package"; done
-          publish_package "packages/jdxcode-aube-node-${version}.tgz"
+          # Relative paths need the ./ prefix or npm parses them as
+          # hosted-git owner/repo shorthands instead of local tarballs.
+          for package in ./packages/*-darwin-*.tgz ./packages/*-linux-*.tgz ./packages/*-win32-*.tgz; do publish_package "$package"; done
+          publish_package "./packages/jdxcode-aube-node-${version}.tgz"


### PR DESCRIPTION
## Summary

The v1.28.0 release published zero `@jdxcode/aube-node` / `@jdxcode/aube-ffi` packages: the publish step's first real execution failed because `npm publish packages/<name>.tgz` parses the bare relative path as a hosted-git `owner/repo` shorthand and tries `git ls-remote ssh://git@github.com/packages/....git`.

Failing runs: [node-addon](https://github.com/jdx/aube/actions/runs/29475302117), [ffi](https://github.com/jdx/aube/actions/runs/29475302142). The ffi failure also blocked its `release-assets` job, so `libaube-*`/`aube.h` are missing from the v1.28.0 release page.

## Changes

- Prefix all published tarball paths with `./` in both workflows.
- Add a `workflow_dispatch` `tag` input that runs the full release path (macOS signing, attestation, npm publish, and ffi release-asset upload) for an existing tag. Release-event re-runs execute the workflow snapshot from the tag, so without this the corrected publish can never run for v1.28.0.

## Recovery after merge

```sh
gh workflow run node-addon.yml --repo jdx/aube -f tag=v1.28.0
gh workflow run ffi.yml --repo jdx/aube -f tag=v1.28.0
```

The publish loop already skips already-published versions, so dispatch re-runs are idempotent. Trusted publishing validates repo + workflow file, which dispatch events satisfy.

## Validation

- `actionlint` and `zizmor` clean on both files
- smoke path (push/PR/dispatch without tag) still uses `0.0.0-smoke.*` versions and skips signing/attest/publish

*This PR was written by an AI coding assistant (Claude Code), directed by @jdx.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes control public npm publishing, signing, and GitHub release uploads; mistakes could affect release artifacts, though existing version skip logic limits duplicate publishes.
> 
> **Overview**
> Fixes failed **npm publish** steps in `ffi.yml` and `node-addon.yml` by passing tarball paths with a **`./` prefix**, so npm treats them as local files instead of hosted-git `owner/repo` shorthands.
> 
> Adds optional **`workflow_dispatch` `tag` input** on both workflows so an existing release tag can run the full release path (checkout at that tag, macOS signing, provenance attestation, npm publish, and ffi **release-assets** upload) without relying on the frozen workflow snapshot from the original release event. Version selection now keys off **any non-empty release tag** (`github.event.release.tag_name` or `inputs.tag`); empty dispatch still does smoke builds with `0.0.0-smoke.*` and skips publish/signing. Concurrency groups use `inputs.tag || github.ref`, and in-flight smoke runs can still be canceled when appropriate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54a2e5a71c30d516feaaaa97ca1a611bfad0944f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added manual, tag-driven build/publish support: smoke builds run when no tag is provided, while tagged runs behave like release builds.
  * Manual tag input now drives versioning, code signing, provenance generation, publishing, and release asset naming.
* **Bug Fixes**
  * Improved publishing so npm correctly treats package tarballs as local artifacts by adjusting the tarball paths.
* **Chores**
  * Standardized release tag derivation across the build and publish steps for consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->