### PR TITLE
feat(runtime): detect FreeBSD as a supported host platform

### DIFF
--- a/crates/aube-codes/src/errors.rs
+++ b/crates/aube-codes/src/errors.rs
@@ -102,6 +102,7 @@ pub const ERR_AUBE_RUNTIME_EXTRACT_FAILED: &str = "ERR_AUBE_RUNTIME_EXTRACT_FAIL
 #[rustfmt::skip] pub const ERR_AUBE_RUNTIME_MISE_INSTALL_FAILED: &str = "ERR_AUBE_RUNTIME_MISE_INSTALL_FAILED";
 #[rustfmt::skip] pub const ERR_AUBE_RUNTIME_UNSUPPORTED_PLATFORM: &str = "ERR_AUBE_RUNTIME_UNSUPPORTED_PLATFORM";
 pub const ERR_AUBE_RUNTIME_IO: &str = "ERR_AUBE_RUNTIME_IO";
+#[rustfmt::skip] pub const ERR_AUBE_SELF_UPDATE_UNSUPPORTED_PLATFORM: &str = "ERR_AUBE_SELF_UPDATE_UNSUPPORTED_PLATFORM";
 
 // ── misc / safety ──────────────────────────────────────────────────
 pub const ERR_AUBE_INSTALL_CANCELLED: &str = "ERR_AUBE_INSTALL_CANCELLED";
@@ -548,6 +549,12 @@ pub const ALL: &[CodeMeta] = &[
         name: ERR_AUBE_RUNTIME_IO,
         category: category::ENGINE_CLI,
         description: "A filesystem operation in the runtime store failed (lock acquisition, staging, or publishing an install). Not a download failure — the message names the failing path.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: ERR_AUBE_SELF_UPDATE_UNSUPPORTED_PLATFORM,
+        category: category::ENGINE_CLI,
+        description: "`aube self-update` has no published aube release archive for this OS/architecture (e.g. FreeBSD, Intel macOS). Install aube via your system package manager or mise. Distinct from ERR_AUBE_RUNTIME_UNSUPPORTED_PLATFORM, which is about the Node.js download.",
         exit_code: None,
     },
     // Misc / safety

--- a/crates/aube-runtime/src/error.rs
+++ b/crates/aube-runtime/src/error.rs
@@ -43,6 +43,15 @@ pub enum Error {
     )]
     UnsupportedPlatform { platform: String },
 
+    /// The self-updater has no aube release archive to fetch for this
+    /// host. Distinct from [`Error::UnsupportedPlatform`] (which is
+    /// about the *Node.js* download): this is about aube's own binary,
+    /// so the message names aube — not Node.
+    #[error(
+        "no aube release build is published for {platform}; install aube via mise or your system package manager"
+    )]
+    NoReleaseBuild { platform: String },
+
     #[error("offline mode is active and {what} is not cached")]
     Offline { what: String },
 
