### PR TITLE
feat(settings): adopt canonical update and audit sections

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -233,8 +233,8 @@ cmd approve-builds help="Approve ignored dependency build scripts" {
 }
 cmd audit help="Check installed packages against the registry advisory DB" {
     after_long_help "Examples:\n\n  $ aube audit\n  Severity  Package    Vulnerable  Title\n  moderate  minimatch  <3.0.5      Regular Expression Denial of Service\n                                   https://github.com/advisories/GHSA-f8q6-p94x\n\n  1 vulnerability found\n\n  # Only fail on high and above\n  $ aube audit --audit-level high\n\n  # Skip optional deps and dev deps\n  $ aube audit --prod --no-optional\n\n  # Pipe into jq\n  $ aube audit --json | jq '.advisories | length'\n\n  # Clean\n  $ aube audit\n  No known vulnerabilities found\n"
-    flag --audit-level help="Only print advisories at or above this severity" default=low {
-        long_help "Only print advisories at or above this severity.\n\nOne of: `info`, `low`, `moderate`, `high`, `critical`. Default: `low`."
+    flag --audit-level help="Only print advisories at or above this severity" {
+        long_help "Only print advisories at or above this severity.\n\nOne of: `info`, `low`, `moderate`, `high`, `critical`. Defaults to `audit.level` (or legacy `auditLevel`), then `low`."
         arg <AUDIT_LEVEL> {
             choices info low moderate high critical
         }

--- a/crates/aube-manifest/src/workspace/config.rs
+++ b/crates/aube-manifest/src/workspace/config.rs
@@ -59,6 +59,31 @@ pub struct JailBuildPermission {
     pub network: bool,
 }
 
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceUpdateConfig {
+    #[serde(default)]
+    pub ignore_deps: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceAuditConfig {
+    #[serde(default)]
+    pub level: Option<String>,
+    #[serde(default)]
+    pub ignore: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyWorkspaceAuditConfig {
+    #[serde(default)]
+    pub ignore_ghsas: Vec<String>,
+    #[serde(default)]
+    pub ignore_cves: Vec<String>,
+}
+
 /// Configuration from `pnpm-workspace.yaml`.
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -260,6 +285,22 @@ pub struct WorkspaceConfig {
     /// Update-time policy knobs.
     #[serde(default)]
     pub update_config: Option<UpdateConfig>,
+
+    /// Canonical pnpm 11.16+ update policy.
+    #[serde(default)]
+    pub update: Option<WorkspaceUpdateConfig>,
+
+    /// Canonical pnpm 11.16+ audit policy.
+    #[serde(default)]
+    pub audit: Option<WorkspaceAuditConfig>,
+
+    /// Deprecated audit policy, retained for pnpm 11 compatibility.
+    #[serde(default)]
+    pub audit_config: Option<LegacyWorkspaceAuditConfig>,
+
+    /// Deprecated audit severity, retained for pnpm 11 compatibility.
+    #[serde(default)]
+    pub audit_level: Option<String>,
 
     /// Node.js download mirror map (pnpm parity), keyed by channel:
     /// `release` is used for runtime downloads; `rc`/`nightly` are

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -110,7 +110,7 @@ examples = [
 ]
 
 ["updateConfig.ignoreDependencies"]
-description = "List of packages to ignore during update checks."
+description = "Deprecated list of packages to ignore during update checks."
 type = "list<string>"
 default = "undefined"
 docs = """
@@ -121,6 +121,71 @@ sources.cli = []
 sources.env = ["npm_config_update_config_ignore_dependencies", "NPM_CONFIG_UPDATE_CONFIG_IGNORE_DEPENDENCIES", "AUBE_UPDATE_CONFIG_IGNORE_DEPENDENCIES"]
 sources.npmrc = ["updateConfig.ignoreDependencies"]
 sources.workspaceYaml = ["updateConfig.ignoreDependencies"]
+examples = []
+
+["update.ignoreDeps"]
+description = "List of packages to ignore during update checks."
+type = "list<string>"
+default = "undefined"
+docs = """
+Packages in this list are never bumped by `aube update` or reported by
+`aube outdated`. This is the canonical pnpm 11.16+ spelling and takes
+precedence over `updateConfig.ignoreDependencies`.
+"""
+sources.cli = []
+sources.env = ["npm_config_update_ignore_deps", "NPM_CONFIG_UPDATE_IGNORE_DEPS", "AUBE_UPDATE_IGNORE_DEPS"]
+sources.npmrc = ["update.ignoreDeps"]
+sources.workspaceYaml = ["update.ignoreDeps"]
+examples = []
+
+["audit.level"]
+description = "Minimum advisory severity reported by audit."
+type = "string"
+default = "undefined"
+docs = """
+Sets the default severity threshold for `aube audit`. A command-line
+`--audit-level` value takes precedence.
+"""
+sources.cli = []
+sources.env = ["npm_config_audit_level", "NPM_CONFIG_AUDIT_LEVEL", "AUBE_AUDIT_LEVEL"]
+sources.npmrc = ["audit.level", "audit-level"]
+sources.workspaceYaml = ["audit.level"]
+examples = []
+
+["audit.ignore"]
+description = "Advisory identifiers ignored by audit."
+type = "list<string>"
+default = "undefined"
+docs = """
+Advisory IDs in this list are filtered from `aube audit`. Values may be
+numeric npm advisory IDs, GHSA identifiers, or CVE identifiers.
+"""
+sources.cli = []
+sources.env = ["npm_config_audit_ignore", "NPM_CONFIG_AUDIT_IGNORE", "AUBE_AUDIT_IGNORE"]
+sources.npmrc = ["audit.ignore"]
+sources.workspaceYaml = ["audit.ignore"]
+examples = []
+
+["auditConfig.ignoreGhsas"]
+description = "Deprecated list of GHSA identifiers ignored by audit."
+type = "list<string>"
+default = "undefined"
+docs = "Use `audit.ignore` instead."
+sources.cli = []
+sources.env = []
+sources.npmrc = ["auditConfig.ignoreGhsas"]
+sources.workspaceYaml = ["auditConfig.ignoreGhsas"]
+examples = []
+
+["auditConfig.ignoreCves"]
+description = "Deprecated list of CVE identifiers ignored by audit."
+type = "list<string>"
+default = "undefined"
+docs = "Use `audit.ignore` instead."
+sources.cli = []
+sources.env = []
+sources.npmrc = ["auditConfig.ignoreCves"]
+sources.workspaceYaml = ["auditConfig.ignoreCves"]
 examples = []
 
 [supportedArchitectures]

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -51,7 +51,8 @@ Examples:
 pub struct AuditArgs {
     /// Only print advisories at or above this severity.
     ///
-    /// One of: `info`, `low`, `moderate`, `high`, `critical`. Default: `low`.
+    /// One of: `info`, `low`, `moderate`, `high`, `critical`.
+    /// Defaults to `audit.level` (or legacy `auditLevel`), then `low`.
     #[arg(long, value_enum)]
     pub audit_level: Option<Severity>,
 
@@ -457,18 +458,20 @@ fn resolve_audit_level(cwd: &std::path::Path, cli: Option<Severity>) -> miette::
     if let Some(level) = cli {
         return Ok(level);
     }
-    let configured =
-        with_audit_settings_ctx(cwd, aube_settings::resolved::audit_level)?.or_else(|| {
+    let configured = with_audit_settings_ctx(cwd, aube_settings::resolved::audit_level)?
+        .map(|value| ("audit.level", value))
+        .or_else(|| {
             let yaml_root =
                 crate::dirs::find_workspace_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
             let raw = aube_manifest::workspace::load_raw(&yaml_root).ok()?;
             aube_settings::workspace_yaml_value(&raw, "auditLevel")
                 .and_then(yaml_serde::Value::as_str)
-                .map(str::to_string)
+                .map(|value| ("auditLevel", value.to_string()))
         });
-    configured.map_or(Ok(Severity::Low), |raw| {
-        raw.parse::<Severity>()
-            .map_err(|_| miette!("invalid audit.level {raw:?}"))
+    configured.map_or(Ok(Severity::Low), |(key, raw)| {
+        raw.parse::<Severity>().map_err(|_| {
+            miette!("invalid {key} {raw:?}; expected one of: info, low, moderate, high, critical")
+        })
     })
 }
 
@@ -1538,6 +1541,22 @@ mod tests {
             resolve_audit_level(dir.path(), None).unwrap(),
             Severity::High
         );
+    }
+
+    #[test]
+    fn invalid_legacy_audit_level_names_key_and_expected_values() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("pnpm-workspace.yaml"),
+            "packages: []\nauditLevel: severe\n",
+        )
+        .unwrap();
+
+        let error = resolve_audit_level(dir.path(), None)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("invalid auditLevel \"severe\""));
+        assert!(error.contains("info, low, moderate, high, critical"));
     }
 
     #[test]

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -1445,8 +1445,9 @@ mod tests {
 
     #[test]
     fn configured_audit_ignores_reads_ghsa_and_legacy_cve_keys() {
+        let dir = tempfile::tempdir().unwrap();
         let manifest = aube_manifest::PackageJson::parse(
-            std::path::Path::new("package.json"),
+            &dir.path().join("package.json"),
             r#"{
               "name": "demo",
               "version": "1.0.0",
@@ -1459,8 +1460,7 @@ mod tests {
         )
         .unwrap();
         let ignores =
-            configured_audit_ignores(std::path::Path::new("."), &manifest, &["1404".to_string()])
-                .unwrap();
+            configured_audit_ignores(dir.path(), &manifest, &["1404".to_string()]).unwrap();
         assert_eq!(
             ignores,
             vec![

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -52,8 +52,8 @@ pub struct AuditArgs {
     /// Only print advisories at or above this severity.
     ///
     /// One of: `info`, `low`, `moderate`, `high`, `critical`. Default: `low`.
-    #[arg(long, value_enum, default_value_t = Severity::Low)]
-    pub audit_level: Severity,
+    #[arg(long, value_enum)]
+    pub audit_level: Option<Severity>,
 
     /// Only audit `devDependencies`.
     #[arg(short = 'D', long, conflicts_with = "prod")]
@@ -153,6 +153,7 @@ pub enum FixMode {
 pub async fn run(args: AuditArgs) -> miette::Result<Option<i32>> {
     args.network.install_overrides();
     let cwd = crate::dirs::project_root()?;
+    let audit_level = resolve_audit_level(&cwd, args.audit_level)?;
 
     let manifest = super::load_manifest(&cwd.join("package.json"))?;
 
@@ -185,7 +186,7 @@ pub async fn run(args: AuditArgs) -> miette::Result<Option<i32>> {
             // so `.advisories` / `.metadata` are always present.
             let report = build_audit_report(
                 &serde_json::json!({}),
-                args.audit_level,
+                audit_level,
                 count_dependencies(&graph, filter, args.no_optional, &closure),
             );
             let out = serde_json::to_string_pretty(&report).into_diagnostic()?;
@@ -239,7 +240,7 @@ pub async fn run(args: AuditArgs) -> miette::Result<Option<i32>> {
         }
     };
 
-    let ignored_ids = configured_audit_ignores(&manifest, &args.ignore);
+    let ignored_ids = configured_audit_ignores(&cwd, &manifest, &args.ignore)?;
 
     // `--ignore` / auditConfig ignores are cheap JSON filters. Run
     // them first so we don't bother fetching packuments for advisories
@@ -258,14 +259,14 @@ pub async fn run(args: AuditArgs) -> miette::Result<Option<i32>> {
         filter_unfixable(
             &raw,
             &client,
-            unfixable_filter_threshold(args.json, args.audit_level),
+            unfixable_filter_threshold(args.json, audit_level),
         )
         .await?
     } else {
         raw
     };
 
-    let rows = flatten_advisories(&raw, args.audit_level);
+    let rows = flatten_advisories(&raw, audit_level);
 
     if args.interactive && args.json {
         return Err(miette!("--interactive cannot be used with --json"));
@@ -319,7 +320,7 @@ pub async fn run(args: AuditArgs) -> miette::Result<Option<i32>> {
         // additionally level-filtered.
         let report = build_audit_report(
             &raw,
-            args.audit_level,
+            audit_level,
             count_dependencies(&graph, filter, args.no_optional, &closure),
         );
         let out = serde_json::to_string_pretty(&report).into_diagnostic()?;
@@ -423,21 +424,63 @@ fn build_client(cwd: &std::path::Path, registry_override: Option<&str>) -> Regis
 /// so users can pass either `GHSA-abcd-...` or the same in uppercase
 /// / lowercase, or the CVE form. Packages whose advisories all get
 /// filtered out drop from the response entirely.
-fn configured_audit_ignores(manifest: &aube_manifest::PackageJson, cli: &[String]) -> Vec<String> {
+fn configured_audit_ignores(
+    cwd: &std::path::Path,
+    manifest: &aube_manifest::PackageJson,
+    cli: &[String],
+) -> miette::Result<Vec<String>> {
     let mut out = cli.to_vec();
-    let Some(config) = manifest
+    if let Some(config) = manifest
         .extra
         .get("auditConfig")
         .and_then(|v| v.as_object())
-    else {
-        return out;
-    };
-    for key in ["ignoreGhsas", "ignoreCves"] {
-        if let Some(values) = config.get(key).and_then(|v| v.as_array()) {
-            out.extend(values.iter().filter_map(|v| v.as_str().map(str::to_string)));
+    {
+        for key in ["ignoreGhsas", "ignoreCves"] {
+            if let Some(values) = config.get(key).and_then(|v| v.as_array()) {
+                out.extend(values.iter().filter_map(|v| v.as_str().map(str::to_string)));
+            }
         }
     }
-    out
+    with_audit_settings_ctx(cwd, |ctx| {
+        if let Some(canonical) = aube_settings::resolved::audit_ignore(ctx) {
+            out.extend(canonical);
+        } else {
+            out.extend(aube_settings::resolved::audit_config_ignore_ghsas(ctx).unwrap_or_default());
+            out.extend(aube_settings::resolved::audit_config_ignore_cves(ctx).unwrap_or_default());
+        }
+    })?;
+    Ok(out)
+}
+
+fn resolve_audit_level(cwd: &std::path::Path, cli: Option<Severity>) -> miette::Result<Severity> {
+    if let Some(level) = cli {
+        return Ok(level);
+    }
+    let configured =
+        with_audit_settings_ctx(cwd, aube_settings::resolved::audit_level)?.or_else(|| {
+            let yaml_root =
+                crate::dirs::find_workspace_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
+            let raw = aube_manifest::workspace::load_raw(&yaml_root).ok()?;
+            aube_settings::values::string_from_workspace_yaml("auditLevel", &raw)
+        });
+    configured.map_or(Ok(Severity::Low), |raw| {
+        raw.parse::<Severity>()
+            .map_err(|_| miette!("invalid audit.level {raw:?}"))
+    })
+}
+
+fn with_audit_settings_ctx<T>(
+    cwd: &std::path::Path,
+    f: impl FnOnce(&aube_settings::ResolveCtx<'_>) -> T,
+) -> miette::Result<T> {
+    let files = crate::commands::FileSources::load(cwd);
+    let yaml_root = crate::dirs::find_workspace_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
+    let (_workspace_config, raw_workspace) = aube_manifest::workspace::load_both(&yaml_root)
+        .into_diagnostic()
+        .wrap_err("failed to read workspace config")?;
+    let env = aube_settings::values::process_env();
+    let ctx = files.ctx(&raw_workspace, env, &[]);
+    Ok(f(&ctx))
 }
 
 fn filter_ignored_ids(v: &serde_json::Value, ignore: &[String]) -> serde_json::Value {
@@ -1411,7 +1454,9 @@ mod tests {
             .to_string(),
         )
         .unwrap();
-        let ignores = configured_audit_ignores(&manifest, &["1404".to_string()]);
+        let ignores =
+            configured_audit_ignores(std::path::Path::new("."), &manifest, &["1404".to_string()])
+                .unwrap();
         assert_eq!(
             ignores,
             vec![
@@ -1419,6 +1464,41 @@ mod tests {
                 "GHSA-aaaa-bbbb-cccc".to_string(),
                 "CVE-2099-0001".to_string()
             ]
+        );
+    }
+
+    #[test]
+    fn reads_canonical_audit_workspace_settings() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("pnpm-workspace.yaml"),
+            "packages: []\naudit:\n  level: critical\n  ignore:\n    - GHSA-aaaa-bbbb-cccc\n",
+        )
+        .unwrap();
+        let manifest = aube_manifest::PackageJson::default();
+
+        assert_eq!(
+            resolve_audit_level(dir.path(), None).unwrap(),
+            Severity::Critical
+        );
+        assert_eq!(
+            configured_audit_ignores(dir.path(), &manifest, &[]).unwrap(),
+            vec!["GHSA-aaaa-bbbb-cccc".to_string()]
+        );
+    }
+
+    #[test]
+    fn audit_cli_level_overrides_workspace_setting() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("pnpm-workspace.yaml"),
+            "packages: []\naudit:\n  level: critical\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            resolve_audit_level(dir.path(), Some(Severity::Low)).unwrap(),
+            Severity::Low
         );
     }
 

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -430,25 +430,26 @@ fn configured_audit_ignores(
     cli: &[String],
 ) -> miette::Result<Vec<String>> {
     let mut out = cli.to_vec();
-    if let Some(config) = manifest
-        .extra
-        .get("auditConfig")
-        .and_then(|v| v.as_object())
-    {
-        for key in ["ignoreGhsas", "ignoreCves"] {
-            if let Some(values) = config.get(key).and_then(|v| v.as_array()) {
-                out.extend(values.iter().filter_map(|v| v.as_str().map(str::to_string)));
+    let canonical = with_audit_settings_ctx(cwd, aube_settings::resolved::audit_ignore)?;
+    if let Some(canonical) = canonical {
+        out.extend(canonical);
+    } else {
+        if let Some(config) = manifest
+            .extra
+            .get("auditConfig")
+            .and_then(|v| v.as_object())
+        {
+            for key in ["ignoreGhsas", "ignoreCves"] {
+                if let Some(values) = config.get(key).and_then(|v| v.as_array()) {
+                    out.extend(values.iter().filter_map(|v| v.as_str().map(str::to_string)));
+                }
             }
         }
-    }
-    with_audit_settings_ctx(cwd, |ctx| {
-        if let Some(canonical) = aube_settings::resolved::audit_ignore(ctx) {
-            out.extend(canonical);
-        } else {
+        with_audit_settings_ctx(cwd, |ctx| {
             out.extend(aube_settings::resolved::audit_config_ignore_ghsas(ctx).unwrap_or_default());
             out.extend(aube_settings::resolved::audit_config_ignore_cves(ctx).unwrap_or_default());
-        }
-    })?;
+        })?;
+    }
     Ok(out)
 }
 
@@ -1486,6 +1487,26 @@ mod tests {
         assert_eq!(
             configured_audit_ignores(dir.path(), &manifest, &[]).unwrap(),
             vec!["GHSA-aaaa-bbbb-cccc".to_string()]
+        );
+    }
+
+    #[test]
+    fn canonical_audit_ignore_replaces_package_json_legacy_values() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("pnpm-workspace.yaml"),
+            "packages: []\naudit:\n  ignore:\n    - GHSA-canonical\n",
+        )
+        .unwrap();
+        let manifest = aube_manifest::PackageJson::parse(
+            &dir.path().join("package.json"),
+            r#"{"auditConfig":{"ignoreGhsas":["GHSA-legacy"]}}"#.to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            configured_audit_ignores(dir.path(), &manifest, &["CLI-IGNORE".to_string()]).unwrap(),
+            vec!["CLI-IGNORE".to_string(), "GHSA-canonical".to_string()]
         );
     }
 

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -479,11 +479,9 @@ fn with_audit_settings_ctx<T>(
     cwd: &std::path::Path,
     f: impl FnOnce(&aube_settings::ResolveCtx<'_>) -> T,
 ) -> miette::Result<T> {
-    let files = crate::commands::FileSources::load(cwd);
     let yaml_root = crate::dirs::find_workspace_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
-    let raw_workspace = aube_manifest::workspace::load_raw(&yaml_root)
-        .into_diagnostic()
-        .wrap_err("failed to read workspace config")?;
+    let files = crate::commands::FileSources::load(&yaml_root);
+    let raw_workspace = aube_manifest::workspace::load_raw(&yaml_root).unwrap_or_default();
     let env = aube_settings::values::process_env();
     let ctx = files.ctx(&raw_workspace, env, &[]);
     Ok(f(&ctx))
@@ -1470,6 +1468,22 @@ mod tests {
                 "GHSA-aaaa-bbbb-cccc".to_string(),
                 "CVE-2099-0001".to_string()
             ]
+        );
+    }
+
+    #[test]
+    fn malformed_workspace_yaml_does_not_block_legacy_audit_ignores() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("pnpm-workspace.yaml"), "packages: [\n").unwrap();
+        let manifest = aube_manifest::PackageJson::parse(
+            &dir.path().join("package.json"),
+            r#"{"auditConfig":{"ignoreGhsas":["GHSA-legacy"]}}"#.to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            configured_audit_ignores(dir.path(), &manifest, &[]).unwrap(),
+            vec!["GHSA-legacy".to_string()]
         );
     }
 

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -461,7 +461,9 @@ fn resolve_audit_level(cwd: &std::path::Path, cli: Option<Severity>) -> miette::
             let yaml_root =
                 crate::dirs::find_workspace_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
             let raw = aube_manifest::workspace::load_raw(&yaml_root).ok()?;
-            aube_settings::values::string_from_workspace_yaml("auditLevel", &raw)
+            aube_settings::workspace_yaml_value(&raw, "auditLevel")
+                .and_then(yaml_serde::Value::as_str)
+                .map(str::to_string)
         });
     configured.map_or(Ok(Severity::Low), |raw| {
         raw.parse::<Severity>()
@@ -1499,6 +1501,21 @@ mod tests {
         assert_eq!(
             resolve_audit_level(dir.path(), Some(Severity::Low)).unwrap(),
             Severity::Low
+        );
+    }
+
+    #[test]
+    fn reads_legacy_top_level_audit_level() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("pnpm-workspace.yaml"),
+            "packages: []\nauditLevel: high\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            resolve_audit_level(dir.path(), None).unwrap(),
+            Severity::High
         );
     }
 

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -481,7 +481,7 @@ fn with_audit_settings_ctx<T>(
 ) -> miette::Result<T> {
     let files = crate::commands::FileSources::load(cwd);
     let yaml_root = crate::dirs::find_workspace_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
-    let (_workspace_config, raw_workspace) = aube_manifest::workspace::load_both(&yaml_root)
+    let raw_workspace = aube_manifest::workspace::load_raw(&yaml_root)
         .into_diagnostic()
         .wrap_err("failed to read workspace config")?;
     let env = aube_settings::values::process_env();

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -481,7 +481,14 @@ fn with_audit_settings_ctx<T>(
 ) -> miette::Result<T> {
     let yaml_root = crate::dirs::find_workspace_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
     let files = crate::commands::FileSources::load(&yaml_root);
-    let raw_workspace = aube_manifest::workspace::load_raw(&yaml_root).unwrap_or_default();
+    let raw_workspace = aube_manifest::workspace::load_raw(&yaml_root).unwrap_or_else(|error| {
+        tracing::debug!(
+            %error,
+            workspace_root = %yaml_root.display(),
+            "ignoring invalid workspace config while resolving audit settings"
+        );
+        BTreeMap::new()
+    });
     let env = aube_settings::values::process_env();
     let ctx = files.ctx(&raw_workspace, env, &[]);
     Ok(f(&ctx))

--- a/crates/aube/src/commands/outdated.rs
+++ b/crates/aube/src/commands/outdated.rs
@@ -200,6 +200,12 @@ async fn run_filtered(
             .get(&importer_path)
             .map(Vec::as_slice)
             .unwrap_or(&[]);
+        let ignored = super::update::ignored_update_dependencies(&pkg.dir, &pkg.manifest)?;
+        let selected_roots: Vec<DirectDep> = roots
+            .iter()
+            .filter(|dep| !ignored.contains(&dep.name))
+            .cloned()
+            .collect();
         // Discussion #602: separate per-importer tables with a blank
         // line so the headers don't pile up against each other when
         // every workspace package has drift. JSON output is suppressed
@@ -211,7 +217,7 @@ async fn run_filtered(
             &root,
             args.clone_for_fanout(),
             &graph,
-            roots,
+            &selected_roots,
             Some(importer),
         )
         .await?;
@@ -326,6 +332,7 @@ async fn run_global(args: OutdatedArgs) -> miette::Result<Option<i32>> {
 
 async fn run_one(cwd: &Path, args: OutdatedArgs, importer: Option<String>) -> miette::Result<bool> {
     let manifest = super::load_manifest(&cwd.join("package.json"))?;
+    let ignored = super::update::ignored_update_dependencies(cwd, &manifest)?;
 
     let graph = match aube_lockfile::parse_lockfile(cwd, &manifest) {
         Ok(g) => g,
@@ -339,7 +346,13 @@ async fn run_one(cwd: &Path, args: OutdatedArgs, importer: Option<String>) -> mi
         Err(e) => return Err(miette::Report::new(e)).wrap_err("failed to parse lockfile"),
     };
 
-    run_graph(cwd, args, &graph, graph.root_deps(), importer).await
+    let roots: Vec<DirectDep> = graph
+        .root_deps()
+        .iter()
+        .filter(|dep| !ignored.contains(&dep.name))
+        .cloned()
+        .collect();
+    run_graph(cwd, args, &graph, &roots, importer).await
 }
 
 async fn run_graph(

--- a/crates/aube/src/commands/outdated.rs
+++ b/crates/aube/src/commands/outdated.rs
@@ -14,7 +14,7 @@ use aube_registry::Packument;
 use clap::Args;
 use miette::{Context, IntoDiagnostic};
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 
 pub const AFTER_LONG_HELP: &str = "\
@@ -189,6 +189,16 @@ async fn run_filtered(
     };
     let mut any_drift = false;
     let mut printed_table = false;
+    let root_files = super::FileSources::load(&root);
+    let raw_workspace = aube_manifest::workspace::load_raw(&root).unwrap_or_else(|error| {
+        tracing::debug!(
+            %error,
+            workspace_root = %root.display(),
+            "ignoring invalid workspace config while resolving outdated settings"
+        );
+        BTreeMap::new()
+    });
+    let env = aube_settings::values::process_env();
     for pkg in matched {
         let importer = pkg
             .name
@@ -200,7 +210,12 @@ async fn run_filtered(
             .get(&importer_path)
             .map(Vec::as_slice)
             .unwrap_or(&[]);
-        let ignored = super::update::ignored_update_dependencies(&pkg.dir, &pkg.manifest)?;
+        let mut files = root_files.clone();
+        if pkg.dir != root {
+            files.extend_project_sources(&pkg.dir);
+        }
+        let ctx = files.ctx(&raw_workspace, env, &[]);
+        let ignored = super::update::ignored_update_dependencies_from_ctx(&ctx, &pkg.manifest);
         let selected_roots: Vec<DirectDep> = roots
             .iter()
             .filter(|dep| !ignored.contains(&dep.name))

--- a/crates/aube/src/commands/settings_context.rs
+++ b/crates/aube/src/commands/settings_context.rs
@@ -114,6 +114,7 @@ pub(crate) fn global_output_flags() -> GlobalOutputFlags {
 /// [`aube_settings::ResolveCtx`]: managed config, project + user `.npmrc`,
 /// and project + user `~/.config/aube/config.toml`. Construct once with
 /// `FileSources::load`, borrow into a `ResolveCtx` via `FileSources::ctx`.
+#[derive(Clone)]
 pub(crate) struct FileSources {
     pub managed_aube_config: Vec<(String, String)>,
     pub user_npmrc: Vec<(String, String)>,
@@ -132,6 +133,13 @@ impl FileSources {
             user_aube_config: config::load_user_aube_config_entries(),
             project_aube_config: config::load_project_aube_config_entries(cwd),
         }
+    }
+
+    pub(crate) fn extend_project_sources(&mut self, cwd: &Path) {
+        let npmrc = aube_registry::config::load_npmrc_entries_split(cwd);
+        self.project_npmrc.extend(npmrc.project);
+        self.project_aube_config
+            .extend(config::load_project_aube_config_entries(cwd));
     }
 
     pub(crate) fn ctx<'a>(

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -1173,14 +1173,21 @@ pub(super) fn ignored_update_dependencies(
     cwd: &std::path::Path,
     manifest: &aube_manifest::PackageJson,
 ) -> miette::Result<BTreeSet<String>> {
-    let mut ignored: BTreeSet<String> = manifest.update_ignore_dependencies().into_iter().collect();
-    with_update_settings_ctx(cwd, |ctx| {
-        if let Some(from_settings) = aube_settings::resolved::update_ignore_deps(ctx)
-            .or_else(|| aube_settings::resolved::update_config_ignore_dependencies(ctx))
-        {
-            ignored.extend(from_settings);
-        }
+    let configured = with_update_settings_ctx(cwd, |ctx| {
+        aube_settings::resolved::update_ignore_deps(ctx)
+            .map(|canonical| (true, canonical))
+            .or_else(|| {
+                aube_settings::resolved::update_config_ignore_dependencies(ctx)
+                    .map(|legacy| (false, legacy))
+            })
     })?;
+    if let Some((true, canonical)) = configured {
+        return Ok(canonical.into_iter().collect());
+    }
+    let mut ignored: BTreeSet<String> = manifest.update_ignore_dependencies().into_iter().collect();
+    if let Some((false, legacy)) = configured {
+        ignored.extend(legacy);
+    }
     Ok(ignored)
 }
 
@@ -1677,6 +1684,26 @@ fn exact_pin_version(spec: &str) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn canonical_update_ignores_replace_package_json_legacy_values() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("pnpm-workspace.yaml"),
+            "packages: []\nupdate:\n  ignoreDeps:\n    - canonical\n",
+        )
+        .unwrap();
+        let manifest = aube_manifest::PackageJson::parse(
+            &dir.path().join("package.json"),
+            r#"{"updateConfig":{"ignoreDependencies":["legacy"]}}"#.to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            ignored_update_dependencies(dir.path(), &manifest).unwrap(),
+            BTreeSet::from(["canonical".to_string()])
+        );
+    }
 
     fn locked(name: &str, version: &str) -> aube_lockfile::LockedPackage {
         aube_lockfile::LockedPackage {

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -1224,7 +1224,14 @@ fn with_update_settings_ctx<T>(
             .project_aube_config
             .extend(member_files.project_aube_config);
     }
-    let raw_workspace = aube_manifest::workspace::load_raw(&yaml_root).unwrap_or_default();
+    let raw_workspace = aube_manifest::workspace::load_raw(&yaml_root).unwrap_or_else(|error| {
+        tracing::debug!(
+            %error,
+            workspace_root = %yaml_root.display(),
+            "ignoring invalid workspace config while resolving update settings"
+        );
+        BTreeMap::new()
+    });
     let env = aube_settings::values::process_env();
     let ctx = files.ctx(&raw_workspace, env, &[]);
     Ok(f(&ctx))

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -1215,7 +1215,7 @@ fn with_update_settings_ctx<T>(
     // recursive picker because of this miss. Fall back to cwd if no
     // workspace root is found (single-project case).
     let yaml_root = crate::dirs::find_workspace_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
-    let (_workspace_config, raw_workspace) = aube_manifest::workspace::load_both(&yaml_root)
+    let raw_workspace = aube_manifest::workspace::load_raw(&yaml_root)
         .into_diagnostic()
         .wrap_err("failed to read workspace config")?;
     let env = aube_settings::values::process_env();

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -297,9 +297,7 @@ pub async fn run(
         for name in packages {
             if all_specifiers.contains_key(name.as_str()) {
                 if ignored_updates.contains(name.as_str()) {
-                    return Err(miette!(
-                        "package '{name}' is ignored by updateConfig.ignoreDependencies"
-                    ));
+                    return Err(miette!("package '{name}' is ignored by update.ignoreDeps"));
                 }
                 continue;
             }
@@ -321,9 +319,7 @@ pub async fn run(
                 return Err(miette!("package '{name}' is not a dependency"));
             }
             if ignored_updates.contains(name.as_str()) {
-                return Err(miette!(
-                    "package '{name}' is ignored by updateConfig.ignoreDependencies"
-                ));
+                return Err(miette!("package '{name}' is ignored by update.ignoreDeps"));
             }
             indirect_arg_names.insert(name.clone());
         }
@@ -340,7 +336,7 @@ pub async fn run(
             .filter(|p| all_specifiers.contains_key(p.as_str()))
             .filter(|p| {
                 if ignored_updates.contains(p.as_str()) {
-                    tracing::info!("skipping {p} (updateConfig.ignoreDependencies)");
+                    tracing::info!("skipping {p} (update.ignoreDeps)");
                     false
                 } else {
                     true
@@ -1163,18 +1159,29 @@ fn resolve_update_settings(
     cwd: &std::path::Path,
     manifest: &aube_manifest::PackageJson,
 ) -> miette::Result<UpdateSettings> {
-    let mut ignored: BTreeSet<String> = manifest.update_ignore_dependencies().into_iter().collect();
+    let ignored = ignored_update_dependencies(cwd, manifest)?;
     let rewrites_specifier = with_update_settings_ctx(cwd, |ctx| {
-        if let Some(from_settings) = aube_settings::resolved::update_config_ignore_dependencies(ctx)
-        {
-            ignored.extend(from_settings);
-        }
         aube_settings::resolved::update_rewrites_specifier(ctx)
     })?;
     Ok(UpdateSettings {
         ignored,
         rewrites_specifier,
     })
+}
+
+pub(super) fn ignored_update_dependencies(
+    cwd: &std::path::Path,
+    manifest: &aube_manifest::PackageJson,
+) -> miette::Result<BTreeSet<String>> {
+    let mut ignored: BTreeSet<String> = manifest.update_ignore_dependencies().into_iter().collect();
+    with_update_settings_ctx(cwd, |ctx| {
+        if let Some(from_settings) = aube_settings::resolved::update_ignore_deps(ctx)
+            .or_else(|| aube_settings::resolved::update_config_ignore_dependencies(ctx))
+        {
+            ignored.extend(from_settings);
+        }
+    })?;
+    Ok(ignored)
 }
 
 fn with_update_settings_ctx<T>(

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -1211,10 +1211,19 @@ fn with_update_settings_ctx<T>(
     // sub-package as cwd, so an unwalked load returns an empty map and
     // `updateConfig.ignoreDependencies` silently drops every entry.
     // Discussion #602: zod was in the ignore list yet appeared in the
-    // recursive picker because of this miss. Fall back to cwd if no
-    // workspace root is found (single-project case).
+    // recursive picker because of this miss. Load root project sources,
+    // then append member project sources so member-local values retain
+    // their normal precedence. Fall back to cwd if no workspace root is
+    // found (single-project case).
     let yaml_root = crate::dirs::find_workspace_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
-    let files = crate::commands::FileSources::load(&yaml_root);
+    let mut files = crate::commands::FileSources::load(&yaml_root);
+    if cwd != yaml_root {
+        let member_files = crate::commands::FileSources::load(cwd);
+        files.project_npmrc.extend(member_files.project_npmrc);
+        files
+            .project_aube_config
+            .extend(member_files.project_aube_config);
+    }
     let raw_workspace = aube_manifest::workspace::load_raw(&yaml_root).unwrap_or_default();
     let env = aube_settings::values::process_env();
     let ctx = files.ctx(&raw_workspace, env, &[]);
@@ -1750,6 +1759,26 @@ mod tests {
         assert_eq!(
             ignored_update_dependencies(&member, &manifest).unwrap(),
             BTreeSet::from(["canonical".to_string()])
+        );
+    }
+
+    #[test]
+    fn workspace_member_update_ignores_override_root_project_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let member = dir.path().join("packages/app");
+        std::fs::create_dir_all(&member).unwrap();
+        std::fs::write(
+            dir.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - packages/*\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join(".npmrc"), "update.ignoreDeps=[\"root\"]\n").unwrap();
+        std::fs::write(member.join(".npmrc"), "update.ignoreDeps=[\"member\"]\n").unwrap();
+        let manifest = aube_manifest::PackageJson::default();
+
+        assert_eq!(
+            ignored_update_dependencies(&member, &manifest).unwrap(),
+            BTreeSet::from(["member".to_string()])
         );
     }
 

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -1159,13 +1159,9 @@ fn resolve_update_settings(
     cwd: &std::path::Path,
     manifest: &aube_manifest::PackageJson,
 ) -> miette::Result<UpdateSettings> {
-    let ignored = ignored_update_dependencies(cwd, manifest)?;
-    let rewrites_specifier = with_update_settings_ctx(cwd, |ctx| {
-        aube_settings::resolved::update_rewrites_specifier(ctx)
-    })?;
-    Ok(UpdateSettings {
-        ignored,
-        rewrites_specifier,
+    with_update_settings_ctx(cwd, |ctx| UpdateSettings {
+        ignored: ignored_update_dependencies_from_ctx(ctx, manifest),
+        rewrites_specifier: aube_settings::resolved::update_rewrites_specifier(ctx),
     })
 }
 
@@ -1173,22 +1169,29 @@ pub(super) fn ignored_update_dependencies(
     cwd: &std::path::Path,
     manifest: &aube_manifest::PackageJson,
 ) -> miette::Result<BTreeSet<String>> {
-    let configured = with_update_settings_ctx(cwd, |ctx| {
-        aube_settings::resolved::update_ignore_deps(ctx)
-            .map(|canonical| (true, canonical))
-            .or_else(|| {
-                aube_settings::resolved::update_config_ignore_dependencies(ctx)
-                    .map(|legacy| (false, legacy))
-            })
-    })?;
+    with_update_settings_ctx(cwd, |ctx| {
+        ignored_update_dependencies_from_ctx(ctx, manifest)
+    })
+}
+
+fn ignored_update_dependencies_from_ctx(
+    ctx: &aube_settings::ResolveCtx<'_>,
+    manifest: &aube_manifest::PackageJson,
+) -> BTreeSet<String> {
+    let configured = aube_settings::resolved::update_ignore_deps(ctx)
+        .map(|canonical| (true, canonical))
+        .or_else(|| {
+            aube_settings::resolved::update_config_ignore_dependencies(ctx)
+                .map(|legacy| (false, legacy))
+        });
     if let Some((true, canonical)) = configured {
-        return Ok(canonical.into_iter().collect());
+        return canonical.into_iter().collect();
     }
     let mut ignored: BTreeSet<String> = manifest.update_ignore_dependencies().into_iter().collect();
     if let Some((false, legacy)) = configured {
         ignored.extend(legacy);
     }
-    Ok(ignored)
+    ignored
 }
 
 fn with_update_settings_ctx<T>(

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -1206,7 +1206,6 @@ fn with_update_settings_ctx<T>(
     cwd: &std::path::Path,
     f: impl FnOnce(&aube_settings::ResolveCtx<'_>) -> T,
 ) -> miette::Result<T> {
-    let files = crate::commands::FileSources::load(cwd);
     // `pnpm-workspace.yaml` lives at the workspace root, not in
     // sub-packages. Filtered runs (`update -r`) call us with the
     // sub-package as cwd, so an unwalked load returns an empty map and
@@ -1215,9 +1214,8 @@ fn with_update_settings_ctx<T>(
     // recursive picker because of this miss. Fall back to cwd if no
     // workspace root is found (single-project case).
     let yaml_root = crate::dirs::find_workspace_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
-    let raw_workspace = aube_manifest::workspace::load_raw(&yaml_root)
-        .into_diagnostic()
-        .wrap_err("failed to read workspace config")?;
+    let files = crate::commands::FileSources::load(&yaml_root);
+    let raw_workspace = aube_manifest::workspace::load_raw(&yaml_root).unwrap_or_default();
     let env = aube_settings::values::process_env();
     let ctx = files.ctx(&raw_workspace, env, &[]);
     Ok(f(&ctx))
@@ -1712,6 +1710,45 @@ mod tests {
 
         assert_eq!(
             ignored_update_dependencies(dir.path(), &manifest).unwrap(),
+            BTreeSet::from(["canonical".to_string()])
+        );
+    }
+
+    #[test]
+    fn malformed_workspace_yaml_does_not_block_package_json_update_ignores() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("pnpm-workspace.yaml"), "packages: [\n").unwrap();
+        let manifest = aube_manifest::PackageJson::parse(
+            &dir.path().join("package.json"),
+            r#"{"updateConfig":{"ignoreDependencies":["legacy"]}}"#.to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            ignored_update_dependencies(dir.path(), &manifest).unwrap(),
+            BTreeSet::from(["legacy".to_string()])
+        );
+    }
+
+    #[test]
+    fn workspace_members_read_update_ignores_from_root_npmrc() {
+        let dir = tempfile::tempdir().unwrap();
+        let member = dir.path().join("packages/app");
+        std::fs::create_dir_all(&member).unwrap();
+        std::fs::write(
+            dir.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - packages/*\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join(".npmrc"),
+            "update.ignoreDeps=[\"canonical\"]\n",
+        )
+        .unwrap();
+        let manifest = aube_manifest::PackageJson::default();
+
+        assert_eq!(
+            ignored_update_dependencies(&member, &manifest).unwrap(),
             BTreeSet::from(["canonical".to_string()])
         );
     }

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -297,7 +297,10 @@ pub async fn run(
         for name in packages {
             if all_specifiers.contains_key(name.as_str()) {
                 if ignored_updates.contains(name.as_str()) {
-                    return Err(miette!("package '{name}' is ignored by update.ignoreDeps"));
+                    return Err(miette!(
+                        "package '{name}' is ignored by update.ignoreDeps \
+                         (or legacy updateConfig.ignoreDependencies)"
+                    ));
                 }
                 continue;
             }
@@ -319,7 +322,10 @@ pub async fn run(
                 return Err(miette!("package '{name}' is not a dependency"));
             }
             if ignored_updates.contains(name.as_str()) {
-                return Err(miette!("package '{name}' is ignored by update.ignoreDeps"));
+                return Err(miette!(
+                    "package '{name}' is ignored by update.ignoreDeps \
+                     (or legacy updateConfig.ignoreDependencies)"
+                ));
             }
             indirect_arg_names.insert(name.clone());
         }
@@ -336,7 +342,9 @@ pub async fn run(
             .filter(|p| all_specifiers.contains_key(p.as_str()))
             .filter(|p| {
                 if ignored_updates.contains(p.as_str()) {
-                    tracing::info!("skipping {p} (update.ignoreDeps)");
+                    tracing::info!(
+                        "skipping {p} (update.ignoreDeps or legacy updateConfig.ignoreDependencies)"
+                    );
                     false
                 } else {
                     true

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -1182,7 +1182,7 @@ pub(super) fn ignored_update_dependencies(
     })
 }
 
-fn ignored_update_dependencies_from_ctx(
+pub(super) fn ignored_update_dependencies_from_ctx(
     ctx: &aube_settings::ResolveCtx<'_>,
     manifest: &aube_manifest::PackageJson,
 ) -> BTreeSet<String> {
@@ -1218,11 +1218,7 @@ fn with_update_settings_ctx<T>(
     let yaml_root = crate::dirs::find_workspace_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
     let mut files = crate::commands::FileSources::load(&yaml_root);
     if cwd != yaml_root {
-        let member_files = crate::commands::FileSources::load(cwd);
-        files.project_npmrc.extend(member_files.project_npmrc);
-        files
-            .project_aube_config
-            .extend(member_files.project_aube_config);
+        files.extend_project_sources(cwd);
     }
     let raw_workspace = aube_manifest::workspace::load_raw(&yaml_root).unwrap_or_else(|error| {
         tracing::debug!(

--- a/docs/cli/audit.md
+++ b/docs/cli/audit.md
@@ -11,7 +11,7 @@ Check installed packages against the registry advisory DB
 
 Only print advisories at or above this severity.
 
-One of: `info`, `low`, `moderate`, `high`, `critical`. Default: `low`.
+One of: `info`, `low`, `moderate`, `high`, `critical`. Defaults to `audit.level` (or legacy `auditLevel`), then `low`.
 
 **Choices:**
 
@@ -20,8 +20,6 @@ One of: `info`, `low`, `moderate`, `high`, `critical`. Default: `low`.
 - `moderate`
 - `high`
 - `critical`
-
-**Default:** `low`
 
 ### `-D --dev`
 

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1042,7 +1042,7 @@
             "name": "audit-level",
             "usage": "--audit-level <AUDIT_LEVEL>",
             "help": "Only print advisories at or above this severity",
-            "help_long": "Only print advisories at or above this severity.\n\nOne of: `info`, `low`, `moderate`, `high`, `critical`. Default: `low`.",
+            "help_long": "Only print advisories at or above this severity.\n\nOne of: `info`, `low`, `moderate`, `high`, `critical`. Defaults to `audit.level` (or legacy `auditLevel`), then `low`.",
             "help_first_line": "Only print advisories at or above this severity",
             "short": [],
             "long": [
@@ -1065,10 +1065,7 @@
                   "critical"
                 ]
               }
-            },
-            "default": [
-              "low"
-            ]
+            }
           },
           {
             "name": "dev",

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -14,7 +14,12 @@ Aube generates this page from [`settings.toml`](https://github.com/jdx/aube/blob
 | [`packageExtensions`](#setting-packageextensions) | `object` | Extend existing package definitions with additional information. |
 | [`allowedDeprecatedVersions`](#setting-alloweddeprecatedversions) | `object` | Mute deprecation warnings for specific package versions. |
 | [`deprecationWarnings`](#setting-deprecationwarnings) | `"none" \| "direct" \| "all" \| "summary"` | Scope of deprecation warnings shown during install. |
-| [`updateConfig.ignoreDependencies`](#setting-updateconfig-ignoredependencies) | `list<string>` | List of packages to ignore during update checks. |
+| [`updateConfig.ignoreDependencies`](#setting-updateconfig-ignoredependencies) | `list<string>` | Deprecated list of packages to ignore during update checks. |
+| [`update.ignoreDeps`](#setting-update-ignoredeps) | `list<string>` | List of packages to ignore during update checks. |
+| [`audit.level`](#setting-audit-level) | `string` | Minimum advisory severity reported by audit. |
+| [`audit.ignore`](#setting-audit-ignore) | `list<string>` | Advisory identifiers ignored by audit. |
+| [`auditConfig.ignoreGhsas`](#setting-auditconfig-ignoreghsas) | `list<string>` | Deprecated list of GHSA identifiers ignored by audit. |
+| [`auditConfig.ignoreCves`](#setting-auditconfig-ignorecves) | `list<string>` | Deprecated list of CVE identifiers ignored by audit. |
 | [`supportedArchitectures`](#setting-supportedarchitectures) | `object` | Specify architectures for optional dependency installation. |
 | [`ignoredOptionalDependencies`](#setting-ignoredoptionaldependencies) | `list<string>` | Skip optional dependencies by name. |
 | [`pnpmfilePath`](#setting-pnpmfilepath) | `string` | Location of the pnpmfile hook file. |
@@ -220,7 +225,7 @@ Examples:
 
 ### `updateConfig.ignoreDependencies` {#setting-updateconfig-ignoredependencies}
 
-List of packages to ignore during update checks.
+Deprecated list of packages to ignore during update checks.
 
 - Type: `list<string>`
 - Default: `undefined`
@@ -230,6 +235,68 @@ List of packages to ignore during update checks.
 
 Packages in this list are never bumped by `aube update`, even when a
 newer version matching their range exists.
+
+### `update.ignoreDeps` {#setting-update-ignoredeps}
+
+List of packages to ignore during update checks.
+
+- Type: `list<string>`
+- Default: `undefined`
+- Environment: `npm_config_update_ignore_deps`, `NPM_CONFIG_UPDATE_IGNORE_DEPS`, `AUBE_UPDATE_IGNORE_DEPS`
+- .npmrc keys: `update.ignoreDeps`, `update.ignore-deps`
+- Workspace YAML keys: `update.ignoreDeps`
+
+Packages in this list are never bumped by `aube update` or reported by
+`aube outdated`. This is the canonical pnpm 11.16+ spelling and takes
+precedence over `updateConfig.ignoreDependencies`.
+
+### `audit.level` {#setting-audit-level}
+
+Minimum advisory severity reported by audit.
+
+- Type: `string`
+- Default: `undefined`
+- Environment: `npm_config_audit_level`, `NPM_CONFIG_AUDIT_LEVEL`, `AUBE_AUDIT_LEVEL`
+- .npmrc keys: `audit.level`, `audit-level`, `auditLevel`
+- Workspace YAML keys: `audit.level`
+
+Sets the default severity threshold for `aube audit`. A command-line
+`--audit-level` value takes precedence.
+
+### `audit.ignore` {#setting-audit-ignore}
+
+Advisory identifiers ignored by audit.
+
+- Type: `list<string>`
+- Default: `undefined`
+- Environment: `npm_config_audit_ignore`, `NPM_CONFIG_AUDIT_IGNORE`, `AUBE_AUDIT_IGNORE`
+- .npmrc keys: `audit.ignore`
+- Workspace YAML keys: `audit.ignore`
+
+Advisory IDs in this list are filtered from `aube audit`. Values may be
+numeric npm advisory IDs, GHSA identifiers, or CVE identifiers.
+
+### `auditConfig.ignoreGhsas` {#setting-auditconfig-ignoreghsas}
+
+Deprecated list of GHSA identifiers ignored by audit.
+
+- Type: `list<string>`
+- Default: `undefined`
+- .npmrc keys: `auditConfig.ignoreGhsas`, `audit-config.ignore-ghsas`
+- Workspace YAML keys: `auditConfig.ignoreGhsas`
+
+Use `audit.ignore` instead.
+
+### `auditConfig.ignoreCves` {#setting-auditconfig-ignorecves}
+
+Deprecated list of CVE identifiers ignored by audit.
+
+- Type: `list<string>`
+- Default: `undefined`
+- .npmrc keys: `auditConfig.ignoreCves`, `audit-config.ignore-cves`
+- Workspace YAML keys: `auditConfig.ignoreCves`
+
+Use `audit.ignore` instead.
 
 ### `supportedArchitectures` {#setting-supportedarchitectures}
 

--- a/test/outdated.bats
+++ b/test/outdated.bats
@@ -42,6 +42,23 @@ _write_pkg_with_old_is_odd() {
 	assert_output --partial "3.0.1"
 }
 
+@test "aube outdated honors workspace update.ignoreDeps" {
+	_write_pkg_with_old_is_odd
+	cat >pnpm-workspace.yaml <<'EOF'
+packages:
+  - "."
+update:
+  ignoreDeps:
+    - is-odd
+EOF
+	run aube install
+	assert_success
+
+	run aube outdated
+	assert_success
+	refute_output --partial "is-odd"
+}
+
 @test "aube outdated --json emits a package-keyed object with dependencyType" {
 	_write_pkg_with_old_is_odd
 	run aube install

--- a/test/update.bats
+++ b/test/update.bats
@@ -192,6 +192,14 @@ EOF
 
 @test "aube update: workspace update.ignoreDeps takes precedence" {
 	_setup_outdated_project
+	run aube add is-even@0.1.0
+	assert_success
+	node -e '
+		const fs = require("fs");
+		const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+		pkg.dependencies["is-even"] = ">=0.1.0";
+		fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
+	'
 	cat >pnpm-workspace.yaml <<'EOF'
 packages:
   - "."
@@ -206,6 +214,8 @@ EOF
 	run aube update
 	assert_success
 	run grep 'is-odd@0.1.2' aube-lock.yaml
+	assert_success
+	run grep 'is-even@1.0.0' aube-lock.yaml
 	assert_success
 }
 

--- a/test/update.bats
+++ b/test/update.bats
@@ -187,7 +187,26 @@ EOF
 
 	run aube update is-odd
 	assert_failure
-	assert_output --partial "ignored by updateConfig.ignoreDependencies"
+	assert_output --partial "ignored by update.ignoreDeps"
+}
+
+@test "aube update: workspace update.ignoreDeps takes precedence" {
+	_setup_outdated_project
+	cat >pnpm-workspace.yaml <<'EOF'
+packages:
+  - "."
+update:
+  ignoreDeps:
+    - is-odd
+updateConfig:
+  ignoreDependencies:
+    - is-even
+EOF
+
+	run aube update
+	assert_success
+	run grep 'is-odd@0.1.2' aube-lock.yaml
+	assert_success
 }
 
 @test "aube update: reports already latest when nothing to update" {


### PR DESCRIPTION
## Summary

- add pnpm 11.16+ `update.ignoreDeps`, `audit.level`, and `audit.ignore` settings
- retain the deprecated update/audit spellings as fallbacks
- make the canonical values take precedence
- apply `update.ignoreDeps` to both `update` and `outdated`
- let CLI `--audit-level` override the workspace default
- regenerate the settings reference

## Impact

Projects using pnpm's new workspace configuration sections now behave the same under aube without rewriting their configuration.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p aube-settings` (65 tests across unit/integration/doc targets)
- `cargo test -p aube commands::audit::tests` (14 passed)
- `mise run test:bats test/update.bats` (20 passed)
- `mise run test:bats test/outdated.bats` (10 passed)

*This pull request was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches audit filtering and update/outdated dependency selection across workspace and npmrc sources; behavior changes for projects that relied on the old CLI default or mixed legacy and canonical keys.
> 
> **Overview**
> Adds **pnpm 11.16+** workspace settings **`update.ignoreDeps`**, **`audit.level`**, and **`audit.ignore`**, with typed parsing in workspace config and entries in the settings registry/docs. Legacy **`updateConfig.ignoreDependencies`**, **`auditConfig`**, and top-level **`auditLevel`** remain as fallbacks; when the canonical keys are set they **replace** the older package.json / legacy lists rather than merging with them.
> 
> **`aube update`** and **`aube outdated`** now share the same ignore list resolution (including workspace-root `.npmrc` and member overrides). **`aube audit`** no longer hard-defaults `--audit-level` to `low`; it resolves severity from config (`audit.level` → legacy `auditLevel` → `low`) and loads ignore IDs from **`audit.ignore`** with legacy fallbacks. Invalid workspace YAML during resolution is skipped so legacy ignores still apply. CLI **`--audit-level`** still wins when provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 635fe46938531a82343534b50b99c719f6cda771. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->