### PR TITLE
ci: gate embedding API breaks in PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,13 +107,19 @@ jobs:
   #   * The C ABI export set via the cdylib's dynamic symbol table diffed
   #     against the frozen crates/aube-ffi/abi-symbols.txt manifest.
   # A Rust break is allowed only when the PR is explicitly marked
-  # breaking — a `!` in the conventional-commit title (feat(ffi)!: ...)
-  # or the `breaking-api` label — the same signal that drives
-  # release-plz's major bump, so the gate and the version bump agree.
+  # breaking — a `!` in the conventional-commit title (feat(ffi)!: ...),
+  # a `BREAKING CHANGE:` footer in the body, or the `breaking-api`
+  # label — the same signals that drive release-plz's major bump, so the
+  # gate and the version bump agree.
   # Symbol drift always blocks (keeps the manifest honest); removing an
   # export shows as a manifest deletion in the diff and must ride a
   # breaking PR.
   api-stability:
+    # PR-time gate only: the checks read `github.event.pull_request.*` and
+    # baseline against main, which is meaningless on push/tag/dispatch runs
+    # (those fields are undefined there). `final` treats the resulting
+    # `skipped` as a pass.
+    if: github.event_name == 'pull_request'
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
     timeout-minutes: 20
     permissions:
@@ -137,11 +143,15 @@ jobs:
         id: gate
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
           PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: |
           breaking=false
           # conventional-commit breaking marker: type(scope)!: or type!:
           if printf '%s' "$PR_TITLE" | grep -qE '^[a-z]+(\([^)]*\))?!:'; then breaking=true; fi
+          # conventional-commit breaking footer in the body (release-plz
+          # honors `BREAKING CHANGE:` / `BREAKING-CHANGE:` for the major bump).
+          if printf '%s' "$PR_BODY" | grep -qE '^BREAKING[ -]CHANGE:'; then breaking=true; fi
           if printf '%s' "$PR_LABELS" | grep -q '"breaking-api"'; then breaking=true; fi
           echo "breaking=$breaking" >> "$GITHUB_OUTPUT"
           echo "breaking override: $breaking"
@@ -178,7 +188,7 @@ jobs:
             if [ "$BREAKING" = true ]; then
               echo "::notice::Rust embedding API change is breaking; allowed because this PR is marked breaking."
             else
-              echo "::error::A breaking change to a Rust embedding API (aube-codes/aube-settings/aube-util) was detected. If intentional, mark the PR breaking: a '!' in the conventional-commit title (e.g. feat(settings)!: ...) or the 'breaking-api' label."
+              echo "::error::A breaking change to a Rust embedding API (aube-codes/aube-settings/aube-util) was detected. If intentional, mark the PR breaking: a '!' in the conventional-commit title (e.g. feat(settings)!: ...), a 'BREAKING CHANGE:' footer in the body, or the 'breaking-api' label."
               fail=1
             fi
           fi
@@ -328,6 +338,8 @@ jobs:
   # Aggregator that required-status-checks can target. If any upstream job
   # failed, was cancelled, or was skipped, this step exits non-zero so the PR is
   # blocked. Lets the branch-protection rule depend on one name instead of ten.
+  # Exception: jobs in SKIP_OK below (api-stability, a PR-only gate) are allowed
+  # to skip on push/tag/dispatch runs without failing the aggregate.
   final:
     needs:
       - build
@@ -335,6 +347,7 @@ jobs:
       - bats
       - bats-serial
       - windows
+      - api-stability
     runs-on: namespace-profile-endev-linux-amd64
     timeout-minutes: 2
     permissions: {}
@@ -351,12 +364,18 @@ jobs:
           import os
           import sys
 
+          # Jobs whose `if:` legitimately skips them on non-PR runs. A skip
+          # here is a pass; every other job must actually succeed.
+          SKIP_OK = {"api-stability"}
+
           needs = json.loads(os.environ["NEEDS_JSON"])
           failed = False
           for name, data in sorted(needs.items()):
               result = data.get("result", "unknown")
               if result == "success":
                   print(f"::notice::{name}: {result}")
+              elif result == "skipped" and name in SKIP_OK:
+                  print(f"::notice::{name}: {result} (allowed to skip)")
               else:
                   print(f"::error::{name}: {result}")
                   failed = True

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,90 @@ jobs:
           fi
       - run: mise run docs:build
 
