### PR TITLE
fix(ci): attach ffi release assets during the draft phase

### DIFF
--- a/.github/workflows/ffi.yml
+++ b/.github/workflows/ffi.yml
@@ -30,6 +30,35 @@ on:
       - ".github/workflows/ffi.yml"
   release:
     types: [published]
+  # Called from release-plz.yml between the CLI asset upload and the
+  # draft→published flip. With immutable GitHub releases enabled, a
+  # release's asset list freezes the moment it publishes — so the C ABI
+  # libraries must be attached while the release is still a draft. npm
+  # publishing intentionally stays on the `release: published` event
+  # above: npm doesn't care about release immutability, and gating it
+  # on the published release means packages only go out for releases
+  # that actually shipped.
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+      # Constant marker distinguishing the draft-phase call from a
+      # direct workflow_dispatch: inside a called workflow,
+      # github.event_name reflects the *caller's* event, which is
+      # itself workflow_dispatch when release-plz.yml is manually
+      # re-run — so the event name alone can't gate the npm publish.
+      draft_phase:
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      AUBE_GH_TOKEN:
+        required: true
+      CERTIFICATES_P12:
+        required: true
+      CERTIFICATES_P12_PASS:
+        required: true
   workflow_dispatch:
     inputs:
       tag:
@@ -185,7 +214,10 @@ jobs:
             packages/libaube-*
             packages/aube.h
       - name: Publish platform and root packages
