### PR TITLE
fix(dlx): tear down spawned tool when aube is terminated

### DIFF
--- a/.rules
+++ b/.rules
@@ -96,7 +96,7 @@ commands:
   test_unit: cargo test
   clippy: cargo clippy --all-targets -- -D warnings
   fmt_check: cargo fmt --check
-  bats: mise run test:bats (needs Node.js 22 + GNU parallel)
+  bats: mise run test:bats (needs Node.js 22; parallel jobs run via mise-managed rush, no system GNU parallel needed)
   bats_single: mise run test:bats test/install.bats
 
 release_profile:

--- a/crates/aube/src/commands/dlx.rs
+++ b/crates/aube/src/commands/dlx.rs
@@ -230,8 +230,8 @@ pub async fn run(args: DlxArgs) -> miette::Result<Option<i32>> {
         crate::runtime::apply_child_env(&mut cmd);
         cmd.env("PATH", &new_path)
             .current_dir(&prev_cwd)
-            .stderr(aube_scripts::child_stderr())
-            .status()
+            .stderr(aube_scripts::child_stderr());
+        crate::process_guard::spawn_and_wait(cmd)
             .await
             .into_diagnostic()
             .wrap_err("failed to execute dlx shell command")?
@@ -275,7 +275,7 @@ pub async fn run(args: DlxArgs) -> miette::Result<Option<i32>> {
             cmd.env("PATH", aube_scripts::prepend_paths(&runtime_dirs));
         }
         crate::runtime::apply_child_env(&mut cmd);
-        cmd.status()
+        crate::process_guard::spawn_and_wait(cmd)
             .await
             .into_diagnostic()
             .wrap_err("failed to execute dlx binary")?

--- a/crates/aube/src/commands/exec.rs
+++ b/crates/aube/src/commands/exec.rs
@@ -332,10 +332,10 @@ pub(crate) async fn exec_bin_with_node_args(
         cmd.args(args);
         cmd
     };
-    let status = command
+    command
         .current_dir(cwd)
-        .stderr(aube_scripts::child_stderr())
-        .status()
+        .stderr(aube_scripts::child_stderr());
+    let status = crate::process_guard::spawn_and_wait(command)
         .await
         .into_diagnostic()
         .wrap_err("failed to execute binary")?;

--- a/crates/aube/src/lib.rs
+++ b/crates/aube/src/lib.rs
@@ -22,6 +22,7 @@ pub mod embed;
 mod engines;
 mod patches;
 mod pnpmfile;
+mod process_guard;
 mod progress;
 mod runtime;
 mod self_version;

--- a/crates/aube/src/process_guard.rs
+++ b/crates/aube/src/process_guard.rs
@@ -1,0 +1,133 @@
+//! Ties a spawned child's lifetime to the aube process so that stopping
+//! aube stops the tool it launched, instead of orphaning it under `init`
+//! (`ppid=1`). See <https://github.com/jdx/aube/discussions/1059>.
+//!
+//! `aube dlx <tool>` / `aube exec <bin>` used to `spawn` a child and simply
+//! await it, with no link between the child and aube's own lifetime. A
+//! supervisor that stops the tool by signalling the `aube` process it
+//! launched (a long-running host running a stdio server via `aube dlx`,
+//! say) would strand the tool on every launch — `npx`, `pnpm dlx`, and
+//! `bunx` all tear it down.
+//!
+//! Coverage:
+//!   - Any Unix: catchable termination signals (SIGTERM/SIGINT/SIGHUP/
+//!     SIGQUIT) delivered to aube are forwarded to the child, so
+//!     `pkill -x aube` tears the tool down.
+//!   - Linux additionally sets `PR_SET_PDEATHSIG`, so even an uncatchable
+//!     `SIGKILL` of aube reaps the child via the kernel — nothing runs in
+//!     aube on `SIGKILL`, so this has to come from the OS.
+//!   - macOS `SIGKILL`-of-aube is the one remaining gap: there is no
+//!     `PDEATHSIG` equivalent and no aube code runs on `SIGKILL`, so the
+//!     teardown has to live in a process that outlives aube. That
+//!     `kqueue`/`NOTE_EXIT` watcher is a tracked follow-up; see the spawn
+//!     site below.
+
+use std::process::ExitStatus;
+
+/// Configure `cmd` so the child is torn down when aube dies, then spawn it
+/// and wait — forwarding catchable termination signals to the child while
+/// it runs. Drop-in replacement for `cmd.status().await`.
+pub(crate) async fn spawn_and_wait(
+    mut cmd: tokio::process::Command,
+) -> std::io::Result<ExitStatus> {
+    set_parent_death_signal(&mut cmd);
+
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+        // Register the signal listeners *before* spawning. Registration is
+        // process-global and independent of the child, and a `signal()`
+        // failure here must not leave a running child behind —
+        // `tokio::process::Child` does not kill on drop, so spawning first
+        // and then erroring out of `?` would orphan exactly what this module
+        // exists to prevent.
+        let mut sigterm = signal(SignalKind::terminate())?;
+        let mut sigint = signal(SignalKind::interrupt())?;
+        let mut sighup = signal(SignalKind::hangup())?;
+        let mut sigquit = signal(SignalKind::quit())?;
+
+        let mut child = cmd.spawn()?;
+
+        // macOS SIGKILL-of-aube teardown (follow-up, discussion #1059):
+        // spawn a `kqueue`/`NOTE_EXIT` watchdog here on `child.id()`. It has
+        // to be a separate process because a `SIGKILL`ed aube runs no code;
+        // the watchdog survives aube (reparented to init) and kills the
+        // child when aube's pid fires `NOTE_EXIT`. Signal forwarding below
+        // already covers the catchable cases on macOS.
+
+        // Cache the pid up front: after `child.wait()` resolves the pid is
+        // gone, and we only ever forward while the child is still running.
+        let pid = child.id();
+        loop {
+            tokio::select! {
+                status = child.wait() => return status,
+                _ = sigterm.recv() => forward_signal(pid, libc::SIGTERM),
+                _ = sigint.recv() => forward_signal(pid, libc::SIGINT),
+                _ = sighup.recv() => forward_signal(pid, libc::SIGHUP),
+                _ = sigquit.recv() => forward_signal(pid, libc::SIGQUIT),
+            }
+            // Keep waiting after forwarding: let the child decide how to
+            // react and propagate its real exit status, matching `npx` /
+            // `pnpm dlx`. If the child ignores the signal, aube stays bound
+            // to it rather than exiting out from under it.
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let mut child = cmd.spawn()?;
+        child.wait().await
+    }
+}
+
+/// Apply the OS-level "die with the parent" hint before spawn. Linux-only
+/// (`PR_SET_PDEATHSIG`); a no-op elsewhere.
+fn set_parent_death_signal(cmd: &mut tokio::process::Command) {
+    #[cfg(target_os = "linux")]
+    {
+        // aube's own pid, captured before the fork. The child compares its
+        // parent against this to detect an aube that already exited — a plain
+        // `getppid() == 1` check would miss it under `PR_SET_CHILD_SUBREAPER`
+        // (containers with tini, `systemd --user` sessions), where orphans
+        // reparent to a subreaper with a pid > 1 rather than to init.
+        let parent_pid = std::process::id() as libc::pid_t;
+        // SAFETY: this closure runs in the forked child between fork and
+        // exec, so it may only touch async-signal-safe libc calls. `prctl`,
+        // `getppid`, and `raise` are all async-signal-safe; there is no
+        // allocation and no lock acquisition on this path.
+        unsafe {
+            cmd.pre_exec(move || {
+                // Deliver SIGTERM to this child when the thread that forked
+                // it goes away — covers an uncatchable SIGKILL of aube.
+                if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM, 0, 0, 0) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                // Race guard: aube may have exited between fork and the prctl
+                // above, in which case the death signal was already (not)
+                // delivered and we would run detached. If our parent is no
+                // longer aube, we have already been reparented — self-
+                // terminate rather than leak.
+                if libc::getppid() != parent_pid {
+                    libc::raise(libc::SIGTERM);
+                }
+                Ok(())
+            });
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = cmd;
+    }
+}
+
+#[cfg(unix)]
+fn forward_signal(pid: Option<u32>, sig: libc::c_int) {
+    let Some(pid) = pid else {
+        return;
+    };
+    // SAFETY: `kill(2)` with a concrete pid and a valid signal number. A
+    // child that has already exited yields `ESRCH`, which we ignore — the
+    // `child.wait()` arm of the select will resolve on the next poll.
+    unsafe {
+        libc::kill(pid as libc::pid_t, sig);
+    }
+}

--- a/mise-tasks/test/bats
+++ b/mise-tasks/test/bats
@@ -24,7 +24,7 @@ fi
 status=0
 ./test/bats/bin/bats \
 	--jobs "$jobs" \
-	--parallel-binary-name parallel \
+	--parallel-binary-name rush \
 	--no-parallelize-within-files \
 	--filter-tags "!serial" \
 	"${targets[@]}" || status=$?

--- a/mise.lock
+++ b/mise.lock
@@ -299,6 +299,45 @@ url = "https://github.com/apple/pkl/releases/download/0.31.1/pkl-macos-amd64"
 checksum = "sha256:a8834481667325b44c539dbb758d7365a16389070f343c04b639bbe525ede013"
 url = "https://github.com/apple/pkl/releases/download/0.31.1/pkl-windows-amd64.exe"
 
+[[tools.rush]]
+version = "0.9.0"
+backend = "aqua:shenwei356/rush"
+
+[tools.rush."platforms.linux-arm64"]
+checksum = "sha256:e8cf6a45eab9e67b952650ea90eb87f457ac1a95a2d7e338eea88a4da488da7b"
+url = "https://github.com/shenwei356/rush/releases/download/v0.9.0/rush_linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/shenwei356/rush/releases/assets/391416978"
+
+[tools.rush."platforms.linux-arm64-musl"]
+checksum = "sha256:e8cf6a45eab9e67b952650ea90eb87f457ac1a95a2d7e338eea88a4da488da7b"
+url = "https://github.com/shenwei356/rush/releases/download/v0.9.0/rush_linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/shenwei356/rush/releases/assets/391416978"
+
+[tools.rush."platforms.linux-x64"]
+checksum = "sha256:436d935bcd0dc263d20674201cd3e9c85059d331d8641f970e1e8958ad0af4fc"
+url = "https://github.com/shenwei356/rush/releases/download/v0.9.0/rush_linux_amd64.tar.gz"
+url_api = "https://api.github.com/repos/shenwei356/rush/releases/assets/391416899"
+
+[tools.rush."platforms.linux-x64-musl"]
+checksum = "sha256:436d935bcd0dc263d20674201cd3e9c85059d331d8641f970e1e8958ad0af4fc"
+url = "https://github.com/shenwei356/rush/releases/download/v0.9.0/rush_linux_amd64.tar.gz"
+url_api = "https://api.github.com/repos/shenwei356/rush/releases/assets/391416899"
+
+[tools.rush."platforms.macos-arm64"]
+checksum = "sha256:f5cd118ee7a04c70849c891e172ed1d3fb85fc5c14a7dacddb1d5c210b0f0613"
+url = "https://github.com/shenwei356/rush/releases/download/v0.9.0/rush_darwin_arm64.tar.gz"
+url_api = "https://api.github.com/repos/shenwei356/rush/releases/assets/391416669"
+
+[tools.rush."platforms.macos-x64"]
+checksum = "sha256:85c43308b935bef7f09922c98dc9f1d304843457c8c0daa06a1a22ae16393f9e"
+url = "https://github.com/shenwei356/rush/releases/download/v0.9.0/rush_darwin_amd64.tar.gz"
+url_api = "https://api.github.com/repos/shenwei356/rush/releases/assets/391416568"
+
+[tools.rush."platforms.windows-x64"]
+checksum = "sha256:4ed40a085fa19ccdb02af418d639f9ef3dba11289454695aef7609a6431ef07e"
+url = "https://github.com/shenwei356/rush/releases/download/v0.9.0/rush_windows_amd64.exe.tar.gz"
+url_api = "https://api.github.com/repos/shenwei356/rush/releases/assets/391417091"
+
 [[tools.shellcheck]]
 version = "0.11.0"
 backend = "aqua:koalaman/shellcheck"

--- a/mise.toml
+++ b/mise.toml
@@ -11,6 +11,11 @@ hk = "latest"
 node = "24"
 pitchfork = "latest"
 pkl = "latest"
+# Parallel-job driver for `mise run test:bats`. bats-core natively
+# supports shenwei356/rush as a GNU-parallel alternative, and unlike GNU
+# parallel (a Perl script with no clean mise backend) rush ships static
+# linux+darwin binaries, so contributors get it with no manual install.
+rush = "latest"
 shellcheck = "latest"
 shfmt = "latest"
 usage = "latest"

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -69,3 +69,55 @@ EOF
 	assert_output --partial "binary not found in b: sentinel"
 	assert_file_not_exist packages/sentinel-ran
 }
