### PR TITLE
feat(embed): let hosts supply the node runtime for lifecycle scripts

### DIFF
--- a/crates/aube-ffi/src/lib.rs
+++ b/crates/aube-ffi/src/lib.rs
@@ -567,6 +567,8 @@ fn add_impl(
             ),
             osv_transitive_check: input.osv_transitive_check && !input.offline,
             control,
+            // C ABI hosts rely on ambient node; no host-supplied runtime.
+            node_bin_dir: None,
         };
         embed::add(&project_dir, &packages, options)
             .await

--- a/crates/aube-node/src/lib.rs
+++ b/crates/aube-node/src/lib.rs
@@ -353,6 +353,8 @@ async fn run_install(
                     dep_selection,
                     osv_transitive_check,
                     control: control.clone(),
+                    // JS hosts rely on ambient node; no host-supplied runtime.
+                    node_bin_dir: None,
                 },
             )
             .await

--- a/crates/aube/src/commands/add/mod.rs
+++ b/crates/aube/src/commands/add/mod.rs
@@ -48,8 +48,9 @@ pub struct AddToProjectOptions {
     /// Directory containing the `node` executable an embedding host wants
     /// lifecycle scripts to run on (see
     /// [`crate::commands::install::InstallOptions::embedder_node_bin_dir`]).
-    /// `None` keeps aube's own runtime resolution.
-    pub embedder_node_bin_dir: Option<std::path::PathBuf>,
+    /// `None` keeps aube's own runtime resolution. Matches the
+    /// `node_bin_dir` field on [`crate::embed::InstallOptions`].
+    pub node_bin_dir: Option<std::path::PathBuf>,
 }
 
 /// Resolve, save, and install packages in an explicitly selected project.
@@ -125,7 +126,7 @@ pub async fn add_to_project(
                 options.dangerously_allow_all_builds,
             );
             install_options.control = options.control;
-            install_options.embedder_node_bin_dir = options.embedder_node_bin_dir;
+            install_options.embedder_node_bin_dir = options.node_bin_dir;
             if options.offline {
                 install_options.network_mode = aube_registry::NetworkMode::Offline;
             }

--- a/crates/aube/src/commands/add/mod.rs
+++ b/crates/aube/src/commands/add/mod.rs
@@ -45,6 +45,11 @@ pub struct AddToProjectOptions {
     pub osv_transitive_check: bool,
     /// Invocation-scoped output and cancellation controls for embedders.
     pub control: install::InstallControl,
+    /// Directory containing the `node` executable an embedding host wants
+    /// lifecycle scripts to run on (see
+    /// [`crate::commands::install::InstallOptions::embedder_node_bin_dir`]).
+    /// `None` keeps aube's own runtime resolution.
+    pub embedder_node_bin_dir: Option<std::path::PathBuf>,
 }
 
 /// Resolve, save, and install packages in an explicitly selected project.
@@ -120,6 +125,7 @@ pub async fn add_to_project(
                 options.dangerously_allow_all_builds,
             );
             install_options.control = options.control;
+            install_options.embedder_node_bin_dir = options.embedder_node_bin_dir;
             if options.offline {
                 install_options.network_mode = aube_registry::NetworkMode::Offline;
             }

