### PR TITLE
feat: make library crates embeddable at MSRV 1.91 with backend-agnostic features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1711,6 +1711,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2181,6 +2196,22 @@ dependencies = [
  "rustls",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -2956,6 +2987,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3177,10 +3225,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "os_pipe"
@@ -3895,10 +3980,12 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -3911,6 +3998,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -5113,6 +5201,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5491,6 +5589,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1711,21 +1711,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2196,22 +2181,6 @@ dependencies = [
  "rustls",
  "tokio",
  "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -2987,23 +2956,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3225,47 +3177,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags 2.13.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "os_pipe"
@@ -3980,12 +3895,10 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -3998,7 +3911,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -5201,16 +5113,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5589,12 +5491,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,10 @@ panic = "unwind"
 [workspace.package]
 version = "1.29.1"
 edition = "2024"
-rust-version = "1.93"
+# Kept at the floor mise can build with (its distro packaging pins the
+# toolchain) so mise can embed the library crates. CI enforces this via
+# `cargo msrv verify` — bump deliberately, not as a side effect.
+rust-version = "1.91"
 license = "MIT"
 repository = "https://github.com/jdx/aube"
 homepage = "https://github.com/jdx/aube"
@@ -72,7 +75,13 @@ clap = { version = "4", features = ["derive"] }
 strum = { version = "0.28", features = ["derive"] }
 
 # HTTP
-reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "rustls", "http2", "charset", "system-proxy", "gzip", "brotli", "zstd", "hickory-dns"] }
+# TLS backend and DNS resolver are deliberately NOT chosen here. Library
+# crates must stay backend-agnostic so embedders (mise) don't get rustls or
+# hickory-dns forced into their build via feature unification — reqwest's
+# hickory-dns cargo feature flips the default resolver for every client in
+# the final binary. The aube binary gets rustls + hickory-dns through
+# aube-registry's default features.
+reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "http2", "charset", "system-proxy", "gzip", "brotli", "zstd"] }
 webpki-root-certs = "1"
 
 # Hashing
@@ -153,7 +162,11 @@ log = "0.4"
 regex = "1"
 
 # Archive extraction
-flate2 = { version = "1", default-features = false, features = ["zlib-ng"] }
+# Pure-Rust backend here so library crates don't force libz-ng-sys (cmake +
+# C toolchain) onto embedders' builds. The aube binary re-enables zlib-ng —
+# feature unification makes it win over rust_backend for the whole workspace
+# build, so standalone aube keeps the fast C backend.
+flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
 tar = "0.4"
 zstd = { version = "0.13", default-features = false }
 # Zip reader for the OSV advisory mirror — the bulk dump at

--- a/crates/aube-registry/Cargo.toml
+++ b/crates/aube-registry/Cargo.toml
@@ -31,6 +31,18 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 zip = { workspace = true }
 
+[features]
+# Defaults preserve standalone aube behavior: rustls + in-process DNS
+# caching. Embedders (mise) use `default-features = false` and pick their
+# own TLS backend so neither rustls nor hickory-dns leaks into their build
+# via feature unification — reqwest's hickory-dns cargo feature would
+# otherwise flip the default resolver for every client in their binary.
+# Exactly one of `rustls` / `native-tls` must be enabled.
+default = ["rustls", "hickory-dns"]
+rustls = ["reqwest/rustls", "aube-util/rustls"]
+native-tls = ["reqwest/native-tls", "aube-util/native-tls"]
+hickory-dns = ["reqwest/hickory-dns"]
+
 [dev-dependencies]
 tempfile = "3"
 flate2 = { workspace = true }

--- a/crates/aube-registry/Cargo.toml
+++ b/crates/aube-registry/Cargo.toml
@@ -33,14 +33,14 @@ zip = { workspace = true }
 
 [features]
 # Defaults preserve standalone aube behavior: rustls + in-process DNS
-# caching. Embedders (mise) use `default-features = false` and pick their
-# own TLS backend so neither rustls nor hickory-dns leaks into their build
-# via feature unification — reqwest's hickory-dns cargo feature would
-# otherwise flip the default resolver for every client in their binary.
-# Exactly one of `rustls` / `native-tls` must be enabled.
+# caching. Embedders (mise) use `default-features = false` and re-enable
+# `rustls` so hickory-dns doesn't leak into their build via feature
+# unification — reqwest's hickory-dns cargo feature flips the default
+# resolver for every client in the final binary. rustls is the only
+# supported TLS backend (no OpenSSL / native-tls — see CLAUDE.md) and is
+# required; without it the crate fails to compile.
 default = ["rustls", "hickory-dns"]
 rustls = ["reqwest/rustls", "aube-util/rustls"]