-        if: github.event_name == 'release' || inputs.tag != ''
+        # `release: published` (or a manual dispatch backfill, where
+        # draft_phase is undeclared and thus falsy) only — never the
+        # workflow_call draft phase; see the trigger comment.
+        if: github.event_name == 'release' || (inputs.tag != '' && !inputs.draft_phase)
         shell: bash
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
@@ -205,18 +237,32 @@ jobs:
           for package in ./packages/*-darwin-*.tgz ./packages/*-linux-*.tgz ./packages/*-win32-*.tgz; do publish_package "$package"; done
           publish_package "./packages/jdxcode-aube-ffi-${version}.tgz"
 
+  # Attach the C ABI libraries + header to the (still-draft) GitHub
+  # release. Runs on the workflow_call from release-plz.yml during a
+  # real release, or on a workflow_dispatch with `tag` as the recovery
+  # path for a draft whose ffi assets are missing. Never on the
+  # `release: published` event: under immutable releases that is
+  # always too late to add assets.
   release-assets:
-    if: github.event_name == 'release' || inputs.tag != ''
+    if: inputs.tag != ''
     needs: packages
     runs-on: ubuntu-latest
-    permissions: { contents: write }
+    # Uploads authenticate with AUBE_GH_TOKEN (the PAT release.yml
+    # already uses for draft asset uploads), not github.token.
+    permissions: {}
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with: { name: aube-ffi-distribution, path: packages }
-      - name: Attach C ABI assets to release
+      - name: Attach C ABI assets to draft release
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          GH_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}
+          RELEASE_TAG: ${{ inputs.tag }}
         # No checkout in this job, so gh needs the repo passed explicitly.
-        run: gh release upload --repo "$GITHUB_REPOSITORY" "$RELEASE_TAG" packages/libaube-* packages/aube.h --clobber
+        run: |
+          is_draft=$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)
+          if [[ "$is_draft" != "true" ]]; then
+            echo "::notice::release $RELEASE_TAG is already published; immutable releases cannot gain assets, skipping upload"
+            exit 0
+          fi
+          gh release upload --repo "$GITHUB_REPOSITORY" "$RELEASE_TAG" packages/libaube-* packages/aube.h --clobber

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -147,6 +147,7 @@ jobs:
     uses: ./.github/workflows/ffi.yml
     with:
       tag: ${{ needs.release-plz-release.outputs.tag }}
+      draft_phase: true
     secrets:
       AUBE_GH_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}
       CERTIFICATES_P12: ${{ secrets.CERTIFICATES_P12 }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -128,19 +128,44 @@ jobs:
       CERTIFICATES_P12: ${{ secrets.CERTIFICATES_P12 }}
       CERTIFICATES_P12_PASS: ${{ secrets.CERTIFICATES_P12_PASS }}
 
+  # Build + codesign the C ABI libraries and attach them (plus aube.h)
+  # to the draft release. Must complete before `publish-release`:
+  # immutable releases freeze the asset list the moment the draft
+  # flips live, so ffi.yml's old post-publish upload path could never
+  # attach anything. npm publishing of @jdxcode/aube-ffi is NOT part
+  # of this call — that stays on ffi.yml's `release: published`
+  # trigger so packages only go out for releases that actually
+  # shipped.
+  upload-ffi-assets:
+    name: Upload ffi assets
+    needs: release-plz-release
+    if: ${{ needs.release-plz-release.outputs.tag != '' }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/ffi.yml
+    with:
+      tag: ${{ needs.release-plz-release.outputs.tag }}
+    secrets:
+      AUBE_GH_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}
+      CERTIFICATES_P12: ${{ secrets.CERTIFICATES_P12 }}
+      CERTIFICATES_P12_PASS: ${{ secrets.CERTIFICATES_P12_PASS }}
+
   # Flip the draft release to non-draft once *every* asset uploaded
   # cleanly. With immutable GitHub releases enabled, a published
   # release can't have its assets replaced — so if any matrix target
   # failed, we leave the draft in place rather than ship a release
   # with missing platform binaries (downstream npm / COPR / PPA jobs
   # would also fail trying to fetch the holes). To recover: manually
-  # re-run `release.yml` via workflow_dispatch with the tag input,
-  # which fills in the missing assets, then either flip the draft by
-  # hand (`gh release edit $TAG --draft=false`) or workflow_dispatch
-  # the whole release-plz workflow again so this job runs.
+  # re-run `release.yml` (CLI binaries) or `ffi.yml` (C ABI libraries)
+  # via workflow_dispatch with the tag input, which fills in the
+  # missing assets, then either flip the draft by hand
+  # (`gh release edit $TAG --draft=false`) or workflow_dispatch the
+  # whole release-plz workflow again so this job runs.
   publish-release:
     name: Publish release
-    needs: [release-plz-release, upload-assets]
+    needs: [release-plz-release, upload-assets, upload-ffi-assets]
     if: ${{ needs.release-plz-release.outputs.tag != '' }}
     runs-on: namespace-profile-endev-linux-amd64
     permissions:


### PR DESCRIPTION
## Problem

jdx/aube has **immutable GitHub releases** enabled: the asset list freezes the moment `publish-release` flips the draft live. `ffi.yml`'s `release-assets` job triggered on `release: published` — which under immutability is *always* too late. The v1.28.0 backfill attempt (run 29516918936) failed on exactly this; v1.28.0 can never receive its `libaube-*`/`aube.h` assets, and every future release would go red the same way. (FFI consumers aren't blocked for v1.28.0 — the `@jdxcode/aube-ffi` npm packages carry the same libraries.)

## Fix

Attach the C ABI assets while the release is still a draft, the same way the CLI binaries are:

- **`ffi.yml`** gains a `workflow_call` trigger (`tag` + the signing/upload secrets). Called this way it builds, signs, smoke-tests, attests, and uploads `libaube-*` + `aube.h` onto the draft — but does **not** publish to npm.
- **`release-plz.yml`** gains an `upload-ffi-assets` job that calls it between `release-plz-release` and `publish-release`; `publish-release` now `needs:` it. The release only flips live once *all* advertised artifacts exist — which is rather the point of immutable releases.
- **npm publishing stays on `release: published`**: npm has no immutability constraint, and gating on the published release means packages only ship for releases that actually went out.

## Details worth reviewing

- Inside a called workflow, `github.event_name` reflects the **caller's** event — and `release-plz.yml` is itself manually dispatchable as a recovery path. The event name alone therefore can't gate the npm publish, so the `workflow_call` trigger carries a constant `draft_phase: true` marker input; direct dispatches leave it undeclared (falsy).
- `release-assets` now checks `isDraft` first and skips with a notice when the release is already published — a dispatch backfill against an immutable release becomes a green no-op instead of a red herring.
- Draft uploads authenticate with `AUBE_GH_TOKEN`, matching `release.yml`'s proven draft-phase uploads; the job drops its `contents: write` grant.
- `workflow_dispatch` with `tag` remains the recovery path for a draft missing its ffi assets (mirroring the documented `release.yml` recovery), and still backfills npm for published releases.
- PR/push CI paths and the empty-tag smoke build are unchanged; `actionlint` and `zizmor` both pass clean.

Behavior by trigger:

| Trigger | sign/attest | npm publish | release-page assets |
|---|---|---|---|
| PR / push to main | no | no | no |
| dispatch, empty tag (smoke) | no | no | no |
| `workflow_call` (draft phase) | yes | no | upload to draft |
| `release: published` | yes | yes | no (frozen) |
| dispatch with tag (recovery) | yes | yes | only if still draft |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release pipeline ordering and secrets for GitHub release uploads; mistakes could block publishes or skip npm/FFI assets, but behavior is narrowly scoped to CI workflows with documented recovery via workflow_dispatch.
> 
> **Overview**
> **Immutable GitHub releases** freeze assets at publish time, so attaching `libaube-*` and `aube.h` on `release: published` could never succeed. This change uploads those C ABI assets **while the release is still a draft**, in line with how CLI binaries are handled.
> 
> `ffi.yml` adds a **`workflow_call`** path (`tag`, signing secrets, and `draft_phase`) that builds, attests, and uploads release-page assets to the draft but **skips npm**. **`release-plz.yml`** adds **`upload-ffi-assets`** (calling `ffi.yml` with `draft_phase: true`) before **`publish-release`**, which now waits on that job so the draft only goes live when FFI assets exist.
> 
> **npm** for `@jdxcode/aube-ffi` stays gated on **`release: published`** or manual **`workflow_dispatch`** with a tag (where `draft_phase` is falsy), using the `draft_phase` input because nested `workflow_call` inherits the caller’s event name. **`release-assets`** uploads with **`AUBE_GH_TOKEN`**, requires `inputs.tag`, checks **`isDraft`** and no-ops with a notice if the release is already published, and no longer runs on the published-release event alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 216958c0daf1bd5926880d57113330bd88c75ecc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->