### PR TITLE
feat(aube): make the crate embeddable without the publish/DNS stack

### DIFF
--- a/crates/aube-registry/Cargo.toml
+++ b/crates/aube-registry/Cargo.toml
@@ -32,14 +32,16 @@ tracing = { workspace = true }
 zip = { workspace = true }
 
 [features]
-# Defaults preserve standalone aube behavior: rustls + in-process DNS
-# caching. Embedders (mise) use `default-features = false` and re-enable
-# `rustls` so hickory-dns doesn't leak into their build via feature
-# unification — reqwest's hickory-dns cargo feature flips the default
-# resolver for every client in the final binary. rustls is the only
+# Default is rustls only. hickory-dns is deliberately NOT default:
+# reqwest's hickory-dns cargo feature flips the default DNS resolver for
+# every reqwest client in the final binary via feature unification, so an
+# embedder (mise) that pulls aube-registry transitively — even through
+# aube-resolver / aube-store — would silently get hickory forced on. The
+# aube binary re-enables it explicitly (see the aube crate's default
+# features); embedders opt in only if they want it. rustls is the only
 # supported TLS backend (no OpenSSL / native-tls — see CLAUDE.md) and is
 # required; without it the crate fails to compile.
-default = ["rustls", "hickory-dns"]
+default = ["rustls"]
 rustls = ["reqwest/rustls", "aube-util/rustls"]
 hickory-dns = ["reqwest/hickory-dns"]
 

--- a/crates/aube/Cargo.toml
+++ b/crates/aube/Cargo.toml
@@ -75,10 +75,13 @@ sha1 = { workspace = true }
 sha2 = { workspace = true }
 blake3 = { workspace = true }
 hex = { workspace = true }
