### PR TITLE
fix(ci): pass repo to gh release upload in ffi release-assets

### DIFF
--- a/.github/workflows/ffi.yml
+++ b/.github/workflows/ffi.yml
@@ -218,4 +218,5 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
-        run: gh release upload "$RELEASE_TAG" packages/libaube-* packages/aube.h --clobber
+        # No checkout in this job, so gh needs the repo passed explicitly.
+        run: gh release upload --repo "$GITHUB_REPOSITORY" "$RELEASE_TAG" packages/libaube-* packages/aube.h --clobber


### PR DESCRIPTION
### Feature hasn't been suggested before.

- [x] I have verified this feature I'm about to request hasn't been suggested before.

### Describe the enhancement you want to request

opencode installs packages at runtime through `@npmcli/arborist`, but this has gaps: installs can't be cancelled, damaged cache dirs are never detected or repaired, `@latest` can resolve from a stale cache (#25293), shared dependencies are duplicated across every cache dir, and there's no supply-chain policy at all — opencode's own dev deps get a 3-day `minimumReleaseAge` via bunfig, but packages the agent installs at runtime get nothing.

I've been building embeddable installers for [aube](https://aube.jdx.dev) (my native npm package manager) and I want to swap it in behind `Npm.Service`. The interface doesn't change, so callers and test fakes stay as-is. Draft PR with implementation details and benchmarks: #37300.

The swap gets us cancellation, verified/self-repairing install state, always-fresh dist-tags, a content-addressable store instead of per-dir file copies, supply-chain protections (minimum release age, OSV checks, typosquat detection) for everything the agent installs, and it drops arborist's large dependency tree from `packages/core`. aube reads and writes all the common lockfile formats, so existing caches migrate transparently.

Longer term, building on aube gives us things arborist can't do at all: real progress reporting for installs in the TUI, sandboxed build scripts for packages that need a postinstall (today `ignoreScripts` silently breaks them), and dependency changes in user projects that preserve whatever lockfile format the project already uses. Anything the embedding API is missing, I'll add on the aube side.

Trade-off worth knowing: first-time installs of `@latest`-style specs get slightly slower because aube revalidates against the registry instead of trusting a cached packument — that's the same behavior that fixes #25293. Details in the PR.