-native-tls = ["reqwest/native-tls", "aube-util/native-tls"]
 hickory-dns = ["reqwest/hickory-dns"]
 
 [dev-dependencies]

--- a/crates/aube-registry/src/client/http.rs
+++ b/crates/aube-registry/src/client/http.rs
@@ -154,7 +154,22 @@ fn build_http_client_inner(
             std::env::consts::ARCH
         )
     });
-    let mut builder = aube_util::http::with_webpki_root_fallback(reqwest::Client::builder())
+    let mut builder = aube_util::http::with_webpki_root_fallback(reqwest::Client::builder());
+    // Pin the TLS backend explicitly instead of relying on reqwest's default
+    // selection. When an embedder's dependency graph enables both native-tls
+    // and rustls cargo features on reqwest, the default silently becomes
+    // native-tls, which would mismatch the rustls `Identity` built by
+    // `client_identity` (and the session-ticket wiring in the aube binary).
+    // rustls wins when both aube-registry features are enabled.
+    #[cfg(feature = "rustls")]
+    {
+        builder = builder.use_rustls_tls();
+    }
+    #[cfg(all(not(feature = "rustls"), feature = "native-tls"))]
+    {
+        builder = builder.use_native_tls();
+    }
+    builder = builder
         .user_agent(user_agent)
         // Wire-level decompression for packument JSON. Tarball
         // requests explicitly send `Accept-Encoding: identity`
@@ -188,13 +203,19 @@ fn build_http_client_inner(
     } else {
         builder = builder.http1_only();
     }
+    // In-process DNS caching via hickory-dns. The system resolver
+    // does not cache and uses a thread pool for `getaddrinfo`,
+    // which serializes the first cold lookup per origin. hickory
+    // resolves async + caches for the process lifetime. Feature-gated
+    // so embedders that keep their host binary on getaddrinfo (reqwest's
+    // hickory-dns cargo feature flips the default for every client in
+    // the binary) can opt out; default features keep it on for aube.
+    #[cfg(feature = "hickory-dns")]
+    {
+        builder = builder.hickory_dns(true);
+    }
     builder = builder
         .tcp_keepalive(std::time::Duration::from_secs(60))
-        // In-process DNS caching via hickory-dns. The system resolver
-        // does not cache and uses a thread pool for `getaddrinfo`,
-        // which serializes the first cold lookup per origin. hickory
-        // resolves async + caches for the process lifetime.
-        .hickory_dns(true)
         // `strict-ssl=false` disables cert validation entirely. This
         // is a security hole on purpose: corporate registries should
         // prefer per-registry `ca` / `cafile` so validation stays on.
