### PR TITLE
feat(ffi): add polled event delivery via aube_events_next

### DIFF
--- a/crates/aube-ffi/include/aube.h
+++ b/crates/aube-ffi/include/aube.h
@@ -50,6 +50,12 @@ AUBE_API uint64_t aube_add(
  * aube_string_free. */
 AUBE_API char *aube_wait(uint64_t handle);
 
+/* Next buffered event for an operation started with bufferEvents: true, or
+ * NULL when none is pending or the handle is unknown/consumed. Free the
+ * returned string with aube_string_free. Events still buffered when
+ * aube_wait returns are discarded with the handle. */
+AUBE_API char *aube_events_next(uint64_t handle);
+
 /* Returns 0 when cancellation was requested, -1 for an unknown handle, and -2
  * when a panic is caught. */
 AUBE_API int32_t aube_cancel(uint64_t handle);

--- a/crates/aube-ffi/poc/bun.ts
+++ b/crates/aube-ffi/poc/bun.ts
@@ -12,6 +12,7 @@ const library = dlopen(libraryPath, {
   aube_install: { args: ["ptr", "ptr", "ptr"], returns: "u64" },
   aube_add: { args: ["ptr", "ptr", "ptr", "ptr", "ptr"], returns: "u64" },
   aube_wait: { args: ["u64"], returns: "ptr" },
+  aube_events_next: { args: ["u64"], returns: "ptr" },
   aube_cancel: { args: ["u64"], returns: "i32" },
   aube_string_free: { args: ["ptr"], returns: "void" },
 })
@@ -53,6 +54,30 @@ try {
   const installResult = wait(library.symbols.aube_install(ptr(installOptions), 0, 0))
   if (!installResult.ok) throw new Error(`offline install failed: ${JSON.stringify(installResult)}`)
   await access(path.join(project, "node_modules", "local-dependency"))
+
+  const polledOptions = cstring(
+    JSON.stringify({ projectDir: project, offline: true, ignoreScripts: true, force: true, bufferEvents: true }),
+  )
+  const polledHandle = library.symbols.aube_install(ptr(polledOptions), 0, 0)
+  const polled: string[] = []
+  for (let attempt = 0; attempt < 600; attempt++) {
+    for (;;) {
+      const event = library.symbols.aube_events_next(polledHandle)
+      if (!event) break
+      polled.push(new CString(event).toString())
+      library.symbols.aube_string_free(event)
+    }
+    if (polled.some((event) => event.includes('"phase":"complete"'))) break
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  if (!polled.some((event) => event.includes('"phase":"complete"'))) {
+    throw new Error(`polled events missing completion: ${JSON.stringify(polled)}`)
+  }
+  const polledResult = wait(polledHandle)
+  if (!polledResult.ok) throw new Error(`polled install failed: ${JSON.stringify(polledResult)}`)
+  if (library.symbols.aube_events_next(polledHandle)) {
+    throw new Error("events_next should be null after wait consumed the handle")
+  }
 
   const malformed = cstring("{")
   const malformedResult = wait(library.symbols.aube_install(ptr(malformed), 0, 0))

--- a/crates/aube-ffi/src/lib.rs
+++ b/crates/aube-ffi/src/lib.rs
@@ -5,7 +5,7 @@ use aube::embed::{
     InstallOutputLevel, InstallPhase, InstallReporter, NetworkMode,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::ffi::{CStr, CString, c_char, c_void};
 use std::future::Future;
 use std::path::PathBuf;
@@ -112,18 +112,61 @@ impl Job {
     }
 }
 
+/// Bounded FIFO of serialized events for hosts that poll instead of
+/// registering a callback (e.g. Bun, where cross-thread JS callbacks are
+/// unsupported). When full, the oldest event is dropped; progress consumers
+/// only care about the most recent snapshot.
+struct EventBuffer {
+    events: Mutex<VecDeque<String>>,
+}
+
+const EVENT_BUFFER_CAP: usize = 4096;
+
+impl EventBuffer {
+    fn new() -> Self {
+        Self {
+            events: Mutex::new(VecDeque::new()),
+        }
+    }
+
+    fn push(&self, json: String) {
+        let mut events = self
+            .events
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if events.len() == EVENT_BUFFER_CAP {
+            events.pop_front();
+        }
+        events.push_back(json);
+    }
+
+    fn next(&self) -> Option<String> {
+        self.events
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .pop_front()
+    }
+}
+
 #[derive(Clone)]
 struct CallbackReporter {
     callback: Option<AubeEventCallback>,
     context: usize,
+    buffer: Option<Arc<EventBuffer>>,
 }
 
 impl CallbackReporter {
     fn report_payload(&self, event: &EventPayload) {
-        let Some(callback) = self.callback else {
+        if self.callback.is_none() && self.buffer.is_none() {
+            return;
+        }
+        let Ok(json) = serde_json::to_string(event) else {
             return;
         };
-        let Ok(json) = serde_json::to_string(event) else {
+        if let Some(buffer) = &self.buffer {
+            buffer.push(json.clone());
+        }
+        let Some(callback) = self.callback else {
             return;
         };
         let Ok(json) = CString::new(json) else {
@@ -242,6 +285,8 @@ struct InstallInput {
     dangerously_allow_all_builds: bool,
     #[serde(default)]
     osv_transitive_check: bool,
+    #[serde(default)]
+    buffer_events: bool,
 }
 
 #[derive(Clone, Copy, Default, Deserialize)]
@@ -269,6 +314,7 @@ struct AddInput {
     dev_only: bool,
     omit_optional: bool,
     osv_transitive_check: bool,
+    buffer_events: bool,
 }
 
 fn default_true() -> bool {
@@ -327,6 +373,19 @@ pub extern "C" fn aube_wait(handle: u64) -> *mut c_char {
         Err(_) => result_json(Err(Failure::panic())),
     };
     owned_c_string(json)
+}
+
+/// Return the next buffered event for an operation started with
+/// `bufferEvents: true`, or null when no event is pending (or the handle is
+/// unknown or already consumed). The returned string must be freed with
+/// [`aube_string_free`]. Events still buffered when [`aube_wait`] returns are
+/// discarded with the handle.
+#[unsafe(no_mangle)]
+pub extern "C" fn aube_events_next(handle: u64) -> *mut c_char {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| events_next_impl(handle))) {
+        Ok(Some(json)) => owned_c_string(json),
+        _ => std::ptr::null_mut(),
+    }
 }
 
 /// Request cooperative cancellation for an operation.
@@ -435,6 +494,7 @@ fn install_impl(
     let reporter = CallbackReporter {
         callback,
         context: context as usize,
+        buffer: input.buffer_events.then(|| Arc::new(EventBuffer::new())),
     };
     let runtime = runtime()?;
     let control = InstallControl::events(Arc::new(reporter.clone()));
@@ -485,6 +545,7 @@ fn add_impl(
     let reporter = CallbackReporter {
         callback,
         context: context as usize,
+        buffer: input.buffer_events.then(|| Arc::new(EventBuffer::new())),
     };
     let runtime = runtime()?;
     let control = InstallControl::events(Arc::new(reporter.clone()));
@@ -551,6 +612,7 @@ fn completed_failure(error: Failure) -> u64 {
     let reporter = CallbackReporter {
         callback: None,
         context: 0,
+        buffer: None,
     };
     let (handle, job) = register_job(InstallControl::silent(), reporter);
     job.finish(Err(error));
@@ -581,6 +643,15 @@ fn wait_impl(handle: u64) -> String {
         .unwrap_or_else(std::sync::PoisonError::into_inner)
         .remove(&handle);
     result
+}
+
+fn events_next_impl(handle: u64) -> Option<String> {
+    let job = jobs()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .get(&handle)
+        .cloned()?;
+    job.callback.buffer.as_ref()?.next()
 }
 
 fn cancel_impl(handle: u64) -> bool {
@@ -745,6 +816,7 @@ mod tests {
         let reporter = CallbackReporter {
             callback: None,
             context: 0,
+            buffer: None,
         };
         let (handle, job) = register_job(InstallControl::silent(), reporter);
         spawn_job(runtime().unwrap(), job, async {
@@ -759,6 +831,7 @@ mod tests {
         let reporter = CallbackReporter {
             callback: None,
             context: 0,
+            buffer: None,
         };
         let (handle, job) = register_job(InstallControl::silent(), reporter);
         let (sender, receiver) = mpsc::channel();
@@ -840,6 +913,75 @@ mod tests {
             project_result["code"],
             aube_codes::errors::ERR_AUBE_EMBED_INSTALL_FAILED
         );
+    }
+
+    fn next_event(handle: u64) -> Option<String> {
+        let value = aube_events_next(handle);
+        if value.is_null() {
+            return None;
+        }
+        // SAFETY: aube_events_next returned an owned NUL-terminated string.
+        let json = unsafe { CStr::from_ptr(value) }
+            .to_str()
+            .unwrap()
+            .to_string();
+        // SAFETY: value was returned by aube_events_next and has not been freed.
+        unsafe { aube_string_free(value) };
+        Some(json)
+    }
+
+    #[test]
+    fn polls_buffered_events_without_a_callback() {
+        initialize();
+        let project = tempfile::tempdir().unwrap();
+        fs::write(project.path().join("package.json"), "{}\n").unwrap();
+        let options = c(serde_json::json!({
+            "projectDir": project.path(),
+            "offline": true,
+            "ignoreScripts": true,
+            "bufferEvents": true
+        })
+        .to_string());
+        let handle = aube_install(options.as_ptr(), None, std::ptr::null_mut());
+
+        let mut events = Vec::new();
+        for _ in 0..600 {
+            while let Some(event) = next_event(handle) {
+                events.push(event);
+            }
+            if events
+                .iter()
+                .any(|event| event.contains(r#""phase":"complete""#))
+            {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            events
+                .iter()
+                .any(|event| event.contains(r#""phase":"complete""#))
+        );
+        assert_eq!(wait(handle)["ok"], true);
+        assert!(aube_events_next(handle).is_null());
+    }
+
+    #[test]
+    fn events_next_is_null_without_buffering_or_for_unknown_handles() {
+        initialize();
+        assert!(aube_events_next(u64::MAX).is_null());
+
+        let project = tempfile::tempdir().unwrap();
+        fs::write(project.path().join("package.json"), "{}\n").unwrap();
+        let options = c(serde_json::json!({
+            "projectDir": project.path(),
+            "offline": true,
+            "ignoreScripts": true
+        })
+        .to_string());
+        let handle = aube_install(options.as_ptr(), None, std::ptr::null_mut());
+        assert!(aube_events_next(handle).is_null());
+        assert_eq!(wait(handle)["ok"], true);
     }
 
     #[test]

--- a/crates/aube-ffi/src/lib.rs
+++ b/crates/aube-ffi/src/lib.rs
@@ -646,12 +646,16 @@ fn wait_impl(handle: u64) -> String {
 }
 
 fn events_next_impl(handle: u64) -> Option<String> {
-    let job = jobs()
+    // Dequeue while holding the jobs lock so a poll cannot race aube_wait's
+    // removal and return an event for an already-consumed handle.
+    jobs()
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .get(&handle)
-        .cloned()?;
-    job.callback.buffer.as_ref()?.next()
+        .get(&handle)?
+        .callback
+        .buffer
+        .as_ref()?
+        .next()
 }
 
 fn cancel_impl(handle: u64) -> bool {

--- a/docs/embedding/ffi.md
+++ b/docs/embedding/ffi.md
@@ -144,18 +144,27 @@ const handle = library.symbols.aube_install(
   null,
   null,
 )
-const poll = setInterval(() => {
+let terminal = false
+while (!terminal) {
   for (;;) {
-    const event = library.symbols.aube_events_next(handle)
-    if (!event) break
-    console.log(JSON.parse(new CString(event).toString()))
-    library.symbols.aube_string_free(event)
+    const raw = library.symbols.aube_events_next(handle)
+    if (!raw) break
+    const event = JSON.parse(new CString(raw).toString())
+    library.symbols.aube_string_free(raw)
+    console.log(event)
+    terminal ||=
+      (event.kind === "phase" && event.phase === "complete") ||
+      (event.kind === "output" && event.level === "error")
   }
-}, 50)
-
-// When aube_wait(handle) returns (on whichever thread waits), stop polling:
-clearInterval(poll)
+  if (!terminal) await new Promise((resolve) => setTimeout(resolve, 50))
+}
+// The terminal event arrived, so aube_wait returns immediately and
+// releases the handle.
+const result = library.symbols.aube_wait(handle)
 ```
+
+The terminal event is the `complete` phase on success or the `error` output a
+failed operation emits last.
 
 `aube_events_next` returns the next buffered event as JSON (same schema as the
 callback transport), or null when no event is pending or the handle is unknown
@@ -175,6 +184,7 @@ const library = dlopen(libraryPath, {
   aube_init: { args: ["ptr"], returns: "i32" },
   aube_install: { args: ["ptr", "ptr", "ptr"], returns: "u64" },
   aube_wait: { args: ["u64"], returns: "ptr" },
+  aube_events_next: { args: ["u64"], returns: "ptr" },
   aube_cancel: { args: ["u64"], returns: "i32" },
   aube_string_free: { args: ["ptr"], returns: "void" },
 })

--- a/docs/embedding/ffi.md
+++ b/docs/embedding/ffi.md
@@ -132,6 +132,36 @@ type InstallEvent =
 
 Codes follow the published [error-code stability policy](/error-codes).
 
+## Polled events
+
+Hosts that cannot receive callbacks on foreign threads (Bun FFI, some ctypes
+setups) can poll instead. Start the operation with `bufferEvents: true` and
+drain the queue from any host thread:
+
+```ts
+const handle = library.symbols.aube_install(
+  ptr(c(JSON.stringify({ projectDir: ".", bufferEvents: true }))),
+  null,
+  null,
+)
+const poll = setInterval(() => {
+  for (;;) {
+    const event = library.symbols.aube_events_next(handle)
+    if (!event) break
+    console.log(JSON.parse(new CString(event).toString()))
+    library.symbols.aube_string_free(event)
+  }
+}, 50)
+```
+
+`aube_events_next` returns the next buffered event as JSON (same schema as the
+callback transport), or null when no event is pending or the handle is unknown
+or already consumed. Each returned string must be freed with
+`aube_string_free`. The buffer holds 4096 events and drops the oldest when
+full; events still buffered when `aube_wait` returns are discarded with the
+handle, so drain before waiting (or poll from a different thread than the one
+that waits).
+
 ## Bun FFI
 
 ```ts
@@ -160,8 +190,9 @@ library.symbols.aube_string_free(resultPointer)
 library.close()
 ```
 
-Bun's FFI and arbitrary-thread JavaScript callbacks remain experimental. Use
-the Node-API package when a JavaScript event callback is required in Bun.
+Bun's FFI and arbitrary-thread JavaScript callbacks remain experimental. In
+Bun, poll with `bufferEvents`/`aube_events_next` (above) instead of passing a
+callback, or use the Node-API package.
 
 ## Deno FFI
 

--- a/docs/embedding/ffi.md
+++ b/docs/embedding/ffi.md
@@ -152,6 +152,9 @@ const poll = setInterval(() => {
     library.symbols.aube_string_free(event)
   }
 }, 50)
+
+// When aube_wait(handle) returns (on whichever thread waits), stop polling:
+clearInterval(poll)
 ```
 
 `aube_events_next` returns the next buffered event as JSON (same schema as the


### PR DESCRIPTION
## Summary

- add `bufferEvents: true` to the C ABI's install/add options: events are additionally queued into a bounded per-operation buffer (4096 entries, drop-oldest)
- add `aube_events_next(handle)`: returns the next buffered event as an owned JSON string (same schema as the callback transport; free with `aube_string_free`), or null when no event is pending or the handle is unknown/consumed
- events remaining when `aube_wait` returns are discarded with the handle (documented); drain before waiting or poll from a different thread
- header, docs (`/embedding/ffi` gains a Polled events section; the Bun note now points at polling instead of steering everyone to Node-API), Bun POC exercises the polling path in CI

## Motivation

Bun cannot safely receive JS callbacks on foreign threads, so FFI hosts on Bun previously had no progress story at all. opencode's aube adoption (anomalyco/opencode#37301) includes surfacing install progress in its TUI; its C ABI variant needs a poll-based transport.

## Validation

- `cargo test --locked -p aube-ffi` (8 tests, including new polling and null-contract tests)
- `cargo clippy --all-targets`, `cargo fmt`
- `crates/aube-ffi/poc/run.sh` covers the polling flow in CI

*This PR was written by an AI coding assistant (Claude Code), directed by @jdx.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Additive C ABI with new threading/handle-lifetime contract; bounded buffer can drop old events under flood, but core install paths are unchanged unless hosts opt in.
> 
> **Overview**
> Adds a **poll-based install progress path** for C ABI hosts that cannot use cross-thread callbacks (notably Bun FFI).
> 
> Install and add options gain **`bufferEvents: true`**, which enqueues serialized progress JSON into a per-operation FIFO (4096 entries, drop-oldest). **`aube_events_next(handle)`** dequeues owned event strings (same schema as callbacks; free with `aube_string_free`), or returns null when idle, unknown, or after **`aube_wait`** consumes the handle—any leftover buffered events are discarded with the handle.
> 
> The reporter still invokes callbacks when provided; buffering is additive. Polling is synchronized with handle lifetime via the jobs map lock so polls cannot race **`aube_wait`** removal. Header, **`/embedding/ffi`** (new Polled events section), Bun POC smoke, and Rust tests cover the contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9edb8d78b516dd2fe9e7593e6ec309f0a4573aa9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `bufferEvents` support for install and add operations.
  * Introduced `aube_events_next(handle)` to poll buffered progress events from any host thread (returns the next JSON event string, or `NULL` when none/unknown/consumed).
  * Events are buffered in a bounded queue (up to 4,096 entries); when full, the oldest events are dropped.

* **Documentation**
  * Added “Polled events” guidance, including freeing returned event strings and discarding any remaining events when `aube_wait(handle)` is called.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->