### PR TITLE
fix(resolver): exclude @octokit/endpoint from no-downgrade by default

### DIFF
--- a/crates/aube-resolver/src/trust.rs
+++ b/crates/aube-resolver/src/trust.rs
@@ -252,6 +252,11 @@ fn cutoff_iso8601(minutes_ago: u64) -> Option<String> {
 /// the name) or `<name>@<semver-range>[ || <semver-range>]…` (no name
 /// globs combined with versions).
 pub const DEFAULT_TRUST_POLICY_EXCLUDES: &[&str] = &[
+    // @octokit maintains several major-version lines in parallel and backports
+    // fixes to older lines without provenance attestation. A backport (e.g.
+    // @octokit/endpoint@9.0.6) is published after an attested newer major
+    // (10.1.0), so the no-downgrade check flags the legitimate older release.
+    "@octokit/endpoint",
     "chokidar",
     "eslint-config-prettier",
     "eslint-import-resolver-typescript",
@@ -1121,6 +1126,28 @@ mod tests {
             );
         }
         assert!(!r.matches("left-pad", &node_semver::Version::parse("1.0.0").unwrap()));
+    }
+
+    #[test]
+    fn default_excludes_scoped_octokit_endpoint_backport() {
+        // Regression: @octokit backports fixes to older major lines without
+        // provenance, so a legitimate older release (e.g. 9.0.6) published
+        // after an attested newer major (10.1.0) tripped no-downgrade. The
+        // scoped name must match every version, and the leading `@` must not
+        // be misparsed as a version separator.
+        let r = TrustExcludeRules::default();
+        assert!(r.matches(
+            "@octokit/endpoint",
+            &node_semver::Version::parse("9.0.6").unwrap()
+        ));
+        assert!(r.matches(
+            "@octokit/endpoint",
+            &node_semver::Version::parse("10.1.0").unwrap()
+        ));
+        assert!(!r.matches(
+            "@octokit/core",
+            &node_semver::Version::parse("9.0.6").unwrap()
+        ));
     }
 
     #[test]

--- a/docs/security.md
+++ b/docs/security.md
@@ -169,6 +169,12 @@ Version selectors are npm-style semver ranges.
 Default: `no-downgrade`. Set `trustPolicy: off` to disable, or use
 `trustPolicyExclude` for per-package opt-outs.
 
+aube also ships a small built-in exclude list for well-known packages whose
+maintainers legitimately publish provenance-inconsistent releases (e.g.
+maintaining multiple major-version lines and backporting to older ones without
+attestation), so common installs don't fail on a known-benign downgrade. Your
+own `trustPolicyExclude` entries are added on top of these defaults.
+
 Settings: [`trustPolicy`](/settings/#setting-trustpolicy),
 [`trustPolicyExclude`](/settings/#setting-trustpolicyexclude),
 [`trustPolicyIgnoreAfter`](/settings/#setting-trustpolicyignoreafter).


### PR DESCRIPTION
## Problem

`@octokit` maintains several major-version lines in parallel and backports fixes to older lines **without** provenance attestation. Concretely for `@octokit/endpoint`:

| version | published | provenance |
|---|---|---|
| `10.1.0` | 2024-04-03 | ✅ SLSA provenance |
| `9.0.6` | 2025-02-14 (backport) | ❌ none |

Because `9.0.6` was published *after* the attested `10.1.0`, `trustPolicy=no-downgrade` treats the legitimate v9 backport as a downgrade and aborts resolution. Any dependency graph that pins the v9 line hits this — e.g. `danger` → `@octokit/rest@20` → `@octokit/endpoint@^9`.

This surfaced downstream in mise as an opaque `failed to resolve dependencies` ([jdx/mise#11224](https://github.com/jdx/mise/discussions/11224)).

## Fix

Add `@octokit/endpoint` to `DEFAULT_TRUST_POLICY_EXCLUDES`, alongside the other known provenance-churn packages (`undici`, `vite`, `semver`, …). Scoped-name matching and parsing were already supported; verified the leading `@` isn't misparsed as a version separator.

Also documented in `docs/security.md` that aube ships a built-in exclude list (a security doc should disclose which packages are silently exempted), and that user `trustPolicyExclude` entries stack on top.

## Scope

Deliberately narrow: I confirmed that excluding just `@octokit/endpoint` lets the full `danger` graph resolve, so this doesn't need to be the whole `@octokit/*` scope. If more octokit packages surface the same backport pattern, a `@octokit/*` glob is the natural follow-up — happy to broaden if you'd prefer that now.

## Testing

- `cargo test -p aube-resolver trust` — all pass, including a new `default_excludes_scoped_octokit_endpoint_backport` case covering the 9.0.6/10.1.0 scenario.
- `cargo fmt` / `cargo clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows no-downgrade enforcement for one known package only; behavior is covered by tests and documented for transparency.
> 
> **Overview**
> Adds **`@octokit/endpoint`** to the built-in **`DEFAULT_TRUST_POLICY_EXCLUDES`** list so **`trustPolicy: no-downgrade`** no longer fails when a legitimate v9 backport (e.g. `9.0.6`) is published after an attested newer major (`10.1.0`) without provenance.
> 
> A regression test asserts the scoped name matches all versions and that **`@`** is not treated as a version separator; **`@octokit/core`** stays subject to the policy.
> 
> **`docs/security.md`** now states that aube ships a small default exclude list for known benign provenance churn and that user **`trustPolicyExclude`** entries stack on top.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15eb673807de795147488deb06381460f9ca139c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->