### PR TITLE
feat(embed): let hosts wrap the Node runtime, not just select one

### DIFF
--- a/crates/aube-ffi/src/lib.rs
+++ b/crates/aube-ffi/src/lib.rs
@@ -568,7 +568,7 @@ fn add_impl(
             osv_transitive_check: input.osv_transitive_check && !input.offline,
             control,
             // C ABI hosts rely on ambient node; no host-supplied runtime.
-            node_bin_dir: None,
+            runtime: None,
         };
         embed::add(&project_dir, &packages, options)
             .await

--- a/crates/aube-node/src/lib.rs
+++ b/crates/aube-node/src/lib.rs
@@ -354,7 +354,7 @@ async fn run_install(
                     osv_transitive_check,
                     control: control.clone(),
                     // JS hosts rely on ambient node; no host-supplied runtime.
-                    node_bin_dir: None,
+                    runtime: None,
                 },
             )
             .await

--- a/crates/aube-scripts/src/lib.rs
+++ b/crates/aube-scripts/src/lib.rs
@@ -41,9 +41,20 @@ pub struct ScriptSettings {
     /// system one while project-local binaries still win. `None` when
     /// no runtime switching is active.
     pub node_bin_dir: Option<PathBuf>,
-    /// The resolved node executable, exported as `npm_node_execpath` /
-    /// `NODE` (npm parity) for every script.
-    pub node_exe: Option<PathBuf>,
+    /// The node exported as `NODE` (npm parity) — the program a
+    /// script's `$NODE` / bare `node` re-spawns. A wrapper's shim; the
+    /// real binary otherwise.
+    pub node_program: Option<PathBuf>,
+    /// The node exported as `npm_node_execpath` — the *real* binary
+    /// node-gyp reads to find Node's install prefix. Equals
+    /// [`Self::node_program`] unless a wrapper split them apart.
+    pub node_execpath: Option<PathBuf>,
+    /// Extra environment an embedder contributes to every script,
+    /// applied last (after `env_clear`) so it survives the jail. Merge
+    /// semantics against aube's own values are resolved upstream; these
+    /// are plain overrides. (`NODE_OPTIONS` folding happens through
+    /// [`Self::node_options`].)
+    pub extra_env: Vec<(std::ffi::OsString, std::ffi::OsString)>,
     /// The top-level package-manager command, exported as `npm_command`
     /// (npm/pnpm parity): `"run-script"` for `aube run`, `"install"`
     /// for install lifecycle hooks, `"rebuild"`, `"pack"`, etc. `None`
@@ -607,11 +618,21 @@ fn apply_script_settings_env(cmd: &mut tokio::process::Command, settings: &Scrip
     if let Some(exe) = aube_exe.as_deref() {
         cmd.env("npm_execpath", exe);
     }
-    // `npm_node_execpath` / `NODE`: the node binary scripts should use
-    // — the switched runtime's node, or the ambient `node` on PATH.
-    // Set here (not at spawn) so it survives the jail's `env_clear`.
-    if let Some(node_exe) = settings.node_exe.as_deref() {
-        cmd.env("npm_node_execpath", node_exe).env("NODE", node_exe);
+    // `npm_node_execpath` / `NODE`: the node binaries scripts should use
+    // — the switched runtime's node, or the ambient `node` on PATH. `NODE`
+    // is the program a script re-spawns (a wrapper's shim); the execpath
+    // is the *real* binary node-gyp reads for Node's install prefix. They
+    // coincide unless a wrapping embedder split them. Set here (not at
+    // spawn) so they survive the jail's `env_clear`.
+    let node_execpath = settings
+        .node_execpath
+        .as_deref()
+        .or(settings.node_program.as_deref());
+    if let Some(execpath) = node_execpath {
+        cmd.env("npm_node_execpath", execpath);
+    }
+    if let Some(node) = settings.node_program.as_deref().or(node_execpath) {
+        cmd.env("NODE", node);
     }
     // `npm_command`: the top-level PM command (run-script / install / …).
     if let Some(command) = settings.command.as_deref() {
@@ -670,6 +691,14 @@ fn apply_script_settings_env(cmd: &mut tokio::process::Command, settings: &Scrip
             cmd.env("NO_PROXY", no_proxy);
         }
         cmd.env("NODE_USE_ENV_PROXY", "1");
+    }
+    // Embedder-contributed env, applied last (after `env_clear`, so it
+    // survives the jail) and after every aube-set var, so a wrapping
+    // host has the final say. `NODE_OPTIONS` is not among these — it is
+    // folded into `settings.node_options` upstream to preserve the
+    // user's value.
+    for (key, value) in &settings.extra_env {
+        cmd.env(key, value);
     }
 }
 
@@ -1512,6 +1541,39 @@ mod jail_tests {
         });
         assert_eq!(env("NO_PROXY"), None);
         assert_eq!(env("NODE_USE_ENV_PROXY"), None);
+    }
+
+    #[test]
+    fn wrapper_node_and_execpath_are_stamped_distinctly() {
+        // A wrapping embedder: `NODE` is the shim (so `$NODE` stays
+        // wrapped) while `npm_node_execpath` is the real binary node-gyp
+        // reads. Embedder `extra_env` lands last.
+        let env = proxy_env(ScriptSettings {
+            node_program: Some(PathBuf::from("/shim/node")),
+            node_execpath: Some(PathBuf::from("/real/node-24.4.1/bin/node")),
+            extra_env: vec![("MYTOOL_WRAPPED".into(), "1".into())],
+            ..Default::default()
+        });
+        assert_eq!(env("NODE").as_deref(), Some("/shim/node"));
+        assert_eq!(
+            env("npm_node_execpath").as_deref(),
+            Some("/real/node-24.4.1/bin/node")
+        );
+        assert_eq!(env("MYTOOL_WRAPPED").as_deref(), Some("1"));
+    }
+
+    #[test]
+    fn node_execpath_falls_back_to_node_program() {
+        // A selector supplies only `node_program`; both vars point at it.
+        let env = proxy_env(ScriptSettings {
+            node_program: Some(PathBuf::from("/opt/node/bin/node")),
+            ..Default::default()
+        });
+        assert_eq!(env("NODE").as_deref(), Some("/opt/node/bin/node"));
+        assert_eq!(
+            env("npm_node_execpath").as_deref(),
+            Some("/opt/node/bin/node")
+        );
     }
 }
 

--- a/crates/aube/src/commands/add/mod.rs
+++ b/crates/aube/src/commands/add/mod.rs
@@ -45,12 +45,13 @@ pub struct AddToProjectOptions {
     pub osv_transitive_check: bool,
     /// Invocation-scoped output and cancellation controls for embedders.
     pub control: install::InstallControl,
-    /// Directory containing the `node` executable an embedding host wants
-    /// lifecycle scripts to run on (see
-    /// [`crate::commands::install::InstallOptions::embedder_node_bin_dir`]).
-    /// `None` keeps aube's own runtime resolution. Matches the
-    /// `node_bin_dir` field on [`crate::embed::InstallOptions`].
-    pub node_bin_dir: Option<std::path::PathBuf>,
+    /// How an embedding host wants Node invoked for lifecycle scripts (see
+    /// [`crate::commands::install::InstallOptions::embedder_runtime`]).
+    /// `None` falls back to the process-wide
+    /// [`crate::runtime::set_embedder_runtime`], else aube's own runtime
+    /// resolution. Matches the `runtime` field on
+    /// [`crate::embed::InstallOptions`].
+    pub runtime: Option<crate::runtime::EmbedderRuntime>,
 }
 
 /// Resolve, save, and install packages in an explicitly selected project.
@@ -126,7 +127,7 @@ pub async fn add_to_project(
                 options.dangerously_allow_all_builds,
             );
             install_options.control = options.control;
-            install_options.embedder_node_bin_dir = options.node_bin_dir;
+            install_options.embedder_runtime = options.runtime;
             if options.offline {
                 install_options.network_mode = aube_registry::NetworkMode::Offline;
             }