-sigstore-sign = { workspace = true }
-sigstore-oidc = { workspace = true }
-sigstore-types = { workspace = true }
-ambient-id = { workspace = true }
+# Provenance/signing stack, only needed by `aube publish`. Optional so
+# embedders (mise) that depend on the aube library for install/resolve do not
+# pull the sigstore + x509 + OIDC supply chain. Gated by the `publish` feature.
+sigstore-sign = { workspace = true, optional = true }
+sigstore-oidc = { workspace = true, optional = true }
+sigstore-types = { workspace = true, optional = true }
+ambient-id = { workspace = true, optional = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 # zlib-ng re-enabled at the binary level only: feature unification makes the
@@ -104,7 +107,7 @@ ratatui = { version = "0.30.0", default-features = false, features = ["crossterm
 crossterm = { version = "0.29.0", optional = true }
 
 [features]
-default = ["mimalloc", "config-tui"]
+default = ["mimalloc", "config-tui", "publish", "rustls", "hickory-dns"]
 # Include the interactive `aube config tui` browser. Builds that want the
 # smallest dependency graph can disable default features and omit this.
 config-tui = ["dep:crossterm", "dep:ratatui"]
@@ -113,6 +116,17 @@ config-tui = ["dep:crossterm", "dep:ratatui"]
 # falls back to the system allocator. Needed for Valgrind, ASAN,
 # Miri, and distros that require libc malloc.
 mimalloc = ["dep:mimalloc"]
+# `aube publish` provenance/signing. Off for embedders that only need the
+# install/resolve library surface, keeping the sigstore stack out of their build.
+publish = ["dep:sigstore-sign", "dep:sigstore-oidc", "dep:sigstore-types", "dep:ambient-id"]
+# TLS backend for the crate's own reqwest clients and the aube-registry /
+# aube-util it re-exports. rustls only (no OpenSSL / native-tls — see CLAUDE.md);
+# required. Embedders depend with `default-features = false, features = ["rustls"]`.
+rustls = ["reqwest/rustls", "aube-registry/rustls", "aube-util/rustls"]
+# In-process DNS caching. Default for the aube binary; opt-in for embedders,
+# because reqwest's hickory-dns feature flips the default resolver for every
+# client in the final binary (see aube-registry's feature docs).
+hickory-dns = ["aube-registry/hickory-dns"]
 
 [dev-dependencies]
 clap-sort = "1"

--- a/crates/aube/Cargo.toml
+++ b/crates/aube/Cargo.toml
@@ -125,8 +125,10 @@ publish = ["dep:sigstore-sign", "dep:sigstore-oidc", "dep:sigstore-types", "dep:
 rustls = ["reqwest/rustls", "aube-registry/rustls", "aube-util/rustls"]
 # In-process DNS caching. Default for the aube binary; opt-in for embedders,
 # because reqwest's hickory-dns feature flips the default resolver for every
-# client in the final binary (see aube-registry's feature docs).
-hickory-dns = ["aube-registry/hickory-dns"]
+# client in the final binary (see aube-registry's feature docs). Lists
+# reqwest/hickory-dns directly — mirroring `rustls` — so the crate's own
+# reqwest clients keep it even if aube-registry's feature graph changes.
+hickory-dns = ["reqwest/hickory-dns", "aube-registry/hickory-dns"]
 
 [dev-dependencies]
 clap-sort = "1"

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -50,7 +50,9 @@ pub mod patch_remove;
 pub mod peers;
 pub mod prefix;
 pub mod prune;
+#[cfg(feature = "publish")]
 pub mod publish;
+#[cfg(feature = "publish")]
 pub mod publish_provenance;
 pub mod query;
 pub mod rebuild;

--- a/crates/aube/src/commands/pack.rs
+++ b/crates/aube/src/commands/pack.rs
@@ -226,7 +226,9 @@ pub(crate) struct BuiltArchive {
     pub filename: String,
     /// Forward-slash project-relative paths included in the tarball.
     pub files: Vec<String>,
-    /// Sum of unpacked file sizes.
+    /// Sum of unpacked file sizes. Only read by `aube publish` (upload
+    /// metadata); dead when the `publish` feature is disabled.
+    #[cfg_attr(not(feature = "publish"), allow(dead_code))]
     pub unpacked_size: u64,
     /// Gzipped tar bytes, ready to write to disk or POST to a registry.
     pub tarball: Vec<u8>,

--- a/crates/aube/src/lib.rs
+++ b/crates/aube/src/lib.rs
@@ -450,6 +450,7 @@ enum Commands {
     #[command(after_long_help = commands::prune::AFTER_LONG_HELP)]
     Prune(commands::prune::PruneArgs),
     /// Publish the current package to the registry
+    #[cfg(feature = "publish")]
     Publish(commands::publish::PublishArgs),
     /// Alias for `clean` — remove `node_modules` across every workspace project.
     ///
@@ -979,6 +980,7 @@ async fn async_main(cli: Cli) -> miette::Result<Option<i32>> {
         }
         Some(Commands::Prefix(args)) => commands::prefix::run(args).await?,
         Some(Commands::Prune(args)) => commands::prune::run(args).await?,
+        #[cfg(feature = "publish")]
         Some(Commands::Publish(args)) => {
             commands::publish::run(args, effective_filter.clone()).await?
         }
@@ -1035,6 +1037,7 @@ async fn async_main(cli: Cli) -> miette::Result<Option<i32>> {
                         return Ok(Some(code));
                     }
                 }
+                #[cfg(feature = "publish")]
                 Some(Commands::Publish(args)) => {
                     commands::publish::run(args, nested_filter).await?
                 }


### PR DESCRIPTION
## Summary

Follow-up to #1068, unblocking mise embedding aube's **install** path (`aube::embed::add`) instead of shelling out to the `aube` binary. Depending on the `aube` crate as a library currently drags in two things an install-only embedder never needs; this makes both opt-out.

### `publish` feature (default on) — gates the sigstore stack

The sigstore provenance/signing supply chain (`sigstore-sign`/`oidc`/`types` + `ambient-id`, transitively `x509-cert`, `sigstore-{bundle,crypto,merkle,rekor,tsa,tuf,trust-root}`, etc.) is only used by `aube publish` — 2 files. It's now behind a `publish` feature (in `default`), so an embedder builds without it. The `Commands::Publish` CLI variant, its dispatch arms, and the two command modules are `#[cfg(feature = "publish")]`.

### hickory-dns out of aube-registry's default

reqwest's `hickory-dns` cargo feature flips the **default DNS resolver for every reqwest client in the final binary** via feature unification. With it in aube-registry's defaults, an embedder pulling aube-registry *transitively* (through `aube-resolver`/`aube-store`) silently gets hickory forced on — even if it carefully disabled it on its own direct dep. Fixed by dropping `hickory-dns` from aube-registry's default (now `default = ["rustls"]`); the aube **binary** re-enables it via the aube crate's default features, so standalone behavior is unchanged, and embedders opt in explicitly.

### aube crate TLS/DNS feature forwards

Adds `rustls` and `hickory-dns` features on the `aube` crate that forward to reqwest / aube-registry / aube-util, so it can be depended on with `default-features = false, features = ["rustls"]`.

## Verification

- **Default build** (`cargo build -p aube`): unchanged — tree still contains sigstore, hickory-dns, ratatui, mimalloc (37 sigstore/hickory nodes). 665 lib tests pass.
- **Embed shape** (`--no-default-features --features rustls`): builds clean under `RUSTFLAGS=-D warnings`; tree contains **0** sigstore / hickory / ratatui / mimalloc nodes. clippy clean.
- One dead-code field (`BuiltArchive.unpacked_size`, read only by publish) is `#[cfg_attr(not(feature = "publish"), allow(dead_code))]`.

## Suggested CI addition (token lacks `workflow` scope)

Alongside the existing embed-shape check, add:
```yaml
      - run: cargo check -p aube --no-default-features --features rustls
```

*This PR was generated by an AI coding assistant (Claude Code).*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cargo feature and cfg gating only; standalone `aube` defaults preserve prior behavior, with embed builds as the main behavioral surface change.
> 
> **Overview**
> **Makes the `aube` library embeddable without dragging in publish/signing or forced Hickory DNS**, so install-only hosts (e.g. mise) can depend on `aube` with `default-features = false, features = ["rustls"]`.
> 
> A new **`publish` feature** (still on by default) gates the sigstore/`ambient-id` dependencies and wraps `publish` / `publish_provenance` plus all `Publish` CLI wiring in `#[cfg(feature = "publish")]`. **`BuiltArchive.unpacked_size`** is allowed as dead code when `publish` is off.
> 
> **`aube-registry` defaults drop `hickory-dns`** (now `default = ["rustls"]` only) so transitive pulls do not flip reqwest’s DNS resolver for the whole binary via feature unification. The **`aube` crate** re-enables Hickory in its own defaults and adds explicit **`rustls`** / **`hickory-dns`** features that forward to reqwest, `aube-registry`, and `aube-util`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 812ad6b366f34446673aa33bd64daa1c8fe1656c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->