+  # Guards the embedding API surfaces `embed` introduced against
+  # unintended breaks:
+  #   * Rust library crates (aube-codes/aube-settings/aube-util) via
+  #     cargo-semver-checks, baselined against main.
+  #   * The C ABI export set via the cdylib's dynamic symbol table diffed
+  #     against the frozen crates/aube-ffi/abi-symbols.txt manifest.
+  # A Rust break is allowed only when the PR is explicitly marked
+  # breaking — a `!` in the conventional-commit title (feat(ffi)!: ...)
+  # or the `breaking-api` label — the same signal that drives
+  # release-plz's major bump, so the gate and the version bump agree.
+  # Symbol drift always blocks (keeps the manifest honest); removing an
+  # export shows as a manifest deletion in the diff and must ride a
+  # breaking PR.
+  api-stability:
+    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    env:
+      RUSTFLAGS: "-D warnings"
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - uses: namespacelabs/nscloud-cache-action@58bf6e08898e88803c098e2b522668541cd3b2e3 # v1.6.0
+        with:
+          cache: rust
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          cache: false
+      - name: Fetch semver baseline
+        run: git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+      - name: Determine breaking-change override
+        id: gate
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          breaking=false
+          # conventional-commit breaking marker: type(scope)!: or type!:
+          if printf '%s' "$PR_TITLE" | grep -qE '^[a-z]+(\([^)]*\))?!:'; then breaking=true; fi
+          if printf '%s' "$PR_LABELS" | grep -q '"breaking-api"'; then breaking=true; fi
+          echo "breaking=$breaking" >> "$GITHUB_OUTPUT"
+          echo "breaking override: $breaking"
+      - name: Rust embedding API — cargo-semver-checks
+        id: semver
+        continue-on-error: true
+        # Version can be bumped freely; a newer checker only adds lints.
+        run: |
+          mise x cargo:cargo-semver-checks@0.49.0 -- cargo semver-checks \
+            --baseline-rev origin/main \
+            --package aube-codes --package aube-settings --package aube-util
+      - name: C ABI — frozen export set
+        id: ffi
+        continue-on-error: true
+        run: |
+          cargo build --locked --profile ffi -p aube-ffi
+          grep -vE '^[[:space:]]*(#|$)' crates/aube-ffi/abi-symbols.txt | sort -u > /tmp/abi-expected.txt
+          nm -D --defined-only --extern-only target/ffi/libaube_ffi.so \
+            | awk '{ print $3 }' | grep '^aube_' | sort -u > /tmp/abi-actual.txt
+          diff -u /tmp/abi-expected.txt /tmp/abi-actual.txt
+      - name: Enforce API stability
+        if: always()
+        env:
+          SEMVER: ${{ steps.semver.outcome }}
+          FFI: ${{ steps.ffi.outcome }}
+          BREAKING: ${{ steps.gate.outputs.breaking }}
+        run: |
+          fail=0
+          if [ "$FFI" = failure ]; then
+            echo "::error::C ABI exports drifted from crates/aube-ffi/abi-symbols.txt. Update the manifest to match; removing or renaming an export is a breaking change — also mark the PR breaking (a '!' in the title or the 'breaking-api' label)."
+            fail=1
+          fi
+          if [ "$SEMVER" = failure ]; then
+            if [ "$BREAKING" = true ]; then
+              echo "::notice::Rust embedding API change is breaking; allowed because this PR is marked breaking."
+            else
+              echo "::error::A breaking change to a Rust embedding API (aube-codes/aube-settings/aube-util) was detected. If intentional, mark the PR breaking: a '!' in the conventional-commit title (e.g. feat(settings)!: ...) or the 'breaking-api' label."
+              fail=1
+            fi
+          fi
+          exit $fail
+
   # BATS integration shards. Linux runs 4 shards (matches Buildkite),
   # macOS runs 2. Keep these on GitHub-hosted runners: the jail-build
   # tests assert native OS sandbox behavior that does not match the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,9 +148,9 @@ jobs:
       - name: Rust embedding API — cargo-semver-checks
         id: semver
         continue-on-error: true
-        # Version can be bumped freely; a newer checker only adds lints.
+        # Version pinned in bin/cargo-semver-checks (mise tool-stub).
         run: |
-          mise x cargo:cargo-semver-checks@0.49.0 -- cargo semver-checks \
+          cargo-semver-checks semver-checks \
             --baseline-rev origin/main \
             --package aube-codes --package aube-settings --package aube-util
       - name: C ABI — frozen export set

--- a/bin/cargo-semver-checks
+++ b/bin/cargo-semver-checks
@@ -1,0 +1,3 @@
+#!/usr/bin/env -S mise tool-stub
+tool = "cargo:cargo-semver-checks"
+version = "0.49.0"

--- a/crates/aube-ffi/abi-symbols.txt
+++ b/crates/aube-ffi/abi-symbols.txt
@@ -1,9 +1,9 @@
 # Frozen C ABI export set for aube-ffi.
 #