@@ -291,13 +312,7 @@ fn build_http_client_inner(
             "per-registry",
         );
         if let (Some(cert), Some(key)) = (&registry_config.tls.cert, &registry_config.tls.key) {
-            let mut pem = Vec::with_capacity(cert.len() + key.len() + 1);
-            pem.extend_from_slice(cert.as_bytes());
-            if !cert.ends_with('\n') {
-                pem.push(b'\n');
-            }
-            pem.extend_from_slice(key.as_bytes());
-            match reqwest::Identity::from_pem(&pem) {
+            match client_identity(cert, key) {
                 Ok(identity) => builder = builder.identity(identity),
                 Err(e) => tracing::warn!(
                     code = aube_codes::warnings::WARN_AUBE_INVALID_CLIENT_CERT,
@@ -308,6 +323,27 @@ fn build_http_client_inner(
     }
 
     builder.build().expect("failed to build HTTP client")
+}
+
+/// Build a client-cert identity from `.npmrc` `cert` / `key` values.
+/// reqwest's `Identity` constructors are TLS-backend-specific: rustls takes
+/// a single combined PEM buffer, native-tls takes cert and PKCS#8 key
+/// separately. rustls is preferred when both features are on (matches the
+/// backend `build_http_client` produces in that configuration).
+#[cfg(feature = "rustls")]
+fn client_identity(cert: &str, key: &str) -> reqwest::Result<reqwest::Identity> {
+    let mut pem = Vec::with_capacity(cert.len() + key.len() + 1);
+    pem.extend_from_slice(cert.as_bytes());
+    if !cert.ends_with('\n') {
+        pem.push(b'\n');
+    }
+    pem.extend_from_slice(key.as_bytes());
+    reqwest::Identity::from_pem(&pem)
+}
+
+#[cfg(all(not(feature = "rustls"), feature = "native-tls"))]
+fn client_identity(cert: &str, key: &str) -> reqwest::Result<reqwest::Identity> {
+    reqwest::Identity::from_pkcs8_pem(cert.as_bytes(), key.as_bytes())
 }
 
 /// BATS-fixture escape hatch: ask the registry for the unabbreviated

--- a/crates/aube-registry/src/client/http.rs
+++ b/crates/aube-registry/src/client/http.rs
@@ -154,22 +154,13 @@ fn build_http_client_inner(
             std::env::consts::ARCH
         )
     });
-    let mut builder = aube_util::http::with_webpki_root_fallback(reqwest::Client::builder());
-    // Pin the TLS backend explicitly instead of relying on reqwest's default
-    // selection. When an embedder's dependency graph enables both native-tls
-    // and rustls cargo features on reqwest, the default silently becomes
-    // native-tls, which would mismatch the rustls `Identity` built by
-    // `client_identity` (and the session-ticket wiring in the aube binary).
-    // rustls wins when both aube-registry features are enabled.
-    #[cfg(feature = "rustls")]
-    {
-        builder = builder.use_rustls_tls();
-    }
-    #[cfg(all(not(feature = "rustls"), feature = "native-tls"))]
-    {
-        builder = builder.use_native_tls();
-    }
-    builder = builder
+    // Pin rustls explicitly instead of relying on reqwest's default backend
+    // selection: if an embedder's dependency graph also turns on reqwest's
+    // native-tls feature, reqwest's default silently becomes native-tls,
+    // which would mismatch the rustls `Identity` built below and the
+    // session-ticket wiring in the aube binary.
+    let mut builder = aube_util::http::with_webpki_root_fallback(reqwest::Client::builder())
+        .use_rustls_tls()
         .user_agent(user_agent)
         // Wire-level decompression for packument JSON. Tarball
         // requests explicitly send `Accept-Encoding: identity`
@@ -326,11 +317,9 @@ fn build_http_client_inner(
 }
 
 /// Build a client-cert identity from `.npmrc` `cert` / `key` values.
-/// reqwest's `Identity` constructors are TLS-backend-specific: rustls takes
-/// a single combined PEM buffer, native-tls takes cert and PKCS#8 key
-/// separately. rustls is preferred when both features are on (matches the
-/// backend `build_http_client` produces in that configuration).
-#[cfg(feature = "rustls")]
+/// rustls' `Identity::from_pem` takes cert and key concatenated in a single
+/// PEM buffer and accepts both PKCS#8 (`BEGIN PRIVATE KEY`) and PKCS#1
+/// (`BEGIN RSA PRIVATE KEY`) keys.
 fn client_identity(cert: &str, key: &str) -> reqwest::Result<reqwest::Identity> {
     let mut pem = Vec::with_capacity(cert.len() + key.len() + 1);
     pem.extend_from_slice(cert.as_bytes());
@@ -339,11 +328,6 @@ fn client_identity(cert: &str, key: &str) -> reqwest::Result<reqwest::Identity> 
     }
     pem.extend_from_slice(key.as_bytes());
     reqwest::Identity::from_pem(&pem)
-}
-
-#[cfg(all(not(feature = "rustls"), feature = "native-tls"))]
-fn client_identity(cert: &str, key: &str) -> reqwest::Result<reqwest::Identity> {
-    reqwest::Identity::from_pkcs8_pem(cert.as_bytes(), key.as_bytes())
 }
 
 /// BATS-fixture escape hatch: ask the registry for the unabbreviated

--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -3,6 +3,12 @@ use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::BTreeMap;
 use std::fmt;
 
+// The registry client is https-only; without a TLS backend every request
+// would fail at runtime with an opaque scheme error. Fail at compile time
+// instead so embedders disabling default features pick a backend.
+#[cfg(not(any(feature = "rustls", feature = "native-tls")))]
+compile_error!("aube-registry requires a TLS backend: enable the `rustls` or `native-tls` feature");
+
 // Visitor helper macros — each tolerant deserializer below picks the
 // subset that matches its custom handlers. Splitting these granularly
 // is what lets `funding_url` keep its own `visit_seq` (array case)

--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -5,9 +5,10 @@ use std::fmt;
 
 // The registry client is https-only; without a TLS backend every request
 // would fail at runtime with an opaque scheme error. Fail at compile time
-// instead so embedders disabling default features pick a backend.
-#[cfg(not(any(feature = "rustls", feature = "native-tls")))]
-compile_error!("aube-registry requires a TLS backend: enable the `rustls` or `native-tls` feature");
+// instead so embedders disabling default features re-enable `rustls`
+// (the only supported backend — see the TLS policy in CLAUDE.md).
+#[cfg(not(feature = "rustls"))]
+compile_error!("aube-registry requires the `rustls` feature");
 
 // Visitor helper macros — each tolerant deserializer below picks the
 // subset that matches its custom handlers. Splitting these granularly

