### PR TITLE
feat(release): support version from-git

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -2127,7 +2127,7 @@ cmd version help="Bump the version in package.json (and optionally create a git 
         arg <ID>
     }
     flag --sign-git-tag help="GPG-sign the created tag (`git tag -s`)"
-    arg "[NEW_VERSION]" help="Bump keyword or an explicit version string" help_long="Bump keyword or an explicit version string.\n\nAccepts `major`, `minor`, `patch`, `premajor`, `preminor`, `prepatch`, `prerelease`, or an explicit version. When omitted, prints the current version." required=#false
+    arg "[NEW_VERSION]" help="Bump keyword or an explicit version string" help_long="Bump keyword or an explicit version string.\n\nAccepts `major`, `minor`, `patch`, `premajor`, `preminor`, `prepatch`, `prerelease`, `from-git`, or an explicit version. `from-git` reads the nearest reachable version-like Git tag. When omitted, prints the current version." required=#false
 }
 cmd view help="Print package metadata from the registry" {
     alias info show

--- a/crates/aube/src/commands/version.rs
+++ b/crates/aube/src/commands/version.rs
@@ -445,24 +445,26 @@ fn version_from_git(cwd: &Path) -> miette::Result<String> {
         for tag in &excluded {
             command.arg(format!("--exclude={tag}"));
         }
-        let output = command
-            .current_dir(cwd)
-            .output()
-            .into_diagnostic()
-            .wrap_err("failed to read version from git tags")?;
+        let output = command.current_dir(cwd).output().map_err(|error| {
+            miette!(
+                code = aube_codes::errors::ERR_AUBE_GIT_ERROR,
+                "failed to read version from git tags: {error}"
+            )
+        })?;
         if !output.status.success() {
-            if !excluded.is_empty() {
-                return Err(miette!("no valid version tags found for `from-git`"));
-            }
             let stderr = String::from_utf8_lossy(&output.stderr);
             return Err(miette!(
+                code = aube_codes::errors::ERR_AUBE_GIT_ERROR,
                 "git describe failed while resolving `from-git`: {}",
                 stderr.trim()
             ));
         }
-        let tag = String::from_utf8(output.stdout)
-            .into_diagnostic()
-            .wrap_err("git version tag is not UTF-8")?;
+        let tag = String::from_utf8(output.stdout).map_err(|error| {
+            miette!(
+                code = aube_codes::errors::ERR_AUBE_GIT_ERROR,
+                "git version tag is not UTF-8: {error}"
+            )
+        })?;
         let tag = tag.trim();
         let candidate = tag.strip_prefix('v').unwrap_or(tag);
         if let Ok(version) = Version::parse(candidate) {
@@ -692,5 +694,34 @@ mod tests {
         run_git(dir.path(), &["tag", "foo.bar.baz"]).unwrap();
 
         assert_eq!(version_from_git(dir.path()).unwrap(), "3.4.5");
+    }
+
+    #[test]
+    fn reports_git_error_after_excluding_every_non_version_tag() {
+        let dir = tempfile::tempdir().unwrap();
+        run_git(dir.path(), &["init"]).unwrap();
+        std::fs::write(dir.path().join("package.json"), "{}").unwrap();
+        run_git(dir.path(), &["add", "package.json"]).unwrap();
+        run_git(
+            dir.path(),
+            &[
+                "-c",
+                "user.name=aube",
+                "-c",
+                "user.email=aube@example.com",
+                "commit",
+                "-m",
+                "initial",
+            ],
+        )
+        .unwrap();
+        run_git(dir.path(), &["tag", "release-9.9.9"]).unwrap();
+
+        let error = version_from_git(dir.path()).unwrap_err();
+        assert_eq!(
+            error.code().map(|code| code.to_string()).as_deref(),
+            Some(aube_codes::errors::ERR_AUBE_GIT_ERROR)
+        );
+        assert!(error.to_string().contains("git describe failed"));
     }
 }

--- a/crates/aube/src/commands/version.rs
+++ b/crates/aube/src/commands/version.rs
@@ -18,8 +18,8 @@ pub struct VersionArgs {
     ///
     /// Accepts `major`, `minor`, `patch`, `premajor`, `preminor`,
     /// `prepatch`, `prerelease`, `from-git`, or an explicit version.
-    /// `from-git` reads the latest version-like Git tag. When omitted,
-    /// prints the current version.
+    /// `from-git` reads the nearest reachable version-like Git tag.
+    /// When omitted, prints the current version.
     pub new_version: Option<String>,
 
     /// Allow setting the version to its current value without erroring.
@@ -654,13 +654,14 @@ mod tests {
     }
 
     #[test]
-    fn reads_version_from_latest_git_tag() {
+    fn reads_version_from_nearest_reachable_git_tag() {
         let dir = tempfile::tempdir().unwrap();
         run_git(dir.path(), &["init"]).unwrap();
         std::fs::write(dir.path().join("package.json"), "{}").unwrap();
         run_git(dir.path(), &["add", "package.json"]).unwrap();
-        let output = Command::new("git")
-            .args([
+        run_git(
+            dir.path(),
+            &[
                 "-c",
                 "user.name=aube",
                 "-c",
@@ -668,16 +669,15 @@ mod tests {
                 "commit",
                 "-m",
                 "initial",
-            ])
-            .current_dir(dir.path())
-            .output()
-            .unwrap();
-        assert!(output.status.success());
+            ],
+        )
+        .unwrap();
         run_git(dir.path(), &["tag", "v3.4.5"]).unwrap();
         std::fs::write(dir.path().join("package.json"), "{\"name\":\"example\"}").unwrap();
         run_git(dir.path(), &["add", "package.json"]).unwrap();
-        let output = Command::new("git")
-            .args([
+        run_git(
+            dir.path(),
+            &[
                 "-c",
                 "user.name=aube",
                 "-c",
@@ -685,11 +685,9 @@ mod tests {
                 "commit",
                 "-m",
                 "newer",
-            ])
-            .current_dir(dir.path())
-            .output()
-            .unwrap();
-        assert!(output.status.success());
+            ],
+        )
+        .unwrap();
         run_git(dir.path(), &["tag", "release-9.9.9"]).unwrap();
         run_git(dir.path(), &["tag", "foo.bar.baz"]).unwrap();
 

--- a/crates/aube/src/commands/version.rs
+++ b/crates/aube/src/commands/version.rs
@@ -470,6 +470,12 @@ fn version_from_git(cwd: &Path) -> miette::Result<String> {
         if let Ok(version) = Version::parse(candidate) {
             return Ok(version.to_string());
         }
+        if excluded.iter().any(|excluded| excluded == tag) {
+            return Err(miette!(
+                code = aube_codes::errors::ERR_AUBE_GIT_ERROR,
+                "git describe repeatedly returned excluded non-version tag {tag:?}"
+            ));
+        }
         excluded.push(tag.to_string());
     }
 }

--- a/crates/aube/src/commands/version.rs
+++ b/crates/aube/src/commands/version.rs
@@ -438,8 +438,36 @@ fn is_git_repo(cwd: &Path) -> bool {
 }
 
 fn version_from_git(cwd: &Path) -> miette::Result<String> {
-    let output = Command::new("git")
-        .args(["describe", "--tags", "--abbrev=0", "--match=*.*.*"])
+    let tags = Command::new("git")
+        .args(["tag", "--merged", "HEAD"])
+        .current_dir(cwd)
+        .output()
+        .into_diagnostic()
+        .wrap_err("failed to list git tags")?;
+    if !tags.status.success() {
+        let stderr = String::from_utf8_lossy(&tags.stderr);
+        return Err(miette!(
+            "git tag failed while resolving `from-git`: {}",
+            stderr.trim()
+        ));
+    }
+    let tags = String::from_utf8(tags.stdout)
+        .into_diagnostic()
+        .wrap_err("git tags are not UTF-8")?;
+    let version_tags: Vec<&str> = tags
+        .lines()
+        .filter(|tag| Version::parse(tag.strip_prefix('v').unwrap_or(tag)).is_ok())
+        .collect();
+    if version_tags.is_empty() {
+        return Err(miette!("no valid version tags found for `from-git`"));
+    }
+
+    let mut command = Command::new("git");
+    command.args(["describe", "--tags", "--abbrev=0"]);
+    for tag in version_tags {
+        command.arg(format!("--match={tag}"));
+    }
+    let output = command
         .current_dir(cwd)
         .output()
         .into_diagnostic()
@@ -663,6 +691,24 @@ mod tests {
             .unwrap();
         assert!(output.status.success());
         run_git(dir.path(), &["tag", "v3.4.5"]).unwrap();
+        std::fs::write(dir.path().join("package.json"), "{\"name\":\"example\"}").unwrap();
+        run_git(dir.path(), &["add", "package.json"]).unwrap();
+        let output = Command::new("git")
+            .args([
+                "-c",
+                "user.name=aube",
+                "-c",
+                "user.email=aube@example.com",
+                "commit",
+                "-m",
+                "newer",
+            ])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        run_git(dir.path(), &["tag", "release-9.9.9"]).unwrap();
+        run_git(dir.path(), &["tag", "foo.bar.baz"]).unwrap();
 
         assert_eq!(version_from_git(dir.path()).unwrap(), "3.4.5");
     }

--- a/crates/aube/src/commands/version.rs
+++ b/crates/aube/src/commands/version.rs
@@ -9,7 +9,6 @@
 use clap::Args;
 use miette::{Context, IntoDiagnostic, miette};
 use node_semver::{Identifier, Version};
-use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::Path;
 use std::process::Command;
 
@@ -439,85 +438,38 @@ fn is_git_repo(cwd: &Path) -> bool {
 }
 
 fn version_from_git(cwd: &Path) -> miette::Result<String> {
-    let tags = Command::new("git")
-        .args([
-            "for-each-ref",
-            "--merged=HEAD",
-            "--format=%(objectname)%09%(*objectname)%09%(refname:strip=2)",
-            "refs/tags",
-        ])
-        .current_dir(cwd)
-        .output()
-        .into_diagnostic()
-        .wrap_err("failed to list git tags")?;
-    if !tags.status.success() {
-        let stderr = String::from_utf8_lossy(&tags.stderr);
-        return Err(miette!(
-            "git for-each-ref failed while resolving `from-git`: {}",
-            stderr.trim()
-        ));
-    }
-    let tags = String::from_utf8(tags.stdout)
-        .into_diagnostic()
-        .wrap_err("git tags are not UTF-8")?;
-    let mut versions_by_commit: HashMap<&str, Vec<Version>> = HashMap::new();
-    for line in tags.lines() {
-        let mut fields = line.splitn(3, '\t');
-        let object = fields.next().unwrap_or_default();
-        let peeled = fields.next().unwrap_or_default();
-        let tag = fields.next().unwrap_or_default();
-        let commit = if peeled.is_empty() { object } else { peeled };
-        if let Ok(version) = Version::parse(tag.strip_prefix('v').unwrap_or(tag)) {
-            versions_by_commit.entry(commit).or_default().push(version);
+    let mut excluded = Vec::new();
+    loop {
+        let mut command = Command::new("git");
+        command.args(["describe", "--tags", "--abbrev=0", "--match=*.*.*"]);
+        for tag in &excluded {
+            command.arg(format!("--exclude={tag}"));
         }
-    }
-    if versions_by_commit.is_empty() {
-        return Err(miette!("no valid version tags found for `from-git`"));
-    }
-
-    let history = Command::new("git")
-        .args(["rev-list", "--parents", "HEAD"])
-        .current_dir(cwd)
-        .output()
-        .into_diagnostic()
-        .wrap_err("failed to read git history")?;
-    if !history.status.success() {
-        let stderr = String::from_utf8_lossy(&history.stderr);
-        return Err(miette!(
-            "git rev-list failed while resolving `from-git`: {}",
-            stderr.trim()
-        ));
-    }
-    let history = String::from_utf8(history.stdout)
-        .into_diagnostic()
-        .wrap_err("git history is not UTF-8")?;
-    let mut parents = HashMap::new();
-    let mut head = None;
-    for line in history.lines() {
-        let mut fields = line.split_whitespace();
-        let Some(commit) = fields.next() else {
-            continue;
-        };
-        head.get_or_insert(commit);
-        parents.insert(commit, fields.collect::<Vec<_>>());
-    }
-
-    let mut queue = VecDeque::from([head.ok_or_else(|| miette!("git history is empty"))?]);
-    let mut seen = HashSet::new();
-    while let Some(commit) = queue.pop_front() {
-        if !seen.insert(commit) {
-            continue;
+        let output = command
+            .current_dir(cwd)
+            .output()
+            .into_diagnostic()
+            .wrap_err("failed to read version from git tags")?;
+        if !output.status.success() {
+            if !excluded.is_empty() {
+                return Err(miette!("no valid version tags found for `from-git`"));
+            }
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(miette!(
+                "git describe failed while resolving `from-git`: {}",
+                stderr.trim()
+            ));
         }
-        if let Some(versions) = versions_by_commit.get(commit)
-            && let Some(version) = versions.iter().max()
-        {
+        let tag = String::from_utf8(output.stdout)
+            .into_diagnostic()
+            .wrap_err("git version tag is not UTF-8")?;
+        let tag = tag.trim();
+        let candidate = tag.strip_prefix('v').unwrap_or(tag);
+        if let Ok(version) = Version::parse(candidate) {
             return Ok(version.to_string());
         }
-        if let Some(commit_parents) = parents.get(commit) {
-            queue.extend(commit_parents.iter().copied());
-        }
+        excluded.push(tag.to_string());
     }
-    Err(miette!("no reachable version tags found for `from-git`"))
 }
 
 fn git_commit_and_tag(

--- a/crates/aube/src/commands/version.rs
+++ b/crates/aube/src/commands/version.rs
@@ -9,6 +9,7 @@
 use clap::Args;
 use miette::{Context, IntoDiagnostic, miette};
 use node_semver::{Identifier, Version};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::Path;
 use std::process::Command;
 
@@ -439,7 +440,12 @@ fn is_git_repo(cwd: &Path) -> bool {
 
 fn version_from_git(cwd: &Path) -> miette::Result<String> {
     let tags = Command::new("git")
-        .args(["tag", "--merged", "HEAD"])
+        .args([
+            "for-each-ref",
+            "--merged=HEAD",
+            "--format=%(objectname)%09%(*objectname)%09%(refname:strip=2)",
+            "refs/tags",
+        ])
         .current_dir(cwd)
         .output()
         .into_diagnostic()
@@ -447,46 +453,71 @@ fn version_from_git(cwd: &Path) -> miette::Result<String> {
     if !tags.status.success() {
         let stderr = String::from_utf8_lossy(&tags.stderr);
         return Err(miette!(
-            "git tag failed while resolving `from-git`: {}",
+            "git for-each-ref failed while resolving `from-git`: {}",
             stderr.trim()
         ));
     }
     let tags = String::from_utf8(tags.stdout)
         .into_diagnostic()
         .wrap_err("git tags are not UTF-8")?;
-    let version_tags: Vec<&str> = tags
-        .lines()
-        .filter(|tag| Version::parse(tag.strip_prefix('v').unwrap_or(tag)).is_ok())
-        .collect();
-    if version_tags.is_empty() {
+    let mut versions_by_commit: HashMap<&str, Vec<Version>> = HashMap::new();
+    for line in tags.lines() {
+        let mut fields = line.splitn(3, '\t');
+        let object = fields.next().unwrap_or_default();
+        let peeled = fields.next().unwrap_or_default();
+        let tag = fields.next().unwrap_or_default();
+        let commit = if peeled.is_empty() { object } else { peeled };
+        if let Ok(version) = Version::parse(tag.strip_prefix('v').unwrap_or(tag)) {
+            versions_by_commit.entry(commit).or_default().push(version);
+        }
+    }
+    if versions_by_commit.is_empty() {
         return Err(miette!("no valid version tags found for `from-git`"));
     }
 
-    let mut command = Command::new("git");
-    command.args(["describe", "--tags", "--abbrev=0"]);
-    for tag in version_tags {
-        command.arg(format!("--match={tag}"));
-    }
-    let output = command
+    let history = Command::new("git")
+        .args(["rev-list", "--parents", "HEAD"])
         .current_dir(cwd)
         .output()
         .into_diagnostic()
-        .wrap_err("failed to read version from git tags")?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
+        .wrap_err("failed to read git history")?;
+    if !history.status.success() {
+        let stderr = String::from_utf8_lossy(&history.stderr);
         return Err(miette!(
-            "git describe failed while resolving `from-git`: {}",
+            "git rev-list failed while resolving `from-git`: {}",
             stderr.trim()
         ));
     }
-    let tag = String::from_utf8(output.stdout)
+    let history = String::from_utf8(history.stdout)
         .into_diagnostic()
-        .wrap_err("git version tag is not UTF-8")?;
-    let tag = tag.trim();
-    let candidate = tag.strip_prefix('v').unwrap_or(tag);
-    Version::parse(candidate)
-        .map(|version| version.to_string())
-        .map_err(|e| miette!("git tag {tag:?} is not a valid version: {e}"))
+        .wrap_err("git history is not UTF-8")?;
+    let mut parents = HashMap::new();
+    let mut head = None;
+    for line in history.lines() {
+        let mut fields = line.split_whitespace();
+        let Some(commit) = fields.next() else {
+            continue;
+        };
+        head.get_or_insert(commit);
+        parents.insert(commit, fields.collect::<Vec<_>>());
+    }
+
+    let mut queue = VecDeque::from([head.ok_or_else(|| miette!("git history is empty"))?]);
+    let mut seen = HashSet::new();
+    while let Some(commit) = queue.pop_front() {
+        if !seen.insert(commit) {
+            continue;
+        }
+        if let Some(versions) = versions_by_commit.get(commit)
+            && let Some(version) = versions.iter().max()
+        {
+            return Ok(version.to_string());
+        }
+        if let Some(commit_parents) = parents.get(commit) {
+            queue.extend(commit_parents.iter().copied());
+        }
+    }
+    Err(miette!("no reachable version tags found for `from-git`"))
 }
 
 fn git_commit_and_tag(

--- a/crates/aube/src/commands/version.rs
+++ b/crates/aube/src/commands/version.rs
@@ -17,7 +17,8 @@ pub struct VersionArgs {
     /// Bump keyword or an explicit version string.
     ///
     /// Accepts `major`, `minor`, `patch`, `premajor`, `preminor`,
-    /// `prepatch`, `prerelease`, or an explicit version. When omitted,
+    /// `prepatch`, `prerelease`, `from-git`, or an explicit version.
+    /// `from-git` reads the latest version-like Git tag. When omitted,
     /// prints the current version.
     pub new_version: Option<String>,
 
@@ -79,7 +80,12 @@ pub async fn run(args: VersionArgs) -> miette::Result<()> {
         return Ok(());
     };
 
-    let new_version = compute_new_version(&current, bump, args.preid.as_deref())?;
+    let requested = if bump == "from-git" {
+        version_from_git(&cwd)?
+    } else {
+        bump.to_string()
+    };
+    let new_version = compute_new_version(&current, &requested, args.preid.as_deref())?;
     if new_version == current && !args.allow_same_version {
         return Err(miette!(
             "version not changed: already at {current} (pass --allow-same-version to force)"
@@ -431,6 +437,30 @@ fn is_git_repo(cwd: &Path) -> bool {
     matches!(out, Ok(o) if o.status.success())
 }
 
+fn version_from_git(cwd: &Path) -> miette::Result<String> {
+    let output = Command::new("git")
+        .args(["describe", "--tags", "--abbrev=0", "--match=*.*.*"])
+        .current_dir(cwd)
+        .output()
+        .into_diagnostic()
+        .wrap_err("failed to read version from git tags")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(miette!(
+            "git describe failed while resolving `from-git`: {}",
+            stderr.trim()
+        ));
+    }
+    let tag = String::from_utf8(output.stdout)
+        .into_diagnostic()
+        .wrap_err("git version tag is not UTF-8")?;
+    let tag = tag.trim();
+    let candidate = tag.strip_prefix('v').unwrap_or(tag);
+    Version::parse(candidate)
+        .map(|version| version.to_string())
+        .map_err(|e| miette!("git tag {tag:?} is not a valid version: {e}"))
+}
+
 fn git_commit_and_tag(
     cwd: &Path,
     new_version: &str,
@@ -610,5 +640,30 @@ mod tests {
     #[test]
     fn invalid_explicit_rejected() {
         assert!(compute_new_version("1.2.3", "not-a-version", None).is_err());
+    }
+
+    #[test]
+    fn reads_version_from_latest_git_tag() {
+        let dir = tempfile::tempdir().unwrap();
+        run_git(dir.path(), &["init"]).unwrap();
+        std::fs::write(dir.path().join("package.json"), "{}").unwrap();
+        run_git(dir.path(), &["add", "package.json"]).unwrap();
+        let output = Command::new("git")
+            .args([
+                "-c",
+                "user.name=aube",
+                "-c",
+                "user.email=aube@example.com",
+                "commit",
+                "-m",
+                "initial",
+            ])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        run_git(dir.path(), &["tag", "v3.4.5"]).unwrap();
+
+        assert_eq!(version_from_git(dir.path()).unwrap(), "3.4.5");
     }
 }

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -12319,7 +12319,7 @@
             "name": "NEW_VERSION",
             "usage": "[NEW_VERSION]",
             "help": "Bump keyword or an explicit version string",
-            "help_long": "Bump keyword or an explicit version string.\n\nAccepts `major`, `minor`, `patch`, `premajor`, `preminor`, `prepatch`, `prerelease`, or an explicit version. When omitted, prints the current version.",
+            "help_long": "Bump keyword or an explicit version string.\n\nAccepts `major`, `minor`, `patch`, `premajor`, `preminor`, `prepatch`, `prerelease`, `from-git`, or an explicit version. `from-git` reads the nearest reachable version-like Git tag. When omitted, prints the current version.",
             "help_first_line": "Bump keyword or an explicit version string",
             "required": false,
             "double_dash": "Optional",

--- a/docs/cli/version.md
+++ b/docs/cli/version.md
@@ -11,7 +11,7 @@ Bump the version in package.json (and optionally create a git commit + tag)
 
 Bump keyword or an explicit version string.
 
-Accepts `major`, `minor`, `patch`, `premajor`, `preminor`, `prepatch`, `prerelease`, or an explicit version. When omitted, prints the current version.
+Accepts `major`, `minor`, `patch`, `premajor`, `preminor`, `prepatch`, `prerelease`, `from-git`, or an explicit version. `from-git` reads the nearest reachable version-like Git tag. When omitted, prints the current version.
 
 ## Flags
 


### PR DESCRIPTION
## Summary

- accept `from-git` as an `aube version` target
- resolve the latest version-like Git tag with `git describe`
- normalize the conventional leading `v` before using the existing version lifecycle

This matches the `pnpm version from-git` compatibility added in pnpm 11.17.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p aube commands::version::tests` (15 passed)

*This pull request was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the version command and local `git describe`; no registry or auth changes. Wrong tag selection could mis-set `package.json` version if tags are unconventional.
> 
> **Overview**
> Adds **`from-git`** as a `NEW_VERSION` option on `aube version`, aligned with **`pnpm version from-git`**.
> 
> When you pass `from-git`, the command resolves the target version from Git before the existing bump/write lifecycle runs. A new **`version_from_git`** helper runs **`git describe --tags --abbrev=0 --match=*.*.*`**, strips an optional leading **`v`**, and accepts the tag only if it parses as semver. Tags that match the pattern but are not valid versions (e.g. `release-9.9.9`) are excluded and describe is retried; if nothing semver-like remains, it fails with **`ERR_AUBE_GIT_ERROR`**.
> 
> CLI help in **`aube.usage.kdl`**, generated **`docs/cli/commands.json`**, and **`docs/cli/version.md`** document the keyword. Unit tests cover picking **`v3.4.5`** over newer non-semver tags and the all-non-version-tag error path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3199308a88e0386c5ac70597b914639c567d2b8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->