### PR TITLE
chore: satisfy nightly clippy (question_mark, fetch_update)

### DIFF
--- a/crates/aube-lockfile/src/source.rs
+++ b/crates/aube-lockfile/src/source.rs
@@ -259,10 +259,9 @@ impl LocalSource {
             ("link", r)
         } else if let Some(r) = spec.strip_prefix("portal:") {
             ("portal", r)
-        } else if let Some(r) = spec.strip_prefix("exec:") {
-            return Some(LocalSource::Exec(PathBuf::from(r)));
         } else {
-            return None;
+            let r = spec.strip_prefix("exec:")?;
+            return Some(LocalSource::Exec(PathBuf::from(r)));
         };
         let rel = PathBuf::from(rest);
         let abs = project_root.join(&rel);

--- a/crates/aube/src/progress/mod.rs
+++ b/crates/aube/src/progress/mod.rs
@@ -72,6 +72,11 @@ fn overflow_fetch_label(count: usize) -> String {
 fn clamp_reused_to(reused: &AtomicUsize, downloaded: &AtomicUsize, total: usize) {
     let dl = downloaded.load(Ordering::Relaxed);
     let cap = total.saturating_sub(dl);
+    // `fetch_update` is renamed to `try_update` in Rust 1.99, but that method
+    // is only stable since 1.95 and our MSRV is 1.93 — switch once the MSRV
+    // clears 1.95. The deprecation is nightly-only for now; allow it so a
+    // nightly `clippy -D warnings` stays green.
+    #[allow(deprecated)]
     let _ = reused.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |cur| {
         (cur > cap).then_some(cap)
     });


### PR DESCRIPTION
## What

Two lints surface under a newer/nightly clippy (0.1.99) that today's stable (0.1.97) doesn't yet flag. This clears both so a `cargo +nightly clippy -- -D warnings` run stays green.

### `clippy::question_mark` — `crates/aube-lockfile/src/source.rs`
Rewrote the trailing `exec:` arm of the source-kind match with the `?` operator. Behavior is identical — the function already returns `Option`, so `strip_prefix("exec:")?` returns `None` exactly where the old `else { return None }` did.

### deprecated `Atomic::fetch_update` — `crates/aube/src/progress/mod.rs`
`fetch_update` is `#[deprecated(since = "1.99.0")]` in favor of `try_update`. I did **not** switch to `try_update`: it's `#[stable(since = "1.95.0")]` and this repo's **MSRV is 1.93**, so the swap would fail the `cargo-msrv` gate. Instead added a scoped `#[allow(deprecated)]` with a comment to swap it once MSRV clears 1.95. The deprecation is nightly-only for now, so stable builds are unaffected either way.

## Verification
- `cargo clippy --all-targets -- -D warnings` (stable 1.97) → exit 0
- `cargo +nightly clippy --all-targets --all-features -- -D warnings` (nightly 0.1.99) → exit 0
- `cargo fmt --check` clean; `cargo test -p aube-lockfile` passes.

## Not addressed
A future-incompat warning from transitive deps (`bytecheck`, `nix`, `rkyv`) is upstream churn, not fixable in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only refactors with documented identical `exec:` parse semantics; progress clamp logic unchanged aside from silencing a nightly-only deprecation.
> 
> **Overview**
> Keeps **`cargo +nightly clippy -D warnings`** green with two lint-only tweaks and no intended behavior changes.
> 
> In **`LocalSource::parse`**, the **`exec:`** branch is folded into the final **`else`** arm using **`strip_prefix("exec:")?`**, matching **`clippy::question_mark`** while preserving the same **`Option`** outcomes as the old explicit **`return None`**.
> 
> In **`clamp_reused_to`**, **`AtomicUsize::fetch_update`** is left in place (MSRV **1.93** blocks switching to **`try_update`**, stable since **1.95**) and a scoped **`#[allow(deprecated)]`** plus an MSRV note documents when to migrate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e80ac6735e8a5f4699057777c9838937cac72aa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->