### PR TITLE
security(login): cap web token responses

### DIFF
--- a/crates/aube-codes/src/errors.rs
+++ b/crates/aube-codes/src/errors.rs
@@ -46,6 +46,7 @@ pub const ERR_AUBE_LOW_DOWNLOAD_PACKAGE: &str = "ERR_AUBE_LOW_DOWNLOAD_PACKAGE";
 pub const ERR_AUBE_ADVISORY_CHECK_FAILED: &str = "ERR_AUBE_ADVISORY_CHECK_FAILED";
 pub const ERR_AUBE_SECURITY_SCANNER_FATAL: &str = "ERR_AUBE_SECURITY_SCANNER_FATAL";
 pub const ERR_AUBE_SECURITY_SCANNER_FAILED: &str = "ERR_AUBE_SECURITY_SCANNER_FAILED";
+pub const ERR_AUBE_WEB_LOGIN_RESPONSE_TOO_LARGE: &str = "ERR_AUBE_WEB_LOGIN_RESPONSE_TOO_LARGE";
 
 // ── tarball / store ─────────────────────────────────────────────────
 pub const ERR_AUBE_TARBALL_INTEGRITY: &str = "ERR_AUBE_TARBALL_INTEGRITY";
@@ -293,6 +294,12 @@ pub const ALL: &[CodeMeta] = &[
         category: category::REGISTRY_NETWORK,
         description: "Registry returned 401/403 — missing or invalid auth. Run `aube login`.",
         exit_code: Some(42),
+    },
+    CodeMeta {
+        name: ERR_AUBE_WEB_LOGIN_RESPONSE_TOO_LARGE,
+        category: category::REGISTRY_NETWORK,
+        description: "The web-login token response exceeded the 64 KiB safety limit.",
+        exit_code: None,
     },
     CodeMeta {
         name: ERR_AUBE_OFFLINE,

--- a/crates/aube/src/commands/login.rs
+++ b/crates/aube/src/commands/login.rs
@@ -20,6 +20,8 @@ use miette::{IntoDiagnostic, miette};
 use std::io::{BufRead, IsTerminal};
 use std::time::{Duration, Instant};
 
+const MAX_TOKEN_RESPONSE_BYTES: usize = 64 * 1024;
+
 #[derive(Debug, Args)]
 pub struct LoginArgs {
     /// Authentication flow: `legacy` (token paste; default) or `web`
@@ -228,11 +230,7 @@ async fn poll_done(client: &reqwest::Client, done_url: &str) -> miette::Result<S
                 tokio::time::sleep(delay).await;
             }
             200 => {
-                let body: serde_json::Value = resp
-                    .json()
-                    .await
-                    .into_diagnostic()
-                    .map_err(|e| miette!("failed to parse doneUrl response: {e}"))?;
+                let body = read_token_response(resp).await?;
                 return body
                     .get("token")
                     .and_then(|v| v.as_str())
@@ -244,6 +242,42 @@ async fn poll_done(client: &reqwest::Client, done_url: &str) -> miette::Result<S
             }
         }
     }
