### PR TITLE
ci: fix api-stability tool invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
         continue-on-error: true
         # Version pinned in bin/cargo-semver-checks (mise tool-stub).
         run: |
-          cargo-semver-checks semver-checks \
+          ./bin/cargo-semver-checks semver-checks \
             --baseline-rev origin/main \
             --package aube-codes --package aube-settings --package aube-util
       - name: C ABI — frozen export set
@@ -186,9 +186,9 @@ jobs:
           fi
           if [ "$SEMVER" = failure ]; then
             if [ "$BREAKING" = true ]; then
-              echo "::notice::Rust embedding API change is breaking; allowed because this PR is marked breaking."
+              echo "::notice::Rust embedding API compatibility check failed; allowed because this PR is marked breaking. Inspect the cargo-semver-checks output to confirm the failure is expected."
             else
-              echo "::error::A breaking change to a Rust embedding API (aube-codes/aube-settings/aube-util) was detected. If intentional, mark the PR breaking: a '!' in the conventional-commit title (e.g. feat(settings)!: ...), a 'BREAKING CHANGE:' footer in the body, or the 'breaking-api' label."
+              echo "::error::Rust embedding API compatibility check failed. Inspect the cargo-semver-checks output above. If it reports an intentional breaking change, mark the PR breaking: a '!' in the conventional-commit title (e.g. feat(settings)!: ...), a 'BREAKING CHANGE:' footer in the body, or the 'breaking-api' label."
               fail=1
             fi
           fi


### PR DESCRIPTION
## Summary

- invoke the pinned `cargo-semver-checks` tool stub by its explicit repository path
- report semver checker failures without assuming every failure proves an API break

## Root cause

`jdx/mise-action` v4.2.1 stopped exporting mise's computed `PATH` into later workflow steps. The API-stability job relied on that previous behavior to put the repository's `bin/` directory on `PATH`, so the checker exited with `cargo-semver-checks: command not found`. The enforcement step then misclassified that execution failure as a detected breaking API change.

## Impact

The API-stability job no longer depends on PATH leakage from mise-action, and future checker or infrastructure failures will point maintainers to the checker output instead of presenting a false-positive API-break diagnosis.

## Validation

- `mise exec -- actionlint .github/workflows/ci.yml`
- `test -x ./bin/cargo-semver-checks`
- `./bin/cargo-semver-checks --version`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes to tool invocation and log text; no runtime or API behavior changes.
> 
> **Overview**
> Fixes the **api-stability** job so it no longer depends on mise-action putting `bin/` on `PATH`: the Rust embedding check now runs **`./bin/cargo-semver-checks`** (the mise tool-stub pin) instead of a bare `cargo-semver-checks` command.
> 
> When the semver step fails, **Enforce API stability** messages no longer claim a breaking API change was *detected*; they report that the **compatibility check failed** and tell maintainers to read the checker output (and use breaking PR markers only when the failure reflects an intentional break).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b51e086f1ad8a48e967ecb52867968de9aa5fd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->