### PR TITLE
docs: use homebrew-core formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ performance. The npm commands above include the flag that keeps that
 working even if your npm config disables scripts. We still recommend mise
 for the smoothest install and runtime management path.
 
-Homebrew installs come from the jdx tap:
+Homebrew installs come from the core tap:
 
 ```sh
-brew install jdx/tap/aube
+brew install aube
 ```
 
 See [other install methods](https://aube.jdx.dev/installation).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -39,13 +39,13 @@ same dependency versions CI built against. The compiled binary lands in
 
 ## From Homebrew
 
-aube is published from the jdx tap until it lands in homebrew-core:
+aube is published from the core tap:
 
 ```sh
-brew install jdx/tap/aube
+brew install aube
 ```
 
-The tap formula builds from source and installs shell completions.
+The tap formula uses prebuilt bottles and installs shell completions.
 
 ## From npm
 


### PR DESCRIPTION
👋 I submitted aube to homebrew-core in https://github.com/Homebrew/homebrew-core/pull/285697 but the docs here remain unchanged. Homebrew provides prebuilt bottles/binaries so should be recommended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Homebrew installation instructions to use the core Homebrew tap.
  * Installation now uses `brew install aube` with prebuilt packages and shell completions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->