### PR TITLE
feat(exec): image-replace the tool on standalone terminal runs

### DIFF
--- a/crates/aube/src/commands/dlx.rs
+++ b/crates/aube/src/commands/dlx.rs
@@ -145,26 +145,39 @@ pub async fn run(args: DlxArgs) -> miette::Result<Option<i32>> {
     // Bin name is only used in the non-shell path. Under shell-mode the
     // user assembles their own line and we run it through `sh -c`, so any
     // bin lookup is the shell's job.
+    // Resolve the runtime from the *user's* project up front — before the
+    // local-bin fast path and before switching into the scratch dir. A dlx
+    // scratch project has no version config, and the OnceCell context is
+    // process-global, so resolving here (original cwd) is what makes both the
+    // local-bin bin and `aubx` honor the project's .nvmrc / devEngines. The
+    // fast path replaces the image immediately, so this must run before it or
+    // a local `dlx` bin would launch with the ambient runtime.
+    let initial_cwd = crate::dirs::cwd()?;
+    crate::runtime::ensure_for_cwd(&initial_cwd).await?;
+
     let bin_name = bin_name_for(&command);
-    if !explicit_package && !shell_mode && can_use_local_bin(&command) {
-        let initial_cwd = crate::dirs::cwd()?;
-        if let Some(project_dir) = crate::dirs::find_project_root(&initial_cwd) {
-            let bin_path = super::project_modules_dir(&project_dir)
-                .join(".bin")
-                .join(&bin_name);
-            if bin_path.exists() {
-                return super::exec::exec_bin(&initial_cwd, &bin_path, &bin_name, &bin_args, false)
-                    .await;
-            }
+    if !explicit_package
+        && !shell_mode
+        && can_use_local_bin(&command)
+        && let Some(project_dir) = crate::dirs::find_project_root(&initial_cwd)
+    {
+        let bin_path = super::project_modules_dir(&project_dir)
+            .join(".bin")
+            .join(&bin_name);
+        if bin_path.exists() {
+            // Local-bin fast path: no scratch dir was created, so nothing
+            // needs to run after the tool. Hand off via image replacement
+            // on the standalone binary (embedded/Windows supervise).
+            return super::exec::exec_bin_terminal(
+                &initial_cwd,
+                &bin_path,
+                &bin_name,
+                &bin_args,
+                false,
+            )
+            .await;
         }
     }
-
-    // Resolve the runtime from the *user's* project before switching
-    // into the scratch dir — a dlx scratch project has no version
-    // config, and the OnceCell context is process-global, so resolving
-    // here (original cwd) is what makes `aubx` honor the project's
-    // .nvmrc / devEngines.
-    crate::runtime::ensure_for_cwd(&crate::dirs::cwd()?).await?;
 
     let tmp = tempfile::Builder::new()
         .prefix("aube-dlx-")

--- a/crates/aube/src/commands/exec.rs
+++ b/crates/aube/src/commands/exec.rs
@@ -119,7 +119,10 @@ pub async fn run(
     }
 
     let bin_path = super::project_modules_dir(&cwd).join(".bin").join(&bin);
-    exec_bin(&cwd, &bin_path, &bin, &args, shell_mode).await
+    // Non-recursive `aube exec` is a terminal single-tool run with no
+    // post-run work, so the standalone binary hands off via image
+    // replacement; embedded hosts / Windows fall back to a supervised child.
+    exec_bin_terminal(&cwd, &bin_path, &bin, &args, shell_mode).await
 }
 
 async fn run_filtered(
@@ -306,12 +309,77 @@ pub(crate) async fn exec_bin_with_node_args(
     shell_mode: bool,
 ) -> miette::Result<Option<i32>> {
     if !shell_mode && !bin_path.exists() {
-        return Err(miette!(
-            "binary not found: {bin}\nTry running `{}` first, or check that the package providing '{bin}' is in your dependencies.",
-            aube_util::cmd("install")
-        ));
+        return Err(bin_not_found_error(bin));
     }
 
+    let command = build_bin_command(cwd, bin_path, bin, args, node_args, shell_mode);
+    let status = crate::process_guard::spawn_and_wait(command)
+        .await
+        .into_diagnostic()
+        .wrap_err("failed to execute binary")?;
+
+    if !status.success() {
+        return Ok(Some(aube_scripts::exit_code_from_status(status)));
+    }
+
+    Ok(None)
+}
+
+/// Run a single terminal tool for the *standalone* binary by replacing the
+/// process image with it (`execvp`), so the tool inherits aube's pid. With
+/// no separate aube process left to outlive, any signal — including an
+/// uncatchable `SIGKILL` — reaches the tool directly, so no supervisor or
+/// `PR_SET_PDEATHSIG` is needed and the macOS `SIGKILL` gap doesn't apply.
+///
+/// Only sound where nothing runs after the tool and aube owns the whole
+/// process: an embedded host must not have its image blown away, and Windows
+/// has no `execvp`. Both fall back to the supervised spawn in `exec_bin`.
+/// Use only from terminal call sites with no post-run cleanup (no dlx scratch
+/// dir, not the recursive workspace loop).
+pub(crate) async fn exec_bin_terminal(
+    cwd: &Path,
+    bin_path: &Path,
+    bin: &str,
+    args: &[String],
+    shell_mode: bool,
+) -> miette::Result<Option<i32>> {
+    #[cfg(unix)]
+    if aube_util::embedder().name == aube_util::AUBE.name {
+        use std::os::unix::process::CommandExt;
+        if !shell_mode && !bin_path.exists() {
+            return Err(bin_not_found_error(bin));
+        }
+        let mut command = build_bin_command(cwd, bin_path, bin, args, &[], shell_mode);
+        // `exec` only returns on failure; on success the tool has replaced us.
+        let err = command.as_std_mut().exec();
+        return Err(miette!(
+            code = aube_codes::errors::ERR_AUBE_SHIM_EXEC_FAILED,
+            "failed to exec `{bin}`: {err}"
+        ));
+    }
+    // Embedded host or Windows: replacing the image is unsafe or unsupported,
+    // so run the tool as a supervised child instead.
+    exec_bin(cwd, bin_path, bin, args, shell_mode).await
+}
+
+fn bin_not_found_error(bin: &str) -> miette::Report {
+    miette!(
+        "binary not found: {bin}\nTry running `{}` first, or check that the package providing '{bin}' is in your dependencies.",
+        aube_util::cmd("install")
+    )
+}
+
+/// Assemble the `tokio::process::Command` that runs `bin`, shared by the
+/// supervised (`spawn_and_wait`) and image-replacing (`exec_bin_terminal`)
+/// paths. Callers own the bin-exists check.
+fn build_bin_command(
+    cwd: &Path,
+    bin_path: &Path,
+    bin: &str,
+    args: &[String],
+    node_args: &[String],
+    shell_mode: bool,
+) -> tokio::process::Command {
     let mut command = if let Some(cmd) = node_bin_command(bin_path, args, node_args, shell_mode) {
         cmd
     } else if shell_mode {
@@ -330,21 +398,21 @@ pub(crate) async fn exec_bin_with_node_args(
         let exec_path = resolve_exec_shim(bin_path);
         let mut cmd = tokio::process::Command::new(exec_path);
         cmd.args(args);
+        // `#!/usr/bin/env node` shebangs resolve through the child's PATH —
+        // put the switched runtime ahead of the inherited one so the bin
+        // (and, on the image-replacing path, the exec'd shim) honors the
+        // project's `.nvmrc` / `devEngines` instead of the ambient node.
+        let runtime_dirs = crate::runtime::path_entries();
+        if !runtime_dirs.is_empty() {
+            cmd.env("PATH", aube_scripts::prepend_paths(&runtime_dirs));
+        }
         cmd
     };
+    crate::runtime::apply_child_env(&mut command);
     command
         .current_dir(cwd)
         .stderr(aube_scripts::child_stderr());
-    let status = crate::process_guard::spawn_and_wait(command)
-        .await
-        .into_diagnostic()
-        .wrap_err("failed to execute binary")?;
-
-    if !status.success() {
-        return Ok(Some(aube_scripts::exit_code_from_status(status)));
-    }
-
-    Ok(None)
+    command
 }
 
 pub(crate) async fn exec_bin_status(

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -71,12 +71,18 @@ EOF
 }
 
 # Regression: terminating the aube process must tear down the tool it
-# spawned instead of orphaning it under init. See discussion #1059.
-# Parameterized over the signal: SIGTERM exercises the forwarding path,
-# SIGKILL exercises Linux PR_SET_PDEATHSIG (skipped elsewhere — macOS
-# SIGKILL-of-parent teardown is a separate follow-up).
-_assert_child_torn_down_on() {
-	local sig="$1" dur="$2"
+# launched instead of orphaning it under init. See discussion #1059.
+#
+# Parameterized over the launcher and signal so both teardown mechanisms
+# are covered:
+#   - `aube exec` on the standalone binary replaces its image with the tool
+#     (execvp), so the tool inherits aube's pid and any signal — SIGTERM or
+#     SIGKILL, on any Unix — reaches it directly.
+#   - `aube run <local-bin>` spawns the tool as a supervised child, so
+#     teardown goes through process_guard: SIGTERM is forwarded (any Unix),
+#     SIGKILL relies on Linux PR_SET_PDEATHSIG.
+_assert_not_orphaned() {
+	local launcher="$1" sig="$2" dur="$3"
 	cat >package.json <<'EOF'
 {"name":"t","version":"0.0.0"}
 EOF
@@ -84,7 +90,7 @@ EOF
 	printf '#!/bin/sh\nexec sleep %s\n' "$dur" >node_modules/.bin/sleeper
 	chmod +x node_modules/.bin/sleeper
 
-	aube exec --no-install sleeper &
+	aube "$launcher" --no-install sleeper &
 	local aube_pid=$!
 
 	local child=""
@@ -95,7 +101,7 @@ EOF
 	done
 	[ -n "$child" ] || {
 		kill "$aube_pid" 2>/dev/null || true
-		fail "spawned tool never started"
+		fail "launched tool never started"
 	}
 
 	kill "-${sig}" "$aube_pid" 2>/dev/null || true
@@ -109,15 +115,80 @@ EOF
 		sleep 0.1
 	done
 	pkill -f "sleep ${dur}\$" 2>/dev/null || true
-	[ -n "$gone" ] || fail "tool orphaned after ${sig} to aube"
+	[ -n "$gone" ] || fail "tool orphaned after ${sig} to aube ${launcher}"
 }
 
-@test "aube exec tears down the spawned tool on SIGTERM" {
+@test "aube exec is not orphaned on SIGTERM (image replacement)" {
 	[ "$(uname -s)" != "Windows_NT" ] || skip "signals are POSIX"
-	_assert_child_torn_down_on TERM 987651
+	_assert_not_orphaned exec TERM 987651
 }
 
-@test "aube exec tears down the spawned tool on SIGKILL (Linux PDEATHSIG)" {
+# Image replacement makes the tool inherit aube's pid, so SIGKILL teardown
+# works on every Unix here — no PDEATHSIG, no macOS gap for this path.
+@test "aube exec is not orphaned on SIGKILL (image replacement)" {
+	[ "$(uname -s)" != "Windows_NT" ] || skip "signals are POSIX"
+	_assert_not_orphaned exec KILL 987652
+}
+
+# `aube run <local-bin>` keeps the supervised-child path, so these cover
+# process_guard's signal forwarding and PDEATHSIG directly.
+@test "aube run forwards SIGTERM to the supervised tool" {
+	[ "$(uname -s)" != "Windows_NT" ] || skip "signals are POSIX"
+	_assert_not_orphaned run TERM 987654
+}
+
+@test "aube run reaps the supervised tool on SIGKILL (Linux PDEATHSIG)" {
 	[ "$(uname -s)" = "Linux" ] || skip "PR_SET_PDEATHSIG is Linux-only"
-	_assert_child_torn_down_on KILL 987652
+	_assert_not_orphaned run KILL 987655
+}
+
+# The standalone binary replaces its image with the tool (execvp) rather
+# than spawning a child, so the tool inherits aube's pid and no separate
+# aube process is left behind. This is what makes a SIGKILL of that pid
+# hit the tool directly, closing the macOS gap for this path.
+@test "aube exec replaces its image with the tool (no separate aube process)" {
+	[ "$(uname -s)" != "Windows_NT" ] || skip "execvp is POSIX"
+	dur=987653
+	cat >package.json <<'EOF'
+{"name":"t","version":"0.0.0"}
+EOF
+	mkdir -p node_modules/.bin
+	printf '#!/bin/sh\nexec sleep %s\n' "$dur" >node_modules/.bin/sleeper
+	chmod +x node_modules/.bin/sleeper
+
+	aube exec --no-install sleeper &
+	launched=$!
+
+	# Tear down the tool no matter which assertion fires — bats exits the
+	# function immediately on `fail`, so cleanup has to run before each one
+	# (mirrors `_assert_child_torn_down_on`).
+	cleanup() {
+		kill -KILL "$launched" 2>/dev/null || true
+		pkill -f "sleep ${dur}\$" 2>/dev/null || true
+	}
+
+	child=""
+	for _ in $(seq 1 50); do
+		child="$(pgrep -f "sleep ${dur}\$" || true)"
+		[ -n "$child" ] && break
+		sleep 0.1
+	done
+	[ -n "$child" ] || {
+		cleanup
+		fail "tool never started"
+	}
+
+	# The launched pid was aube; after execvp it is the tool itself, so the
+	# sleep runs *as* that pid and its comm is no longer aube.
+	[ "$child" = "$launched" ] || {
+		cleanup
+		fail "tool did not inherit aube's pid (image not replaced): launched=$launched tool=$child"
+	}
+	comm="$(ps -o comm= -p "$launched" | tr -d ' ')"
+	[ "$comm" != "aube" ] || {
+		cleanup
+		fail "aube image was not replaced (comm still aube)"
+	}
+
+	cleanup
 }


### PR DESCRIPTION
## What

Follow-up to #1065. For the two *terminal single-tool* paths — non-recursive `aube exec <bin>` and `aube dlx`'s local-bin fast path — replace the process image with the tool (`execvp`) instead of spawning it as a supervised child, **when aube is the standalone binary on Unix**.

The tool then **inherits aube's pid**, so there's no separate aube process to outlive: any signal, including an uncatchable `SIGKILL`, reaches the tool directly. No supervisor, no `PR_SET_PDEATHSIG`, and the macOS `SIGKILL`-of-aube gap left open by #1065 simply doesn't exist for these paths. This is the same mechanism `aube node` already uses (and why `mise x` never orphans).

## Why it's gated

Image replacement is only sound where nothing runs after the tool and aube owns the whole process. These fall back to the supervised spawn from #1065:

- **Embedded hosts** — `aube-ffi` / `aube-node` drive aube in-process; `execvp` would blow away the *host* process. Detected via `aube_util::embedder().name == AUBE.name`.
- **Windows** — no `execvp`.

And these deliberately keep spawning (out of scope for replacement):

- **`dlx` install path** — creates a scratch `TempDir` cleaned up on `Drop`; exec would leak it.
- **Recursive workspace exec** (`aube exec -r`) — runs many bins and aggregates exit codes.

## Behavior change worth noting

On the standalone binary, `aube exec <bin>` / `aube dlx <local-bin>` no longer appears as a parent process — the tool takes over aube's pid. This matches `npx`/`mise x` and is what a supervisor signalling "the aube it launched" actually wants.

## Implementation

- New `exec_bin_terminal`: `execvp` on standalone + Unix, else delegates to the supervised `exec_bin`.
- Command construction factored into `build_bin_command`, shared by the supervised and image-replacing paths so they can't drift.

## Verification

- New bats test asserts the tool **inherits aube's pid** and no separate `aube` process remains (i.e. the image was actually replaced), then SIGKILLs that pid.
- Existing SIGTERM/SIGKILL teardown tests still pass (now via the image-replacement path).
- `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `cargo test -p aube` (665 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core process-launch behavior for `aube exec` and `dlx` local-bin on Unix; fallbacks limit blast radius but mis-gated exec could break embedded hosts or leave edge-case orphans.
> 
> **Overview**
> On **standalone Unix**, non-recursive `aube exec` and `dlx`'s **local-bin fast path** now **`execvp` into the tool** instead of spawning a supervised child, so the tool keeps aube's PID and signals (including **SIGKILL**) reach it directly—no orphan gap on macOS for these paths. **Embedded hosts** and **Windows** still use supervised `exec_bin`.
> 
> **`dlx`** resolves the project runtime **before** the local-bin fast path so image replacement still honors `.nvmrc` / `devEngines`.
> 
> Command setup is centralized in **`build_bin_command`** (shared by exec and supervise paths), with runtime **`PATH`** / **`apply_child_env`** on direct bin launches. Bats tests cover image replacement (PID inheritance) and split orphan regressions between `exec` vs supervised `run`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f2d0d193c66fabf2855b9e1d6e8fccaf4b06817. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced `aube exec` and local `aube dlx` to hand off directly to the selected tool when possible, improving process image replacement and lifecycle handling.
* **Bug Fixes**
  * Improved “binary not found” error handling for more consistent messaging.
* **Tests**
  * Added a POSIX-only regression test ensuring `aube exec` replaces its image (no separate intermediary `aube` process remains).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->