--- a/crates/aube-util/Cargo.toml
+++ b/crates/aube-util/Cargo.toml
@@ -25,12 +25,12 @@ webpki-root-certs = { workspace = true }
 thiserror = { workspace = true }
 
 [features]
-# No TLS backend by default: the choice belongs to the final binary.
-# aube-registry's default features select rustls for the aube binary;
-# embedders (mise) pick their own backend instead of inheriting ours.
+# No TLS backend by default so embedders control when reqwest/rustls is
+# enabled; aube-registry's default features turn it on for the aube binary.
+# rustls is the only supported backend (no OpenSSL / native-tls — see the
+# TLS policy in CLAUDE.md).
 default = []
 rustls = ["reqwest/rustls"]
-native-tls = ["reqwest/native-tls"]
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/aube-util/Cargo.toml
+++ b/crates/aube-util/Cargo.toml
@@ -24,6 +24,14 @@ reqwest = { workspace = true }
 webpki-root-certs = { workspace = true }
 thiserror = { workspace = true }
 
+[features]
+# No TLS backend by default: the choice belongs to the final binary.
+# aube-registry's default features select rustls for the aube binary;
+# embedders (mise) pick their own backend instead of inheriting ours.
+default = []
+rustls = ["reqwest/rustls"]
+native-tls = ["reqwest/native-tls"]
+
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
 

--- a/crates/aube-util/src/http/mod.rs
+++ b/crates/aube-util/src/http/mod.rs
@@ -22,8 +22,16 @@ pub mod ticket_cache;
 /// reqwest 0.13 can merge extra roots with the platform verifier on Unix
 /// (except Android) and Windows. On other targets, leave the builder alone
 /// so client construction does not fail at runtime.
+///
+/// Compiled to a no-op when neither the `rustls` nor `native-tls` feature is
+/// enabled — reqwest's `Certificate`/`tls_certs_merge` APIs only exist with a
+/// TLS backend, and this crate deliberately leaves that choice to the final
+/// binary (the aube binary selects rustls via aube-registry's defaults).
 pub fn with_webpki_root_fallback(builder: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
-    #[cfg(any(all(unix, not(target_os = "android")), target_os = "windows"))]
+    #[cfg(all(
+        any(feature = "rustls", feature = "native-tls"),
+        any(all(unix, not(target_os = "android")), target_os = "windows")
+    ))]
     {
         let certs = webpki_root_certs::TLS_SERVER_ROOT_CERTS
             .iter()
@@ -36,7 +44,10 @@ pub fn with_webpki_root_fallback(builder: reqwest::ClientBuilder) -> reqwest::Cl
         builder.tls_certs_merge(certs)
     }
 
-    #[cfg(not(any(all(unix, not(target_os = "android")), target_os = "windows")))]
+    #[cfg(not(all(
+        any(feature = "rustls", feature = "native-tls"),
+        any(all(unix, not(target_os = "android")), target_os = "windows")
+    )))]
     {
         builder
     }

--- a/crates/aube-util/src/http/mod.rs
+++ b/crates/aube-util/src/http/mod.rs
@@ -23,13 +23,13 @@ pub mod ticket_cache;
 /// (except Android) and Windows. On other targets, leave the builder alone
 /// so client construction does not fail at runtime.
 ///
-/// Compiled to a no-op when neither the `rustls` nor `native-tls` feature is
-/// enabled — reqwest's `Certificate`/`tls_certs_merge` APIs only exist with a
-/// TLS backend, and this crate deliberately leaves that choice to the final
-/// binary (the aube binary selects rustls via aube-registry's defaults).
+/// Compiled to a no-op when the `rustls` feature is not enabled — reqwest's
+/// `Certificate`/`tls_certs_merge` APIs only exist with a TLS backend, and
+/// this crate leaves that choice to the final binary (the aube binary selects
+/// rustls via aube-registry's defaults).
 pub fn with_webpki_root_fallback(builder: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
     #[cfg(all(
-        any(feature = "rustls", feature = "native-tls"),
+        feature = "rustls",
         any(all(unix, not(target_os = "android")), target_os = "windows")
     ))]
     {
@@ -45,7 +45,7 @@ pub fn with_webpki_root_fallback(builder: reqwest::ClientBuilder) -> reqwest::Cl
     }
 
     #[cfg(not(all(