--- a/crates/aube/src/commands/auto_install.rs
+++ b/crates/aube/src/commands/auto_install.rs
@@ -3,6 +3,19 @@ use miette::miette;
 use super::install;
 
 pub(crate) async fn ensure_installed(no_install: bool) -> miette::Result<()> {
+    ensure_installed_in(no_install, None).await
+}
+
+/// [`ensure_installed`] anchored at an explicit `base_dir` instead of the
+/// process cwd — the in-process embedding entry points (`embed::run` /
+/// `embed::exec`) resolve their project from a caller-supplied directory,
+/// so the freshness check and any auto-install must target that tree, not
+/// wherever the host process happens to be. `None` reproduces the CLI
+/// behavior (anchor at the process cwd).
+pub(crate) async fn ensure_installed_in(
+    no_install: bool,
+    base_dir: Option<&std::path::Path>,
+) -> miette::Result<()> {
     if no_install {
         return Ok(());
     }
@@ -20,7 +33,10 @@ pub(crate) async fn ensure_installed(no_install: bool) -> miette::Result<()> {
         return Ok(());
     }
 
-    let initial_cwd = crate::dirs::cwd()?;
+    let initial_cwd = match base_dir {
+        Some(dir) => dir.to_path_buf(),
+        None => crate::dirs::cwd()?,
+    };
     // Prefer the workspace root as the freshness anchor. A monorepo
     // install writes its state files at the workspace root —
     // subpackages get symlinked `node_modules/` with no state file of
@@ -83,6 +99,9 @@ pub(crate) async fn ensure_installed(no_install: bool) -> miette::Result<()> {
     let mode = super::chained_frozen_mode(install::FrozenMode::Prefer);
     let mut opts = install::InstallOptions::with_mode(mode);
     opts.strict_no_lockfile = matches!(g, Some(install::FrozenOverride::Frozen));
+    // Anchor the auto-install at the resolved tree, not the process cwd,
+    // so an embedding host installs the project it asked to run.
+    opts.project_dir = Some(cwd);
     install::run(opts).await?;
 
     Ok(())

--- a/crates/aube/src/commands/ci.rs
+++ b/crates/aube/src/commands/ci.rs
@@ -64,7 +64,7 @@ pub async fn run(args: CiArgs) -> miette::Result<()> {
     // Propagate --ignore-scripts so root lifecycle hooks are skipped.
     let opts = install::InstallOptions {
         control: install::InstallControl::default(),
-        embedder_node_bin_dir: None,
+        embedder_runtime: None,
         project_dir: None,
         mode: install::FrozenMode::Frozen,
         dep_selection: install::DepSelection::from_flags(false, false, no_optional),

--- a/crates/aube/src/commands/deploy/mod.rs
+++ b/crates/aube/src/commands/deploy/mod.rs
@@ -315,7 +315,7 @@ pub async fn run(
         };
         let opts = InstallOptions {
             control: install::InstallControl::default(),
-            embedder_node_bin_dir: None,
+            embedder_runtime: None,
             project_dir: Some(s.target.clone()),
             mode,
             dep_selection: dep_selection_for_args(&args),

--- a/crates/aube/src/commands/dlx.rs
+++ b/crates/aube/src/commands/dlx.rs
@@ -6,7 +6,7 @@ use miette::{Context, IntoDiagnostic, miette};
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-#[derive(Debug, Args)]
+#[derive(Debug, Default, Args)]
 // dlx forwards everything after `<command>` to the bin it runs, including
 // `--help` and `--version`. Let clap auto-inject its own `-h`/`--help` and
 // `--version` handlers and they'd silently swallow those flags before they
@@ -80,6 +80,17 @@ pub struct DlxArgs {
 ///   3. Exec `<tmp>/node_modules/.bin/<command>` from the user's original cwd.
 ///   4. tempfile removes the scratch dir on drop.
 pub async fn run(args: DlxArgs) -> miette::Result<Option<i32>> {
+    run_in(args, None).await
+}
+
+/// `dlx` rooted at an explicit `base_dir` instead of the process cwd for
+/// runtime resolution and the local-bin fast path — the in-process
+/// embedding entry. `None` reproduces the CLI behavior. The transient
+/// install still runs in its own scratch project regardless.
+pub async fn run_in(
+    args: DlxArgs,
+    base_dir: Option<std::path::PathBuf>,
+) -> miette::Result<Option<i32>> {
     args.network.install_overrides();
     args.lockfile.install_overrides();
     args.virtual_store.install_overrides();
@@ -152,7 +163,10 @@ pub async fn run(args: DlxArgs) -> miette::Result<Option<i32>> {
     // local-bin bin and `aubx` honor the project's .nvmrc / devEngines. The
     // fast path replaces the image immediately, so this must run before it or
     // a local `dlx` bin would launch with the ambient runtime.
-    let initial_cwd = crate::dirs::cwd()?;
+    let initial_cwd = match base_dir {
+        Some(dir) => dir,
+        None => crate::dirs::cwd()?,
+    };
     crate::runtime::ensure_for_cwd(&initial_cwd).await?;
 
     let bin_name = bin_name_for(&command);

--- a/crates/aube/src/commands/doctor.rs
+++ b/crates/aube/src/commands/doctor.rs
@@ -169,7 +169,7 @@ fn runtime_section(warnings: &mut Vec<String>) -> Section {
                 ));
             }
         }
-        if let Some(bin) = &ctx.node_bin {
+        if let Some(bin) = &ctx.node_program {
             s.push("node-bin", display_path_owned(bin.clone()));
         }
     }

--- a/crates/aube/src/commands/exec.rs
+++ b/crates/aube/src/commands/exec.rs
@@ -1,4 +1,4 @@
-use super::ensure_installed;
+use super::ensure_installed_in;
 use clap::Args;
 use miette::{Context, IntoDiagnostic, miette};
 use std::path::Path;
@@ -124,7 +124,7 @@ pub async fn run_in(
         )
     })?;
 
-    ensure_installed(no_install).await?;
+    ensure_installed_in(no_install, Some(&cwd)).await?;
 
     if !filter.is_empty() {
         // Same defaulting rule as `aube run`: sort=on unless `--no-sort`

--- a/crates/aube/src/commands/exec.rs
+++ b/crates/aube/src/commands/exec.rs
@@ -3,7 +3,7 @@ use clap::Args;
 use miette::{Context, IntoDiagnostic, miette};
 use std::path::Path;
 
-#[derive(Debug, Args)]
+#[derive(Debug, Default, Args)]
 pub struct ExecArgs {
     /// Binary name
     pub bin: String,
@@ -76,12 +76,29 @@ pub async fn run(
     exec_args: ExecArgs,
     filter: aube_workspace::selector::EffectiveFilter,
 ) -> miette::Result<Option<i32>> {
+    run_in(exec_args, filter, None).await
+}
+
+/// `exec` rooted at an explicit `base_dir` instead of the process cwd.
+/// `None` reproduces the CLI behavior (resolve from the process cwd);
+/// `Some(dir)` is the in-process embedding entry — the project is
+/// resolved from `dir`, so concurrent embed calls in different projects
+/// don't race on process-global cwd.
+pub async fn run_in(
+    exec_args: ExecArgs,
+    filter: aube_workspace::selector::EffectiveFilter,
+    base_dir: Option<std::path::PathBuf>,
+) -> miette::Result<Option<i32>> {
     exec_args.network.install_overrides();
     exec_args.lockfile.install_overrides();
     exec_args.virtual_store.install_overrides();
+    let effective_cwd = match base_dir {
+        Some(dir) => dir,
+        None => crate::dirs::cwd()?,
+    };
     // Resolve the project's Node runtime before anything spawns (see
     // run.rs for the warm-path rationale).
-    crate::runtime::ensure_for_cwd(&crate::dirs::cwd()?).await?;
+    crate::runtime::ensure_for_cwd(&effective_cwd).await?;
     let ExecArgs {
         bin,
         args,
@@ -100,7 +117,12 @@ pub async fn run(
         network: _,
         virtual_store: _,
     } = exec_args;
-    let cwd = crate::dirs::project_root()?;
+    let cwd = crate::dirs::find_project_root(&effective_cwd).ok_or_else(|| {
+        miette!(
+            "no package.json found in {} or any parent directory",
+            effective_cwd.display()
+        )
+    })?;
 
     ensure_installed(no_install).await?;
 

--- a/crates/aube/src/commands/install/args.rs
+++ b/crates/aube/src/commands/install/args.rs
@@ -309,7 +309,7 @@ impl InstallArgs {
             // every install — neither needs the caller to opt in.
             osv_transitive_check: false,
             control: super::InstallControl::default(),
-            embedder_node_bin_dir: None,
+            embedder_runtime: None,
         }
     }
 }
@@ -445,12 +445,14 @@ pub struct InstallOptions {
     /// embedders can select structured events or silence independently for
     /// each concurrent install.
     pub control: super::InstallControl,
-    /// Directory containing the `node` executable an embedding host wants
-    /// lifecycle scripts to run on. When set, it seeds the install's runtime
-    /// slot ([`crate::runtime::seed_embedder_node`]) so scripts spawn on that
-    /// node and find it on PATH — aube does no runtime resolution of its own.
-    /// `None` keeps aube's normal runtime switching / PATH fallback.
-    pub embedder_node_bin_dir: Option<std::path::PathBuf>,
+    /// How an embedding host wants Node invoked for lifecycle scripts. When
+    /// set, it seeds the install's runtime slot
+    /// ([`crate::runtime::seed_install_embedder_runtime`]) so scripts invoke
+    /// that Node and find it on PATH — aube does no runtime resolution of its
+    /// own. Takes precedence over any process-wide
+    /// [`crate::runtime::set_embedder_runtime`]. `None` falls back to the
+    /// process-wide runtime, else aube's normal switching / PATH fallback.
+    pub embedder_runtime: Option<crate::runtime::EmbedderRuntime>,
 }
 
 impl InstallOptions {
@@ -495,7 +497,7 @@ impl InstallOptions {
             // fallback) instead of an unconditional API hit.
             osv_transitive_check: false,
             control: super::InstallControl::default(),
-            embedder_node_bin_dir: None,
+            embedder_runtime: None,
         }
     }
 }

--- a/crates/aube/src/commands/install/fetch.rs
+++ b/crates/aube/src/commands/install/fetch.rs
@@ -90,7 +90,7 @@ pub(super) async fn import_local_source(
                 "buildDir": build_dir,
                 "locator": format!("{pkg_name}@{}", local.specifier()),
             });
-            let status = tokio::process::Command::new(crate::runtime::node_program())
+            let status = tokio::process::Command::new(crate::runtime::internal_node_program())
                 .arg("-e")
                 .arg(aube_resolver::YARN_EXEC_WRAPPER)
                 .arg(&script)

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -596,13 +596,12 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     let lockfile_parse_options = aube_lockfile::ParseOptions {
         strict_store_integrity: strict_store_integrity_setting,
     };
-    // An embedding host (mise) can supply the node runtime for lifecycle
-    // scripts. Seed it into the scoped runtime slot before `ensure` runs —
-    // `ensure` returns early when the slot is set, so aube skips its own
-    // runtime resolution and scripts spawn on the host's node.
-    if let Some(bin_dir) = &opts.embedder_node_bin_dir {
-        crate::runtime::seed_embedder_node(bin_dir.clone()).await;
-    }
+    // An embedding host (mise, or a wrapper) can describe how Node is
+    // invoked for lifecycle scripts. Seed it into the scoped runtime slot
+    // before `ensure` runs — `ensure` returns early when the slot is set,
+    // so aube skips its own runtime resolution and scripts invoke the
+    // host's Node. A per-call runtime wins over the process-wide one.
+    crate::runtime::seed_install_embedder_runtime(opts.embedder_runtime.as_ref());
     if !opts.dry_run {
         crate::runtime::ensure(
             &cwd,

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -1267,7 +1267,7 @@ mod finalize_lockfile_graph_tests {
     use super::*;
 
     fn node_available() -> bool {
-        std::process::Command::new(crate::runtime::node_program())
+        std::process::Command::new(crate::runtime::internal_node_program())
             .arg("--version")
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -86,7 +86,7 @@ mod script_settings;
 mod settings_context;
 mod workspace_helpers;
 
-pub(crate) use auto_install::ensure_installed;
+pub(crate) use auto_install::{ensure_installed, ensure_installed_in};
 
 pub(crate) fn settings_hoisting_limits_to_linker(
     value: aube_settings::resolved::HoistingLimits,

--- a/crates/aube/src/commands/node.rs
+++ b/crates/aube/src/commands/node.rs
@@ -1,8 +1,8 @@
 use clap::Args;
-#[cfg(not(unix))]
 use miette::IntoDiagnostic;
 use miette::miette;
 use std::ffi::OsString;
+use std::path::PathBuf;
 
 #[derive(Debug, Args)]
 #[command(disable_help_flag = true, disable_version_flag = true)]
@@ -26,6 +26,12 @@ pub async fn run(args: NodeArgs) -> miette::Result<Option<i32>> {
     if !runtime_dirs.is_empty() {
         cmd.env("PATH", aube_scripts::prepend_paths(&runtime_dirs));
     }
+    // `NODE` / `npm_node_execpath` and any embedder env (e.g. a wrapper's
+    // `NODE_OPTIONS` preload), so a direct `aube node` is invoked the same
+    // way lifecycle scripts are.
+    for (key, value) in crate::runtime::child_env_vars() {
+        cmd.env(key, value);
+    }
 
     #[cfg(unix)]
     {
@@ -48,4 +54,39 @@ pub async fn run(args: NodeArgs) -> miette::Result<Option<i32>> {
         })?;
         Ok(status.code())
     }
+}
+
+/// Run Node as a supervised child (spawn + wait) rooted at an explicit
+/// `base_dir` instead of the process cwd — the in-process embedding
+/// entry. Unlike the CLI [`run`], this never image-replaces the process,
+/// so a host can call it in-process and get the child's exit code back.
+/// `base_dir` roots runtime resolution; `None` uses the process cwd.
+pub async fn run_spawn(
+    args: Vec<OsString>,
+    base_dir: Option<PathBuf>,
+) -> miette::Result<Option<i32>> {
+    let cwd = match base_dir {
+        Some(dir) => dir,
+        None => crate::dirs::cwd()?,
+    };
+    crate::runtime::ensure_for_cwd(&cwd).await?;
+    let node = crate::runtime::node_program();
+    let mut cmd = tokio::process::Command::new(&node);
+    cmd.args(&args);
+    cmd.current_dir(&cwd);
+    let runtime_dirs = crate::runtime::path_entries();
+    if !runtime_dirs.is_empty() {
+        cmd.env("PATH", aube_scripts::prepend_paths(&runtime_dirs));
+    }
+    for (key, value) in crate::runtime::child_env_vars() {
+        cmd.env(key, value);
+    }
+    let status = cmd.status().await.into_diagnostic().map_err(|e| {
+        miette!(
+            code = aube_codes::errors::ERR_AUBE_SHIM_EXEC_FAILED,
+            "failed to spawn node at {}: {e}",
+            node.display()
+        )
+    })?;
+    Ok(status.code())
 }

--- a/crates/aube/src/commands/node.rs
+++ b/crates/aube/src/commands/node.rs
@@ -81,12 +81,18 @@ pub async fn run_spawn(
     for (key, value) in crate::runtime::child_env_vars() {
         cmd.env(key, value);
     }
-    let status = cmd.status().await.into_diagnostic().map_err(|e| {
-        miette!(
-            code = aube_codes::errors::ERR_AUBE_SHIM_EXEC_FAILED,
-            "failed to spawn node at {}: {e}",
-            node.display()
-        )
-    })?;
+    // Tie the child to aube's lifetime (signal forwarding + PDEATHSIG) the
+    // same way dlx/exec supervised children are, so a host that stops the
+    // embedding process doesn't strand Node. Drop-in for `cmd.status()`.
+    let status = crate::process_guard::spawn_and_wait(cmd)
+        .await
+        .into_diagnostic()
+        .map_err(|e| {
+            miette!(
+                code = aube_codes::errors::ERR_AUBE_SHIM_EXEC_FAILED,
+                "failed to spawn node at {}: {e}",
+                node.display()
+            )
+        })?;
     Ok(status.code())
 }

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -186,6 +186,7 @@ pub async fn run(
     };
     run_script_with(
         &script, &args, &node_args, no_install, if_present, parallel, silent, &filter, recursive,
+        None,
     )
     .await
 }
@@ -352,6 +353,36 @@ pub(crate) async fn run_script(
         silent,
         filter,
         RecursiveOpts::default(),
+        None,
+    )
+    .await
+}
+
+/// Run a script rooted at an explicit `base_dir` instead of the process
+/// cwd — the in-process embedding entry. Resolves the project runtime and
+/// the project root from `base_dir`, so concurrent embed calls in
+/// different projects don't race on process-global cwd.
+pub(crate) async fn run_script_in(
+    base_dir: std::path::PathBuf,
+    script: &str,
+    args: &[String],
+    no_install: bool,
+    if_present: bool,
+    filter: &aube_workspace::selector::EffectiveFilter,
+) -> miette::Result<Option<i32>> {
+    crate::runtime::ensure_for_cwd(&base_dir).await?;
+    let silent = super::global_output_flags().silent;
+    run_script_with(
+        script,
+        args,
+        &[],
+        no_install,
+        if_present,
+        false,
+        silent,
+        filter,
+        RecursiveOpts::default(),
+        Some(base_dir),
     )
     .await
 }
@@ -367,8 +398,12 @@ pub(crate) async fn run_script_with(
     silent: bool,
     filter: &aube_workspace::selector::EffectiveFilter,
     recursive: RecursiveOpts,
+    base_dir: Option<std::path::PathBuf>,
 ) -> miette::Result<Option<i32>> {
-    let initial_cwd = crate::dirs::cwd()?;
+    let initial_cwd = match base_dir {
+        Some(dir) => dir,
+        None => crate::dirs::cwd()?,
+    };
     // Walk upward to the nearest `package.json` so `aube run` from a
     // subdirectory picks up the project root's scripts, matching pnpm.
     // Filtered/recursive runs accept a yaml-only workspace root —

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -1,4 +1,4 @@
-use super::ensure_installed;
+use super::ensure_installed_in;
 use aube_manifest::PackageJson;
 use clap::Args;
 use miette::{Context, IntoDiagnostic, miette};
@@ -449,7 +449,7 @@ pub(crate) async fn run_script_with(
 
     let manifest = load_manifest(&cwd)?;
     if !manifest.scripts.contains_key(script) {
-        ensure_installed(no_install).await?;
+        ensure_installed_in(no_install, Some(&cwd)).await?;
         let bin_path = super::project_modules_dir(&cwd).join(".bin").join(script);
         if bin_path.exists() {
             return super::exec::exec_bin_with_node_args(
@@ -475,7 +475,7 @@ pub(crate) async fn run_script_with(
         return Err(miette!("script not found: {script}\n  {hint}"));
     }
 
-    ensure_installed(no_install).await?;
+    ensure_installed_in(no_install, Some(&cwd)).await?;
     exec_script_chain(
         &cwd,
         &manifest,
@@ -527,7 +527,7 @@ async fn run_script_filtered(
     // isolated linker already materializes every workspace package's
     // deps in a single pass, so per-package reinstalls would just
     // re-check the same lockfile N times.
-    ensure_installed(no_install).await?;
+    ensure_installed_in(no_install, Some(cwd)).await?;
 
     if let Some(concurrency) = effective_concurrency(parallel, recursive.workspace_concurrency) {
         return run_filtered_parallel(

--- a/crates/aube/src/commands/runtime.rs
+++ b/crates/aube/src/commands/runtime.rs
@@ -322,7 +322,7 @@ async fn run_list() -> miette::Result<()> {
             None => println!("node: none found on PATH and no project pin"),
         },
     }
-    if let Some(bin) = &ctx.node_bin {
+    if let Some(bin) = &ctx.node_program {
         println!("  bin: {}", bin.display());
     }
 

--- a/crates/aube/src/commands/script_settings.rs
+++ b/crates/aube/src/commands/script_settings.rs
@@ -8,7 +8,12 @@ pub(crate) fn configure_script_settings(
     ctx: &aube_settings::ResolveCtx<'_>,
     command: Option<&str>,
 ) {
-    let node_options = aube_settings::resolved::node_options(ctx).and_then(non_empty_string);
+    // Fold an embedder's `NODE_OPTIONS` contribution over the resolved
+    // `nodeOptions` setting (append by default, so a wrapper's `--import`
+    // preload adds to the user's value rather than replacing it).
+    let node_options = crate::runtime::merge_node_options(
+        aube_settings::resolved::node_options(ctx).and_then(non_empty_string),
+    );
     let script_shell = aube_settings::resolved::script_shell(ctx)
         .and_then(|s| non_empty_string(s).map(Into::into));
     let unsafe_perm = aube_settings::resolved::unsafe_perm(ctx);
@@ -38,10 +43,15 @@ pub(crate) fn configure_script_settings(
         unsafe_perm,
         shell_emulator,
         node_bin_dir: runtime.as_ref().and_then(|r| r.bin_dir.clone()),
-        node_exe: runtime
+        node_program: runtime
             .as_ref()
-            .and_then(|r| r.node_bin.clone())
+            .and_then(|r| r.node_program.clone())
             .or_else(aube_runtime::node_on_path),
+        node_execpath: runtime
+            .as_ref()
+            .and_then(|r| r.node_execpath.clone().or_else(|| r.node_program.clone()))
+            .or_else(aube_runtime::node_on_path),
+        extra_env: crate::runtime::embedder_extra_env(),
         command: command.map(str::to_string),
         // `npm_config_node_gyp` parity: hand every lifecycle script a
         // runnable node-gyp stand-in. The shim is written once into

--- a/crates/aube/src/commands/script_settings.rs
+++ b/crates/aube/src/commands/script_settings.rs
@@ -22,9 +22,10 @@ pub(crate) fn configure_script_settings(
     // this for lifecycle scripts to see the pinned node — the install
     // driver resolves the runtime early, then configures script
     // settings. When no context exists (or no switching is active)
-    // `node_bin_dir` stays `None` (PATH untouched); `node_exe` still
-    // falls back to the ambient `node` on PATH so `npm_node_execpath` /
-    // `NODE` are populated for lifecycle scripts the way pnpm/npm do.
+    // `node_bin_dir` stays `None` (PATH untouched); `node_program` /
+    // `node_execpath` still fall back to the ambient `node` on PATH so
+    // `NODE` / `npm_node_execpath` are populated for lifecycle scripts
+    // the way pnpm/npm do.
     let runtime = crate::runtime::current();
     // Resolve the proxy the same way the registry client does, so a
     // dependency's install script honors it too. `httpProxy` inherits

--- a/crates/aube/src/commands/security_scanner.rs
+++ b/crates/aube/src/commands/security_scanner.rs
@@ -236,7 +236,7 @@ async fn invoke(
         .map_err(|e| format!("failed to encode scanner request: {e}"))?;
 
     let bridge = write_bridge_dir()?;
-    let mut cmd = tokio::process::Command::new(crate::runtime::node_program());
+    let mut cmd = tokio::process::Command::new(crate::runtime::internal_node_program());
     cmd.current_dir(cwd)
         // `--experimental-strip-types` lets node import `.ts`
         // entrypoints (Socket's scanner package is the canonical
@@ -530,7 +530,7 @@ mod tests {
     /// Returns true iff `node --version` exits 0. e2e tests gate
     /// on this — CI runners without node skip rather than fail.
     fn node_available() -> bool {
-        std::process::Command::new(crate::runtime::node_program())
+        std::process::Command::new(crate::runtime::internal_node_program())
             .arg("--version")
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
@@ -827,7 +827,7 @@ export const scanner = {
         // --experimental-strip-types. Cheap probe: `node
         // --experimental-strip-types -e ''` is a no-op on
         // supported versions and exits non-zero on unsupported.
-        let probe = std::process::Command::new(crate::runtime::node_program())
+        let probe = std::process::Command::new(crate::runtime::internal_node_program())
             .arg("--experimental-strip-types")
             .arg("-e")
             .arg("''")

--- a/crates/aube/src/embed.rs
+++ b/crates/aube/src/embed.rs
@@ -146,15 +146,26 @@ pub async fn add(
 ///
 /// The project is resolved from `project_dir` (walking up to the nearest
 /// `package.json`), never the process cwd, so concurrent calls in different
-/// projects don't race. Every spawn honors the active [`EmbedderRuntime`].
-pub async fn run(project_dir: &Path, script: &str, args: Vec<String>) -> Result<Option<i32>> {
-    crate::commands::run::run_script_in(
-        project_dir.to_path_buf(),
-        script,
-        &args,
-        false,
-        false,
-        &aube_workspace::selector::EffectiveFilter::default(),
+/// projects don't race. Every spawn honors `runtime` when given, else the
+/// process-wide [`set_embedder_runtime`] — pass a per-call runtime when it
+/// varies per invocation (e.g. a fresh shim dir per command), since the
+/// process-wide registration is set-once.
+pub async fn run(
+    project_dir: &Path,
+    script: &str,
+    args: Vec<String>,
+    runtime: Option<EmbedderRuntime>,
+) -> Result<Option<i32>> {
+    crate::runtime::with_embedder_runtime(
+        runtime,
+        crate::commands::run::run_script_in(
+            project_dir.to_path_buf(),
+            script,
+            &args,
+            false,
+            false,
+            &aube_workspace::selector::EffectiveFilter::default(),
+        ),
     )
     .await
 }
@@ -162,17 +173,26 @@ pub async fn run(project_dir: &Path, script: &str, args: Vec<String>) -> Result<
 /// Run a project-local binary (`node_modules/.bin/<bin>`) in `project_dir`,
 /// the in-process equivalent of `aube exec <bin> -- <args>`. Returns the
 /// binary's exit code. The project is resolved from `project_dir`, not the
-/// process cwd; every spawn honors the active [`EmbedderRuntime`].
-pub async fn exec(project_dir: &Path, bin: &str, args: Vec<String>) -> Result<Option<i32>> {
+/// process cwd; every spawn honors `runtime` when given, else the
+/// process-wide [`set_embedder_runtime`].
+pub async fn exec(
+    project_dir: &Path,
+    bin: &str,
+    args: Vec<String>,
+    runtime: Option<EmbedderRuntime>,
+) -> Result<Option<i32>> {
     let exec_args = crate::commands::exec::ExecArgs {
         bin: bin.to_string(),
         args,
         ..Default::default()
     };
-    crate::commands::exec::run_in(
-        exec_args,
-        aube_workspace::selector::EffectiveFilter::default(),
-        Some(project_dir.to_path_buf()),
+    crate::runtime::with_embedder_runtime(
+        runtime,
+        crate::commands::exec::run_in(
+            exec_args,
+            aube_workspace::selector::EffectiveFilter::default(),
+            Some(project_dir.to_path_buf()),
+        ),
     )
     .await
 }
@@ -184,27 +204,42 @@ pub async fn exec(project_dir: &Path, bin: &str, args: Vec<String>) -> Result<Op
 ///
 /// The transient install runs in its own scratch project; `project_dir`
 /// roots runtime resolution and the local-`.bin` fast path. Every spawn
-/// honors the active [`EmbedderRuntime`].
+/// honors `runtime` when given, else the process-wide
+/// [`set_embedder_runtime`].
 pub async fn dlx(
     project_dir: &Path,
     params: Vec<String>,
     packages: Vec<String>,
+    runtime: Option<EmbedderRuntime>,
 ) -> Result<Option<i32>> {
     let args = crate::commands::dlx::DlxArgs {
         params,
         package: packages,
         ..Default::default()
     };
-    crate::commands::dlx::run_in(args, Some(project_dir.to_path_buf())).await
+    crate::runtime::with_embedder_runtime(
+        runtime,
+        crate::commands::dlx::run_in(args, Some(project_dir.to_path_buf())),
+    )
+    .await
 }
 
 /// Run Node as a supervised child in `project_dir`, the in-process
 /// equivalent of `aube node -- <args>`. Unlike the CLI, this never
 /// image-replaces the host process; it returns Node's exit code. Runtime is
-/// resolved from `project_dir`; the spawn honors the active
-/// [`EmbedderRuntime`] (a wrapper's `NODE`/`NODE_OPTIONS` included).
-pub async fn node(project_dir: &Path, args: Vec<std::ffi::OsString>) -> Result<Option<i32>> {
-    crate::commands::node::run_spawn(args, Some(project_dir.to_path_buf())).await
+/// resolved from `project_dir`; the spawn honors `runtime` when given —
+/// a wrapper's `NODE`/`NODE_OPTIONS` included — else the process-wide
+/// [`set_embedder_runtime`].
+pub async fn node(
+    project_dir: &Path,
+    args: Vec<std::ffi::OsString>,
+    runtime: Option<EmbedderRuntime>,
+) -> Result<Option<i32>> {
+    crate::runtime::with_embedder_runtime(
+        runtime,
+        crate::commands::node::run_spawn(args, Some(project_dir.to_path_buf())),
+    )
+    .await
 }
 
 /// Extract a stable `ERR_AUBE_*` identifier from a failed operation.

--- a/crates/aube/src/embed.rs
+++ b/crates/aube/src/embed.rs
@@ -13,6 +13,7 @@ pub use crate::commands::install::{
     DepSelection, FrozenMode, InstallControl, InstallEvent, InstallOutputLevel, InstallOutputMode,
     InstallPhase, InstallProgressSnapshot, InstallReporter,
 };
+pub use crate::runtime::{EmbedderRuntime, EnvMerge, set_embedder_runtime};
 pub use aube_registry::NetworkMode;
 pub use aube_util::{AUBE, Embedder as Host};
 
@@ -50,11 +51,13 @@ pub struct InstallOptions {
     pub osv_transitive_check: bool,
     /// Invocation-scoped output, progress reporting, and cancellation.
     pub control: InstallControl,
-    /// Directory containing the `node` executable to run lifecycle scripts on.
-    /// Set this when the host manages its own node runtime (e.g. mise) so
-    /// scripts spawn on it and find it on PATH; `None` uses aube's own runtime
-    /// resolution / PATH fallback.
-    pub node_bin_dir: Option<PathBuf>,
+    /// How the host wants Node invoked for lifecycle scripts. Use
+    /// [`EmbedderRuntime::selector`] when the host merely manages a Node
+    /// toolchain (e.g. mise), or [`EmbedderRuntime::wrapper`] to interpose on
+    /// Node (instrumenting runtime, transpiling loader, sandbox). Takes
+    /// precedence over any process-wide [`set_embedder_runtime`]; `None` falls
+    /// back to that, else aube's own runtime resolution / PATH fallback.
+    pub runtime: Option<EmbedderRuntime>,
 }
 
 impl InstallOptions {
@@ -74,7 +77,7 @@ impl InstallOptions {
             dangerously_allow_all_builds: false,
             osv_transitive_check: false,
             control: InstallControl::default(),
-            node_bin_dir: None,
+            runtime: None,
         }
     }
 }
@@ -118,7 +121,7 @@ pub async fn install(options: InstallOptions) -> Result<()> {
     command_options.dangerously_allow_all_builds = options.dangerously_allow_all_builds;
     command_options.osv_transitive_check = options.osv_transitive_check;
     command_options.control = options.control;
-    command_options.embedder_node_bin_dir = options.node_bin_dir;
+    command_options.embedder_runtime = options.runtime;
     crate::commands::install::run(command_options).await
 }
 
@@ -135,6 +138,73 @@ pub async fn add(
     options: AddToProjectOptions,
 ) -> Result<()> {
     crate::commands::add::add_to_project(project_dir, packages, options).await
+}
+
+/// Run a package's script (`package.json` `scripts.<name>`) in `project_dir`,
+/// the in-process equivalent of `aube run <script> -- <args>`. Runs pre/post
+/// hooks and returns the script's exit code (`None` when nothing ran).
+///
+/// The project is resolved from `project_dir` (walking up to the nearest
+/// `package.json`), never the process cwd, so concurrent calls in different
+/// projects don't race. Every spawn honors the active [`EmbedderRuntime`].
+pub async fn run(project_dir: &Path, script: &str, args: Vec<String>) -> Result<Option<i32>> {
+    crate::commands::run::run_script_in(
+        project_dir.to_path_buf(),
+        script,
+        &args,
+        false,
+        false,
+        &aube_workspace::selector::EffectiveFilter::default(),
+    )
+    .await
+}
+
+/// Run a project-local binary (`node_modules/.bin/<bin>`) in `project_dir`,
+/// the in-process equivalent of `aube exec <bin> -- <args>`. Returns the
+/// binary's exit code. The project is resolved from `project_dir`, not the
+/// process cwd; every spawn honors the active [`EmbedderRuntime`].
+pub async fn exec(project_dir: &Path, bin: &str, args: Vec<String>) -> Result<Option<i32>> {
+    let exec_args = crate::commands::exec::ExecArgs {
+        bin: bin.to_string(),
+        args,
+        ..Default::default()
+    };
+    crate::commands::exec::run_in(
+        exec_args,
+        aube_workspace::selector::EffectiveFilter::default(),
+        Some(project_dir.to_path_buf()),
+    )
+    .await
+}
+
+/// Install one or more packages into a throwaway project and run a binary
+/// from them, the in-process equivalent of `aube dlx`. `params` is the
+/// command followed by its arguments; `packages` overrides the inferred
+/// install target (the `-p` flag), empty to infer from the command.
+///
+/// The transient install runs in its own scratch project; `project_dir`
+/// roots runtime resolution and the local-`.bin` fast path. Every spawn
+/// honors the active [`EmbedderRuntime`].
+pub async fn dlx(
+    project_dir: &Path,
+    params: Vec<String>,
+    packages: Vec<String>,
+) -> Result<Option<i32>> {
+    let args = crate::commands::dlx::DlxArgs {
+        params,
+        package: packages,
+        ..Default::default()
+    };
+    crate::commands::dlx::run_in(args, Some(project_dir.to_path_buf())).await
+}
+
+/// Run Node as a supervised child in `project_dir`, the in-process
+/// equivalent of `aube node -- <args>`. Unlike the CLI, this never
+/// image-replaces the host process; it returns Node's exit code. Runtime is
+/// resolved from `project_dir`; the spawn honors the active
+/// [`EmbedderRuntime`] (a wrapper's `NODE`/`NODE_OPTIONS` included).
+pub async fn node(project_dir: &Path, args: Vec<std::ffi::OsString>) -> Result<Option<i32>> {
+    crate::commands::node::run_spawn(args, Some(project_dir.to_path_buf())).await
 }
 
 /// Extract a stable `ERR_AUBE_*` identifier from a failed operation.

--- a/crates/aube/src/embed.rs
+++ b/crates/aube/src/embed.rs
@@ -13,7 +13,7 @@ pub use crate::commands::install::{
     DepSelection, FrozenMode, InstallControl, InstallEvent, InstallOutputLevel, InstallOutputMode,
     InstallPhase, InstallProgressSnapshot, InstallReporter,
 };
-pub use crate::runtime::{EmbedderRuntime, EnvMerge, set_embedder_runtime};
+pub use crate::runtime::{EmbedderRuntime, set_embedder_runtime};
 pub use aube_registry::NetworkMode;
 pub use aube_util::{AUBE, Embedder as Host};
 
@@ -206,6 +206,11 @@ pub async fn exec(
 /// roots runtime resolution and the local-`.bin` fast path. Every spawn
 /// honors `runtime` when given, else the process-wide
 /// [`set_embedder_runtime`].
+///
+/// Unlike [`run`] / [`exec`], `dlx` changes the process working directory
+/// (into its scratch project) for the duration of the transient install —
+/// inherent to how dlx works. A host should not run `dlx` concurrently
+/// with other cwd-sensitive work in the same process.
 pub async fn dlx(
     project_dir: &Path,
     params: Vec<String>,

--- a/crates/aube/src/engines.rs
+++ b/crates/aube/src/engines.rs
@@ -109,7 +109,13 @@ pub fn effective_node_version(override_: Option<&str>) -> Option<String> {
 }
 
 fn probe_node_version() -> Option<String> {
-    let output = std::process::Command::new("node")
+    // Prefer the active runtime's real binary (`npm_node_execpath`) so a
+    // wrapper embedder that left `version` unset gets the underlying
+    // Node's version, not whatever bare `node` PATH resolves to. Falls
+    // back to bare `node` when no runtime is active.
+    let program =
+        crate::runtime::node_execpath().unwrap_or_else(|| std::path::PathBuf::from("node"));
+    let output = std::process::Command::new(program)
         .arg("--version")
         .output()
         .ok()?;

--- a/crates/aube/src/engines.rs
+++ b/crates/aube/src/engines.rs
@@ -78,13 +78,13 @@ pub fn resolve_node_version(override_: Option<&str>) -> Option<String> {
     if let Some(v) = override_ {
         return Some(v.trim().trim_start_matches('v').to_string());
     }
-    // Memoize the `node --version` probe. Spawning a process is cheap
-    // individually but this is called once per install and may end up
-    // called again by future callers in the same process (workspace
-    // installs, `aube add` chaining into `install`, tests). OnceLock
-    // gives us zero-cost lookups after the first probe.
-    static PROBED: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
-    PROBED.get_or_init(probe_node_version).clone()
+    // Prefer the active runtime's real binary (`npm_node_execpath`) so a
+    // wrapper embedder that left `version` unset gets the underlying
+    // Node's version, not whatever bare `node` PATH resolves to. Falls
+    // back to bare `node` when no runtime is active.
+    let program =
+        crate::runtime::node_execpath().unwrap_or_else(|| std::path::PathBuf::from("node"));
+    probe_node_version(&program)
 }
 
 /// The Node version aube should report for engines checks once
@@ -108,22 +108,37 @@ pub fn effective_node_version(override_: Option<&str>) -> Option<String> {
     resolve_node_version(None)
 }
 
-fn probe_node_version() -> Option<String> {
-    // Prefer the active runtime's real binary (`npm_node_execpath`) so a
-    // wrapper embedder that left `version` unset gets the underlying
-    // Node's version, not whatever bare `node` PATH resolves to. Falls
-    // back to bare `node` when no runtime is active.
-    let program =
-        crate::runtime::node_execpath().unwrap_or_else(|| std::path::PathBuf::from("node"));
-    let output = std::process::Command::new(program)
-        .arg("--version")
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
+/// Probe `program --version`, memoized **per program path** — spawning is
+/// cheap individually but this is hit once per install and again by later
+/// callers in the same process (workspace installs, `aube add` chaining
+/// into `install`, tests). Keying the cache by path (rather than a single
+/// process-global slot) means a runtime that became active after an
+/// earlier bare-`node` probe still gets its own binary probed, instead of
+/// returning the stale first result.
+fn probe_node_version(program: &std::path::Path) -> Option<String> {
+    static PROBED: std::sync::OnceLock<
+        std::sync::Mutex<std::collections::HashMap<std::path::PathBuf, Option<String>>>,
+    > = std::sync::OnceLock::new();
+    let cache = PROBED.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+    if let Some(cached) = cache.lock().expect("probe cache poisoned").get(program) {
+        return cached.clone();
     }
-    let s = String::from_utf8(output.stdout).ok()?;
-    Some(s.trim().trim_start_matches('v').to_string())
+    let probed = (|| {
+        let output = std::process::Command::new(program)
+            .arg("--version")
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let s = String::from_utf8(output.stdout).ok()?;
+        Some(s.trim().trim_start_matches('v').to_string())
+    })();
+    cache
+        .lock()
+        .expect("probe cache poisoned")
+        .insert(program.to_path_buf(), probed.clone());
+    probed
 }
 
 /// Test whether `version` satisfies `range`. A version or range we can't

--- a/crates/aube/src/engines.rs
+++ b/crates/aube/src/engines.rs
@@ -120,7 +120,10 @@ fn probe_node_version(program: &std::path::Path) -> Option<String> {
         std::sync::Mutex<std::collections::HashMap<std::path::PathBuf, Option<String>>>,
     > = std::sync::OnceLock::new();
     let cache = PROBED.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
-    if let Some(cached) = cache.lock().expect("probe cache poisoned").get(program) {
+    // Recover from a poisoned lock rather than panic: this runs in
+    // embedded/library contexts, and a stale cache entry from a panicked
+    // probe is harmless (worst case: one redundant `--version` spawn).
+    if let Some(cached) = cache.lock().unwrap_or_else(|e| e.into_inner()).get(program) {
         return cached.clone();
     }
     let probed = (|| {
@@ -136,7 +139,7 @@ fn probe_node_version(program: &std::path::Path) -> Option<String> {
     })();
     cache
         .lock()
-        .expect("probe cache poisoned")
+        .unwrap_or_else(|e| e.into_inner())
         .insert(program.to_path_buf(), probed.clone());
     probed
 }

--- a/crates/aube/src/pnpmfile.rs
+++ b/crates/aube/src/pnpmfile.rs
@@ -411,7 +411,7 @@ async fn run_one_shot_hook(
 ) -> Result<Vec<u8>> {
     tracing::debug!("running pnpmfile hook {hook_name} ({})", pnpmfile.display());
 
-    let mut cmd = tokio::process::Command::new(crate::runtime::node_program());
+    let mut cmd = tokio::process::Command::new(crate::runtime::internal_node_program());
     cmd.arg("-e")
         .arg(one_shot_hook_shim())
         .env("AUBE_PNPMFILE", pnpmfile)
@@ -728,7 +728,7 @@ impl ReadPackageHost {
             "spawning pnpmfile readPackage host ({})",
             pnpmfile.display()
         );
-        let mut cmd = tokio::process::Command::new(crate::runtime::node_program());
+        let mut cmd = tokio::process::Command::new(crate::runtime::internal_node_program());
         cmd.arg("-e")
             .arg(read_package_shim())
             .env("AUBE_PNPMFILE", pnpmfile)
@@ -955,7 +955,7 @@ loadPnpmfile(process.env.AUBE_PNPMFILE)
 /// `export const hooks = …` all count, mirroring pnpm's resolution.
 pub async fn exports_hooks(pnpmfile: &Path) -> Result<bool> {
     let shim = format!("{LOAD_PNPMFILE_JS}{HOOKS_GATE_SHIM}");
-    let output = tokio::process::Command::new(crate::runtime::node_program())
+    let output = tokio::process::Command::new(crate::runtime::internal_node_program())
         .arg("-e")
         .arg(shim)
         .env("AUBE_PNPMFILE", pnpmfile)
@@ -1124,7 +1124,7 @@ mod tests {
     /// True iff `node --version` exits 0. The `exports_hooks` tests gate
     /// on this so CI runners without node skip rather than fail.
     fn node_available() -> bool {
-        std::process::Command::new(crate::runtime::node_program())
+        std::process::Command::new(crate::runtime::internal_node_program())
             .arg("--version")
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())

--- a/crates/aube/src/runtime.rs
+++ b/crates/aube/src/runtime.rs
@@ -156,7 +156,15 @@ pub fn scope_current<F: Future>(future: F) -> impl Future<Output = F::Output> {
 pub fn current() -> Option<Arc<RuntimeContext>> {
     match INSTALL_RUNTIME.try_with(|runtime| runtime.get().map(Arc::clone)) {
         Ok(runtime) => runtime,
-        Err(_) => RUNTIME.get().map(Arc::clone),
+        // Non-install commands (dlx/exec/run/node). A process-wide
+        // embedder runtime is authoritative over a `RUNTIME` an earlier
+        // `ensure` may have populated, so registration order can't leave
+        // these paths on a pre-registration runtime while install scopes
+        // see the registered one.
+        Err(_) => EMBEDDER_CONTEXT
+            .get()
+            .map(Arc::clone)
+            .or_else(|| RUNTIME.get().map(Arc::clone)),
     }
 }
 
@@ -480,61 +488,103 @@ pub fn child_env_vars() -> Vec<(std::ffi::OsString, std::ffi::OsString)> {
         vars.push(("NODE".into(), node.into_os_string()));
     }
     if let Some(ctx) = ctx {
-        for entry in &ctx.env {
-            let value = match entry.merge {
-                EnvMerge::Replace => entry.val.clone(),
-                EnvMerge::Append => match std::env::var_os(&entry.key).filter(|v| !v.is_empty()) {
+        // Non-jailed spawns inherit the parent env, so `Append` composes
+        // onto the inherited value of the key.
+        vars.extend(fold_env(&ctx.env, |key| {
+            std::env::var_os(key).filter(|v| !v.is_empty())
+        }));
+    }
+    vars
+}
+
+/// Fold embedder env entries into resolved `(key, value)` pairs, in the
+/// order keys first appear. [`EnvMerge::Append`] composes onto the
+/// running value for that key — seeded from `base(key)` (the inherited
+/// env for non-jailed spawns, `None` in the cleared jail) — so several
+/// appends to one key chain in order; [`EnvMerge::Replace`] overwrites,
+/// and a later append composes onto the replaced value. Kept pure (the
+/// base is supplied by the caller) so it is unit-testable without
+/// touching the process environment.
+fn fold_env(
+    entries: &[EmbedderEnv],
+    base: impl Fn(&std::ffi::OsStr) -> Option<std::ffi::OsString>,
+) -> Vec<(std::ffi::OsString, std::ffi::OsString)> {
+    let mut order: Vec<std::ffi::OsString> = Vec::new();
+    let mut acc: std::collections::HashMap<std::ffi::OsString, std::ffi::OsString> =
+        std::collections::HashMap::new();
+    for entry in entries {
+        if !acc.contains_key(&entry.key) {
+            order.push(entry.key.clone());
+        }
+        let value = match entry.merge {
+            EnvMerge::Replace => entry.val.clone(),
+            EnvMerge::Append => {
+                let running = acc
+                    .get(&entry.key)
+                    .cloned()
+                    .or_else(|| base(&entry.key))
+                    .filter(|v| !v.is_empty());
+                match running {
                     Some(mut existing) => {
                         existing.push(" ");
                         existing.push(&entry.val);
                         existing
                     }
                     None => entry.val.clone(),
-                },
-            };
-            vars.push((entry.key.clone(), value));
-        }
+                }
+            }
+        };
+        acc.insert(entry.key.clone(), value);
     }
-    vars
+    order
+        .into_iter()
+        .map(|key| {
+            let value = acc.remove(&key).unwrap_or_default();
+            (key, value)
+        })
+        .collect()
 }
 
 /// The `NODE_OPTIONS` an embedder contributed, folded over `base` (the
-/// resolved `nodeOptions` setting). Used by spawn paths that build env
-/// through a settings snapshot rather than [`apply_child_env`]. Returns
-/// `base` unchanged when no embedder `NODE_OPTIONS` entry is active.
+/// resolved `nodeOptions` setting). Used by the jailed lifecycle-script
+/// path, which builds env through a settings snapshot rather than
+/// [`apply_child_env`]. Returns `base` unchanged when no embedder
+/// `NODE_OPTIONS` entry is active; multiple appends chain in order.
 pub fn merge_node_options(base: Option<String>) -> Option<String> {
     let ctx = current();
     let entries = ctx.as_ref().map(|c| c.env.as_slice()).unwrap_or(&[]);
-    let mut value = base;
-    for entry in entries {
-        if entry.key != std::ffi::OsStr::new("NODE_OPTIONS") {
-            continue;
-        }
-        let contrib = entry.val.to_string_lossy().into_owned();
-        value = match (entry.merge, value.take()) {
-            (EnvMerge::Replace, _) => Some(contrib),
-            (EnvMerge::Append, Some(existing)) if !existing.is_empty() => {
-                Some(format!("{existing} {contrib}"))
-            }
-            (EnvMerge::Append, _) => Some(contrib),
-        };
+    let node_options: Vec<EmbedderEnv> = entries
+        .iter()
+        .filter(|e| e.key == std::ffi::OsStr::new("NODE_OPTIONS"))
+        .cloned()
+        .collect();
+    if node_options.is_empty() {
+        return base;
     }
-    value
+    let base_os = base.map(std::ffi::OsString::from);
+    fold_env(&node_options, |_| base_os.clone())
+        .into_iter()
+        .next()
+        .map(|(_, v)| v.to_string_lossy().into_owned())
+        .or_else(|| base_os.map(|b| b.to_string_lossy().into_owned()))
 }
 
 /// Embedder env entries other than `NODE_OPTIONS` (which
-/// [`merge_node_options`] handles), as plain `(key, value)` pairs to
-/// stamp on a child. `Append` here collapses to the value, since aube
-/// has no base for these keys — documented behavior.
+/// [`merge_node_options`] handles), as resolved `(key, value)` pairs for
+/// the jailed lifecycle-script path. `env_clear` means there is no
+/// inherited base, so `Append` composes only across the embedder's own
+/// entries for a key; `Replace` overwrites.
 pub fn embedder_extra_env() -> Vec<(std::ffi::OsString, std::ffi::OsString)> {
     let Some(ctx) = current() else {
         return Vec::new();
     };
-    ctx.env
+    let entries: Vec<EmbedderEnv> = ctx
+        .env
         .iter()
         .filter(|e| e.key != std::ffi::OsStr::new("NODE_OPTIONS"))
-        .map(|e| (e.key.clone(), e.val.clone()))
-        .collect()
+        .cloned()
+        .collect();
+    fold_env(&entries, |_| None)
 }
 
 /// The runtime-relevant settings, extracted from a `ResolveCtx` so
@@ -1239,6 +1289,41 @@ mod tests {
             assert_eq!(node_program(), bin.join(node_exe));
         })
         .await;
+    }
+
+    #[test]
+    fn fold_env_composes_appends_and_honors_replace() {
+        fn os(s: &str) -> std::ffi::OsString {
+            std::ffi::OsString::from(s)
+        }
+        fn entry(k: &str, v: &str, merge: EnvMerge) -> EmbedderEnv {
+            EmbedderEnv {
+                key: os(k),
+                val: os(v),
+                merge,
+            }
+        }
+        // Append seeds from the caller's base and chains multiple entries
+        // for the same key in order; a key with no base starts empty.
+        let entries = vec![
+            entry("NODE_OPTIONS", "--a", EnvMerge::Append),
+            entry("NODE_OPTIONS", "--b", EnvMerge::Append),
+            entry("FRESH", "x", EnvMerge::Append),
+        ];
+        let out = fold_env(&entries, |k| {
+            (k == std::ffi::OsStr::new("NODE_OPTIONS")).then(|| os("--base"))
+        });
+        assert_eq!(out[0], (os("NODE_OPTIONS"), os("--base --a --b")));
+        assert_eq!(out[1], (os("FRESH"), os("x")));
+
+        // Replace overwrites even a present base; a later append composes
+        // onto the replaced value, not the base.
+        let entries = vec![
+            entry("K", "one", EnvMerge::Replace),
+            entry("K", "two", EnvMerge::Append),
+        ];
+        let out = fold_env(&entries, |_| Some(os("IGNORED")));
+        assert_eq!(out, vec![(os("K"), os("one two"))]);
     }
 
     #[tokio::test]

--- a/crates/aube/src/runtime.rs
+++ b/crates/aube/src/runtime.rs
@@ -79,6 +79,12 @@ pub struct RuntimeContext {
     /// the unwrapped binary for a wrapper. `None` falls back to
     /// `node_program`, then to the ambient `node`.
     pub node_execpath: Option<PathBuf>,
+    /// The node aube's internal machinery spawns (pnpmfile hooks,
+    /// security scanner, version probes) when it should differ from
+    /// `node_program` — a wrapping embedder points this at the real
+    /// binary so aube's own hot paths skip the wrapper hop. `None`
+    /// falls back to `node_program`.
+    pub internal_node: Option<PathBuf>,
     /// Exact resolved version (`"24.4.1"`), when known without probing.
     /// An embedder may leave this unset; [`crate::engines`] probes
     /// [`Self::node_execpath`] lazily (memoized) when a version is
@@ -108,6 +114,7 @@ impl RuntimeContext {
             bin_dir: None,
             node_program: None,
             node_execpath: None,
+            internal_node: None,
             version: None,
             requested: None,
             source: RuntimeSource::PathFallback,
@@ -192,6 +199,7 @@ pub struct EmbedderRuntime {
     bin_dir: Option<PathBuf>,
     node_program: Option<PathBuf>,
     node_execpath: Option<PathBuf>,
+    internal_node: Option<PathBuf>,
     version: Option<String>,
     env: Vec<EmbedderEnv>,
 }
@@ -229,6 +237,17 @@ impl EmbedderRuntime {
     /// program's parent (e.g. a shim dir separate from the real bin).
     pub fn path_dir(mut self, dir: impl Into<PathBuf>) -> Self {
         self.bin_dir = Some(dir.into());
+        self
+    }
+
+    /// The node aube's *internal* machinery spawns — pnpmfile hooks, the
+    /// security scanner, version probes — when it should differ from
+    /// [`wrapper`](Self::wrapper)'s shim. A wrapping host typically points
+    /// this at the real binary so aube's own hot paths skip the wrapper
+    /// hop; user-facing spawns (scripts, `NODE`, `node`) stay wrapped.
+    /// Defaults to `node_program`.
+    pub fn internal_node(mut self, path: impl Into<PathBuf>) -> Self {
+        self.internal_node = Some(path.into());
         self
     }
 
@@ -297,10 +316,12 @@ impl EmbedderRuntime {
             .clone()
             .map(|p| abs(&p))
             .or_else(|| node_program.clone());
+        let internal_node = self.internal_node.clone().map(|p| abs(&p));
         RuntimeContext {
             bin_dir,
             node_program,
             node_execpath,
+            internal_node,
             version: self.version.clone().filter(|v| !v.is_empty()),
             requested: None,
             source: RuntimeSource::Embedder,
@@ -356,12 +377,46 @@ pub fn seed_install_embedder_runtime(per_call: Option<&EmbedderRuntime>) {
     });
 }
 
+/// Run `future` with a per-call embedder runtime active, falling through
+/// to the process-wide state when `runtime` is `None`. This is how the
+/// non-install embed entry points (`run`/`exec`/`dlx`/`node`) honor a
+/// per-call [`EmbedderRuntime`]: the process-wide `RUNTIME` slot is
+/// set-once, so a host that varies the runtime per invocation (e.g. a
+/// fresh shim dir per command) scopes each call instead. The task-local
+/// slot shadows the process-wide one for every `current()` read inside.
+pub async fn with_embedder_runtime<F: Future>(
+    runtime: Option<EmbedderRuntime>,
+    future: F,
+) -> F::Output {
+    match runtime {
+        Some(rt) => {
+            scope(async move {
+                seed_install_embedder_runtime(Some(&rt));
+                future.await
+            })
+            .await
+        }
+        None => future.await,
+    }
+}
+
 /// The node executable spawn sites should use: the runtime's
 /// `node_program` (the wrapper/shim for an embedder, the selected binary
 /// otherwise), else bare `"node"` (PATH lookup at spawn time).
 pub fn node_program() -> PathBuf {
     current()
         .and_then(|c| c.node_program.clone())
+        .unwrap_or_else(|| PathBuf::from("node"))
+}
+
+/// The node for aube's *internal* spawns — pnpmfile hooks, the security
+/// scanner, version probes. A wrapping embedder may split this off via
+/// [`EmbedderRuntime::internal_node`] so aube's own machinery runs on
+/// the real binary while user-facing spawns stay wrapped; otherwise it
+/// is [`node_program`].
+pub fn internal_node_program() -> PathBuf {
+    current()
+        .and_then(|c| c.internal_node.clone().or_else(|| c.node_program.clone()))
         .unwrap_or_else(|| PathBuf::from("node"))
 }
 
@@ -712,6 +767,7 @@ async fn resolve_context(
             // `npm_node_execpath` are the same binary.
             node_program: Some(res.node_bin.clone()),
             node_execpath: Some(res.node_bin.clone()),
+            internal_node: None,
             version: Some(res.version.to_string()),
             requested: Some(requested),
             source,
@@ -1100,11 +1156,13 @@ mod tests {
     fn wrapper_splits_shim_from_real_node() {
         let ctx = EmbedderRuntime::wrapper("/shim/node")
             .real_node("/node-24.4.1/bin/node")
+            .internal_node("/node-24.4.1/bin/node")
             .version("24.4.1")
             .env_append("NODE_OPTIONS", "--import /preload.mjs")
             .resolve();
         // PATH entry defaults to the shim's parent; `NODE` is the shim; the
-        // execpath is the real binary node-gyp reads.
+        // execpath is the real binary node-gyp reads; internal spawns
+        // (pnpmfile, scanner) skip the wrapper hop.
         assert_eq!(ctx.bin_dir.as_deref(), Some(abs("/shim").as_path()));
         assert_eq!(
             ctx.node_program.as_deref(),
@@ -1114,9 +1172,50 @@ mod tests {
             ctx.node_execpath.as_deref(),
             Some(abs("/node-24.4.1/bin/node").as_path())
         );
+        assert_eq!(
+            ctx.internal_node.as_deref(),
+            Some(abs("/node-24.4.1/bin/node").as_path())
+        );
         assert_eq!(ctx.version.as_deref(), Some("24.4.1"));
         assert_eq!(ctx.env.len(), 1);
         assert_eq!(ctx.env[0].merge, EnvMerge::Append);
+    }
+
+    #[tokio::test]
+    async fn internal_node_defaults_to_node_program() {
+        scope(async {
+            let rt = EmbedderRuntime::wrapper("/shim/node");
+            seed_install_embedder_runtime(Some(&rt));
+            // Without an explicit internal_node, internal spawns use the
+            // wrapper too (today's behavior for a plain wrapper).
+            assert_eq!(internal_node_program(), abs("/shim/node"));
+        })
+        .await;
+        scope(async {
+            let rt = EmbedderRuntime::wrapper("/shim/node").internal_node("/real/node");
+            seed_install_embedder_runtime(Some(&rt));
+            assert_eq!(internal_node_program(), abs("/real/node"));
+            // User-facing program stays the shim.
+            assert_eq!(node_program(), abs("/shim/node"));
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn with_embedder_runtime_scopes_a_per_call_runtime() {
+        // A per-call runtime is visible inside the scoped future and gone
+        // after it — the process-wide state is untouched, so a host can
+        // vary the runtime per invocation (fresh shim dir per command).
+        let seen = with_embedder_runtime(Some(EmbedderRuntime::wrapper("/shim-a/node")), async {
+            node_program()
+        })
+        .await;
+        assert_eq!(seen, abs("/shim-a/node"));
+        // A fresh scope afterwards starts empty — nothing leaked.
+        scope(async {
+            assert!(current().is_none());
+        })
+        .await;
     }
 
     #[tokio::test]

--- a/crates/aube/src/runtime.rs
+++ b/crates/aube/src/runtime.rs
@@ -47,6 +47,9 @@ pub enum RuntimeProvenance {
     Mise,
     AubeManaged,
     System,
+    /// An embedding host described the node invocation directly (see
+    /// [`EmbedderRuntime`]) — aube neither resolved nor probed it.
+    Embedder,
 }
 
 impl RuntimeProvenance {
@@ -55,6 +58,7 @@ impl RuntimeProvenance {
             RuntimeProvenance::Mise => "mise",
             RuntimeProvenance::AubeManaged => aube_util::embedder().name,
             RuntimeProvenance::System => "system",
+            RuntimeProvenance::Embedder => aube_util::embedder().name,
         }
     }
 }
@@ -64,14 +68,30 @@ pub struct RuntimeContext {
     /// Directory to prepend to PATH for child processes. `None` means
     /// no switching (ambient node already satisfies, or no config).
     pub bin_dir: Option<PathBuf>,
-    /// Absolute path of the selected node binary, when one resolved.
-    pub node_bin: Option<PathBuf>,
-    /// Exact resolved version (`"24.4.1"`), when known.
+    /// The node aube spawns and exports as `NODE`: the program a
+    /// script's bare `node` / `$NODE` resolves to. For a selector this
+    /// is the real binary; for a wrapper it is the shim. `None` falls
+    /// back to a bare `node` PATH lookup at spawn time.
+    pub node_program: Option<PathBuf>,
+    /// The node exported as `npm_node_execpath` — the *real* binary
+    /// node-gyp and native-addon tooling read to find Node's install
+    /// prefix. Equals [`Self::node_program`] for a selector; points at
+    /// the unwrapped binary for a wrapper. `None` falls back to
+    /// `node_program`, then to the ambient `node`.
+    pub node_execpath: Option<PathBuf>,
+    /// Exact resolved version (`"24.4.1"`), when known without probing.
+    /// An embedder may leave this unset; [`crate::engines`] probes
+    /// [`Self::node_execpath`] lazily (memoized) when a version is
+    /// actually needed.
     pub version: Option<String>,
     /// The requested range/spec as written (`"^24.4.0"`, `"lts/jod"`).
     pub requested: Option<String>,
     pub source: RuntimeSource,
     pub provenance: RuntimeProvenance,
+    /// Embedder-supplied environment applied last to every spawn (see
+    /// [`EmbedderRuntime::env_append`] / [`EmbedderRuntime::env_set`]).
+    /// Empty unless an embedder contributed env.
+    pub env: Vec<EmbedderEnv>,
     /// Full per-platform pin computed during a network resolve —
     /// the install pipeline records it into the lockfile.
     pub fresh_pin: Option<aube_runtime::PinnedNode>,
@@ -86,11 +106,13 @@ impl RuntimeContext {
     fn path_fallback() -> RuntimeContext {
         RuntimeContext {
             bin_dir: None,
-            node_bin: None,
+            node_program: None,
+            node_execpath: None,
             version: None,
             requested: None,
             source: RuntimeSource::PathFallback,
             provenance: RuntimeProvenance::System,
+            env: Vec::new(),
             fresh_pin: None,
         }
     }
@@ -131,67 +153,215 @@ pub fn current() -> Option<Arc<RuntimeContext>> {
     }
 }
 
-/// Seed the current install's runtime slot with a node binary supplied by an
-/// embedding host (e.g. mise), so lifecycle scripts spawn on that node and
-/// find it on PATH instead of relying on an ambient `node`.
+/// How an embedder-supplied env var combines with any value aube would
+/// otherwise set for the same key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnvMerge {
+    /// Overwrite the key outright.
+    Replace,
+    /// Space-join after the value aube resolved (e.g. the `nodeOptions`
+    /// setting), so an embedder's `--import` preload adds to the user's
+    /// `NODE_OPTIONS` rather than dropping it. When aube has no value
+    /// for the key this is just the embedder's value.
+    Append,
+}
+
+/// One embedder-contributed environment entry.
+#[derive(Debug, Clone)]
+pub struct EmbedderEnv {
+    pub key: std::ffi::OsString,
+    pub val: std::ffi::OsString,
+    pub merge: EnvMerge,
+}
+
+/// A host's description of *how Node should be invoked*, rather than
+/// merely which `node` to select.
 ///
-/// `bin_dir` is the directory containing the `node` executable; it is
-/// prepended to the script PATH ([`path_entries`]) and its `node` is used as
-/// [`node_program`]. Must be called inside a [`scope`] (the install task) and
-/// before [`ensure`] runs — `ensure` returns early when the slot is already
-/// set, so this override wins without aube probing for its own runtime. A
-/// no-op outside a scope or if the slot is already populated.
-pub async fn seed_embedder_node(bin_dir: PathBuf) {
-    // No-op outside an install scope, or when the slot is already seeded.
-    // Check first so the path/version probing below is skipped entirely in
-    // those cases (a later `set` would be a no-op anyway).
-    let should_seed = INSTALL_RUNTIME
-        .try_with(|slot| slot.get().is_none())
-        .unwrap_or(false);
-    if !should_seed {
-        return;
+/// A version manager selects a toolchain — one binary that is `NODE`,
+/// `npm_node_execpath`, and the PATH entry all at once. A wrapper
+/// (instrumenting runtime, transpiling loader, sandbox) interposes on
+/// Node, and needs those three distinct: a shim on PATH and at `NODE`
+/// so `$NODE child.js` stays wrapped, but the *real* binary at
+/// `npm_node_execpath` so node-gyp finds Node's install prefix.
+///
+/// Construct via [`selector`](Self::selector) (today's single-bin-dir
+/// behavior) or [`wrapper`](Self::wrapper); unspecified fields derive
+/// from what you supply, so no invalid combination is representable.
+#[derive(Debug, Clone, Default)]
+pub struct EmbedderRuntime {
+    bin_dir: Option<PathBuf>,
+    node_program: Option<PathBuf>,
+    node_execpath: Option<PathBuf>,
+    version: Option<String>,
+    env: Vec<EmbedderEnv>,
+}
+
+impl EmbedderRuntime {
+    /// A version-manager-style runtime: `bin_dir` holds `node` (plus
+    /// `npm`/`npx`) and is prepended to PATH; that `node` is both `NODE`
+    /// and `npm_node_execpath`. This is the degenerate case that
+    /// reproduces the pre-wrapper `node_bin_dir` behavior.
+    pub fn selector(bin_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            bin_dir: Some(bin_dir.into()),
+            ..Default::default()
+        }
     }
-    // Absolutize: lifecycle scripts may run with a different working
-    // directory, so both `node_program()` and the prepended PATH entry must
-    // resolve independently of cwd. `absolute` doesn't require the dir to
-    // exist or touch symlinks; fall back to the input if it errors.
-    let bin_dir = std::path::absolute(&bin_dir).unwrap_or(bin_dir);
-    let node_exe = if cfg!(windows) { "node.exe" } else { "node" };
-    let node_bin = bin_dir.join(node_exe);
-    // Probe the supplied node for its version so engine checks and
-    // virtual-store hashing key off the *same* node as lifecycle scripts,
-    // instead of `effective_node_version` falling back to an ambient `node`.
-    // Async spawn so the install task doesn't block a Tokio worker on the
-    // child process.
-    let version = tokio::process::Command::new(&node_bin)
-        .arg("--version")
-        .output()
-        .await
-        .ok()
-        .filter(|out| out.status.success())
-        .and_then(|out| String::from_utf8(out.stdout).ok())
-        .map(|v| v.trim().trim_start_matches('v').to_string())
-        .filter(|v| !v.is_empty());
-    let ctx = RuntimeContext {
-        node_bin: Some(node_bin),
-        bin_dir: Some(bin_dir),
-        version,
-        requested: None,
-        source: RuntimeSource::Embedder,
-        provenance: RuntimeProvenance::Mise,
-        fresh_pin: None,
+
+    /// A wrapping runtime: `node_program` is the shim aube spawns and
+    /// exports as `NODE`. PATH defaults to its parent directory and
+    /// `npm_node_execpath` defaults to it; override with
+    /// [`real_node`](Self::real_node) / [`path_dir`](Self::path_dir).
+    pub fn wrapper(node_program: impl Into<PathBuf>) -> Self {
+        Self {
+            node_program: Some(node_program.into()),
+            ..Default::default()
+        }
+    }
+
+    /// The real, unwrapped node exported as `npm_node_execpath`.
+    pub fn real_node(mut self, path: impl Into<PathBuf>) -> Self {
+        self.node_execpath = Some(path.into());
+        self
+    }
+
+    /// The directory prepended to PATH, when it differs from the
+    /// program's parent (e.g. a shim dir separate from the real bin).
+    pub fn path_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.bin_dir = Some(dir.into());
+        self
+    }
+
+    /// Supply the node version instead of having aube probe for it.
+    pub fn version(mut self, version: impl Into<String>) -> Self {
+        self.version = Some(version.into());
+        self
+    }
+
+    /// Contribute an env var to every spawn, appended after any value
+    /// aube resolves for the key (see [`EnvMerge::Append`]). This is how
+    /// a wrapper adds a `NODE_OPTIONS` preload without clobbering the
+    /// user's `nodeOptions`.
+    pub fn env_append(
+        mut self,
+        key: impl Into<std::ffi::OsString>,
+        val: impl Into<std::ffi::OsString>,
+    ) -> Self {
+        self.env.push(EmbedderEnv {
+            key: key.into(),
+            val: val.into(),
+            merge: EnvMerge::Append,
+        });
+        self
+    }
+
+    /// Contribute an env var to every spawn, overwriting any value aube
+    /// would set for the key (see [`EnvMerge::Replace`]).
+    pub fn env_set(
+        mut self,
+        key: impl Into<std::ffi::OsString>,
+        val: impl Into<std::ffi::OsString>,
+    ) -> Self {
+        self.env.push(EmbedderEnv {
+            key: key.into(),
+            val: val.into(),
+            merge: EnvMerge::Replace,
+        });
+        self
+    }
+
+    /// Materialize into a [`RuntimeContext`], filling derived paths.
+    /// Paths are absolutized so they resolve independently of a script's
+    /// working directory; `absolute` neither requires existence nor
+    /// touches symlinks, so a not-yet-created shim is fine.
+    fn resolve(&self) -> RuntimeContext {
+        let abs = |p: &PathBuf| std::path::absolute(p).unwrap_or_else(|_| p.clone());
+        let node_exe = if cfg!(windows) { "node.exe" } else { "node" };
+        let node_program = self
+            .node_program
+            .clone()
+            .or_else(|| self.bin_dir.as_ref().map(|d| d.join(node_exe)))
+            .map(|p| abs(&p));
+        let bin_dir = self
+            .bin_dir
+            .clone()
+            .or_else(|| {
+                node_program
+                    .as_ref()
+                    .and_then(|p| p.parent())
+                    .map(Path::to_path_buf)
+            })
+            .map(|p| abs(&p));
+        let node_execpath = self
+            .node_execpath
+            .clone()
+            .map(|p| abs(&p))
+            .or_else(|| node_program.clone());
+        RuntimeContext {
+            bin_dir,
+            node_program,
+            node_execpath,
+            version: self.version.clone().filter(|v| !v.is_empty()),
+            requested: None,
+            source: RuntimeSource::Embedder,
+            provenance: RuntimeProvenance::Embedder,
+            env: self.env.clone(),
+            fresh_pin: None,
+        }
+    }
+}
+
+/// Process-wide embedder runtime resolved from [`set_embedder_runtime`].
+/// Covers every spawn path outside an install scope (dlx/exec/run/node);
+/// the install scope seeds its own slot from it (or a per-call override).
+static EMBEDDER_CONTEXT: std::sync::OnceLock<Arc<RuntimeContext>> = std::sync::OnceLock::new();
+
+/// Register a process-wide embedder runtime so every aube spawn path —
+/// install lifecycle scripts, `dlx`, `exec`, `run`, `node` — invokes
+/// Node the way the host describes. First-write-wins, mirroring
+/// `set_embedder` / `set_embedder_defaults`. A per-call runtime on
+/// `InstallOptions` takes precedence over this for that install.
+///
+/// Honored regardless of `runtime_switching`: an explicit invocation is
+/// an override, not a resolution aube performs.
+pub fn set_embedder_runtime(runtime: EmbedderRuntime) {
+    let ctx = Arc::new(runtime.resolve());
+    let _ = EMBEDDER_CONTEXT.set(Arc::clone(&ctx));
+    // Pre-fill the process-wide slot so non-install commands early-return
+    // it from `ensure` and read it through `current()` without resolving.
+    let _ = RUNTIME.set(ctx);
+}
+
+/// Seed the current install's runtime slot from an embedder-supplied
+/// runtime, so lifecycle scripts invoke Node the way the host describes
+/// instead of relying on an ambient `node`. `per_call` (from
+/// `InstallOptions`) wins outright; otherwise the process-wide runtime
+/// from [`set_embedder_runtime`] applies; otherwise this is a no-op and
+/// aube resolves its own runtime.
+///
+/// Must be called inside a [`scope`] (the install task) and before
+/// [`ensure`] runs — `ensure` returns early when the slot is set, so
+/// this override wins without aube resolving its own runtime. No probing:
+/// the version, if any, is supplied on the [`EmbedderRuntime`].
+pub fn seed_install_embedder_runtime(per_call: Option<&EmbedderRuntime>) {
+    let ctx = match per_call {
+        Some(rt) => Arc::new(rt.resolve()),
+        None => match EMBEDDER_CONTEXT.get() {
+            Some(ctx) => Arc::clone(ctx),
+            None => return,
+        },
     };
     let _ = INSTALL_RUNTIME.try_with(|slot| {
-        let _ = slot.set(Arc::new(ctx));
+        let _ = slot.set(ctx);
     });
 }
 
-/// The node executable spawn sites should use: the switched runtime's
-/// binary when one resolved, otherwise bare `"node"` (PATH lookup at
-/// spawn time, today's behavior).
+/// The node executable spawn sites should use: the runtime's
+/// `node_program` (the wrapper/shim for an embedder, the selected binary
+/// otherwise), else bare `"node"` (PATH lookup at spawn time).
 pub fn node_program() -> PathBuf {
     current()
-        .and_then(|c| c.node_bin.clone())
+        .and_then(|c| c.node_program.clone())
         .unwrap_or_else(|| PathBuf::from("node"))
 }
 
@@ -204,22 +374,112 @@ pub fn path_entries() -> Vec<PathBuf> {
         .collect()
 }
 
+/// The binary to probe for a node version when one wasn't supplied: the
+/// real `npm_node_execpath` (so a wrapper's `--version` reflects the
+/// underlying Node), falling back to `node_program`.
+pub fn node_execpath() -> Option<PathBuf> {
+    current().and_then(|c| c.node_execpath.clone().or_else(|| c.node_program.clone()))
+}
+
 /// Set the npm-compat env vars naming the node binary on a child
-/// command (`npm_node_execpath`, and `NODE` which npm also exports).
-///
-/// Prefers the switched runtime's node; when no switch is active,
-/// falls back to the ambient `node` resolved on `PATH` so these vars
-/// are populated on every spawn — pnpm/npm always set them, and tools
-/// (`node-gyp`, `node-pre-gyp`, re-spawners) read `npm_node_execpath`
-/// to locate the exact node that drove the package manager.
+/// command: `NODE` (the program scripts re-spawn) and `npm_node_execpath`
+/// (the *real* node node-gyp reads to find Node's install prefix), then
+/// apply the embedder's env contributions. See [`child_env_vars`].
 pub fn apply_child_env(cmd: &mut tokio::process::Command) {
-    let node_bin = current()
-        .and_then(|ctx| ctx.node_bin.clone())
-        .or_else(aube_runtime::node_on_path);
-    if let Some(node_bin) = node_bin {
-        cmd.env("npm_node_execpath", &node_bin);
-        cmd.env("NODE", &node_bin);
+    for (key, value) in child_env_vars() {
+        cmd.env(key, value);
     }
+}
+
+/// The child env — `NODE`, `npm_node_execpath`, and the embedder's env
+/// contributions — as resolved `(key, value)` pairs, for spawn paths
+/// that inherit the parent environment (dlx/exec/node — no jail
+/// `env_clear`). Exposed as pairs (rather than only mutating a
+/// `tokio::process::Command`) so the `aube node` exec path, which uses a
+/// `std::process::Command`, can apply the same env.
+///
+/// `NODE`/`npm_node_execpath` prefer the switched runtime's node, falling
+/// back to the ambient `node` on `PATH` so they're populated on every
+/// spawn (pnpm/npm parity). [`EnvMerge::Append`] joins after the
+/// inherited value of the key (so a `NODE_OPTIONS` preload adds to the
+/// user's ambient value rather than dropping it); [`EnvMerge::Replace`]
+/// overwrites. Jailed lifecycle scripts don't use this — they resolve
+/// `NODE_OPTIONS` through [`merge_node_options`] (the base is the
+/// `nodeOptions` setting, not the cleared env) and stamp the rest via
+/// [`embedder_extra_env`].
+pub fn child_env_vars() -> Vec<(std::ffi::OsString, std::ffi::OsString)> {
+    let ctx = current();
+    let execpath = ctx
+        .as_ref()
+        .and_then(|c| c.node_execpath.clone().or_else(|| c.node_program.clone()))
+        .or_else(aube_runtime::node_on_path);
+    let node = ctx
+        .as_ref()
+        .and_then(|c| c.node_program.clone())
+        .or_else(|| execpath.clone());
+    let mut vars: Vec<(std::ffi::OsString, std::ffi::OsString)> = Vec::new();
+    if let Some(execpath) = execpath {
+        vars.push(("npm_node_execpath".into(), execpath.into_os_string()));
+    }
+    if let Some(node) = node {
+        vars.push(("NODE".into(), node.into_os_string()));
+    }
+    if let Some(ctx) = ctx {
+        for entry in &ctx.env {
+            let value = match entry.merge {
+                EnvMerge::Replace => entry.val.clone(),
+                EnvMerge::Append => match std::env::var_os(&entry.key).filter(|v| !v.is_empty()) {
+                    Some(mut existing) => {
+                        existing.push(" ");
+                        existing.push(&entry.val);
+                        existing
+                    }
+                    None => entry.val.clone(),
+                },
+            };
+            vars.push((entry.key.clone(), value));
+        }
+    }
+    vars
+}
+
+/// The `NODE_OPTIONS` an embedder contributed, folded over `base` (the
+/// resolved `nodeOptions` setting). Used by spawn paths that build env
+/// through a settings snapshot rather than [`apply_child_env`]. Returns
+/// `base` unchanged when no embedder `NODE_OPTIONS` entry is active.
+pub fn merge_node_options(base: Option<String>) -> Option<String> {
+    let ctx = current();
+    let entries = ctx.as_ref().map(|c| c.env.as_slice()).unwrap_or(&[]);
+    let mut value = base;
+    for entry in entries {
+        if entry.key != std::ffi::OsStr::new("NODE_OPTIONS") {
+            continue;
+        }
+        let contrib = entry.val.to_string_lossy().into_owned();
+        value = match (entry.merge, value.take()) {
+            (EnvMerge::Replace, _) => Some(contrib),
+            (EnvMerge::Append, Some(existing)) if !existing.is_empty() => {
+                Some(format!("{existing} {contrib}"))
+            }
+            (EnvMerge::Append, _) => Some(contrib),
+        };
+    }
+    value
+}
+
+/// Embedder env entries other than `NODE_OPTIONS` (which
+/// [`merge_node_options`] handles), as plain `(key, value)` pairs to
+/// stamp on a child. `Append` here collapses to the value, since aube
+/// has no base for these keys — documented behavior.
+pub fn embedder_extra_env() -> Vec<(std::ffi::OsString, std::ffi::OsString)> {
+    let Some(ctx) = current() else {
+        return Vec::new();
+    };
+    ctx.env
+        .iter()
+        .filter(|e| e.key != std::ffi::OsStr::new("NODE_OPTIONS"))
+        .map(|e| (e.key.clone(), e.val.clone()))
+        .collect()
 }
 
 /// The runtime-relevant settings, extracted from a `ResolveCtx` so
@@ -448,7 +708,10 @@ async fn resolve_context(
         }
         Some(res) => RuntimeContext {
             bin_dir: res.bin_dir.clone(),
-            node_bin: Some(res.node_bin.clone()),
+            // A resolved runtime is a selector: `NODE` and
+            // `npm_node_execpath` are the same binary.
+            node_program: Some(res.node_bin.clone()),
+            node_execpath: Some(res.node_bin.clone()),
             version: Some(res.version.to_string()),
             requested: Some(requested),
             source,
@@ -460,6 +723,7 @@ async fn resolve_context(
                     aube_runtime::InstallOrigin::Aube => RuntimeProvenance::AubeManaged,
                 },
             },
+            env: Vec::new(),
             fresh_pin: res.fresh_pin,
         },
     })
@@ -812,39 +1076,98 @@ mod tests {
         context
     }
 
+    fn abs(p: &str) -> PathBuf {
+        let p = PathBuf::from(p);
+        std::path::absolute(&p).unwrap_or(p)
+    }
+
+    #[test]
+    fn selector_derives_one_binary_for_all_three_paths() {
+        let node_exe = if cfg!(windows) { "node.exe" } else { "node" };
+        let ctx = EmbedderRuntime::selector("/opt/mise/node/bin").resolve();
+        let bin = abs("/opt/mise/node/bin");
+        assert_eq!(ctx.bin_dir.as_deref(), Some(bin.as_path()));
+        // `NODE` and `npm_node_execpath` are the same binary for a selector.
+        assert_eq!(
+            ctx.node_program.as_deref(),
+            Some(bin.join(node_exe).as_path())
+        );
+        assert_eq!(ctx.node_execpath, ctx.node_program);
+        assert_eq!(ctx.source, RuntimeSource::Embedder);
+    }
+
+    #[test]
+    fn wrapper_splits_shim_from_real_node() {
+        let ctx = EmbedderRuntime::wrapper("/shim/node")
+            .real_node("/node-24.4.1/bin/node")
+            .version("24.4.1")
+            .env_append("NODE_OPTIONS", "--import /preload.mjs")
+            .resolve();
+        // PATH entry defaults to the shim's parent; `NODE` is the shim; the
+        // execpath is the real binary node-gyp reads.
+        assert_eq!(ctx.bin_dir.as_deref(), Some(abs("/shim").as_path()));
+        assert_eq!(
+            ctx.node_program.as_deref(),
+            Some(abs("/shim/node").as_path())
+        );
+        assert_eq!(
+            ctx.node_execpath.as_deref(),
+            Some(abs("/node-24.4.1/bin/node").as_path())
+        );
+        assert_eq!(ctx.version.as_deref(), Some("24.4.1"));
+        assert_eq!(ctx.env.len(), 1);
+        assert_eq!(ctx.env[0].merge, EnvMerge::Append);
+    }
+
     #[tokio::test]
-    async fn seed_embedder_node_drives_node_program_and_path() {
+    async fn seed_install_runtime_drives_node_program_and_path() {
         scope(async {
             assert!(current().is_none(), "slot starts empty");
-            let bin_dir = PathBuf::from("/opt/mise/node/bin");
-            seed_embedder_node(bin_dir.clone()).await;
-
-            // The seed absolutizes the dir; compute the expected the same way
-            // so this holds on Windows (where `/opt/...` isn't absolute).
-            let expected = std::path::absolute(&bin_dir).unwrap_or(bin_dir);
             let node_exe = if cfg!(windows) { "node.exe" } else { "node" };
+            let bin = abs("/opt/mise/node/bin");
+            let rt = EmbedderRuntime::selector("/opt/mise/node/bin");
+            seed_install_embedder_runtime(Some(&rt));
 
             let ctx = current().expect("slot seeded");
             assert_eq!(ctx.source, RuntimeSource::Embedder);
-            assert_eq!(ctx.bin_dir.as_deref(), Some(expected.as_path()));
-            assert_eq!(node_program(), expected.join(node_exe));
-            assert_eq!(path_entries(), vec![expected.clone()]);
+            assert_eq!(ctx.bin_dir.as_deref(), Some(bin.as_path()));
+            assert_eq!(node_program(), bin.join(node_exe));
+            assert_eq!(path_entries(), vec![bin.clone()]);
 
-            // `ensure`-style early return: a second seed does not clobber the
-            // first (OnceCell is set once).
-            seed_embedder_node(PathBuf::from("/other")).await;
-            assert_eq!(node_program(), expected.join(node_exe));
+            // Slot is set-once: a second seed does not clobber the first.
+            let other = EmbedderRuntime::selector("/other");
+            seed_install_embedder_runtime(Some(&other));
+            assert_eq!(node_program(), bin.join(node_exe));
         })
         .await;
     }
 
     #[tokio::test]
-    async fn seed_embedder_node_is_a_noop_outside_scope() {
+    async fn merge_node_options_appends_embedder_preload() {
+        scope(async {
+            let rt = EmbedderRuntime::wrapper("/shim/node")
+                .env_append("NODE_OPTIONS", "--import /preload.mjs");
+            seed_install_embedder_runtime(Some(&rt));
+            // Appends after the user's resolved value; falls back to just the
+            // embedder value when there's no base.
+            assert_eq!(
+                merge_node_options(Some("--enable-source-maps".into())).as_deref(),
+                Some("--enable-source-maps --import /preload.mjs")
+            );
+            assert_eq!(
+                merge_node_options(None).as_deref(),
+                Some("--import /preload.mjs")
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn seed_install_runtime_is_a_noop_outside_scope() {
         // No install scope active: the seed can't set a task-local slot, so it
-        // must not panic and must not leak into a later scope. Asserting via a
-        // fresh `scope` reads the (empty) task-local, not the process-wide
-        // `RUNTIME`, so this stays deterministic regardless of test order.
-        seed_embedder_node(PathBuf::from("/opt/mise/node/bin")).await;
+        // must not panic and must not leak into a later scope.
+        let rt = EmbedderRuntime::selector("/opt/mise/node/bin");
+        seed_install_embedder_runtime(Some(&rt));
         scope(async {
             assert!(current().is_none(), "seed outside a scope must not leak in");
         })

--- a/crates/aube/src/runtime.rs
+++ b/crates/aube/src/runtime.rs
@@ -131,6 +131,13 @@ type RuntimeSlot = Arc<tokio::sync::OnceCell<Arc<RuntimeContext>>>;
 
 tokio::task_local! {
     static INSTALL_RUNTIME: RuntimeSlot;
+    /// A per-call embedder runtime for an in-process embed invocation.
+    /// Unlike [`INSTALL_RUNTIME`], it is *not* re-scoped by [`scope`], so
+    /// it survives the fresh scope `install::run` opens for a nested
+    /// install (e.g. `dlx`'s transient install, or `run`/`exec`
+    /// auto-install) — that's what lets a per-call runtime reach lifecycle
+    /// scripts in those nested installs.
+    static PER_CALL_RUNTIME: Arc<RuntimeContext>;
 }
 
 /// Run an install with an isolated runtime slot. Standalone commands outside
@@ -155,17 +162,22 @@ pub fn scope_current<F: Future>(future: F) -> impl Future<Output = F::Output> {
 /// The resolved context, if [`ensure`] has run.
 pub fn current() -> Option<Arc<RuntimeContext>> {
     match INSTALL_RUNTIME.try_with(|runtime| runtime.get().map(Arc::clone)) {
+        // Inside an install scope the slot is authoritative (it may be
+        // `None` mid-resolution, before `ensure`/seed fills it).
         Ok(runtime) => runtime,
-        // Non-install commands (dlx/exec/run/node). A process-wide
-        // embedder runtime is authoritative over a `RUNTIME` an earlier
-        // `ensure` may have populated, so registration order can't leave
-        // these paths on a pre-registration runtime while install scopes
-        // see the registered one.
-        Err(_) => EMBEDDER_CONTEXT
-            .get()
-            .map(Arc::clone)
+        // Non-install commands (dlx/exec/run/node). Precedence: a per-call
+        // embed runtime, then a process-wide `set_embedder_runtime` (both
+        // authoritative over a `RUNTIME` an earlier `ensure` may have
+        // populated, so registration order can't strand these paths on a
+        // pre-registration runtime), then the ambient resolved runtime.
+        Err(_) => per_call_runtime()
+            .or_else(|| EMBEDDER_CONTEXT.get().map(Arc::clone))
             .or_else(|| RUNTIME.get().map(Arc::clone)),
     }
+}
+
+fn per_call_runtime() -> Option<Arc<RuntimeContext>> {
+    PER_CALL_RUNTIME.try_with(Arc::clone).ok()
 }
 
 /// How an embedder-supplied env var combines with any value aube would
@@ -375,8 +387,12 @@ pub fn set_embedder_runtime(runtime: EmbedderRuntime) {
 pub fn seed_install_embedder_runtime(per_call: Option<&EmbedderRuntime>) {
     let ctx = match per_call {
         Some(rt) => Arc::new(rt.resolve()),
-        None => match EMBEDDER_CONTEXT.get() {
-            Some(ctx) => Arc::clone(ctx),
+        // No explicit per-install runtime: inherit the enclosing embed
+        // call's per-call runtime (survives this fresh install scope),
+        // else the process-wide registration. Neither → aube resolves its
+        // own runtime for the install.
+        None => match per_call_runtime().or_else(|| EMBEDDER_CONTEXT.get().map(Arc::clone)) {
+            Some(ctx) => ctx,
             None => return,
         },
     };
@@ -385,26 +401,40 @@ pub fn seed_install_embedder_runtime(per_call: Option<&EmbedderRuntime>) {
     });
 }
 
-/// Run `future` with a per-call embedder runtime active, falling through
-/// to the process-wide state when `runtime` is `None`. This is how the
-/// non-install embed entry points (`run`/`exec`/`dlx`/`node`) honor a
-/// per-call [`EmbedderRuntime`]: the process-wide `RUNTIME` slot is
-/// set-once, so a host that varies the runtime per invocation (e.g. a
-/// fresh shim dir per command) scopes each call instead. The task-local
-/// slot shadows the process-wide one for every `current()` read inside.
+/// Run an in-process embed command (`run`/`exec`/`dlx`/`node`) with its
+/// runtime isolated to this call. Always opens a fresh [`scope`] so the
+/// call's runtime resolution lands in its own slot rather than reusing a
+/// process-wide `RUNTIME` an earlier call resolved — sequential embed
+/// calls to different projects don't cross-contaminate.
+///
+/// A per-call `runtime` is also published to [`PER_CALL_RUNTIME`] so it
+/// reaches lifecycle scripts in any nested install (`dlx`'s transient
+/// install, `run`/`exec` auto-install), which open their own scope and
+/// otherwise wouldn't see this one's slot. `None` falls through to a
+/// process-wide [`set_embedder_runtime`], else aube's own resolution.
 pub async fn with_embedder_runtime<F: Future>(
     runtime: Option<EmbedderRuntime>,
     future: F,
 ) -> F::Output {
     match runtime {
         Some(rt) => {
-            scope(async move {
-                seed_install_embedder_runtime(Some(&rt));
-                future.await
-            })
-            .await
+            let ctx = Arc::new(rt.resolve());
+            let seeded = Arc::clone(&ctx);
+            PER_CALL_RUNTIME
+                .scope(
+                    ctx,
+                    scope(async move {
+                        // Seed this call's own slot so direct spawns and
+                        // `ensure_for_cwd` see the runtime without resolving.
+                        let _ = INSTALL_RUNTIME.try_with(|slot| {
+                            let _ = slot.set(seeded);
+                        });
+                        future.await
+                    }),
+                )
+                .await
         }
-        None => future.await,
+        None => scope(future).await,
     }
 }
 
@@ -1264,6 +1294,25 @@ mod tests {
         // A fresh scope afterwards starts empty — nothing leaked.
         scope(async {
             assert!(current().is_none());
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn per_call_runtime_reaches_a_nested_install_scope() {
+        // The per-call runtime must survive the *fresh* scope a nested
+        // install opens (dlx's transient install, run/exec auto-install):
+        // `seed_install_embedder_runtime(None)` inside that inner scope
+        // should still pick it up, so lifecycle scripts run wrapped.
+        with_embedder_runtime(Some(EmbedderRuntime::wrapper("/shim-b/node")), async {
+            // Simulate `install::run`: a fresh scope with no per-install
+            // runtime of its own.
+            scope(async {
+                assert!(current().is_none(), "nested scope starts empty");
+                seed_install_embedder_runtime(None);
+                assert_eq!(node_program(), abs("/shim-b/node"));
+            })
+            .await;
         })
         .await;
     }

--- a/crates/aube/src/runtime.rs
+++ b/crates/aube/src/runtime.rs
@@ -148,12 +148,22 @@ pub async fn scope<F: Future>(future: F) -> F::Output {
         .await
 }
 
-/// Propagate the current install's runtime slot into a spawned task.
+/// Propagate the current install's runtime slot — and any active
+/// per-call embed runtime — into a spawned task. Task-locals don't cross
+/// `tokio::spawn`, so a fan-out that skips this would fall back to the
+/// process-wide state inside the child task.
 pub fn scope_current<F: Future>(future: F) -> impl Future<Output = F::Output> {
     let runtime = INSTALL_RUNTIME.try_with(Arc::clone).ok();
+    let per_call = per_call_runtime();
     async move {
-        match runtime {
-            Some(runtime) => INSTALL_RUNTIME.scope(runtime, future).await,
+        let future = async move {
+            match runtime {
+                Some(runtime) => INSTALL_RUNTIME.scope(runtime, future).await,
+                None => future.await,
+            }
+        };
+        match per_call {
+            Some(per_call) => PER_CALL_RUNTIME.scope(per_call, future).await,
             None => future.await,
         }
     }
@@ -361,16 +371,15 @@ static EMBEDDER_CONTEXT: std::sync::OnceLock<Arc<RuntimeContext>> = std::sync::O
 /// install lifecycle scripts, `dlx`, `exec`, `run`, `node` — invokes
 /// Node the way the host describes. First-write-wins, mirroring
 /// `set_embedder` / `set_embedder_defaults`. A per-call runtime on
-/// `InstallOptions` takes precedence over this for that install.
+/// `InstallOptions` (or on the embed run-class entry points) takes
+/// precedence over this for that call.
 ///
 /// Honored regardless of `runtime_switching`: an explicit invocation is
-/// an override, not a resolution aube performs.
+/// an override, not a resolution aube performs. Registration order
+/// doesn't matter — [`current`] and [`ensure`] consult this before any
+/// previously-resolved process-wide runtime.
 pub fn set_embedder_runtime(runtime: EmbedderRuntime) {
-    let ctx = Arc::new(runtime.resolve());
-    let _ = EMBEDDER_CONTEXT.set(Arc::clone(&ctx));
-    // Pre-fill the process-wide slot so non-install commands early-return
-    // it from `ensure` and read it through `current()` without resolving.
-    let _ = RUNTIME.set(ctx);
+    let _ = EMBEDDER_CONTEXT.set(Arc::new(runtime.resolve()));
 }
 
 /// Seed the current install's runtime slot from an embedder-supplied
@@ -407,34 +416,35 @@ pub fn seed_install_embedder_runtime(per_call: Option<&EmbedderRuntime>) {
 /// process-wide `RUNTIME` an earlier call resolved — sequential embed
 /// calls to different projects don't cross-contaminate.
 ///
-/// A per-call `runtime` is also published to [`PER_CALL_RUNTIME`] so it
-/// reaches lifecycle scripts in any nested install (`dlx`'s transient
-/// install, `run`/`exec` auto-install), which open their own scope and
-/// otherwise wouldn't see this one's slot. `None` falls through to a
-/// process-wide [`set_embedder_runtime`], else aube's own resolution.
+/// Both arms seed the fresh slot through
+/// [`seed_install_embedder_runtime`]`(None)`, whose lookup chain is
+/// per-call → process-wide [`set_embedder_runtime`] → none (aube
+/// resolves for this call). Seeding in the `None` arm is what keeps a
+/// *globally* registered runtime effective inside the isolation scope —
+/// without it, `ensure` would resolve aube's own runtime in the empty
+/// slot and silently bypass the registered wrapper.
+///
+/// A per-call `runtime` is additionally published to `PER_CALL_RUNTIME`
+/// so it reaches lifecycle scripts in any nested install (`dlx`'s
+/// transient install, `run`/`exec` auto-install), which open their own
+/// scope and otherwise wouldn't see this one's slot.
 pub async fn with_embedder_runtime<F: Future>(
     runtime: Option<EmbedderRuntime>,
     future: F,
 ) -> F::Output {
+    let seeded_scope = |future: F| {
+        scope(async move {
+            seed_install_embedder_runtime(None);
+            future.await
+        })
+    };
     match runtime {
         Some(rt) => {
-            let ctx = Arc::new(rt.resolve());
-            let seeded = Arc::clone(&ctx);
             PER_CALL_RUNTIME
-                .scope(
-                    ctx,
-                    scope(async move {
-                        // Seed this call's own slot so direct spawns and
-                        // `ensure_for_cwd` see the runtime without resolving.
-                        let _ = INSTALL_RUNTIME.try_with(|slot| {
-                            let _ = slot.set(seeded);
-                        });
-                        future.await
-                    }),
-                )
+                .scope(Arc::new(rt.resolve()), seeded_scope(future))
                 .await
         }
-        None => scope(future).await,
+        None => seeded_scope(future).await,
     }
 }
 
@@ -740,6 +750,12 @@ pub async fn ensure(
             })
             .await
             .map(Arc::clone);
+    }
+    // No scope: a registered embedder runtime is authoritative and
+    // registration-order independent — prefer it over (and never let it
+    // race with) a `RUNTIME` an earlier resolution may have filled.
+    if let Some(ctx) = EMBEDDER_CONTEXT.get() {
+        return Ok(Arc::clone(ctx));
     }
     RUNTIME
         .get_or_try_init(|| async {
@@ -1294,6 +1310,32 @@ mod tests {
         // A fresh scope afterwards starts empty — nothing leaked.
         scope(async {
             assert!(current().is_none());
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn none_arm_still_seeds_from_the_ambient_embedder_runtime() {
+        // Regression: the `None` arm of `with_embedder_runtime` opens an
+        // isolation scope, and an empty slot there means `ensure` would
+        // resolve aube's own runtime — silently bypassing a registered
+        // embedder runtime. Both arms must seed through
+        // `seed_install_embedder_runtime(None)`, whose lookup chain is
+        // per-call → process-wide. Exercised via the per-call tier (the
+        // process-wide `set_embedder_runtime` is once-per-process and
+        // would leak into unrelated tests in this binary; both tiers flow
+        // through the same seed path).
+        with_embedder_runtime(Some(EmbedderRuntime::wrapper("/shim-c/node")), async {
+            with_embedder_runtime(None, async {
+                // Inside the inner isolation scope the ambient embedder
+                // runtime must already be seeded — not an empty slot that
+                // `ensure` would fill with aube's own resolution.
+                assert_eq!(
+                    current().map(|c| c.node_program.clone()),
+                    Some(Some(abs("/shim-c/node")))
+                );
+            })
+            .await;
         })
         .await;
     }

--- a/docs/embedding/rust.md
+++ b/docs/embedding/rust.md
@@ -126,9 +126,15 @@ sandbox — uses `wrapper`. The shim is `NODE` and goes on `PATH` so a script's
 ```rust
 let runtime = EmbedderRuntime::wrapper("/opt/mytool/shim/node")
     .real_node("/opt/mytool/node-24.4.1/bin/node")
+    .internal_node("/opt/mytool/node-24.4.1/bin/node") // aube's own spawns skip the wrapper
     .version("24.4.1") // supplied, not probed
     .env_append("NODE_OPTIONS", "--import /opt/mytool/preload.mjs");
 ```
+
+`internal_node` splits off the node aube's *internal* machinery spawns —
+pnpmfile hooks, the security scanner, version probes — so those hot paths run
+on the real binary while user-facing spawns (scripts, `NODE`, `aube node`)
+stay wrapped. It defaults to the wrapper program.
 
 Apply it per call, or register it once so every spawn path — install lifecycle
 scripts, `dlx`, `exec`, `run`, `node` — is covered:
@@ -155,14 +161,17 @@ Each resolves its project from the directory passed in — never the process
 working directory — and returns the child's exit code:
 
 ```rust
-embed::run(&project_dir, "build", vec![]).await?;          // package script
-embed::exec(&project_dir, "eslint", vec![".".into()]).await?; // node_modules/.bin
-embed::dlx(&project_dir, vec!["cowsay".into(), "hi".into()], vec![]).await?;
-embed::node(&project_dir, vec!["--eval".into(), "console.log(1)".into()]).await?;
+embed::run(&project_dir, "build", vec![], None).await?;          // package script
+embed::exec(&project_dir, "eslint", vec![".".into()], None).await?; // node_modules/.bin
+embed::dlx(&project_dir, vec!["cowsay".into(), "hi".into()], vec![], None).await?;
+embed::node(&project_dir, vec!["--eval".into(), "console.log(1)".into()], None).await?;
 ```
 
-Unlike the CLI, `embed::node` supervises a child rather than replacing the
-host process.
+The trailing parameter is an optional per-call `EmbedderRuntime`. `None` uses
+the process-wide registration; pass `Some(runtime)` when the runtime varies
+per invocation (e.g. a host that provisions a fresh shim directory per
+command), since `set_embedder_runtime` is set-once. Unlike the CLI,
+`embed::node` supervises a child rather than replacing the host process.
 
 ## Progress and cancellation
 

--- a/docs/embedding/rust.md
+++ b/docs/embedding/rust.md
@@ -100,6 +100,70 @@ Offline mode always disables that live request. Set
 `dangerously_allow_all_builds` to bypass the lifecycle build allowlist for the
 invocation; `ignore_scripts` still disables scripts entirely.
 
+## Node runtime
+
+By default aube resolves its own Node for lifecycle scripts. A host that
+manages Node itself describes how Node should be invoked with an
+`EmbedderRuntime`.
+
+A host that merely selects a toolchain (a version manager) uses `selector` —
+the bin directory goes on `PATH` and its `node` is both `NODE` and
+`npm_node_execpath`:
+
+```rust
+use aube::embed::EmbedderRuntime;
+
+let runtime = EmbedderRuntime::selector("/opt/mytool/node-24.4.1/bin");
+```
+
+A host that *wraps* Node — an instrumenting runtime, a transpiling loader, a
+sandbox — uses `wrapper`. The shim is `NODE` and goes on `PATH` so a script's
+`node` / `$NODE` stays wrapped, while `real_node` is exported as
+`npm_node_execpath` so `node-gyp` builds against the real binary. Use
+`env_append` to add a `NODE_OPTIONS` preload without dropping the user's value
+(`env_set` overwrites):
+
+```rust
+let runtime = EmbedderRuntime::wrapper("/opt/mytool/shim/node")
+    .real_node("/opt/mytool/node-24.4.1/bin/node")
+    .version("24.4.1") // supplied, not probed
+    .env_append("NODE_OPTIONS", "--import /opt/mytool/preload.mjs");
+```
+
+Apply it per call, or register it once so every spawn path — install lifecycle
+scripts, `dlx`, `exec`, `run`, `node` — is covered:
+
+```rust
+// Per call.
+let mut options = InstallOptions::new(&project_dir);
+options.runtime = Some(runtime.clone());
+embed::install(options).await?;
+
+// Or once at startup (first-write-wins; a per-call `runtime` still wins for
+// that install).
+embed::set_embedder_runtime(runtime);
+```
+
+Every field is optional and unset reproduces standalone aube's behavior. The
+runtime is honored regardless of the host's `runtime_switching` flag — an
+explicit invocation is an override, not a resolution.
+
+## Run scripts, binaries, and Node
+
+With a runtime registered, a host can drive the run-class commands in process.
+Each resolves its project from the directory passed in — never the process
+working directory — and returns the child's exit code:
+
+```rust
+embed::run(&project_dir, "build", vec![]).await?;          // package script
+embed::exec(&project_dir, "eslint", vec![".".into()]).await?; // node_modules/.bin
+embed::dlx(&project_dir, vec!["cowsay".into(), "hi".into()], vec![]).await?;
+embed::node(&project_dir, vec!["--eval".into(), "console.log(1)".into()]).await?;
+```
+
+Unlike the CLI, `embed::node` supervises a child rather than replacing the
+host process.
+
 ## Progress and cancellation
 
 Implement `InstallReporter` and pass it through `InstallControl::events`.


### PR DESCRIPTION
Implements the proposal in [discussion #1083](https://github.com/jdx/aube/discussions/1083): extend the embedder Node hook from #1079 so a host can describe a Node *invocation* rather than a bin dir — covering wrappers (instrumenting runtimes, transpiling loaders, sandboxes), not just version managers.

## What changed

**`EmbedderRuntime` builder** — two named constructors so no invalid combination is representable:
- `selector(bin_dir)` — the version-manager case; reproduces #1079's `node_bin_dir` exactly.
- `wrapper(node_program).real_node().path_dir().version().env_append()/.env_set()` — the shim on `PATH` and at `NODE` (so `$NODE child.js` stays wrapped), the real binary at `npm_node_execpath` (so `node-gyp` finds Node's install prefix).

The three spawn signals — `bin_dir` (PATH), `node_program` (`NODE` + spawn program), `node_execpath` (`npm_node_execpath`) — are now distinct in `RuntimeContext`.

**Lifecycle-script env contribution** — `env_append` / `env_set`. `NODE_OPTIONS` appends over the user's `nodeOptions` by default (a wrapper's `--import` preload adds rather than clobbers); `env_set` replaces. Applied to every spawn: jailed lifecycle scripts (folded through `merge_node_options`) and dlx/exec/node (inherit-and-append).

**Process-wide registration** — `set_embedder_runtime` (first-write-wins, mirroring `set_embedder`) covers every spawn path. A per-call `InstallOptions.runtime` fully replaces it. Honored regardless of `runtime_switching` — an explicit invocation is an override, not a resolution.

**Lazy version** — supplied on the runtime, not probed at seed time; `engines::probe_node_version` probes `node_execpath` (memoized) only when a version is actually needed.

**Every spawn path** — `exec`/`run` are decoupled from process cwd (they take an explicit `base_dir`, so concurrent embed calls in different projects don't race), and `node` gains a supervised-spawn variant (the CLI path image-replaces the process). New entry points `embed::{run, exec, dlx, node}` drive the run-class commands in process, each rooted at an explicit `project_dir`.

Every field is optional; unset reproduces standalone aube's behavior byte-for-byte, so `selector` is the degenerate case (`{ bin_dir }`).

## Tests

- `runtime`: selector/wrapper derivation, `NODE_OPTIONS` append fold, scoped seed + set-once, no-op outside scope.
- `aube-scripts`: `NODE` vs `npm_node_execpath` stamped distinctly for a wrapper; execpath falls back to program for a selector; `extra_env` applied.
- Full `cargo test -p aube --lib` (670) + `-p aube-scripts` (76) pass; `cargo clippy --all-targets` and `cargo fmt --check` clean.

Docs: new "Node runtime" and "Run scripts, binaries, and Node" sections in `docs/embedding/rust.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches every Node spawn path (scripts, install lifecycle, pnpmfile, scanners) and changes the embed install API from a bin dir to a richer runtime model; incorrect shim/execpath wiring could break native builds or concurrent multi-project embed calls.
> 
> **Overview**
> Replaces the embedder **`node_bin_dir`** hook with **`EmbedderRuntime`**: **`selector(bin_dir)`** for toolchain pickers (same behavior as before) and **`wrapper(shim)`** with optional **`real_node`**, **`internal_node`**, **`path_dir`**, **`version`**, and **`env_append` / `env_set`** so **`NODE`** can stay on a shim while **`npm_node_execpath`** points at the real binary node-gyp expects.
> 
> **`set_embedder_runtime`** registers that description process-wide; per-install **`InstallOptions.runtime`** and per-call overrides on new **`embed::{run, exec, dlx, node}`** win via **`with_embedder_runtime`** and a **`PER_CALL_RUNTIME`** task-local so nested installs (auto-install, dlx scratch) still see the host’s wrapper.
> 
> Lifecycle and non-jailed spawns get split **`NODE` / `npm_node_execpath`**, folded **`NODE_OPTIONS`**, and **`extra_env`**; aube’s own Node-driven paths use **`internal_node_program()`** to skip wrapper hops. **`run` / `exec` / `dlx` / auto-install** anchor on an explicit **`base_dir`** / **`project_dir`** instead of process cwd; **`aube node`** gains a supervised **`run_spawn`** path that applies the same child env as scripts.
> 
> Engines version probing is keyed off **`node_execpath`** with a per-binary cache. C/Node-API bindings still pass **`runtime: None`** (ambient node). Docs add embedding sections for runtime modes and in-process run-class commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3c6cd257dec0c1be2c97346dde65bcc6053a953. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded configurable Node.js runtime support for embedded hosts, including runtime-selection vs wrapper mode and per-install overrides.
  * Added/updated embedding APIs to run scripts, exec binaries, dlx packages, and supervise a Node subprocess against a specified project directory.

* **Bug Fixes**
  * Improved Node version detection and environment stamping for wrapper/shims (correct `NODE` vs `npm_node_execpath`, `NODE_OPTIONS` merging, and embedder `extra_env` ordering).
  * Anchored auto-installs and command root resolution to the intended directory.

* **Documentation**
  * Updated embedding Rust docs with new Node runtime behavior and embedded execution guidance.
* **Tests**
  * Added coverage for `NODE`/`npm_node_execpath` stamping and fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->