+
+# Regression: terminating the aube process must tear down the tool it
+# spawned instead of orphaning it under init. See discussion #1059.
+# Parameterized over the signal: SIGTERM exercises the forwarding path,
+# SIGKILL exercises Linux PR_SET_PDEATHSIG (skipped elsewhere — macOS
+# SIGKILL-of-parent teardown is a separate follow-up).
+_assert_child_torn_down_on() {
+	local sig="$1" dur="$2"
+	cat >package.json <<'EOF'
+{"name":"t","version":"0.0.0"}
+EOF
+	mkdir -p node_modules/.bin
+	printf '#!/bin/sh\nexec sleep %s\n' "$dur" >node_modules/.bin/sleeper
+	chmod +x node_modules/.bin/sleeper
+
+	aube exec --no-install sleeper &
+	local aube_pid=$!
+
+	local child=""
+	for _ in $(seq 1 50); do
+		child="$(pgrep -f "sleep ${dur}\$" || true)"
+		[ -n "$child" ] && break
+		sleep 0.1
+	done
+	[ -n "$child" ] || {
+		kill "$aube_pid" 2>/dev/null || true
+		fail "spawned tool never started"
+	}
+
+	kill "-${sig}" "$aube_pid" 2>/dev/null || true
+
+	local gone=""
+	for _ in $(seq 1 30); do
+		pgrep -f "sleep ${dur}\$" >/dev/null || {
+			gone=1
+			break
+		}
+		sleep 0.1
+	done
+	pkill -f "sleep ${dur}\$" 2>/dev/null || true
+	[ -n "$gone" ] || fail "tool orphaned after ${sig} to aube"
+}
+
+@test "aube exec tears down the spawned tool on SIGTERM" {
+	[ "$(uname -s)" != "Windows_NT" ] || skip "signals are POSIX"
+	_assert_child_torn_down_on TERM 987651
+}
+
+@test "aube exec tears down the spawned tool on SIGKILL (Linux PDEATHSIG)" {
+	[ "$(uname -s)" = "Linux" ] || skip "PR_SET_PDEATHSIG is Linux-only"
+	_assert_child_torn_down_on KILL 987652
+}