@@ -65,6 +74,7 @@ impl Error {
             Error::ExtractFailed { .. } => errors::ERR_AUBE_RUNTIME_EXTRACT_FAILED,
             Error::MiseInstallFailed { .. } => errors::ERR_AUBE_RUNTIME_MISE_INSTALL_FAILED,
             Error::UnsupportedPlatform { .. } => errors::ERR_AUBE_RUNTIME_UNSUPPORTED_PLATFORM,
+            Error::NoReleaseBuild { .. } => errors::ERR_AUBE_SELF_UPDATE_UNSUPPORTED_PLATFORM,
             Error::Offline { .. } => errors::ERR_AUBE_OFFLINE,
             // Generic exit code (no EXIT_TABLE entry) — a lock or
             // rename failure is not a download failure, and the

--- a/crates/aube-runtime/src/platform.rs
+++ b/crates/aube-runtime/src/platform.rs
@@ -2,7 +2,8 @@
 //! into:
 //!
 //! - **lockfile vocabulary** (pnpm / Node `process.platform`):
-//!   `darwin` / `linux` / `win32`, `x64` / `arm64`, `libc: musl`;
+//!   `darwin` / `linux` / `win32` / `freebsd`, `x64` / `arm64`,
+//!   `libc: musl`;
 //! - **dist-file vocabulary** (nodejs.org artifact names):
 //!   `node-v{V}-darwin-arm64.tar.gz`, `node-v{V}-linux-x64-musl.tar.gz`,
 //!   `node-v{V}-win-x64.zip`.
@@ -33,6 +34,17 @@ impl Platform {
             "macos" => "darwin",
             "linux" => "linux",
             "windows" => "win32",
+            // FreeBSD reports Node's `process.platform` value verbatim.
+            // nodejs.org ships no FreeBSD artifacts, so the download
+            // path can't satisfy a request here — but resolution reaches
+            // it only after the zero-network fast paths (PATH probe,
+            // installed scan, mise delegation) miss, and a missing dist
+            // then surfaces the normal `NoMatchingVersion` /
+            // `UnsupportedPlatform` diagnostic. Detecting the platform
+            // (rather than erroring outright) is what lets those local
+            // paths, `os`-field package filtering, and multi-platform
+            // lockfile pins behave correctly on FreeBSD.
+            "freebsd" => "freebsd",
             other => {
                 return Err(Error::UnsupportedPlatform {
                     platform: format!("{other}-{}", std::env::consts::ARCH),
@@ -152,6 +164,21 @@ mod tests {
             "linux-x64-musl"
         );
         assert_eq!(plat("win32", "x64", None).dist_slug(), "win-x64");
+        assert_eq!(plat("freebsd", "x64", None).dist_slug(), "freebsd-x64");
+    }
+
+    #[test]
+    fn freebsd_token_falls_back_to_linux() {
+        // nodejs.org has no FreeBSD `files[]` token, so availability
+        // gating reuses the linux token. Download still fails later at
+        // the SHASUMS lookup (no `node-v*-freebsd-*` artifact), which is
+        // the intended graceful outcome — FreeBSD relies on system/mise
+        // Node, not aube's self-download.
+        assert_eq!(
+            plat("freebsd", "x64", None).index_files_token(),
+            "linux-x64"
+        );
+        assert_eq!(plat("freebsd", "x64", None).archive_ext(), "tar.gz");
     }
 
     #[test]

--- a/crates/aube-runtime/src/self_install.rs
+++ b/crates/aube-runtime/src/self_install.rs
@@ -155,25 +155,40 @@ fn validate_aube_install(
 
 /// The release-archive target triple for the host. aube publishes:
 /// `aarch64-apple-darwin`, `{x86_64,aarch64}-unknown-linux-{gnu,musl}`,
-/// `{x86_64,aarch64}-pc-windows-msvc`. Hosts without a published
-/// build (e.g. Intel macOS) get an [`Error::UnsupportedPlatform`]
-/// pointing at mise.
+/// `{x86_64,aarch64}-pc-windows-msvc`. Hosts without a published build
+/// (e.g. Intel macOS, or any FreeBSD arch) get an
+/// [`Error::NoReleaseBuild`] pointing at mise / the system package
+/// manager.
 pub fn release_target_triple() -> Result<String, Error> {
-    let arch = match std::env::consts::ARCH {
+    let os = std::env::consts::OS;
+    let raw_arch = std::env::consts::ARCH;
+
+    // FreeBSD has no published aube archive on any architecture, so
+    // short-circuit before the arch whitelist — otherwise a non-x86/arm
+    // FreeBSD host would fall into the arch reject and miss the
+    // aube-specific guidance. `Platform::current()` still recognizes
+    // FreeBSD (see platform.rs), so Node installs keep working against
+    // system/mise; only the self-updater is unavailable here.
+    if os == "freebsd" {
+        return Err(Error::NoReleaseBuild {
+            platform: format!("freebsd-{raw_arch}"),
+        });
+    }
+
+    let arch = match raw_arch {
         "x86_64" => "x86_64",
         "aarch64" => "aarch64",
         other => {
-            return Err(Error::UnsupportedPlatform {
-                platform: format!("{}-{other}", std::env::consts::OS),
+            return Err(Error::NoReleaseBuild {
+                platform: format!("{os}-{other}"),
             });
         }
     };
-    let triple = match std::env::consts::OS {
+    let triple = match os {
         "macos" => {
             if arch != "aarch64" {
-                return Err(Error::UnsupportedPlatform {
-                    platform: "macos-x86_64 (no published aube build; install via mise)"
-                        .to_string(),
+                return Err(Error::NoReleaseBuild {
+                    platform: "macos-x86_64".to_string(),
                 });
             }
             format!("{arch}-apple-darwin")
@@ -187,19 +202,8 @@ pub fn release_target_triple() -> Result<String, Error> {
             format!("{arch}-unknown-linux-{libc}")
         }
         "windows" => format!("{arch}-pc-windows-msvc"),
-        // aube publishes no FreeBSD release archive, so self-update has
-        // nothing to fetch. `Platform::current()` still recognizes
-        // FreeBSD (see platform.rs) so installs run against system/mise
-        // Node; only the self-updater is unavailable here.
-        "freebsd" => {
-            return Err(Error::UnsupportedPlatform {
-                platform: format!(
-                    "freebsd-{arch} (no published aube build; install via pkg or mise)"
-                ),
-            });
-        }
         other => {
-            return Err(Error::UnsupportedPlatform {
+            return Err(Error::NoReleaseBuild {
                 platform: format!("{other}-{arch}"),
             });
         }
@@ -647,7 +651,7 @@ mod tests {
                     "{t}"
                 );
             }
-            Err(Error::UnsupportedPlatform { .. }) => {
+            Err(Error::NoReleaseBuild { .. }) => {
                 let os = std::env::consts::OS;
                 assert!(
                     os == "freebsd" || (os == "macos" && std::env::consts::ARCH == "x86_64"),

--- a/crates/aube-runtime/src/self_install.rs
+++ b/crates/aube-runtime/src/self_install.rs
@@ -187,6 +187,17 @@ pub fn release_target_triple() -> Result<String, Error> {
             format!("{arch}-unknown-linux-{libc}")
         }
         "windows" => format!("{arch}-pc-windows-msvc"),
+        // aube publishes no FreeBSD release archive, so self-update has
+        // nothing to fetch. `Platform::current()` still recognizes
+        // FreeBSD (see platform.rs) so installs run against system/mise
+        // Node; only the self-updater is unavailable here.
+        "freebsd" => {
+            return Err(Error::UnsupportedPlatform {
+                platform: format!(
+                    "freebsd-{arch} (no published aube build; install via pkg or mise)"
+                ),
+            });
+        }
         other => {
             return Err(Error::UnsupportedPlatform {
                 platform: format!("{other}-{arch}"),
@@ -625,8 +636,8 @@ mod tests {
     #[test]
     fn target_triple_is_publishable() {
         // On every platform CI runs, the host triple must map to a
-        // name aube actually publishes (Intel macOS is the documented
-        // exception).
+        // name aube actually publishes. Documented exceptions with no
+        // published build: Intel macOS, and FreeBSD (any arch).
         match release_target_triple() {
             Ok(t) => {
                 assert!(
@@ -637,8 +648,12 @@ mod tests {
                 );
             }
             Err(Error::UnsupportedPlatform { .. }) => {
-                assert_eq!(std::env::consts::OS, "macos");
-                assert_eq!(std::env::consts::ARCH, "x86_64");
+                let os = std::env::consts::OS;
+                assert!(
+                    os == "freebsd" || (os == "macos" && std::env::consts::ARCH == "x86_64"),
+                    "unexpected unsupported host: {os}-{}",
+                    std::env::consts::ARCH
+                );
             }
             Err(other) => panic!("unexpected error: {other}"),
         }

--- a/crates/aube/src/commands/global.rs
+++ b/crates/aube/src/commands/global.rs
@@ -94,7 +94,10 @@ pub fn prefix_dir() -> miette::Result<PathBuf> {
     resolve_home()
 }
 
-#[cfg(target_os = "linux")]
+// Linux plus every other Unix (FreeBSD, …): pnpm special-cases only
+// macOS (`~/Library/pnpm`) and Windows (`%LOCALAPPDATA%`), and uses the
+// XDG default everywhere else.
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 fn platform_default() -> miette::Result<PathBuf> {
     if let Some(xdg) = aube_util::env::xdg_data_home() {
         return Ok(xdg.join("pnpm"));

--- a/crates/aube/src/commands/global.rs
+++ b/crates/aube/src/commands/global.rs
@@ -95,9 +95,11 @@ pub fn prefix_dir() -> miette::Result<PathBuf> {
 }
 
 // Linux plus every other Unix (FreeBSD, …): pnpm special-cases only
-// macOS (`~/Library/pnpm`) and Windows (`%LOCALAPPDATA%`), and uses the
-// XDG default everywhere else.
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+// macOS (`~/Library/pnpm`), while Windows has its own arm below. Scoped
+// to `unix` so a non-Unix, non-Windows target doesn't silently inherit
+// the XDG/HOME logic — it gets a compile error instead, which is the
+// signal we'd want before shipping such a build.
+#[cfg(all(unix, not(target_os = "macos")))]
 fn platform_default() -> miette::Result<PathBuf> {
     if let Some(xdg) = aube_util::env::xdg_data_home() {
         return Ok(xdg.join("pnpm"));

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -403,6 +403,12 @@
       "exit_code": null
     },
     {
+      "name": "ERR_AUBE_SELF_UPDATE_UNSUPPORTED_PLATFORM",
+      "category": "Engine / CLI",
+      "description": "`aube self-update` has no published aube release archive for this OS/architecture (e.g. FreeBSD, Intel macOS). Install aube via your system package manager or mise. Distinct from ERR_AUBE_RUNTIME_UNSUPPORTED_PLATFORM, which is about the Node.js download.",
+      "exit_code": null
+    },
+    {
       "name": "ERR_AUBE_INSTALL_CANCELLED",
       "category": "Misc / safety",
       "description": "An in-process install was cooperatively cancelled by its embedding host. Cancellation is observed at safe install boundaries so an in-flight filesystem phase is not abandoned mid-mutation.",


### PR DESCRIPTION
## What

Makes `aube` build and run correctly on FreeBSD. Scoped to **source compatibility only** — no CI job and no published FreeBSD release binaries (see caveats below).

The single functional break was runtime Node detection: `Platform::current()` matched only macOS/Linux/Windows and hard-errored (`UnsupportedPlatform`) on every other OS. This blocked runtime resolution on FreeBSD **even when a suitable Node was already on PATH or installed via mise**, because the error propagated before the local fast paths could be used.

### Changes
- **`crates/aube-runtime/src/platform.rs`** — `Platform::current()` now detects FreeBSD (`os: "freebsd"`, matching Node's `process.platform`). This is what lets the zero-network resolution paths (PATH probe, installed-Node scan, mise delegation), `os`-field package filtering, and multi-platform lockfile pins behave correctly. Added unit tests for the FreeBSD dist-slug and the `files[]` token fallback.
- **`crates/aube-runtime/src/self_install.rs`** — `aube self-update` now returns a clear `freebsd-<arch> (no published aube build; install via pkg or mise)` message, mirroring the existing macOS-x86_64 precedent. Broadened the `target_triple_is_publishable` test so `cargo test` stays green when run on a FreeBSD host.

## Why the download path is fine

nodejs.org publishes no FreeBSD artifacts. Detection (rather than erroring) is intentional: resolution reaches the self-download path only *after* the local fast paths miss, and a missing dist then surfaces the normal `NoMatchingVersion` / `UnsupportedPlatform` diagnostic. FreeBSD relies on system/mise Node — the intended story — rather than aube self-downloading.

## Reviewer notes / caveats (deliberately out of scope)

- **No FreeBSD CI** — GitHub has no native FreeBSD runner; would require a VM action.
- **No published `*-unknown-freebsd` release binaries** — hence `self-update` is unavailable on FreeBSD (points to `pkg`/mise).
- **Lifecycle scripts run unconfined on FreeBSD** — same fallback as any non-Linux/non-macOS Unix today (Linux uses landlock+seccomp, macOS uses sandbox-exec). Scripts are deny-by-default (allowlist opt-in). A native Capsicum/jail sandbox is a possible follow-up.

## Verification

- `cargo test -p aube-runtime` — 40 passed (incl. new FreeBSD tests)
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

A full FreeBSD cross-link can't be reproduced locally: the only blocker is `aws-lc-sys` needing a FreeBSD C sysroot (no cross `cc`/`clang` in the dev env). That's a toolchain limitation, not an aube source issue — `aws-lc-rs` officially supports `x86_64-unknown-freebsd`, and a real FreeBSD host's base-system `cc` compiles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Platform detection and error-code splits are localized to runtime/CLI paths; behavior change is enabling FreeBSD hosts that previously hard-failed at platform detection, with no auth or data-handling impact.
> 
> **Overview**
> **FreeBSD is now a recognized host** so Node runtime resolution can use PATH, installed scans, and mise before any nodejs.org download attempt. `Platform::current()` maps FreeBSD to `os: "freebsd"` (Node’s `process.platform`), with dist-slug/index-token behavior and tests for the linux-token fallback when official artifacts are absent.
> 
> **Self-update failures are separated from Node platform errors.** Missing published **aube** binaries (FreeBSD, Intel macOS, unknown arch) now use `Error::NoReleaseBuild` and stable code `ERR_AUBE_SELF_UPDATE_UNSUPPORTED_PLATFORM`, instead of reusing the Node-oriented `UnsupportedPlatform` / `ERR_AUBE_RUNTIME_UNSUPPORTED_PLATFORM`.
> 
> **Global install defaults on non-macOS Unix** (including FreeBSD) use the same XDG/`~/.local/share/pnpm` path as Linux via `#[cfg(all(unix, not(target_os = "macos")))]` instead of Linux-only cfg.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b5a2415da33d4f17347c3d69d0a715074d29513. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added FreeBSD platform recognition, including correct handling of non-zip tarball archives and Linux index fallback behavior when needed.
  * Extended Unix default data path resolution to all Unix platforms except macOS.

* **Bug Fixes**
  * Improved `aube self-update` behavior for unsupported host platforms by providing clearer, consistent “no release build available” errors, including a new stable error code.

* **Documentation**
  * Updated platform lockfile vocabulary documentation to include FreeBSD (`freebsd`).

* **Tests**
  * Added/extended test coverage for FreeBSD platform detection and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->