+}
+
+async fn read_token_response(mut resp: reqwest::Response) -> miette::Result<serde_json::Value> {
+    if resp
+        .content_length()
+        .is_some_and(|len| len > MAX_TOKEN_RESPONSE_BYTES as u64)
+    {
+        return Err(miette::miette!(
+            code = aube_codes::errors::ERR_AUBE_WEB_LOGIN_RESPONSE_TOO_LARGE,
+            "web login token response exceeds {MAX_TOKEN_RESPONSE_BYTES} bytes"
+        ));
+    }
+
+    let mut body = bytes::BytesMut::with_capacity(
+        resp.content_length()
+            .map(|len| len as usize)
+            .unwrap_or(1024),
+    );
+    while let Some(chunk) = resp
+        .chunk()
+        .await
+        .into_diagnostic()
+        .map_err(|e| miette!("failed to read doneUrl response: {e}"))?
+    {
+        if body.len().saturating_add(chunk.len()) > MAX_TOKEN_RESPONSE_BYTES {
+            return Err(miette::miette!(
+                code = aube_codes::errors::ERR_AUBE_WEB_LOGIN_RESPONSE_TOO_LARGE,
+                "web login token response exceeds {MAX_TOKEN_RESPONSE_BYTES} bytes"
+            ));
+        }
+        body.extend_from_slice(&chunk);
+    }
+
+    serde_json::from_slice(&body)
+        .into_diagnostic()
+        .map_err(|e| miette!("failed to parse doneUrl response: {e}"))
 }
 
 /// Best-effort launch the OS's default browser. Failures are intentionally

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -151,6 +151,12 @@
       "exit_code": 42
     },
     {
+      "name": "ERR_AUBE_WEB_LOGIN_RESPONSE_TOO_LARGE",
+      "category": "Registry / network",
+      "description": "The web-login token response exceeded the 64 KiB safety limit.",
+      "exit_code": null
+    },
+    {
       "name": "ERR_AUBE_OFFLINE",
       "category": "Registry / network",
       "description": "Offline mode and the requested resource isn't in the local cache.",

--- a/test/fixtures/web-login-server.mjs
+++ b/test/fixtures/web-login-server.mjs
@@ -53,7 +53,10 @@ const server = createServer((req, res) => {
 			res.end();
 			return;
 		}
-		const body = JSON.stringify({ token: TOKEN });
+		const token = process.env.MOCK_WEB_LOGIN_OVERSIZED_TOKEN
+			? "x".repeat(64 * 1024)
+			: TOKEN;
+		const body = JSON.stringify({ token });
 		res.writeHead(200, {
 			"content-type": "application/json",
 			"content-length": Buffer.byteLength(body),

--- a/test/fixtures/web-login-server.mjs
+++ b/test/fixtures/web-login-server.mjs
@@ -53,10 +53,20 @@ const server = createServer((req, res) => {
 			res.end();
 			return;
 		}
-		const token = process.env.MOCK_WEB_LOGIN_OVERSIZED_TOKEN
+		const token =
+			process.env.MOCK_WEB_LOGIN_OVERSIZED_TOKEN ||
+			process.env.MOCK_WEB_LOGIN_CHUNKED_TOKEN
 			? "x".repeat(64 * 1024)
 			: TOKEN;
 		const body = JSON.stringify({ token });
+		if (process.env.MOCK_WEB_LOGIN_CHUNKED_TOKEN) {
+			res.writeHead(200, { "content-type": "application/json" });
+			for (let offset = 0; offset < body.length; offset += 4096) {
+				res.write(body.slice(offset, offset + 4096));
+			}
+			res.end();
+			return;
+		}
 		res.writeHead(200, {
 			"content-type": "application/json",
 			"content-length": Buffer.byteLength(body),

--- a/test/login.bats
+++ b/test/login.bats
@@ -115,6 +115,19 @@ teardown() {
 		"//127.0.0.1:$MOCK_WEB_LOGIN_PORT/:_authToken=mock-web-token"
 }
 
+@test "aube login --auth-type=web caps the token response body" {
+	export MOCK_WEB_LOGIN_OVERSIZED_TOKEN=1
+	_start_mock_web_login
+	AUBE_NO_BROWSER=1 run aube login \
+		--auth-type=web \
+		--registry="http://127.0.0.1:$MOCK_WEB_LOGIN_PORT/"
+	assert_failure
+	assert_output --partial "ERR_AUBE_WEB_LOGIN_RESPONSE_TOO_LARGE"
+	assert_output --partial "exceeds 65536 bytes"
+	run grep "_authToken" "$HOME/.npmrc"
+	assert_failure
+}
+
 @test "aube login --auth-type=web --scope writes the scope mapping" {
 	_start_mock_web_login
 	AUBE_NO_BROWSER=1 run aube login \

--- a/test/login.bats
+++ b/test/login.bats
@@ -128,6 +128,19 @@ teardown() {
 	assert_failure
 }
 
+@test "aube login --auth-type=web caps a chunked token response body" {
+	export MOCK_WEB_LOGIN_CHUNKED_TOKEN=1
+	_start_mock_web_login
+	AUBE_NO_BROWSER=1 run aube login \
+		--auth-type=web \
+		--registry="http://127.0.0.1:$MOCK_WEB_LOGIN_PORT/"
+	assert_failure
+	assert_output --partial "ERR_AUBE_WEB_LOGIN_RESPONSE_TOO_LARGE"
+	assert_output --partial "exceeds 65536 bytes"
+	run grep "_authToken" "$HOME/.npmrc"
+	assert_failure
+}
+
 @test "aube login --auth-type=web --scope writes the scope mapping" {
 	_start_mock_web_login
 	AUBE_NO_BROWSER=1 run aube login \


### PR DESCRIPTION
## Summary

- cap successful web-login token responses at 64 KiB
- enforce the limit for both declared and chunked response bodies
- emit stable `ERR_AUBE_WEB_LOGIN_RESPONSE_TOO_LARGE` diagnostics
- verify oversized responses never persist a registry token

## Why

A malicious or compromised registry could previously return an unbounded successful token response and force aube to buffer it through `Response::json`. This mirrors the hardening shipped in pnpm 11.17.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p aube-codes` (7 passed)
- `mise run test:bats test/login.bats` (15 passed)

*This pull request was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth/login against untrusted registries; the change is defensive (bounded reads, fail-closed) with focused tests and mirrors prior pnpm hardening.
> 
> **Overview**
> **Web login** no longer buffers unbounded `doneUrl` bodies: successful token responses are capped at **64 KiB** via streamed reads instead of `Response::json()`, with the same limit applied when `Content-Length` is oversized and while reading **chunked** bodies.
> 
> Failures surface **`ERR_AUBE_WEB_LOGIN_RESPONSE_TOO_LARGE`** (registered in `aube-codes` and error docs). Bats cover oversized and chunked mock responses and assert **`~/.npmrc` is not updated** when the cap trips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41002904041f9493e993d79e75e9f5fccad55283. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->