### PR TITLE
feat(node): add configure() for embedder setting defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,6 +407,7 @@ dependencies = [
  "aube",
  "aube-codes",
  "aube-registry",
+ "aube-settings",
  "miette",
  "napi",
  "napi-build",

--- a/crates/aube-codes/src/errors.rs
+++ b/crates/aube-codes/src/errors.rs
@@ -109,6 +109,8 @@ pub const ERR_AUBE_PATCHES_TRACKING_WRITE: &str = "ERR_AUBE_PATCHES_TRACKING_WRI
 pub const ERR_AUBE_UNSAFE_SHEBANG_INTERPRETER: &str = "ERR_AUBE_UNSAFE_SHEBANG_INTERPRETER";
 pub const ERR_AUBE_EMBED_INVALID_PROJECT: &str = "ERR_AUBE_EMBED_INVALID_PROJECT";
 pub const ERR_AUBE_EMBED_INSTALL_FAILED: &str = "ERR_AUBE_EMBED_INSTALL_FAILED";
+pub const ERR_AUBE_EMBED_INVALID_SETTING: &str = "ERR_AUBE_EMBED_INVALID_SETTING";
+pub const ERR_AUBE_EMBED_ALREADY_INITIALIZED: &str = "ERR_AUBE_EMBED_ALREADY_INITIALIZED";
 pub const ERR_AUBE_FFI_INVALID_ARGUMENT: &str = "ERR_AUBE_FFI_INVALID_ARGUMENT";
 pub const ERR_AUBE_FFI_UNKNOWN_HANDLE: &str = "ERR_AUBE_FFI_UNKNOWN_HANDLE";
 pub const ERR_AUBE_FFI_RUNTIME: &str = "ERR_AUBE_FFI_RUNTIME";
@@ -577,6 +579,18 @@ pub const ALL: &[CodeMeta] = &[
         name: ERR_AUBE_EMBED_INSTALL_FAILED,
         category: category::MISC_SAFETY,
         description: "An in-process embedder could not initialize its host callback or received an install failure without a more specific stable code.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: ERR_AUBE_EMBED_INVALID_SETTING,
+        category: category::MISC_SAFETY,
+        description: "An in-process embedder passed a setting default whose name is not a canonical aube setting.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: ERR_AUBE_EMBED_ALREADY_INITIALIZED,
+        category: category::MISC_SAFETY,
+        description: "An in-process embedder tried to register setting defaults after the process already initialized its embedder profile.",
         exit_code: None,
     },
     CodeMeta {

--- a/crates/aube-node/Cargo.toml
+++ b/crates/aube-node/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib"]
 aube = { workspace = true }
 aube-codes = { workspace = true }
 aube-registry = { workspace = true }
+aube-settings = { workspace = true }
 miette = { workspace = true }
 napi = { workspace = true }
 napi-derive = { workspace = true }

--- a/crates/aube-node/README.md
+++ b/crates/aube-node/README.md
@@ -46,6 +46,31 @@ Rejected promises are `AubeError` objects with a stable `code` and a
 human-readable `diagnostic`. Published `ERR_AUBE_*` values follow aube's
 [error-code stability policy](https://github.com/jdx/aube/blob/main/docs/error-codes.md).
 
+## Configuration
+
+Register embedder setting defaults before the first `install`:
+
+```ts
+import { configure, install } from "@jdxcode/aube-node"
+
+configure({
+  defaults: {
+    minimumReleaseAge: "259200", // seconds; 3-day cooldown for fresh releases
+  },
+})
+```
+
+Defaults use canonical setting names and sit at the lowest precedence —
+environment variables, project files, and user configuration all override
+them. Registration is process-global and first-write-wins: calling
+`configure` after an install (or a second time) rejects with
+`ERR_AUBE_EMBED_ALREADY_INITIALIZED`, and unknown setting names reject with
+`ERR_AUBE_EMBED_INVALID_SETTING`. Without a `configure` call the addon
+applies its built-in defaults (`nodeLinker=hoisted`, `minimumReleaseAge=0`).
+
+Per-install, `osvTransitiveCheck: true` forces a live transitive OSV check
+even when resolution reused every version from the existing lockfile.
+
 ## Compiled Bun executables
 
 Add `bunPlugin({ os, arch, libc })` from `@jdxcode/aube-node/bun-plugin` to each

--- a/crates/aube-node/npm/index.d.ts
+++ b/crates/aube-node/npm/index.d.ts
@@ -16,10 +16,19 @@ export interface AubeError extends Error {
   diagnostic: string
 }
 
+export type ConfigureInput = {
+  /**
+   * Embedder setting defaults by canonical setting name (e.g.
+   * `minimumReleaseAge`). Lowest precedence: environment variables, project
+   * files, and user configuration all override them.
+   */
+  defaults?: Record<string, string>
+}
 export type InstallInput = {
   add?: { name: string; version?: string; dev?: boolean }[]
   force?: boolean
   offline?: boolean
+  osvTransitiveCheck?: boolean
   onEvent?: (event: InstallEvent) => void
   signal?: AbortSignal
 }
@@ -31,4 +40,10 @@ export type InstallResult = {
   downloaded: number
   durationMs: number
 }
+/**
+ * Register embedder setting defaults for this process. Call before the first
+ * `install`; later (or repeated) calls throw `ERR_AUBE_EMBED_ALREADY_INITIALIZED`,
+ * and unknown setting names throw `ERR_AUBE_EMBED_INVALID_SETTING`.
+ */
+export function configure(input?: ConfigureInput): void
 export function install(projectDir: string, input?: InstallInput): Promise<InstallResult>

--- a/crates/aube-node/npm/index.js
+++ b/crates/aube-node/npm/index.js
@@ -28,4 +28,5 @@ function load() {
 }
 
 const addon = load()
+exports.configure = addon.configure
 exports.install = addon.install

--- a/crates/aube-node/npm/typecheck.ts
+++ b/crates/aube-node/npm/typecheck.ts
@@ -1,4 +1,4 @@
-import { install, type AubeError, type InstallEvent } from "@jdxcode/aube-node"
+import { configure, install, type AubeError, type InstallEvent } from "@jdxcode/aube-node"
 
 function handleEvent(event: InstallEvent) {
   switch (event.kind) {
@@ -15,8 +15,11 @@ function handleEvent(event: InstallEvent) {
   }
 }
 
+configure({ defaults: { minimumReleaseAge: "259200" } })
+
 const controller = new AbortController()
 install(".", {
+  osvTransitiveCheck: true,
   add: [{ name: "typescript", version: "latest", dev: true }],
   signal: controller.signal,
   onEvent: handleEvent,

--- a/crates/aube-node/src/lib.rs
+++ b/crates/aube-node/src/lib.rs
@@ -13,8 +13,7 @@ use napi::{Env, Status};
 use napi_derive::napi;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Instant;
 
 type NodeError = napi::Error;
@@ -49,11 +48,12 @@ static NODE_HOST: embed::Host = embed::Host {
     self_update_enabled: false,
 };
 
-/// Whether this process has registered its embedder profile and setting
-/// defaults. `configure` and the first `install` race for it; registration is
-/// process-global and first-write-wins, so a `configure` that loses the race
-/// must fail loudly rather than silently not apply.
-static EMBEDDER_INITIALIZED: AtomicBool = AtomicBool::new(false);
+/// Registration of the embedder profile and setting defaults. `configure` and
+/// the first `install` race for it; `OnceLock` both serializes the race (a
+/// concurrent install blocks until registration completes rather than
+/// proceeding under the standalone profile) and records who won, so a
+/// `configure` that loses must fail loudly rather than silently not apply.
+static EMBEDDER_INIT: OnceLock<()> = OnceLock::new();
 
 fn builtin_defaults() -> Vec<(String, String)> {
     vec![
@@ -101,6 +101,21 @@ pub struct ConfigureInput {
 /// with `ERR_AUBE_EMBED_INVALID_SETTING`.
 #[napi(catch_unwind)]
 pub fn configure(env: &Env, input: Option<ConfigureInput>) -> NodeResult<()> {
+    let already_initialized = || {
+        into_napi_error(
+            env,
+            InstallFailure {
+                code: aube_codes::errors::ERR_AUBE_EMBED_ALREADY_INITIALIZED.to_string(),
+                message: "configure must be called before the first install".to_string(),
+                diagnostic: "embedder defaults are process-global and first-write-wins; this \
+                             process already registered them"
+                    .to_string(),
+            },
+        )
+    };
+    if EMBEDDER_INIT.get().is_some() {
+        return Err(already_initialized());
+    }
     let defaults = input.and_then(|input| input.defaults).unwrap_or_default();
     let overrides = validate_defaults(defaults).map_err(|key| {
         into_napi_error(
@@ -114,19 +129,14 @@ pub fn configure(env: &Env, input: Option<ConfigureInput>) -> NodeResult<()> {
             },
         )
     })?;
-    if EMBEDDER_INITIALIZED.swap(true, Ordering::SeqCst) {
-        return Err(into_napi_error(
-            env,
-            InstallFailure {
-                code: aube_codes::errors::ERR_AUBE_EMBED_ALREADY_INITIALIZED.to_string(),
-                message: "configure must be called before the first install".to_string(),
-                diagnostic: "embedder defaults are process-global and first-write-wins; this \
-                             process already registered them"
-                    .to_string(),
-            },
-        ));
+    let mut applied = false;
+    EMBEDDER_INIT.get_or_init(|| {
+        embed::initialize(&NODE_HOST, merged_defaults(overrides));
+        applied = true;
+    });
+    if !applied {
+        return Err(already_initialized());
     }
-    embed::initialize(&NODE_HOST, merged_defaults(overrides));
     Ok(())
 }
 
@@ -394,10 +404,7 @@ fn npmrc_dep_selection(project_dir: &Path) -> DepSelection {
 }
 
 fn initialize_embedder() {
-    if EMBEDDER_INITIALIZED.swap(true, Ordering::SeqCst) {
-        return;
-    }
-    embed::initialize(&NODE_HOST, builtin_defaults());
+    EMBEDDER_INIT.get_or_init(|| embed::initialize(&NODE_HOST, builtin_defaults()));
 }
 
 async fn prepare_project_dir(project_dir: &Path) -> Result<PathBuf, InstallFailure> {

--- a/crates/aube-node/src/lib.rs
+++ b/crates/aube-node/src/lib.rs
@@ -11,7 +11,9 @@ use napi::bindgen_prelude::{
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi::{Env, Status};
 use napi_derive::napi;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -47,6 +49,87 @@ static NODE_HOST: embed::Host = embed::Host {
     self_update_enabled: false,
 };
 
+/// Whether this process has registered its embedder profile and setting
+/// defaults. `configure` and the first `install` race for it; registration is
+/// process-global and first-write-wins, so a `configure` that loses the race
+/// must fail loudly rather than silently not apply.
+static EMBEDDER_INITIALIZED: AtomicBool = AtomicBool::new(false);
+
+fn builtin_defaults() -> Vec<(String, String)> {
+    vec![
+        ("nodeLinker".to_string(), "hoisted".to_string()),
+        ("minimumReleaseAge".to_string(), "0".to_string()),
+    ]
+}
+
+fn merged_defaults(overrides: Vec<(String, String)>) -> Vec<(String, String)> {
+    let mut merged = builtin_defaults();
+    for (key, value) in overrides {
+        match merged.iter_mut().find(|(name, _)| *name == key) {
+            Some(existing) => existing.1 = value,
+            None => merged.push((key, value)),
+        }
+    }
+    merged
+}
+
+fn validate_defaults(defaults: HashMap<String, String>) -> Result<Vec<(String, String)>, String> {
+    let mut overrides = defaults.into_iter().collect::<Vec<_>>();
+    // HashMap iteration order is random; keep registration deterministic.
+    overrides.sort();
+    for (key, _) in &overrides {
+        if aube_settings::find(key).is_none() {
+            return Err(key.clone());
+        }
+    }
+    Ok(overrides)
+}
+
+#[napi(object)]
+pub struct ConfigureInput {
+    /// Embedder setting defaults by canonical setting name (e.g.
+    /// `minimumReleaseAge`). They sit at the lowest precedence, below
+    /// environment variables, project files, and user configuration.
+    pub defaults: Option<HashMap<String, String>>,
+}
+
+/// Register embedder setting defaults for this process.
+///
+/// Call before the first `install`; registration is process-global and
+/// first-write-wins, so calling after an install (or a second time) rejects
+/// with `ERR_AUBE_EMBED_ALREADY_INITIALIZED`. Unknown setting names reject
+/// with `ERR_AUBE_EMBED_INVALID_SETTING`.
+#[napi(catch_unwind)]
+pub fn configure(env: &Env, input: Option<ConfigureInput>) -> NodeResult<()> {
+    let defaults = input.and_then(|input| input.defaults).unwrap_or_default();
+    let overrides = validate_defaults(defaults).map_err(|key| {
+        into_napi_error(
+            env,
+            InstallFailure {
+                code: aube_codes::errors::ERR_AUBE_EMBED_INVALID_SETTING.to_string(),
+                message: format!("unknown setting {key:?}"),
+                diagnostic: format!(
+                    "{key:?} is not a canonical aube setting name; see https://aube.jdx.dev/settings"
+                ),
+            },
+        )
+    })?;
+    if EMBEDDER_INITIALIZED.swap(true, Ordering::SeqCst) {
+        return Err(into_napi_error(
+            env,
+            InstallFailure {
+                code: aube_codes::errors::ERR_AUBE_EMBED_ALREADY_INITIALIZED.to_string(),
+                message: "configure must be called before the first install".to_string(),
+                diagnostic: "embedder defaults are process-global and first-write-wins; this \
+                             process already registered them"
+                    .to_string(),
+            },
+        ));
+    }
+    embed::initialize(&NODE_HOST, merged_defaults(overrides));
+    Ok(())
+}
+
 #[napi(object)]
 pub struct PackageToAdd {
     pub name: String,
@@ -59,6 +142,7 @@ pub struct InstallInput {
     pub add: Option<Vec<PackageToAdd>>,
     pub force: Option<bool>,
     pub offline: Option<bool>,
+    pub osv_transitive_check: Option<bool>,
     pub on_event: Option<Function<'static, FnArgs<(InstallEventPayload,)>, ()>>,
     pub signal: Option<Object<'static>>,
 }
@@ -136,12 +220,14 @@ pub fn install<'env>(
         add,
         force,
         offline,
+        osv_transitive_check,
         on_event,
         signal,
     } = input.unwrap_or(InstallInput {
         add: None,
         force: None,
         offline: None,
+        osv_transitive_check: None,
         on_event: None,
         signal: None,
     });
@@ -195,11 +281,21 @@ pub fn install<'env>(
         .collect::<Vec<_>>();
     let force = force.unwrap_or(false);
     let offline = offline.unwrap_or(false);
+    let osv_transitive_check = osv_transitive_check.unwrap_or(false);
 
     env.spawn_future_with_callback(
         async move {
             Ok::<_, napi::Error>(
-                run_install(project_dir, packages, force, offline, control, stats).await,
+                run_install(
+                    project_dir,
+                    packages,
+                    force,
+                    offline,
+                    osv_transitive_check,
+                    control,
+                    stats,
+                )
+                .await,
             )
         },
         |env, result| match result {
@@ -214,6 +310,7 @@ async fn run_install(
     packages: Vec<(String, bool)>,
     force: bool,
     offline: bool,
+    osv_transitive_check: bool,
     control: InstallControl,
     stats: Arc<Mutex<InstallStats>>,
 ) -> Result<InstallResult, InstallFailure> {
@@ -244,7 +341,7 @@ async fn run_install(
                     dangerously_allow_all_builds: false,
                     offline,
                     dep_selection,
-                    osv_transitive_check: false,
+                    osv_transitive_check,
                     control: control.clone(),
                 },
             )
@@ -256,6 +353,7 @@ async fn run_install(
         options.ignore_scripts = true;
         options.force = force;
         options.dep_selection = dep_selection;
+        options.osv_transitive_check = osv_transitive_check;
         options.control = control;
         if offline {
             options.network_mode = NetworkMode::Offline;
@@ -296,13 +394,10 @@ fn npmrc_dep_selection(project_dir: &Path) -> DepSelection {
 }
 
 fn initialize_embedder() {
-    embed::initialize(
-        &NODE_HOST,
-        vec![
-            ("nodeLinker".to_string(), "hoisted".to_string()),
-            ("minimumReleaseAge".to_string(), "0".to_string()),
-        ],
-    );
+    if EMBEDDER_INITIALIZED.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    embed::initialize(&NODE_HOST, builtin_defaults());
 }
 
 async fn prepare_project_dir(project_dir: &Path) -> Result<PathBuf, InstallFailure> {
@@ -440,5 +535,58 @@ fn level_name(level: InstallOutputLevel) -> &'static str {
         InstallOutputLevel::Info => "info",
         InstallOutputLevel::Warning => "warning",
         InstallOutputLevel::Error => "error",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merged_defaults_lets_overrides_replace_builtins() {
+        let merged = merged_defaults(vec![(
+            "minimumReleaseAge".to_string(),
+            "259200".to_string(),
+        )]);
+        assert!(merged.contains(&("minimumReleaseAge".to_string(), "259200".to_string())));
+        assert!(merged.contains(&("nodeLinker".to_string(), "hoisted".to_string())));
+        assert_eq!(
+            merged
+                .iter()
+                .filter(|(key, _)| key == "minimumReleaseAge")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn merged_defaults_appends_settings_without_builtin_values() {
+        let merged = merged_defaults(vec![("paranoid".to_string(), "true".to_string())]);
+        assert!(merged.contains(&("paranoid".to_string(), "true".to_string())));
+        assert_eq!(merged.len(), builtin_defaults().len() + 1);
+    }
+
+    #[test]
+    fn validate_defaults_rejects_unknown_setting_names() {
+        let defaults = HashMap::from([("minimumRelaseAge".to_string(), "259200".to_string())]);
+        assert_eq!(
+            validate_defaults(defaults),
+            Err("minimumRelaseAge".to_string())
+        );
+    }
+
+    #[test]
+    fn validate_defaults_sorts_canonical_names() {
+        let defaults = HashMap::from([
+            ("nodeLinker".to_string(), "hoisted".to_string()),
+            ("minimumReleaseAge".to_string(), "259200".to_string()),
+        ]);
+        assert_eq!(
+            validate_defaults(defaults),
+            Ok(vec![
+                ("minimumReleaseAge".to_string(), "259200".to_string()),
+                ("nodeLinker".to_string(), "hoisted".to_string()),
+            ])
+        );
     }
 }

--- a/docs/embedding/node.md
+++ b/docs/embedding/node.md
@@ -44,6 +44,31 @@ saves an entry to `devDependencies`. Lifecycle scripts are skipped.
 Setting `offline: true` refuses registry access and resolves from the local
 store and packument caches. A missing cached package rejects the operation.
 
+## Configuration
+
+Register embedder setting defaults before the first `install`:
+
+```ts
+import { configure, install } from "@jdxcode/aube-node"
+
+configure({
+  defaults: {
+    minimumReleaseAge: "259200", // seconds; 3-day cooldown for fresh releases
+  },
+})
+```
+
+Defaults use canonical setting names and sit at the lowest precedence —
+environment variables, project files, and user configuration all override
+them. Registration is process-global and first-write-wins: calling
+`configure` after an install (or a second time) rejects with
+`ERR_AUBE_EMBED_ALREADY_INITIALIZED`, and unknown setting names reject with
+`ERR_AUBE_EMBED_INVALID_SETTING`. Without a `configure` call the addon
+applies its built-in defaults (`nodeLinker=hoisted`, `minimumReleaseAge=0`).
+
+Per-install, `osvTransitiveCheck: true` forces a live transitive OSV check
+even when resolution reused every version from the existing lockfile.
+
 ## Events
 
 `InstallEvent` is a discriminated union:

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -433,6 +433,18 @@
       "exit_code": null
     },
     {
+      "name": "ERR_AUBE_EMBED_INVALID_SETTING",
+      "category": "Misc / safety",
+      "description": "An in-process embedder passed a setting default whose name is not a canonical aube setting.",
+      "exit_code": null
+    },
+    {
+      "name": "ERR_AUBE_EMBED_ALREADY_INITIALIZED",
+      "category": "Misc / safety",
+      "description": "An in-process embedder tried to register setting defaults after the process already initialized its embedder profile.",
+      "exit_code": null
+    },
+    {
       "name": "ERR_AUBE_FFI_INVALID_ARGUMENT",
       "category": "Misc / safety",
       "description": "A C ABI call received a null pointer, invalid UTF-8, malformed JSON, or an unsupported option value.",


### PR DESCRIPTION
## Summary

- add `configure({ defaults })` to `@jdxcode/aube-node` so embedding hosts can register setting defaults (e.g. `minimumReleaseAge`) programmatically — previously the addon hardcoded `minimumReleaseAge=0` with no override short of env vars or per-project `.npmrc`
- validate default names against canonical settings; unknown names reject with new stable code `ERR_AUBE_EMBED_INVALID_SETTING`
- reject configure-after-install (or repeated configure) with new stable code `ERR_AUBE_EMBED_ALREADY_INITIALIZED` — registration is process-global and first-write-wins, so silent non-application would be a policy hazard
- expose `osvTransitiveCheck` on `InstallInput`, matching the C ABI's install options
- npm surface: `configure` re-export, `.d.ts` types, typecheck fixture, README + docs

## Motivation

opencode's aube adoption (anomalyco/opencode#37301) promises supply-chain policy on runtime installs — a cooldown matching its bunfig `minimumReleaseAge`. The C ABI already supports this via `aube_init` host-profile defaults; the Node-API addon had no equivalent.

## Validation

- `cargo test --locked -p aube-node` (new unit tests for default merging and name validation)
- `cargo clippy --all-targets`, `cargo fmt`
- `docs/error-codes.data.json` regenerated
- CI's npm smoke/typecheck covers the new export

*This PR was written by an AI coding assistant (Claude Code), directed by @jdx.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Process-global embedder init and supply-chain settings (`minimumReleaseAge`, `osvTransitiveCheck`) affect install behavior for all subsequent installs in the host; mis-ordered `configure` vs `install` is fail-closed but hosts must adopt the new API correctly.
> 
> **Overview**
> Adds **`configure({ defaults })`** to `@jdxcode/aube-node` so hosts can register embedder setting defaults (e.g. `minimumReleaseAge`) before the first `install`, paralleling C ABI `aube_init` host-profile defaults. Defaults merge with built-ins (`nodeLinker=hoisted`, `minimumReleaseAge=0`), validate names via `aube_settings::find`, and register once per process through `EMBEDDER_INIT` so `configure` and the first `install` race safely.
> 
> Late or duplicate `configure` throws **`ERR_AUBE_EMBED_ALREADY_INITIALIZED`**; unknown keys throw **`ERR_AUBE_EMBED_INVALID_SETTING`** (new stable codes in `aube-codes` and `docs/error-codes.data.json`). **`osvTransitiveCheck`** is wired through `InstallInput` into both `embed::add` and `embed::install`.
> 
> The npm layer re-exports `configure`, updates `.d.ts`, README, embedding docs, and typecheck fixture; `aube-node` gains `aube-settings` and unit tests for default merge/validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45ecae42a4eabce5b25be60d25e65f3a6df7cdf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->