-        any(feature = "rustls", feature = "native-tls"),
+        feature = "rustls",
         any(all(unix, not(target_os = "android")), target_os = "windows")
     )))]
     {

--- a/crates/aube/Cargo.toml
+++ b/crates/aube/Cargo.toml
@@ -81,7 +81,11 @@ sigstore-types = { workspace = true }
 ambient-id = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-flate2 = { workspace = true }
+# zlib-ng re-enabled at the binary level only: feature unification makes the
+# C backend win for the whole aube build (same perf as before), while library
+# crates stay on the pure-Rust backend so embedders don't inherit a cmake
+# build dependency. See the workspace flate2 entry.
+flate2 = { workspace = true, features = ["zlib-ng"] }
 glob = { workspace = true }
 ignore = { workspace = true }
 node-semver = { workspace = true }


### PR DESCRIPTION
## Summary

Groundwork for embedding aube's library crates in [mise](https://github.com/jdx/mise) (first `aube-registry` for npm metadata/installs, potentially resolver/store/linker later — see jdx/mise#11147). Two things blocked that today: the declared MSRV, and workspace-level cargo features that leak global build side effects into any embedding binary.

### MSRV: 1.93 → 1.91

mise's MSRV is pinned to 1.91 by its distro packaging (Debian PPA, Fedora COPR), and cargo's MSRV-aware resolver silently falls back to `aube-registry 1.0.0-beta.2` when a 1.91 project adds the dependency. The whole workspace already compiles and tests cleanly on 1.91 — the 1.93 declaration was incidental from `init`, not a real requirement. The existing `cargo msrv verify` step in CI enforces the new floor automatically.

### Feature hygiene: TLS / DNS / zlib backends move from workspace to leaf

Cargo features unify across the final binary, so workspace-wide choices became the *embedder's* choices too:

- **`reqwest/hickory-dns`** flips the default DNS resolver for **every reqwest client in the host binary** (`hickory_dns: cfg!(feature = "hickory-dns")` in reqwest's builder) — in mise's case that would silently change DNS behavior for its own HTTP plus rattler/gix/sigstore internals.
- **`reqwest/rustls`** forces a second TLS stack into the host build even when the embedder never constructs an aube client.
- **`flate2/zlib-ng`** forces libz-ng-sys (cmake + C toolchain) onto every cross-compile target of the embedder.

None of these are code dependencies of the library crates (the rustls `ClientSessionStore` wiring lives in the bin crate; libs only use TLS-generic reqwest APIs), so they're now selected at the edges:

- workspace `reqwest` drops `rustls`/`hickory-dns`; **`aube-registry` gains features** `default = ["rustls", "hickory-dns"]` plus a standalone `rustls` — standalone aube behavior is unchanged via defaults, embedders use `default-features = false, features = ["rustls"]` (a `compile_error!` fires if `rustls` is off)
- **rustls stays the only TLS backend** per the CLAUDE.md policy (no OpenSSL / native-tls); embedders disabling defaults just re-enable `rustls` to keep hickory-dns out of their build
- `aube-util` gains a matching `rustls` forward (default empty) and its webpki-root-fallback helper compiles to a no-op without it
- `build_http_client` now **pins rustls explicitly** (`use_rustls_tls()`) instead of relying on reqwest's default selection, which silently becomes native-tls if an embedder's *other* deps pull reqwest's native-tls feature in — that would mismatch the rustls client-cert `Identity` and session-ticket wiring
- workspace `flate2` moves to `rust_backend`; **the aube binary re-enables `zlib-ng`**, and feature unification makes the C backend win for the whole standalone aube build, so no perf change

### Verified

- `cargo check`/`test` on the full workspace with defaults (stable + 1.91): behavior-identical, `aube` binary tree still contains hickory-dns, rustls, and libz-ng-sys
- Embed shape `cargo check/test -p aube-registry --no-default-features --features rustls`: passes (227 registry unit tests), tree contains **zero** hickory/libz-ng entries
- `openssl` / `native-tls` / `hyper-tls`: **0 entries** in Cargo.lock; `cargo deny check bans` passes
- `--no-default-features` alone fails fast with the intended `compile_error!`

### Suggested CI addition (couldn't push workflow changes — token lacks `workflow` scope)

To keep the embed shape from regressing, add to `test-linux` after the `cargo msrv` step:

```yaml
      # The library shape mise embeds: no default features, rustls-only,
      # no hickory-dns, no zlib-ng. Keeps that build from silently
      # regressing when features or deps change.
      - run: cargo check -p aube-registry --no-default-features --features rustls
```

*This PR was generated by an AI coding assistant (Claude Code).*