-# One exported symbol per line, sorted. The api-stability workflow
-# (.github/workflows/api-stability.yml) builds the cdylib, reads its
-# dynamic symbol table, and fails the PR if the `aube_`-prefixed exports
-# drift from this list.
+# One exported symbol per line, sorted. The `api-stability` job in
+# .github/workflows/ci.yml builds the cdylib, reads its dynamic symbol
+# table, and fails the PR if the `aube_`-prefixed exports drift from
+# this list.
 #
 # Removing or renaming a line is a breaking C ABI change: mark the PR
 # breaking (a `!` in the conventional-commit title, e.g. `feat(ffi)!:`,

--- a/crates/aube-ffi/abi-symbols.txt
+++ b/crates/aube-ffi/abi-symbols.txt
@@ -1,0 +1,20 @@
+# Frozen C ABI export set for aube-ffi.
+#
+# One exported symbol per line, sorted. The api-stability workflow
+# (.github/workflows/api-stability.yml) builds the cdylib, reads its
+# dynamic symbol table, and fails the PR if the `aube_`-prefixed exports
+# drift from this list.
+#
+# Removing or renaming a line is a breaking C ABI change: mark the PR
+# breaking (a `!` in the conventional-commit title, e.g. `feat(ffi)!:`,
+# or the `breaking-api` label) and update this file in the same PR.
+# Adding a new export is non-breaking; append it here so CI stays green.
+#
+# Blank lines and `#` comments are ignored.
+aube_add
+aube_cancel
+aube_events_next
+aube_init
+aube_install
+aube_string_free
+aube_wait


### PR DESCRIPTION
## Why

`embed` gave aube three stability surfaces with no automated breaking-change gate: the Rust library crates (`aube-codes`/`aube-settings`/`aube-util`), the C ABI (`aube-ffi` exports + `aube.h`), and the TS declarations. Nothing caught a removed export or changed signature at PR time — and because `aube.h` is hand-maintained (no cbindgen), it could silently drift from the actual symbols.

## What

A new `api-stability` job in `ci.yml`:

- **Rust surface** — `cargo semver-checks` over the three library crates, baselined against `main`, run via `mise x cargo:...` to match how CI already runs `cargo-audit`/`cargo-deny`.
- **C ABI surface** — builds the cdylib under the `ffi` profile, reads its dynamic symbol table with `nm`, and diffs the `aube_*` exports against a new frozen manifest at `crates/aube-ffi/abi-symbols.txt`.
- **Enforcement** — symbol drift always blocks (keeps the manifest honest). A Rust break is waived only when the PR is marked breaking (a `!` in the conventional-commit title or a `breaking-api` label) — the same signal release-plz uses for the major bump, so the gate and the version bump agree.

Validated locally: `actionlint` clean; symbol extraction matches the manifest (7 exports, incl. `aube_string_free`).

## Not covered (by design, for a first cut)

- Struct-layout / signature ABI changes (would need `abidiff` against the last released `.so`) — the symbol check catches add/remove/rename only.
- The `aube` crate's own `pub` surface and the `.d.ts` (already typecheck-gated via `typecheck.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI enforcement and a documented ABI manifest; runtime behavior is unchanged unless contributors mis-label intentional breaking API work.
> 
> **Overview**
> Adds a PR-only **`api-stability`** CI job that blocks accidental breaks to the embedding surfaces introduced by `embed`.
> 
> On pull requests it runs **`cargo-semver-checks`** against `origin/main` for `aube-codes`, `aube-settings`, and `aube-util` (via a new **`bin/cargo-semver-checks`** mise stub at 0.49.0), and builds **`aube-ffi`** under the `ffi` profile to diff `aube_*` exports from `nm` against a new frozen manifest at **`crates/aube-ffi/abi-symbols.txt`**. C ABI symbol drift always fails; Rust semver failures are waived only when the PR is explicitly marked breaking (`!` in the title, `BREAKING CHANGE:` in the body, or **`breaking-api`** label).
> 
> The **`final`** aggregator now depends on `api-stability` and treats a **skipped** result as success on non-PR runs, since the job’s `if:` limits it to `pull_request` events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4cdd4ed2f839f83548536365520e6f1c0b48724. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added automated checks to detect unintended changes to the public Rust API and C ABI.
  * Pull requests with breaking changes must be explicitly marked; unmarked compatibility issues now fail validation.
  * CI aggregation now handles API checks correctly when they are not applicable outside pull requests.

* **Documentation**
  * Added a tracked manifest of exported C ABI symbols to support compatibility verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->