### PR TITLE
fix(linker): apply registry-name patches to npm-aliased installs

### DIFF
--- a/crates/aube-linker/src/hoisted.rs
+++ b/crates/aube-linker/src/hoisted.rs
@@ -487,10 +487,9 @@ pub(crate) fn link_hoisted_importer(
             }
         }
 
-        let patch_key = pkg.spec_key();
-        if let Some(patch_text) = linker.patches.get(&patch_key) {
+        if let Some((patch_key, patch_text)) = pkg.lookup_patch(&linker.patches) {
             apply_multi_file_patch(&pkg_dir, patch_text)
-                .map_err(|msg| Error::Patch(patch_key.clone(), msg))?;
+                .map_err(|msg| Error::Patch(patch_key, msg))?;
         }
 
         stats.packages_linked += 1;

--- a/crates/aube-linker/src/materialize.rs
+++ b/crates/aube-linker/src/materialize.rs
@@ -589,10 +589,9 @@ impl Linker {
         // patched bytes live alongside the unpatched ones at a
         // distinct subdir (the graph hash callback is responsible for
         // making sure that's true).
-        let patch_key = pkg.spec_key();
-        if let Some(patch_text) = self.patches.get(&patch_key) {
+        if let Some((patch_key, patch_text)) = pkg.lookup_patch(&self.patches) {
             apply_multi_file_patch(&pkg_nm_dir, patch_text)
-                .map_err(|msg| Error::Patch(patch_key.clone(), msg))?;
+                .map_err(|msg| Error::Patch(patch_key, msg))?;
         }
 
         // Create symlinks for transitive dependencies. Parents for

--- a/crates/aube-linker/src/patches.rs
+++ b/crates/aube-linker/src/patches.rs
@@ -83,8 +83,13 @@ pub(crate) fn wipe_changed_patched_entries(
         return;
     }
     for (dep_path, pkg) in &graph.packages {
-        let key = pkg.spec_key();
-        if affected.contains(&key) {
+        // Patch fingerprints are keyed by the declared selector (the
+        // registry identity), so an npm-aliased entry must match on
+        // `registry_name()@version` as well as its alias-qualified
+        // `spec_key()`. Mirrors `LockedPackage::lookup_patch`.
+        let spec_key = pkg.spec_key();
+        let registry_key = format!("{}@{}", pkg.registry_name(), pkg.version);
+        if affected.contains(&spec_key) || affected.contains(&registry_key) {
             let entry = aube_dir.join(dep_path_to_filename(dep_path, max_length));
             let _ = std::fs::remove_dir_all(entry);
         }

--- a/crates/aube-lockfile/src/graph_hash.rs
+++ b/crates/aube-lockfile/src/graph_hash.rs
@@ -422,7 +422,12 @@ fn full_pkg_id(pkg: &LockedPackage, patch_hash: PatchHashFn<'_>, content: Option
     let content = content
         .map(|hex| format!(":content:{hex}"))
         .unwrap_or_default();
-    match patch_hash(&pkg.name, &pkg.version) {
+    // Patches are declared against the registry identity, so an
+    // npm-aliased entry (`name` = alias) must resolve its patch hash by
+    // `registry_name()@version`; the callbacks key the patch map that
+    // way. The node identity string still uses `pkg.name` so the alias
+    // keeps its own dep_path. Mirrors `LockedPackage::lookup_patch`.
+    match patch_hash(pkg.registry_name(), &pkg.version) {
         Some(hex) => format!(
             "{}@{}:patch:{hex}{source}{content}:{integrity}",
             pkg.name, pkg.version

--- a/crates/aube-lockfile/src/graph_hash.rs
+++ b/crates/aube-lockfile/src/graph_hash.rs
@@ -422,12 +422,22 @@ fn full_pkg_id(pkg: &LockedPackage, patch_hash: PatchHashFn<'_>, content: Option
     let content = content
         .map(|hex| format!(":content:{hex}"))
         .unwrap_or_default();
-    // Patches are declared against the registry identity, so an
-    // npm-aliased entry (`name` = alias) must resolve its patch hash by
-    // `registry_name()@version`; the callbacks key the patch map that
-    // way. The node identity string still uses `pkg.name` so the alias
-    // keeps its own dep_path. Mirrors `LockedPackage::lookup_patch`.
-    match patch_hash(pkg.registry_name(), &pkg.version) {
+    // Resolve the patch fingerprint with the SAME precedence as
+    // `LockedPackage::lookup_patch` — alias-qualified `name@version`
+    // first, then `registry_name()@version` — so the virtual-store hash
+    // always reflects the exact patch the apply sites write to disk. An
+    // npm-aliased entry (`name` = alias) declares its patch against the
+    // registry identity in the common case, but a patch keyed by the
+    // alias must win here too; otherwise the patched node would share a
+    // dep_path with the unpatched one. The identity string keeps
+    // `pkg.name` so the alias retains its own node.
+    let patch = patch_hash(&pkg.name, &pkg.version).or_else(|| {
+        let registry_name = pkg.registry_name();
+        (registry_name != pkg.name)
+            .then(|| patch_hash(registry_name, &pkg.version))
+            .flatten()
+    });
+    match patch {
         Some(hex) => format!(
             "{}@{}:patch:{hex}{source}{content}:{integrity}",
             pkg.name, pkg.version
@@ -913,5 +923,60 @@ mod tests {
         // Unknown architectures pass through rather than getting
         // silently remapped onto an adjacent bucket.
         assert_eq!(node_arch("riscv64"), "riscv64");
+    }
+
+    #[test]
+    fn aliased_patch_hash_resolves_by_registry_identity() {
+        // `"odd-alias": "npm:is-odd@3.0.1"` with a patch declared against
+        // the registry identity `is-odd@3.0.1`. The graph hash must fold
+        // that patch in even though the node's `name` is the alias, so
+        // the patched node lands on a distinct dep_path from an unpatched
+        // one. Mirrors what `LockedPackage::lookup_patch` does at the
+        // apply sites.
+        let mut g = empty_graph();
+        let mut pkg = mk_pkg("odd-alias", "3.0.1", Some("sha512-A"));
+        pkg.alias_of = Some("is-odd".into());
+        g.packages.insert("odd-alias@3.0.1".into(), pkg);
+
+        let unpatched = compute_graph_hashes_with_patches(&g, &|_| false, None, &|_, _| None);
+        let patched = compute_graph_hashes_with_patches(&g, &|_| false, None, &|name, ver| {
+            (name == "is-odd" && ver == "3.0.1").then(|| "deadbeef".to_string())
+        });
+        assert_ne!(
+            unpatched.node_hash["odd-alias@3.0.1"], patched.node_hash["odd-alias@3.0.1"],
+            "a registry-name patch must change the aliased node's graph hash"
+        );
+    }
+
+    #[test]
+    fn aliased_patch_hash_prefers_alias_key_over_registry_key() {
+        // A patch declared against the alias identity must win over one
+        // declared against the registry identity — the same precedence
+        // `LockedPackage::lookup_patch` uses (`spec_key()` first). If the
+        // graph hash resolved registry-first, the on-disk bytes (patched
+        // via the alias key) and the dep_path would disagree.
+        let mut g = empty_graph();
+        let mut pkg = mk_pkg("odd-alias", "3.0.1", Some("sha512-A"));
+        pkg.alias_of = Some("is-odd".into());
+        g.packages.insert("odd-alias@3.0.1".into(), pkg);
+
+        let alias_keyed =
+            compute_graph_hashes_with_patches(
+                &g,
+                &|_| false,
+                None,
+                &|name, ver| match (name, ver) {
+                    ("odd-alias", "3.0.1") => Some("alias-patch".to_string()),
+                    ("is-odd", "3.0.1") => Some("registry-patch".to_string()),
+                    _ => None,
+                },
+            );
+        let alias_only = compute_graph_hashes_with_patches(&g, &|_| false, None, &|name, ver| {
+            (name == "odd-alias" && ver == "3.0.1").then(|| "alias-patch".to_string())
+        });
+        assert_eq!(
+            alias_keyed.node_hash["odd-alias@3.0.1"], alias_only.node_hash["odd-alias@3.0.1"],
+            "alias-keyed patch must take precedence over the registry-keyed one"
+        );
     }
 }

--- a/crates/aube-lockfile/src/lib.rs
+++ b/crates/aube-lockfile/src/lib.rs
@@ -487,6 +487,31 @@ impl LockedPackage {
         format!("{}@{}", self.name, self.version)
     }
 
+    /// Resolve a patch entry for this package from a `name@version`-keyed
+    /// map, returning the matched key alongside the value.
+    ///
+    /// Tries the alias-qualified [`Self::spec_key`] first, then falls
+    /// back to the registry identity (`registry_name()@version`).
+    /// `patchedDependencies` are declared against the *real* package
+    /// name, so an npm-aliased entry (`"odd-alias": "npm:is-odd@3.0.1"`)
+    /// carries `name = "odd-alias"` while the patch is keyed
+    /// `is-odd@3.0.1`; the fallback is what lets the patch reach the
+    /// aliased install. Mirrors pnpm, which resolves patches on the
+    /// resolved manifest name and keeps no separate alias node.
+    pub fn lookup_patch<'a, V>(&self, map: &'a BTreeMap<String, V>) -> Option<(String, &'a V)> {
+        let spec_key = self.spec_key();
+        if let Some(value) = map.get(&spec_key) {
+            return Some((spec_key, value));
+        }
+        let registry_key = format!("{}@{}", self.registry_name(), self.version);
+        if registry_key != spec_key
+            && let Some(value) = map.get(&registry_key)
+        {
+            return Some((registry_key, value));
+        }
+        None
+    }
+
     /// Exact approval key for non-registry package sources.
     ///
     /// Name-wide build approvals are only trustworthy for packages
@@ -575,6 +600,61 @@ mod locked_package_tests {
         pkg.registry_git_hosted = true;
 
         assert_eq!(pkg.source_approval_key(), None);
+    }
+
+    #[test]
+    fn lookup_patch_matches_plain_spec_key() {
+        let pkg = pkg();
+        let map = BTreeMap::from([("pkg@1.0.0".to_string(), "patch".to_string())]);
+        assert_eq!(
+            pkg.lookup_patch(&map),
+            Some(("pkg@1.0.0".to_string(), &"patch".to_string()))
+        );
+    }
+
+    #[test]
+    fn lookup_patch_falls_back_to_registry_name_for_alias() {
+        // `"odd-alias": "npm:is-odd@3.0.1"` records name = alias,
+        // alias_of = registry name. The patch is declared against the
+        // registry identity, so the aliased entry must resolve it via
+        // the fallback (this is the discussion #1082 bug).
+        let mut pkg = pkg();
+        pkg.name = "odd-alias".to_string();
+        pkg.version = "3.0.1".to_string();
+        pkg.alias_of = Some("is-odd".to_string());
+
+        let map = BTreeMap::from([("is-odd@3.0.1".to_string(), "patch".to_string())]);
+        assert_eq!(
+            pkg.lookup_patch(&map),
+            Some(("is-odd@3.0.1".to_string(), &"patch".to_string()))
+        );
+    }
+
+    #[test]
+    fn lookup_patch_prefers_alias_qualified_key_over_registry_key() {
+        // A patch declared against the alias identity wins over one
+        // declared against the registry identity — spec_key is tried
+        // first.
+        let mut pkg = pkg();
+        pkg.name = "odd-alias".to_string();
+        pkg.version = "3.0.1".to_string();
+        pkg.alias_of = Some("is-odd".to_string());
+
+        let map = BTreeMap::from([
+            ("odd-alias@3.0.1".to_string(), "alias-patch".to_string()),
+            ("is-odd@3.0.1".to_string(), "registry-patch".to_string()),
+        ]);
+        assert_eq!(
+            pkg.lookup_patch(&map),
+            Some(("odd-alias@3.0.1".to_string(), &"alias-patch".to_string()))
+        );
+    }
+
+    #[test]
+    fn lookup_patch_returns_none_when_unpatched() {
+        let pkg = pkg();
+        let map = BTreeMap::from([("other@2.0.0".to_string(), "patch".to_string())]);
+        assert_eq!(pkg.lookup_patch(&map), None);
     }
 
     #[test]

--- a/crates/aube/src/commands/install/delta.rs
+++ b/crates/aube/src/commands/install/delta.rs
@@ -189,8 +189,11 @@ pub fn compute_package_hashes(
         .packages
         .par_iter()
         .map(|(dep_path, pkg)| {
-            let patch_key = format!("{}@{}", pkg.name, pkg.version);
-            let patch = patch_hashes.get(&patch_key).map(String::as_str);
+            // Alias-aware so an npm-aliased patched entry's fingerprint
+            // tracks its patch hash (keyed by the registry identity).
+            let patch = pkg
+                .lookup_patch(patch_hashes)
+                .map(|(_, hash)| hash.as_str());
             (dep_path.clone(), fingerprint(pkg, patch, project_root))
         })
         .collect()

--- a/test/patch.bats
+++ b/test/patch.bats
@@ -64,6 +64,46 @@ EOF
 	assert_failure
 }
 
+# A patch declared against a package's registry name must apply when the
+# package is installed under an npm alias. Regression for discussion
+# #1082: the patch map is keyed by the registry selector
+# (`is-odd@3.0.1`) while the aliased entry's `spec_key()` is
+# `odd-alias@3.0.1`, so the apply site missed the patch even though the
+# lockfile recorded it.
+@test "patch keyed by registry name applies to an npm-aliased install" {
+	cat >package.json <<'EOF'
+{
+  "name": "aliased-patch-test",
+  "version": "1.0.0",
+  "dependencies": { "odd-alias": "npm:is-odd@3.0.1" },
+  "pnpm": {
+    "patchedDependencies": { "is-odd@3.0.1": "patches/is-odd@3.0.1.patch" }
+  }
+}
+EOF
+	mkdir patches
+	cat >patches/is-odd@3.0.1.patch <<'EOF'
+diff --git a/index.js b/index.js
+index 79d1f22a8e7a27efb8841bb83cb682ea1ff3a59c..1e33b4cf949b73bde8861ad65de71b4e46360259 100644
+--- a/index.js
++++ b/index.js
+@@ -24,1 +24,2 @@ module.exports = function isOdd(value) {
+ };
++module.exports.patched = 'v1';
+EOF
+
+	run aube install --ignore-scripts
+	assert_success
+
+	# The aliased folder's bytes must carry the patch.
+	run grep -q "module.exports.patched = 'v1';" node_modules/odd-alias/index.js
+	assert_success
+
+	# Requiring through the alias should see the patched export.
+	run node -e 'if (require("odd-alias").patched !== "v1") process.exit(1)'
+	assert_success
+}
+
 @test "aube patch rejects bare names" {
 	cat >package.json <<'EOF'
 { "name": "p", "version": "1.0.0" }


### PR DESCRIPTION
Fixes the bug reported in [discussion #1082](https://github.com/jdx/aube/discussions/1082): a patch declared against a package's registry name is not applied when the package is installed under an npm alias, even though the lockfile records the patched identity.

## Repro

```json
{
  "dependencies": { "odd-alias": "npm:is-odd@3.0.1" },
  "pnpm": { "patchedDependencies": { "is-odd@3.0.1": "patches/is-odd@3.0.1.patch" } }
}
```

Before this change, `node_modules/odd-alias/index.js` came out unpatched under aube while pnpm patched it from the same input.

## Cause

The patch map is keyed by the declared selector — the **registry** name (`is-odd@3.0.1`). Every apply/hash site looked it up by `pkg.spec_key()`, which for an aliased entry is the **alias-qualified** `odd-alias@3.0.1` (the alias is `name`; the registry name lives in `alias_of`). The keys never matched, so the linked bytes stayed unpatched.

The pnpm lockfile writer already had an `alias_of` fallback (which is why the lockfile *recorded* the patch), but the materialize/apply path did not — hence "same lockfile, patched under pnpm, unpatched under aube." pnpm avoids the split by resolving patches on the resolved manifest name and keeping no separate alias node.

## Fix

- Add `LockedPackage::lookup_patch`, which tries `spec_key()` then falls back to `registry_name()@version`.
- Route every patch-lookup site through it (or its two-key equivalent):
  - isolated-mode apply — `aube-linker/src/materialize.rs`
  - hoisted-mode apply — `aube-linker/src/hoisted.rs`
  - graph-hash patch callback (so patched aliased nodes get a distinct dep_path) — `aube-lockfile/src/graph_hash.rs`
  - delta install fingerprint — `aube/src/commands/install/delta.rs`
  - stale-entry wipe — `aube-linker/src/patches.rs`

## Tests

- Unit tests for `lookup_patch` (plain key, alias fallback, alias-key precedence, unpatched).
- `test/patch.bats`: "patch keyed by registry name applies to an npm-aliased install" — mirrors the discussion repro and asserts the aliased folder's bytes carry the patch and `require("odd-alias").patched === "v1"`.

`cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and the touched unit + bats suites all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches patch apply, GVS graph hashing, and install delta invalidation—behavioral linker/install changes with good test coverage but not trivial plumbing.
> 
> **Overview**
> Fixes **discussion #1082**: `patchedDependencies` keyed by the real package name (e.g. `is-odd@3.0.1`) were not applied when that package was installed under an npm alias (`odd-alias` → `npm:is-odd@3.0.1`), because every site looked up patches with alias-qualified `spec_key()` only.
> 
> Adds **`LockedPackage::lookup_patch`**, which tries `name@version` (alias) first, then **`registry_name()@version`**, and wires it through isolated/hoisted materialize, graph-hash patch folding, install delta fingerprints, and stale patched-entry wipes so lookup, on-disk bytes, and virtual-store hashing stay aligned. **Alias-keyed patches still win** when both keys exist.
> 
> Adds unit tests for `lookup_patch` and graph-hash alias precedence, plus a **bats** regression that installs an aliased dep and asserts the patch lands in `node_modules/odd-alias`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dcb8155a3db061337aa5f929443bc8ee06b717e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed patch application for dependencies installed through npm aliases.
  - Improved patch detection and cache invalidation when patches use a package’s registry name.
  - Ensured alias-qualified patch definitions take precedence when multiple matches exist.

- **Tests**
  - Added regression coverage verifying aliased dependencies receive patches and expose the expected runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->