--- a/crates/aube/src/commands/ci.rs
+++ b/crates/aube/src/commands/ci.rs
@@ -64,6 +64,7 @@ pub async fn run(args: CiArgs) -> miette::Result<()> {
     // Propagate --ignore-scripts so root lifecycle hooks are skipped.
     let opts = install::InstallOptions {
         control: install::InstallControl::default(),
+        embedder_node_bin_dir: None,
         project_dir: None,
         mode: install::FrozenMode::Frozen,
         dep_selection: install::DepSelection::from_flags(false, false, no_optional),

--- a/crates/aube/src/commands/deploy/mod.rs
+++ b/crates/aube/src/commands/deploy/mod.rs
@@ -315,6 +315,7 @@ pub async fn run(
         };
         let opts = InstallOptions {
             control: install::InstallControl::default(),
+            embedder_node_bin_dir: None,
             project_dir: Some(s.target.clone()),
             mode,
             dep_selection: dep_selection_for_args(&args),

--- a/crates/aube/src/commands/install/args.rs
+++ b/crates/aube/src/commands/install/args.rs
@@ -309,6 +309,7 @@ impl InstallArgs {
             // every install — neither needs the caller to opt in.
             osv_transitive_check: false,
             control: super::InstallControl::default(),
+            embedder_node_bin_dir: None,
         }
     }
 }
@@ -444,6 +445,12 @@ pub struct InstallOptions {
     /// embedders can select structured events or silence independently for
     /// each concurrent install.
     pub control: super::InstallControl,
+    /// Directory containing the `node` executable an embedding host wants
+    /// lifecycle scripts to run on. When set, it seeds the install's runtime
+    /// slot ([`crate::runtime::seed_embedder_node`]) so scripts spawn on that
+    /// node and find it on PATH — aube does no runtime resolution of its own.
+    /// `None` keeps aube's normal runtime switching / PATH fallback.
+    pub embedder_node_bin_dir: Option<std::path::PathBuf>,
 }
 
 impl InstallOptions {
@@ -488,6 +495,7 @@ impl InstallOptions {
             // fallback) instead of an unconditional API hit.
             osv_transitive_check: false,
             control: super::InstallControl::default(),
+            embedder_node_bin_dir: None,
         }
     }
 }

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -601,7 +601,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     // `ensure` returns early when the slot is set, so aube skips its own
     // runtime resolution and scripts spawn on the host's node.
     if let Some(bin_dir) = &opts.embedder_node_bin_dir {
-        crate::runtime::seed_embedder_node(bin_dir.clone());
+        crate::runtime::seed_embedder_node(bin_dir.clone()).await;
     }
     if !opts.dry_run {
         crate::runtime::ensure(

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -596,6 +596,13 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     let lockfile_parse_options = aube_lockfile::ParseOptions {
         strict_store_integrity: strict_store_integrity_setting,
     };
+    // An embedding host (mise) can supply the node runtime for lifecycle
+    // scripts. Seed it into the scoped runtime slot before `ensure` runs —
+    // `ensure` returns early when the slot is set, so aube skips its own
+    // runtime resolution and scripts spawn on the host's node.
+    if let Some(bin_dir) = &opts.embedder_node_bin_dir {
+        crate::runtime::seed_embedder_node(bin_dir.clone());
+    }
     if !opts.dry_run {
         crate::runtime::ensure(
             &cwd,

--- a/crates/aube/src/embed.rs
+++ b/crates/aube/src/embed.rs
@@ -50,6 +50,11 @@ pub struct InstallOptions {
     pub osv_transitive_check: bool,
     /// Invocation-scoped output, progress reporting, and cancellation.
     pub control: InstallControl,
+    /// Directory containing the `node` executable to run lifecycle scripts on.
+    /// Set this when the host manages its own node runtime (e.g. mise) so
+    /// scripts spawn on it and find it on PATH; `None` uses aube's own runtime
+    /// resolution / PATH fallback.
+    pub node_bin_dir: Option<PathBuf>,
 }
 
 impl InstallOptions {
@@ -69,6 +74,7 @@ impl InstallOptions {
             dangerously_allow_all_builds: false,
             osv_transitive_check: false,
             control: InstallControl::default(),
+            node_bin_dir: None,
         }
     }
 }
@@ -112,6 +118,7 @@ pub async fn install(options: InstallOptions) -> Result<()> {
     command_options.dangerously_allow_all_builds = options.dangerously_allow_all_builds;
     command_options.osv_transitive_check = options.osv_transitive_check;
     command_options.control = options.control;
+    command_options.embedder_node_bin_dir = options.node_bin_dir;
     crate::commands::install::run(command_options).await
 }
 

--- a/crates/aube/src/runtime.rs
+++ b/crates/aube/src/runtime.rs
@@ -142,11 +142,28 @@ pub fn current() -> Option<Arc<RuntimeContext>> {
 /// set, so this override wins without aube probing for its own runtime. A
 /// no-op outside a scope or if the slot is already populated.
 pub fn seed_embedder_node(bin_dir: PathBuf) {
+    // Absolutize: lifecycle scripts may run with a different working
+    // directory, so both `node_program()` and the prepended PATH entry must
+    // resolve independently of cwd. `absolute` doesn't require the dir to
+    // exist or touch symlinks; fall back to the input if it errors.
+    let bin_dir = std::path::absolute(&bin_dir).unwrap_or(bin_dir);
     let node_exe = if cfg!(windows) { "node.exe" } else { "node" };
+    let node_bin = bin_dir.join(node_exe);
+    // Probe the supplied node for its version so engine checks and
+    // virtual-store hashing key off the *same* node as lifecycle scripts,
+    // instead of `effective_node_version` falling back to an ambient `node`.
+    let version = std::process::Command::new(&node_bin)
+        .arg("--version")
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .and_then(|out| String::from_utf8(out.stdout).ok())
+        .map(|v| v.trim().trim_start_matches('v').to_string())
+        .filter(|v| !v.is_empty());
     let ctx = RuntimeContext {
-        node_bin: Some(bin_dir.join(node_exe)),
+        node_bin: Some(node_bin),
         bin_dir: Some(bin_dir),
-        version: None,
+        version,
         requested: None,
         source: RuntimeSource::Embedder,
         provenance: RuntimeProvenance::Mise,
@@ -808,9 +825,15 @@ mod tests {
 
     #[tokio::test]
     async fn seed_embedder_node_is_a_noop_outside_scope() {
-        // No install scope active → nothing to seed, and no panic.
+        // No install scope active: the seed can't set a task-local slot, so it
+        // must not panic and must not leak into a later scope. Asserting via a
+        // fresh `scope` reads the (empty) task-local, not the process-wide
+        // `RUNTIME`, so this stays deterministic regardless of test order.
         seed_embedder_node(PathBuf::from("/opt/mise/node/bin"));
-        assert!(current().is_none());
+        scope(async {
+            assert!(current().is_none(), "seed outside a scope must not leak in");
+        })
+        .await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/aube/src/runtime.rs
+++ b/crates/aube/src/runtime.rs
@@ -141,7 +141,16 @@ pub fn current() -> Option<Arc<RuntimeContext>> {
 /// before [`ensure`] runs — `ensure` returns early when the slot is already
 /// set, so this override wins without aube probing for its own runtime. A
 /// no-op outside a scope or if the slot is already populated.
-pub fn seed_embedder_node(bin_dir: PathBuf) {
+pub async fn seed_embedder_node(bin_dir: PathBuf) {
+    // No-op outside an install scope, or when the slot is already seeded.
+    // Check first so the path/version probing below is skipped entirely in
+    // those cases (a later `set` would be a no-op anyway).
+    let should_seed = INSTALL_RUNTIME
+        .try_with(|slot| slot.get().is_none())
+        .unwrap_or(false);
+    if !should_seed {
+        return;
+    }
     // Absolutize: lifecycle scripts may run with a different working
     // directory, so both `node_program()` and the prepended PATH entry must
     // resolve independently of cwd. `absolute` doesn't require the dir to
@@ -152,9 +161,12 @@ pub fn seed_embedder_node(bin_dir: PathBuf) {
     // Probe the supplied node for its version so engine checks and
     // virtual-store hashing key off the *same* node as lifecycle scripts,
     // instead of `effective_node_version` falling back to an ambient `node`.
-    let version = std::process::Command::new(&node_bin)
+    // Async spawn so the install task doesn't block a Tokio worker on the
+    // child process.
+    let version = tokio::process::Command::new(&node_bin)
         .arg("--version")
         .output()
+        .await
         .ok()
         .filter(|out| out.status.success())
         .and_then(|out| String::from_utf8(out.stdout).ok())
@@ -805,7 +817,7 @@ mod tests {
         scope(async {
             assert!(current().is_none(), "slot starts empty");
             let bin_dir = PathBuf::from("/opt/mise/node/bin");
-            seed_embedder_node(bin_dir.clone());
+            seed_embedder_node(bin_dir.clone()).await;
 
             // The seed absolutizes the dir; compute the expected the same way
             // so this holds on Windows (where `/opt/...` isn't absolute).
@@ -820,7 +832,7 @@ mod tests {
 
             // `ensure`-style early return: a second seed does not clobber the
             // first (OnceCell is set once).
-            seed_embedder_node(PathBuf::from("/other"));
+            seed_embedder_node(PathBuf::from("/other")).await;
             assert_eq!(node_program(), expected.join(node_exe));
         })
         .await;
@@ -832,7 +844,7 @@ mod tests {
         // must not panic and must not leak into a later scope. Asserting via a
         // fresh `scope` reads the (empty) task-local, not the process-wide
         // `RUNTIME`, so this stays deterministic regardless of test order.
-        seed_embedder_node(PathBuf::from("/opt/mise/node/bin"));
+        seed_embedder_node(PathBuf::from("/opt/mise/node/bin")).await;
         scope(async {
             assert!(current().is_none(), "seed outside a scope must not leak in");
         })

--- a/crates/aube/src/runtime.rs
+++ b/crates/aube/src/runtime.rs
@@ -24,6 +24,9 @@ pub enum RuntimeSource {
     /// No requirement configured (or policy said keep the ambient
     /// node) — PATH is left alone.
     PathFallback,
+    /// A host embedding aube (e.g. mise) supplied the node runtime to
+    /// use for lifecycle scripts, rather than aube resolving one itself.
+    Embedder,
 }
 
 impl RuntimeSource {
@@ -33,6 +36,7 @@ impl RuntimeSource {
             RuntimeSource::NodeVersionFile => ".node-version",
             RuntimeSource::Nvmrc => ".nvmrc",
             RuntimeSource::PathFallback => "PATH",
+            RuntimeSource::Embedder => "embedder",
         }
     }
 }
@@ -125,6 +129,32 @@ pub fn current() -> Option<Arc<RuntimeContext>> {
         Ok(runtime) => runtime,
         Err(_) => RUNTIME.get().map(Arc::clone),
     }
+}
+
+/// Seed the current install's runtime slot with a node binary supplied by an
+/// embedding host (e.g. mise), so lifecycle scripts spawn on that node and
+/// find it on PATH instead of relying on an ambient `node`.
+///
+/// `bin_dir` is the directory containing the `node` executable; it is
+/// prepended to the script PATH ([`path_entries`]) and its `node` is used as
+/// [`node_program`]. Must be called inside a [`scope`] (the install task) and
+/// before [`ensure`] runs — `ensure` returns early when the slot is already
+/// set, so this override wins without aube probing for its own runtime. A
+/// no-op outside a scope or if the slot is already populated.
+pub fn seed_embedder_node(bin_dir: PathBuf) {
+    let node_exe = if cfg!(windows) { "node.exe" } else { "node" };
+    let ctx = RuntimeContext {
+        node_bin: Some(bin_dir.join(node_exe)),
+        bin_dir: Some(bin_dir),
+        version: None,
+        requested: None,
+        source: RuntimeSource::Embedder,
+        provenance: RuntimeProvenance::Mise,
+        fresh_pin: None,
+    };
+    let _ = INSTALL_RUNTIME.try_with(|slot| {
+        let _ = slot.set(Arc::new(ctx));
+    });
 }
 
 /// The node executable spawn sites should use: the switched runtime's
@@ -751,6 +781,36 @@ mod tests {
         let mut context = RuntimeContext::path_fallback();
         context.requested = Some(requested.to_string());
         context
+    }
+
+    #[tokio::test]
+    async fn seed_embedder_node_drives_node_program_and_path() {
+        scope(async {
+            assert!(current().is_none(), "slot starts empty");
+            let bin_dir = PathBuf::from("/opt/mise/node/bin");
+            seed_embedder_node(bin_dir.clone());
+
+            let ctx = current().expect("slot seeded");
+            assert_eq!(ctx.source, RuntimeSource::Embedder);
+            assert_eq!(ctx.bin_dir.as_deref(), Some(bin_dir.as_path()));
+
+            let node_exe = if cfg!(windows) { "node.exe" } else { "node" };
+            assert_eq!(node_program(), bin_dir.join(node_exe));
+            assert_eq!(path_entries(), vec![bin_dir.clone()]);
+
+            // `ensure`-style early return: a second seed does not clobber the
+            // first (OnceCell is set once).
+            seed_embedder_node(PathBuf::from("/other"));
+            assert_eq!(node_program(), bin_dir.join(node_exe));
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn seed_embedder_node_is_a_noop_outside_scope() {
+        // No install scope active → nothing to seed, and no panic.
+        seed_embedder_node(PathBuf::from("/opt/mise/node/bin"));
+        assert!(current().is_none());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/aube/src/runtime.rs
+++ b/crates/aube/src/runtime.rs
@@ -807,18 +807,21 @@ mod tests {
             let bin_dir = PathBuf::from("/opt/mise/node/bin");
             seed_embedder_node(bin_dir.clone());
 
+            // The seed absolutizes the dir; compute the expected the same way
+            // so this holds on Windows (where `/opt/...` isn't absolute).
+            let expected = std::path::absolute(&bin_dir).unwrap_or(bin_dir);
+            let node_exe = if cfg!(windows) { "node.exe" } else { "node" };
+
             let ctx = current().expect("slot seeded");
             assert_eq!(ctx.source, RuntimeSource::Embedder);
-            assert_eq!(ctx.bin_dir.as_deref(), Some(bin_dir.as_path()));
-
-            let node_exe = if cfg!(windows) { "node.exe" } else { "node" };
-            assert_eq!(node_program(), bin_dir.join(node_exe));
-            assert_eq!(path_entries(), vec![bin_dir.clone()]);
+            assert_eq!(ctx.bin_dir.as_deref(), Some(expected.as_path()));
+            assert_eq!(node_program(), expected.join(node_exe));
+            assert_eq!(path_entries(), vec![expected.clone()]);
 
             // `ensure`-style early return: a second seed does not clobber the
             // first (OnceCell is set once).
             seed_embedder_node(PathBuf::from("/other"));
-            assert_eq!(node_program(), bin_dir.join(node_exe));
+            assert_eq!(node_program(), expected.join(node_exe));
         })
         .await;
     }


### PR DESCRIPTION
## Summary

Adds a way for a host embedding aube (e.g. [mise](https://github.com/jdx/mise)) to supply the node runtime that dependency **lifecycle scripts** run on, instead of aube falling back to an ambient `node` PATH lookup.

Motivation: mise embeds `aube::embed::add` to install `npm:` tools ([jdx/mise#11149](https://github.com/jdx/mise/pull/11149)) with node managed as a mise *dependency* — not on the process `PATH`. Today `runtime::node_program()` falls back to `PathBuf::from("node")` when no runtime switch is active, so `allow_builds` installs whose dependencies run lifecycle scripts fail to find node. The old subprocess path (`aube add --global`) avoided this by `prepend_path`-ing the dependency toolset; this restores that for the in-process path.

## Change

- `embed::InstallOptions` and `AddToProjectOptions` gain `node_bin_dir: Option<PathBuf>` (the dir containing the host's `node`). Threads into `install::InstallOptions::embedder_node_bin_dir`.
- Inside `install::run` — within the runtime `scope`, before `runtime::ensure` — `runtime::seed_embedder_node(bin_dir)` sets the scoped runtime slot to a `RuntimeContext` pointing at the host's node (`source: Embedder`, `provenance: Mise`). `ensure` returns early when the slot is populated, so aube does no runtime resolution of its own and `node_program()` / `path_entries()` return the host's node.
- Safe under concurrent installs: the runtime slot is a `tokio::task_local`, scoped per-install — no process-global mutation.
- Behavior-preserving when unset (`None`): normal runtime switching / PATH fallback.

## Tests

- New `runtime::tests::seed_embedder_node_drives_node_program_and_path` — within a `scope`, the seed drives `node_program()` and `path_entries()`, and is idempotent (a second seed doesn't clobber, matching `ensure`'s early return).
- `seed_embedder_node_is_a_noop_outside_scope` — no scope → no-op, no panic.
- Full `cargo test -p aube --lib` (667) passes; clippy clean.

*This PR was generated by an AI coding assistant (Claude Code).*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how lifecycle scripts resolve Node for embedders that opt in; scoped per-install via task-local state, but incorrect `node_bin_dir` could break builds or version checks for those hosts.
> 
> **Overview**
> Adds **`node_bin_dir`** on embed APIs (`embed::InstallOptions`, `AddToProjectOptions`) and **`embedder_node_bin_dir`** on `install::InstallOptions`, wired through `embed::install` / `add_to_project`.
> 
> Before **`runtime::ensure`**, install calls **`runtime::seed_embedder_node`**, which fills the per-install task-local runtime slot with the host’s `node` (`RuntimeSource::Embedder`), prepends that bin dir to script PATH, and probes `--version` so engine checks match the same binary. **`ensure`** then skips its own resolution when the slot is already set.
> 
> CLI, CI, deploy, FFI, and Node-API callers keep **`None`** (unchanged behavior). New unit tests cover seeding inside an install scope and no-op behavior outside it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df3e68e9d942506c6c65e043c33befdf3363f07f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedded installations can run lifecycle scripts using a host-provided `node` executable directory.
  * Lifecycle script runtime selection is now scoped to the installation for consistent `node` resolution.

* **Bug Fixes**
  * Prevents embedded flows from unnecessarily resolving/downloading a different Node.js runtime.

* **Compatibility**
  * Default behavior remains unchanged when no host `node` directory is provided across CLI, CI, deployment, and FFI paths.

* **Tests**
  * Added coverage for scoped Node seeding behavior and ensuring it doesn’t leak outside the install scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->