### PR DESCRIPTION
## What

`aube dlx <tool>` orphaned the tool it launched when the `aube` process was terminated. The child kept running, reparented to `init` (`ppid=1`), surviving even a catchable SIGTERM. `npx`, `pnpm dlx`, and `bunx` all tear the tool down in the same scenario. Reported in [discussion #1059](https://github.com/jdx/aube/discussions/1059).

The root cause: `dlx` (and the shared `exec` helper) spawned the child with `Command::status().await` and had nothing linking the child's lifetime to aube's — no signal handling, no parent-death propagation. This stranded long-running stdio servers launched via `aube dlx` on every host teardown, leaking processes and memory.

## Fix

Route the `dlx` (non-shell + shell-mode) and `exec_bin` spawns through a new `process_guard::spawn_and_wait` that ties the child to aube:

- **Any Unix** — forwards catchable termination signals (SIGTERM / SIGINT / SIGHUP / SIGQUIT) from aube to the child, so `pkill -x aube` stops the tool. Fixes the headline "survives even a catchable SIGTERM" complaint on both Linux and macOS.
- **Linux** — additionally sets `PR_SET_PDEATHSIG` (with a `getppid()` race guard) via `pre_exec`, so even an uncatchable `SIGKILL` of aube reaps the child via the kernel. Follows the existing `prctl` usage in `aube-scripts/src/linux_jail.rs`.

### Known gap

macOS `SIGKILL`-of-aube is intentionally unsupported. There is no `PDEATHSIG` equivalent and no aube code runs after `SIGKILL`; supporting it would require an out-of-process `kqueue`/`NOTE_EXIT` watchdog plus a hidden re-exec path. We are deliberately not adding that complexity for an uncatchable signal. Catchable teardown on macOS **is** fixed by the signal forwarding above.

## Verification

- New bats regression tests in `test/exec.bats`, parameterized over the signal: SIGTERM (forwarding, any Unix) and SIGKILL (Linux PDEATHSIG, skipped elsewhere). Both assert the spawned tool is gone after signalling aube.
- Confirmed the tests discriminate: against the pre-fix binary both leak; with the fix both tear down.
- `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test -p aube` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process lifecycle and signal handling for dlx/exec child spawns on Unix/Linux; behavior is intentional but affects long-running tools and supervisors. Parallel exec / `run` paths still use `run_command` and are unchanged.
> 
> **Overview**
> **`aube dlx` and `aube exec`** no longer leave the launched binary running when the parent `aube` process is stopped. Spawns that used to call `Command::status().await` now go through **`process_guard::spawn_and_wait`**, which keeps the child tied to aube’s lifetime.
> 
> On **Unix**, catchable signals (SIGTERM, SIGINT, SIGHUP, SIGQUIT) received by aube are **forwarded** to the child so supervisors can stop the tool by killing aube. On **Linux**, **`PR_SET_PDEATHSIG`** (with a parent-PID race guard in `pre_exec`) also reaps the child when aube is SIGKILL’d. **macOS SIGKILL-of-aube** is still a documented gap (no PDEATHSIG / no code after SIGKILL).
> 
> **Tests and dev tooling:** BATS gains regression cases in `test/exec.bats` (SIGTERM everywhere; SIGKILL on Linux only). Parallel BATS jobs use mise-managed **`rush`** instead of system GNU `parallel` (`mise.toml`, `mise.lock`, `mise-tasks/test/bats`, `.rules`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29a33790fda51ee9636595de70d471541b78f4b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved process cleanup when commands are interrupted, preventing spawned tools from continuing to run after the parent command exits.
  - Improved handling of termination signals across supported platforms.

- **Testing**
  - Added regression coverage for cleanup after termination signals, including Linux-specific behavior.

- **Documentation**
  - Updated BATS testing instructions to require Node.js 22 and use the new parallel test runner.

- **Chores**
  - Updated the BATS test configuration to use the new parallel execution tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->