### PR TITLE
fix(linker): expose global virtual store to Vite

### DIFF
--- a/crates/aube-linker/src/builder.rs
+++ b/crates/aube-linker/src/builder.rs
@@ -23,6 +23,7 @@ impl Linker {
             virtual_store: store.virtual_store_dir(),
             store: store.clone(),
             use_global_virtual_store,
+            project_local_dep_paths: rustc_hash::FxHashSet::default(),
             strategy,
             patches: Patches::new(),
             hashes: None,
@@ -128,6 +129,19 @@ impl Linker {
     /// anything that lands outside its declared filesystem root.
     pub fn with_use_global_virtual_store(mut self, enabled: bool) -> Self {
         self.use_global_virtual_store = enabled;
+        self
+    }
+
+    /// Materialize selected dep paths into the project-local virtual
+    /// store while all other packages continue to use the GVS.
+    ///
+    /// Callers use this for package-specific compatibility transforms
+    /// that must never mutate a shared store entry.
+    pub fn with_project_local_dep_paths(
+        mut self,
+        dep_paths: impl IntoIterator<Item = String>,
+    ) -> Self {
+        self.project_local_dep_paths = dep_paths.into_iter().collect();
         self
     }
 

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -97,6 +97,11 @@ pub struct Linker {
     /// `allowBuilds` entries flipped, engine version bumped).
     pub(crate) store: Store,
     use_global_virtual_store: bool,
+    /// Exact dep paths that must be materialized into the project's
+    /// `.aube/` tree even while the rest of the graph uses the global
+    /// virtual store. This is reserved for compatibility transforms
+    /// that need to mutate one package without touching shared bytes.
+    project_local_dep_paths: rustc_hash::FxHashSet<String>,
     strategy: LinkStrategy,
     /// Per-`name@version` patch contents applied at materialize
     /// time. Empty when the project has no `pnpm.patchedDependencies`.

--- a/crates/aube-linker/src/link.rs
+++ b/crates/aube-linker/src/link.rs
@@ -276,6 +276,7 @@ impl Linker {
                             let mut local_stats = LinkStats::default();
                             let local_aube_entry = aube_dir.join(entry_name);
                             let global_entry = self.virtual_store.join(subdir);
+                            let project_local = self.project_local_dep_paths.contains(dep_path);
 
                             // Single readlink classifies the entry into one of
                             // three states and drives the whole per-package
@@ -287,7 +288,7 @@ impl Linker {
                             // install on the medium fixture.
                             let state = classify_entry_state(&local_aube_entry, &global_entry);
 
-                            if matches!(state, EntryState::Fresh) {
+                            if !project_local && matches!(state, EntryState::Fresh) {
                                 local_stats.packages_cached += 1;
                                 return Ok(local_stats);
                             }
@@ -317,6 +318,23 @@ impl Linker {
                                     &owned_index
                                 }
                             };
+                            if project_local {
+                                if !matches!(state, EntryState::Missing) {
+                                    try_remove_entry(&local_aube_entry);
+                                }
+                                self.materialize_into(
+                                    &aube_dir,
+                                    &aube_dir,
+                                    dep_path,
+                                    pkg,
+                                    index,
+                                    &mut local_stats,
+                                    false,
+                                    nested_link_targets.as_ref(),
+                                )?;
+                                return Ok(local_stats);
+                            }
+
                             self.ensure_in_virtual_store_with_subdir(
                                 dep_path,
                                 subdir,

--- a/crates/aube-linker/src/link.rs
+++ b/crates/aube-linker/src/link.rs
@@ -855,10 +855,11 @@ impl Linker {
                             let mut local_stats = LinkStats::default();
                             let local_aube_entry = aube_dir.join(entry_name);
                             let global_entry = self.virtual_store.join(subdir);
+                            let project_local = self.project_local_dep_paths.contains(dep_path);
 
                             let state = classify_entry_state(&local_aube_entry, &global_entry);
 
-                            if matches!(state, EntryState::Fresh) {
+                            if !project_local && matches!(state, EntryState::Fresh) {
                                 local_stats.packages_cached += 1;
                                 return Ok(local_stats);
                             }
@@ -880,6 +881,23 @@ impl Linker {
                                     &owned_index
                                 }
                             };
+                            if project_local {
+                                if !matches!(state, EntryState::Missing) {
+                                    try_remove_entry(&local_aube_entry);
+                                }
+                                self.materialize_into(
+                                    &aube_dir,
+                                    &aube_dir,
+                                    dep_path,
+                                    pkg,
+                                    index,
+                                    &mut local_stats,
+                                    false,
+                                    nested_link_targets.as_ref(),
+                                )?;
+                                return Ok(local_stats);
+                            }
+
                             self.ensure_in_virtual_store_with_subdir(
                                 dep_path,
                                 subdir,

--- a/crates/aube-linker/src/link.rs
+++ b/crates/aube-linker/src/link.rs
@@ -6,9 +6,9 @@ use crate::patches::{
 };
 use crate::pool::with_link_pool;
 use crate::sweep::{
-    EntryState, classify_entry_state, is_physical_importer, mkdirp, remove_hidden_hoist_tree,
-    sweep_dead_hidden_hoist_entries, sweep_stale_tmp_dirs, sweep_stale_top_level_entries,
-    try_remove_entry,
+    EntryState, classify_entry_state, classify_local_entry_state, is_physical_importer, mkdirp,
+    remove_hidden_hoist_tree, sweep_dead_hidden_hoist_entries, sweep_stale_tmp_dirs,
+    sweep_stale_top_level_entries, try_remove_entry,
 };
 use crate::{Error, HoistedPlacements, LinkStats, Linker, NodeLinker, hoisted, sys};
 use aube_lockfile::{LocalSource, LockedPackage, LockfileGraph};
@@ -286,9 +286,13 @@ impl Linker {
                             // `remove_dir`/`remove_file` pair on cold installs,
                             // which strace showed as ~1.4k ENOENT syscalls per
                             // install on the medium fixture.
-                            let state = classify_entry_state(&local_aube_entry, &global_entry);
+                            let state = if project_local {
+                                classify_local_entry_state(&local_aube_entry)
+                            } else {
+                                classify_entry_state(&local_aube_entry, &global_entry)
+                            };
 
-                            if !project_local && matches!(state, EntryState::Fresh) {
+                            if matches!(state, EntryState::Fresh) {
                                 local_stats.packages_cached += 1;
                                 return Ok(local_stats);
                             }
@@ -857,9 +861,13 @@ impl Linker {
                             let global_entry = self.virtual_store.join(subdir);
                             let project_local = self.project_local_dep_paths.contains(dep_path);
 
-                            let state = classify_entry_state(&local_aube_entry, &global_entry);
+                            let state = if project_local {
+                                classify_local_entry_state(&local_aube_entry)
+                            } else {
+                                classify_entry_state(&local_aube_entry, &global_entry)
+                            };
 
-                            if !project_local && matches!(state, EntryState::Fresh) {
+                            if matches!(state, EntryState::Fresh) {
                                 local_stats.packages_cached += 1;
                                 return Ok(local_stats);
                             }

--- a/crates/aube-linker/src/sweep.rs
+++ b/crates/aube-linker/src/sweep.rs
@@ -312,8 +312,24 @@ pub(crate) fn classify_entry_state(link_path: &Path, expected: &Path) -> EntrySt
 #[inline]
 pub(crate) fn classify_local_entry_state(path: &Path) -> EntryState {
     match std::fs::symlink_metadata(path) {
-        Ok(metadata) if metadata.file_type().is_dir() => EntryState::Fresh,
-        Ok(_) => EntryState::Stale,
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() {
+                return EntryState::Stale;
+            }
+            #[cfg(windows)]
+            {
+                use std::os::windows::fs::MetadataExt;
+                const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0400;
+                if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+                    return EntryState::Stale;
+                }
+            }
+            if metadata.file_type().is_dir() {
+                EntryState::Fresh
+            } else {
+                EntryState::Stale
+            }
+        }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => EntryState::Missing,
         Err(_) => EntryState::Stale,
     }

--- a/crates/aube-linker/src/sweep.rs
+++ b/crates/aube-linker/src/sweep.rs
@@ -306,6 +306,19 @@ pub(crate) fn classify_entry_state(link_path: &Path, expected: &Path) -> EntrySt
     }
 }
 
+/// Classify a project-local virtual-store entry. A real directory is
+/// already materialized and reusable; symlinks and other file types are
+/// stale shapes left by a different layout mode.
+#[inline]
+pub(crate) fn classify_local_entry_state(path: &Path) -> EntryState {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_dir() => EntryState::Fresh,
+        Ok(_) => EntryState::Stale,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => EntryState::Missing,
+        Err(_) => EntryState::Stale,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::is_physical_importer;

--- a/crates/aube-linker/src/tests.rs
+++ b/crates/aube-linker/src/tests.rs
@@ -488,8 +488,8 @@ fn selected_package_materializes_locally_while_dependencies_keep_using_gvs() {
     );
 
     let second = linker.link_all(&project_dir, &graph, &indices).unwrap();
-    assert_eq!(second.packages_linked, 1);
-    assert_eq!(second.packages_cached, 1);
+    assert_eq!(second.packages_linked, 0);
+    assert_eq!(second.packages_cached, 2);
 }
 
 #[test]
@@ -538,6 +538,12 @@ fn workspace_selected_package_materializes_locally_while_dependencies_use_gvs() 
             .join("packages/app/node_modules/foo/index.js")
             .exists()
     );
+
+    let second = linker
+        .link_workspace(&project_dir, &graph, &indices, &workspace_dirs)
+        .unwrap();
+    assert_eq!(second.packages_linked, 0);
+    assert_eq!(second.packages_cached, 2);
 }
 
 #[test]

--- a/crates/aube-linker/src/tests.rs
+++ b/crates/aube-linker/src/tests.rs
@@ -450,6 +450,49 @@ fn test_link_all_creates_pnpm_virtual_store() {
 }
 
 #[test]
+fn selected_package_materializes_locally_while_dependencies_keep_using_gvs() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = dir.path().join("project");
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    let (store, indices) = setup_store_with_files(dir.path());
+    let graph = make_graph();
+    Linker::new_with_gvs(&store, LinkStrategy::Copy, true)
+        .link_all(&project_dir, &graph, &indices)
+        .unwrap();
+    let initial_foo = project_dir.join("node_modules/.aube/foo@1.0.0");
+    assert!(
+        std::fs::read_link(&initial_foo).is_ok(),
+        "fixture should start with an existing GVS symlink"
+    );
+
+    let linker = Linker::new_with_gvs(&store, LinkStrategy::Copy, true)
+        .with_project_local_dep_paths(["foo@1.0.0".to_string()]);
+    linker.link_all(&project_dir, &graph, &indices).unwrap();
+
+    let aube_dir = project_dir.join("node_modules/.aube");
+    let foo = aube_dir.join("foo@1.0.0");
+    let bar = aube_dir.join("bar@2.0.0");
+    assert!(foo.is_dir());
+    assert!(
+        std::fs::read_link(&foo).is_err(),
+        "selected package must be a real project-local directory"
+    );
+    assert!(
+        std::fs::read_link(&bar).is_ok(),
+        "unselected dependency must remain linked to the GVS"
+    );
+    assert_eq!(
+        std::fs::read_to_string(foo.join("node_modules/foo/index.js")).unwrap(),
+        "module.exports = 'foo';"
+    );
+
+    let second = linker.link_all(&project_dir, &graph, &indices).unwrap();
+    assert_eq!(second.packages_linked, 1);
+    assert_eq!(second.packages_cached, 1);
+}
+
+#[test]
 fn test_link_file_fresh_reports_missing_cas_shard_and_invalidates_cache() {
     // Reproduces jdx/aube#393: a partially corrupt CAS leaves the
     // cached package index pointing at a missing shard. Materialize

--- a/crates/aube-linker/src/tests.rs
+++ b/crates/aube-linker/src/tests.rs
@@ -493,6 +493,54 @@ fn selected_package_materializes_locally_while_dependencies_keep_using_gvs() {
 }
 
 #[test]
+fn workspace_selected_package_materializes_locally_while_dependencies_use_gvs() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = dir.path().join("project");
+    std::fs::create_dir_all(project_dir.join("packages/app")).unwrap();
+
+    let (store, indices) = setup_store_with_files(dir.path());
+    let mut graph = make_graph();
+    graph.importers.insert(
+        "packages/app".to_string(),
+        vec![DirectDep {
+            name: "foo".to_string(),
+            dep_path: "foo@1.0.0".to_string(),
+            dep_type: DepType::Dev,
+            specifier: None,
+        }],
+    );
+    let workspace_dirs = BTreeMap::new();
+    Linker::new_with_gvs(&store, LinkStrategy::Copy, true)
+        .link_workspace(&project_dir, &graph, &indices, &workspace_dirs)
+        .unwrap();
+    let aube_dir = project_dir.join("node_modules/.aube");
+    assert!(std::fs::read_link(aube_dir.join("foo@1.0.0")).is_ok());
+
+    let linker = Linker::new_with_gvs(&store, LinkStrategy::Copy, true)
+        .with_project_local_dep_paths(["foo@1.0.0".to_string()]);
+    linker
+        .link_workspace(&project_dir, &graph, &indices, &workspace_dirs)
+        .unwrap();
+
+    let foo = aube_dir.join("foo@1.0.0");
+    let bar = aube_dir.join("bar@2.0.0");
+    assert!(foo.is_dir());
+    assert!(
+        std::fs::read_link(&foo).is_err(),
+        "selected workspace package must be project-local"
+    );
+    assert!(
+        std::fs::read_link(&bar).is_ok(),
+        "unselected workspace dependency must stay in the GVS"
+    );
+    assert!(
+        project_dir
+            .join("packages/app/node_modules/foo/index.js")
+            .exists()
+    );
+}
+
+#[test]
 fn test_link_file_fresh_reports_missing_cas_shard_and_invalidates_cache() {
     // Reproduces jdx/aube#393: a partially corrupt CAS leaves the
     // cached package index pointing at a missing shard. Materialize

--- a/crates/aube-manifest/src/workspace/config.rs
+++ b/crates/aube-manifest/src/workspace/config.rs
@@ -90,16 +90,14 @@ pub struct WorkspaceConfig {
 
     /// Package names whose presence in any importer forces
     /// per-project materialization (disabling the global virtual
-    /// store for that install). Defaults to the common bundler /
-    /// framework direct-devDeps whose module resolvers follow
-    /// symlinks then walk up (Next.js's Turbopack, Vite, Rollup,
-    /// Webpack, Parcel, Nuxt, VitePress) — the global virtual store
-    /// makes `.aube/<pkg>` an absolute symlink that escapes the
-    /// project's filesystem root, which those resolvers can't walk
-    /// back from. Add more names as you discover tools with the same
-    /// restriction; set to `[]` to disable the heuristic. Declared
-    /// here so `settings.toml`'s workspaceYaml source stays in sync
-    /// with the actual deserialize surface.
+    /// store for that install). Defaults to tools with concrete
+    /// realpath/walk-up failures (Next.js, Nuxt, and Parcel). Vite
+    /// 8.1+ instead reads the `.modules.yaml` compatibility metadata
+    /// aube writes and allows the shared store explicitly. Add more
+    /// names as you discover tools with the same restriction; set to
+    /// `[]` to disable the heuristic. Declared here so
+    /// `settings.toml`'s workspaceYaml source stays in sync with the
+    /// actual deserialize surface.
     #[serde(default)]
     pub disable_global_virtual_store_for_packages: Option<Vec<String>>,
 

--- a/crates/aube-manifest/src/workspace/config.rs
+++ b/crates/aube-manifest/src/workspace/config.rs
@@ -92,8 +92,9 @@ pub struct WorkspaceConfig {
     /// per-project materialization (disabling the global virtual
     /// store for that install). Defaults to tools with concrete
     /// realpath/walk-up failures (Next.js, Nuxt, and Parcel). Vite
-    /// 8.1+ instead reads the `.modules.yaml` compatibility metadata
-    /// aube writes and allows the shared store explicitly. Add more
+    /// 8.1+ reads the `.modules.yaml` compatibility metadata aube
+    /// writes; older Vite dependency paths are materialized locally
+    /// and receive the same allow-list lookup as a backport. Add more
     /// names as you discover tools with the same restriction; set to
     /// `[]` to disable the heuristic. Declared here so
     /// `settings.toml`'s workspaceYaml source stays in sync with the

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -1079,7 +1079,10 @@ canonicalizes through symlinks and walks up for app-router/monorepo detection,
 Nuxt plugins walk up for config discovery, and Parcel's resolver walks up for
 `.parcelrc`. Vite and VitePress are compatible with the global virtual store:
 aube writes `node_modules/.modules.yaml` with the store location, which Vite
-8.1+ reads when constructing its filesystem allow-list.
+8.1+ reads when constructing its filesystem allow-list. For older Vite
+versions, aube materializes only the Vite dependency path locally and backports
+the same allow-list lookup into that project-local copy; unrelated dependencies
+remain in the shared store.
 
 Webpack and Rollup are *not* on the default list: plain Webpack
 resolves via the sibling symlinks aube already places inside

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -1059,7 +1059,7 @@ examples = [
 [disableGlobalVirtualStoreForPackages]
 description = "Package names whose presence in any importer forces per-project materialization."
 type = "list<string>"
-default = "[\"next\", \"nuxt\", \"vite\", \"vitepress\", \"parcel\"]"
+default = "[\"next\", \"nuxt\", \"parcel\"]"
 docs = """
 aube's global virtual store makes `node_modules/.aube/<pkg>` an
 absolute symlink into `~/.cache/aube/virtual-store/`. Tools whose
@@ -1073,12 +1073,14 @@ When `aube install` finds one of these names in any importer's
 forces per-project materialization for that install and prints a
 one-line warning naming the trigger.
 
-The default list — `next`, `nuxt`, `vite`, `vitepress`, `parcel` —
+The default list — `next`, `nuxt`, `parcel` —
 covers the tools with concrete walk-up failures: Next.js's Turbopack
-canonicalizes through symlinks and walks up for app-router/monorepo
-detection, Vite/VitePress/Nuxt plugins walk up for config discovery
-(see [jdx/mise#9261](https://github.com/jdx/mise/pull/9261) for the
-VitePress case), and Parcel's resolver walks up for `.parcelrc`.
+canonicalizes through symlinks and walks up for app-router/monorepo detection,
+Nuxt plugins walk up for config discovery, and Parcel's resolver walks up for
+`.parcelrc`. Vite and VitePress are compatible with the global virtual store:
+aube writes `node_modules/.modules.yaml` with the store location, which Vite
+8.1+ reads when constructing its filesystem allow-list.
+
 Webpack and Rollup are *not* on the default list: plain Webpack
 resolves via the sibling symlinks aube already places inside
 `.aube/<pkg>/node_modules/`, and Rollup is rarely a direct dep (it's

--- a/crates/aube/src/commands/install/fetch.rs
+++ b/crates/aube/src/commands/install/fetch.rs
@@ -426,6 +426,7 @@ pub(in crate::commands) async fn fetch_packages(
         &aube_dir,
         /*materialize_tx=*/ None,
         /*skip_already_linked_shortcut=*/ true,
+        /*force_index_dep_paths=*/ &std::collections::BTreeSet::new(),
         virtual_store_dir_max_length,
         ignore_scripts,
         network_concurrency,
@@ -482,6 +483,9 @@ pub(super) async fn fetch_packages_with_root<F>(
     // `store.load_index` → either `Cached` (store has it) or
     // `NeedsFetch` (store is missing the file, download fresh).
     skip_already_linked_shortcut: bool,
+    // Packages selected for project-local compatibility materialization
+    // need an index even when their prior GVS entry still exists.
+    force_index_dep_paths: &std::collections::BTreeSet<String>,
     virtual_store_dir_max_length: usize,
     ignore_scripts: bool,
     network_concurrency: Option<usize>,
@@ -572,7 +576,7 @@ where
         .par_iter()
         .filter(|(_, pkg)| pkg.local_source.is_none())
         .map(|(dep_path, pkg)| {
-            if !skip_already_linked_shortcut {
+            if !skip_already_linked_shortcut && !force_index_dep_paths.contains(dep_path) {
                 let entry_name = dep_path_to_filename(dep_path, virtual_store_dir_max_length);
                 if aube_dir.join(&entry_name).exists() {
                     return (dep_path.clone(), pkg, CheckResult::AlreadyLinked);

--- a/crates/aube/src/commands/install/finalize.rs
+++ b/crates/aube/src/commands/install/finalize.rs
@@ -113,6 +113,16 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
         gvs::write_modules_metadata(cwd, graph_for_link, modules_dir_name, &virtual_store_dir)
             .into_diagnostic()
             .wrap_err("failed to write node_modules/.modules.yaml")?;
+        if planned_gvs && node_linker == aube_linker::NodeLinker::Isolated {
+            gvs::patch_legacy_vite_copies(
+                aube_dir,
+                graph_for_link,
+                virtual_store_dir_max_length,
+                &store.virtual_store_dir(),
+            )
+            .into_diagnostic()
+            .wrap_err("failed to backport Vite global virtual store support")?;
+        }
     }
 
     if !ignore_scripts && strict_dep_builds_setting && !virtual_store_only {

--- a/crates/aube/src/commands/install/finalize.rs
+++ b/crates/aube/src/commands/install/finalize.rs
@@ -6,7 +6,7 @@ use super::side_effects_cache::{SideEffectsCacheConfig, side_effects_cache_root}
 use super::summary::{print_direct_dependency_summary, should_print_human_install_summary};
 use super::sweep::sweep_orphaned_aube_entries;
 use super::workspace::importer_project_dir;
-use super::{InstallPhaseTimings, delta, unreviewed_builds};
+use super::{InstallPhaseTimings, delta, gvs, unreviewed_builds};
 use crate::state;
 use miette::{Context, IntoDiagnostic, miette};
 use std::collections::BTreeMap;
@@ -26,6 +26,7 @@ pub(super) struct FinalizePhaseInput<'a> {
     pub(super) jail_policy: &'a JailBuildPolicy,
     pub(super) stats: &'a aube_linker::LinkStats,
     pub(super) node_linker: aube_linker::NodeLinker,
+    pub(super) planned_gvs: bool,
     pub(super) virtual_store_only: bool,
     pub(super) current_leaf_hashes: Option<BTreeMap<String, String>>,
     pub(super) current_subtree_hashes: Option<BTreeMap<String, String>>,
@@ -64,6 +65,7 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
         jail_policy,
         stats,
         node_linker,
+        planned_gvs,
         virtual_store_only,
         current_leaf_hashes,
         current_subtree_hashes,
@@ -100,6 +102,17 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
     let install_is_noop = stats.packages_linked == 0 && stats.top_level_linked == 0;
     if let Some(p) = prog_ref {
         p.finish(!install_is_noop);
+    }
+
+    if !virtual_store_only {
+        let virtual_store_dir = if planned_gvs && node_linker == aube_linker::NodeLinker::Isolated {
+            store.virtual_store_dir()
+        } else {
+            aube_dir.to_path_buf()
+        };
+        gvs::write_modules_metadata(cwd, graph_for_link, modules_dir_name, &virtual_store_dir)
+            .into_diagnostic()
+            .wrap_err("failed to write node_modules/.modules.yaml")?;
     }
 
     if !ignore_scripts && strict_dep_builds_setting && !virtual_store_only {

--- a/crates/aube/src/commands/install/finalize.rs
+++ b/crates/aube/src/commands/install/finalize.rs
@@ -112,13 +112,14 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
         };
         gvs::write_modules_metadata(cwd, graph_for_link, modules_dir_name, &virtual_store_dir)
             .into_diagnostic()
-            .wrap_err("failed to write node_modules/.modules.yaml")?;
+            .wrap_err_with(|| format!("failed to write {modules_dir_name}/.modules.yaml"))?;
         if planned_gvs && node_linker == aube_linker::NodeLinker::Isolated {
             gvs::patch_legacy_vite_copies(
                 aube_dir,
                 graph_for_link,
                 virtual_store_dir_max_length,
                 &store.virtual_store_dir(),
+                modules_dir_name,
             )
             .into_diagnostic()
             .wrap_err("failed to backport Vite global virtual store support")?;

--- a/crates/aube/src/commands/install/gvs.rs
+++ b/crates/aube/src/commands/install/gvs.rs
@@ -202,11 +202,46 @@ pub(super) fn modules_metadata_is_current<'a>(
                 .ok()
                 .and_then(|bytes| metadata_virtual_store_dir(&bytes))
             else {
+                tracing::debug!(
+                    "install warm path skipped: {} has no virtualStoreDir",
+                    project_dir
+                        .join(modules_dir_name)
+                        .join(".modules.yaml")
+                        .display()
+                );
                 return false;
             };
-            expected_virtual_store_dir
-                .is_none_or(|expected| actual == expected.to_string_lossy().as_ref())
+            let matches = expected_virtual_store_dir
+                .is_none_or(|expected| actual == expected.to_string_lossy());
+            if !matches {
+                tracing::debug!(
+                    "install warm path skipped: {} has virtualStoreDir={actual}, expected {}",
+                    project_dir
+                        .join(modules_dir_name)
+                        .join(".modules.yaml")
+                        .display(),
+                    expected_virtual_store_dir
+                        .map_or_else(|| "<any>".into(), |path| path.to_string_lossy())
+                );
+            }
+            matches
         })
+}
+
+pub(super) fn detect_existing_global_virtual_store(
+    workspace_root: &Path,
+    aube_dir: &Path,
+    modules_dir_name: &str,
+) -> Option<bool> {
+    let mut existing_gvs = super::settings::detect_aube_dir_gvs_mode(aube_dir)?;
+    if !existing_gvs {
+        let metadata_path = workspace_root.join(modules_dir_name).join(".modules.yaml");
+        existing_gvs = std::fs::read(metadata_path)
+            .ok()
+            .and_then(|bytes| metadata_virtual_store_dir(&bytes))
+            .is_some_and(|path| Path::new(&path) != aube_dir);
+    }
+    Some(existing_gvs)
 }
 
 fn legacy_vite_dep_paths(
@@ -425,7 +460,8 @@ pub(super) fn reset_on_mode_change(
     modules_dir_name: &str,
     planned_gvs: bool,
 ) -> miette::Result<()> {
-    let Some(existing_gvs) = super::settings::detect_aube_dir_gvs_mode(aube_dir) else {
+    let Some(existing_gvs) = detect_existing_global_virtual_store(cwd, aube_dir, modules_dir_name)
+    else {
         return Ok(());
     };
     if existing_gvs == planned_gvs {
@@ -574,6 +610,30 @@ mod tests {
                 .and_then(yaml_serde::Value::as_i64),
             Some(5)
         );
+    }
+
+    #[test]
+    fn metadata_disambiguates_gvs_trees_with_only_local_packages() {
+        let tmp = tempfile::tempdir().expect("tempdir should be created");
+        let root = tmp.path();
+        let aube_dir = root.join("node_modules/.aube");
+        std::fs::create_dir_all(aube_dir.join("vendor-dir@9.9.9"))
+            .expect("local package should be created");
+        let shared_store = root.join("shared/virtual-store");
+        std::fs::write(
+            root.join("node_modules/.modules.yaml"),
+            format!(
+                "virtualStoreDir: {}\n",
+                serde_json::to_string(&shared_store.to_string_lossy())
+                    .expect("store path should serialize")
+            ),
+        )
+        .expect("metadata should be written");
+
+        reset_on_mode_change(root, &aube_dir, "node_modules", true)
+            .expect("matching GVS mode should be preserved");
+
+        assert!(aube_dir.join("vendor-dir@9.9.9").is_dir());
     }
 
     #[test]

--- a/crates/aube/src/commands/install/gvs.rs
+++ b/crates/aube/src/commands/install/gvs.rs
@@ -82,6 +82,168 @@ pub(super) fn write_modules_metadata(
     Ok(())
 }
 
+fn legacy_vite_dep_paths(
+    graph: &aube_lockfile::LockfileGraph,
+) -> std::collections::BTreeSet<String> {
+    graph
+        .packages
+        .iter()
+        .filter(|(_, pkg)| {
+            pkg.registry_name() == "vite" && vite_needs_modules_metadata_backport(&pkg.version)
+        })
+        .map(|(dep_path, _)| dep_path.clone())
+        .collect()
+}
+
+/// Select each legacy Vite package plus every package ancestor needed
+/// to make the root/importer resolution path reach that local copy.
+///
+/// Other branches of the graph remain in the GVS. Dependencies of a
+/// selected ancestor that are not themselves selected still resolve
+/// through the ordinary local `.aube` symlinks into the shared store.
+pub(super) fn legacy_vite_project_local_closure(
+    graph: &aube_lockfile::LockfileGraph,
+) -> std::collections::BTreeSet<String> {
+    let mut selected = legacy_vite_dep_paths(graph);
+    loop {
+        let mut added = false;
+        for (parent_path, parent) in &graph.packages {
+            if selected.contains(parent_path) {
+                continue;
+            }
+            let reaches_selected = parent.dependencies.iter().any(|(name, tail)| {
+                aube_lockfile::resolve_dep_edge(name, tail, |key| graph.packages.contains_key(key))
+                    .is_some_and(|child| selected.contains(&child))
+            });
+            if reaches_selected {
+                selected.insert(parent_path.clone());
+                added = true;
+            }
+        }
+        if !added {
+            break;
+        }
+    }
+    selected
+}
+
+fn vite_needs_modules_metadata_backport(version: &str) -> bool {
+    let core = version.split(['-', '+']).next().unwrap_or(version);
+    let mut parts = core.split('.');
+    let Some(major) = parts.next().and_then(|part| part.parse::<u32>().ok()) else {
+        return false;
+    };
+    if major != 8 {
+        return major < 8;
+    }
+    parts
+        .next()
+        .and_then(|part| part.parse::<u32>().ok())
+        .unwrap_or(0)
+        < 1
+}
+
+const VITE_COMPAT_PREPEND: &str = "import{readFileSync as __aubeRfs}from\"node:fs\";\
+import{join as __aubeJoin,isAbsolute as __aubeIsAbs,resolve as __aubeResolve}from\"node:path\";\n";
+const VITE_COMPAT_INSERT: &str = ";const __awr=searchForWorkspaceRoot(root);\
+if(!allowDirs)allowDirs=[__awr];\
+try{const __ac=__aubeRfs(__aubeJoin(__awr,\"node_modules\",\".modules.yaml\"),\"utf-8\");\
+const __av=JSON.parse(__ac).virtualStoreDir;\
+if(__av){if(__aubeIsAbs(__av))allowDirs.push(__av);\
+else if(__av.startsWith(\"..\"))allowDirs.push(__aubeResolve(__aubeJoin(__awr,\"node_modules\"),__av));}}catch{}";
+const VITE_COMPAT_ANCHORS: &[&str] = &[
+    "let allowDirs = server.fs.allow;",
+    "let allowDirs = server.fs?.allow;",
+    "let allowDirs = (_a = server.fs) === null || _a === void 0 ? void 0 : _a.allow;",
+];
+const VITE_COMPAT_MARKER: &str = "__aubeRfs(__aubeJoin";
+
+/// Backport Vite 8.1's `.modules.yaml` allow-list sniff into the
+/// project-local legacy Vite copies.
+///
+/// The linker may hardlink package files from the CAS. Atomic sibling
+/// replacement is therefore load-bearing: truncating the installed
+/// file in place would mutate the shared CAS inode.
+pub(super) fn patch_legacy_vite_copies(
+    aube_dir: &Path,
+    graph: &aube_lockfile::LockfileGraph,
+    virtual_store_dir_max_length: usize,
+    global_virtual_store: &Path,
+) -> std::io::Result<usize> {
+    let global_virtual_store = std::fs::canonicalize(global_virtual_store)
+        .unwrap_or_else(|_| global_virtual_store.to_path_buf());
+    let mut patched = 0;
+    for dep_path in legacy_vite_dep_paths(graph) {
+        let Some(pkg) = graph.packages.get(&dep_path) else {
+            continue;
+        };
+        let entry = aube_lockfile::dep_path_filename::dep_path_to_filename(
+            &dep_path,
+            virtual_store_dir_max_length,
+        );
+        let vite_dir = aube_dir.join(entry).join("node_modules").join(&pkg.name);
+        let real_vite_dir = match std::fs::canonicalize(&vite_dir) {
+            Ok(path) => path,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error),
+        };
+        if real_vite_dir.starts_with(&global_virtual_store) {
+            return Err(std::io::Error::other(format!(
+                "refusing to patch shared Vite package at {}",
+                real_vite_dir.display()
+            )));
+        }
+        let dist_node = real_vite_dir.join("dist").join("node");
+        if !dist_node.is_dir() {
+            continue;
+        }
+        let mut files = Vec::new();
+        collect_vite_js(&dist_node, &mut files, 0)?;
+        for file in files {
+            patched += usize::from(patch_vite_file(&file)?);
+        }
+    }
+    Ok(patched)
+}
+
+fn collect_vite_js(
+    dir: &Path,
+    out: &mut Vec<std::path::PathBuf>,
+    depth: usize,
+) -> std::io::Result<()> {
+    if depth > 8 {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            collect_vite_js(&path, out, depth + 1)?;
+        } else if file_type.is_file() && path.extension().is_some_and(|ext| ext == "js") {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn patch_vite_file(file: &Path) -> std::io::Result<bool> {
+    let source = std::fs::read_to_string(file)?;
+    if source.contains(VITE_COMPAT_MARKER) {
+        return Ok(false);
+    }
+    let Some(anchor) = VITE_COMPAT_ANCHORS
+        .iter()
+        .find(|anchor| source.contains(**anchor))
+    else {
+        return Ok(false);
+    };
+    let patched = source.replacen(anchor, &format!("{anchor}{VITE_COMPAT_INSERT}"), 1);
+    let patched = format!("{VITE_COMPAT_PREPEND}{patched}");
+    aube_util::fs_atomic::atomic_write(file, patched.as_bytes())?;
+    Ok(true)
+}
+
 pub(super) fn reset_on_mode_change(
     cwd: &Path,
     aube_dir: &Path,
@@ -133,6 +295,7 @@ fn remove_dir_all_if_exists(path: &Path) -> std::io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aube_lockfile::{DepType, DirectDep, LockedPackage};
 
     #[test]
     fn writes_vite_metadata_for_each_importer_and_preserves_unknown_keys() {
@@ -174,5 +337,171 @@ mod tests {
         )
         .expect("root metadata should parse");
         assert_eq!(root_metadata["packageManager"], "pnpm@11.0.0");
+    }
+
+    #[test]
+    fn legacy_direct_vite_is_selected_but_modern_vite_is_not() {
+        let mut graph = aube_lockfile::LockfileGraph::default();
+        graph.importers.insert(
+            ".".to_string(),
+            vec![
+                DirectDep {
+                    name: "vite".to_string(),
+                    dep_path: "vite@7.3.6".to_string(),
+                    dep_type: DepType::Dev,
+                    specifier: Some("^7.0.0".to_string()),
+                },
+                DirectDep {
+                    name: "vite".to_string(),
+                    dep_path: "vite@8.1.0".to_string(),
+                    dep_type: DepType::Dev,
+                    specifier: Some("^8.1.0".to_string()),
+                },
+            ],
+        );
+        for version in ["7.3.6", "8.1.0"] {
+            let dep_path = format!("vite@{version}");
+            graph.packages.insert(
+                dep_path.clone(),
+                LockedPackage {
+                    name: "vite".to_string(),
+                    version: version.to_string(),
+                    dep_path,
+                    ..Default::default()
+                },
+            );
+        }
+
+        assert_eq!(
+            legacy_vite_dep_paths(&graph),
+            ["vite@7.3.6".to_string()].into_iter().collect()
+        );
+    }
+
+    #[test]
+    fn legacy_vite_local_closure_includes_framework_ancestors_only() {
+        let mut graph = aube_lockfile::LockfileGraph::default();
+        graph.importers.insert(
+            ".".to_string(),
+            vec![DirectDep {
+                name: "vitepress".to_string(),
+                dep_path: "vitepress@1.6.4".to_string(),
+                dep_type: DepType::Dev,
+                specifier: Some("^1.6.0".to_string()),
+            }],
+        );
+        graph.packages.insert(
+            "vite@5.4.21".to_string(),
+            LockedPackage {
+                name: "vite".to_string(),
+                version: "5.4.21".to_string(),
+                dep_path: "vite@5.4.21".to_string(),
+                ..Default::default()
+            },
+        );
+        graph.packages.insert(
+            "vitepress@1.6.4".to_string(),
+            LockedPackage {
+                name: "vitepress".to_string(),
+                version: "1.6.4".to_string(),
+                dep_path: "vitepress@1.6.4".to_string(),
+                dependencies: [("vite".to_string(), "5.4.21".to_string())]
+                    .into_iter()
+                    .collect(),
+                ..Default::default()
+            },
+        );
+        graph.packages.insert(
+            "unrelated@1.0.0".to_string(),
+            LockedPackage {
+                name: "unrelated".to_string(),
+                version: "1.0.0".to_string(),
+                dep_path: "unrelated@1.0.0".to_string(),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(
+            legacy_vite_project_local_closure(&graph),
+            ["vite@5.4.21".to_string(), "vitepress@1.6.4".to_string()]
+                .into_iter()
+                .collect()
+        );
+    }
+
+    #[test]
+    fn legacy_vite_patch_is_anchored_idempotent_and_breaks_cas_hardlinks() {
+        let tmp = tempfile::tempdir().expect("tempdir should be created");
+        let aube_dir = tmp.path().join("project/node_modules/.aube");
+        let vite_dir = aube_dir.join("vite@7.3.6/node_modules/vite");
+        let chunks = vite_dir.join("dist/node/chunks");
+        let global = tmp.path().join("global-virtual-store");
+        std::fs::create_dir_all(&chunks).expect("Vite chunks should be created");
+        std::fs::create_dir_all(&global).expect("global store should be created");
+
+        let mut graph = aube_lockfile::LockfileGraph::default();
+        graph.importers.insert(
+            ".".to_string(),
+            vec![DirectDep {
+                name: "vite".to_string(),
+                dep_path: "vite@7.3.6".to_string(),
+                dep_type: DepType::Dev,
+                specifier: Some("^7.0.0".to_string()),
+            }],
+        );
+        graph.packages.insert(
+            "vite@7.3.6".to_string(),
+            LockedPackage {
+                name: "vite".to_string(),
+                version: "7.3.6".to_string(),
+                dep_path: "vite@7.3.6".to_string(),
+                ..Default::default()
+            },
+        );
+
+        let cas = tmp.path().join("cas.js");
+        let chunk = chunks.join("config.js");
+        let source = "let allowDirs = server.fs.allow;\n";
+        std::fs::write(&cas, source).expect("CAS stand-in should be written");
+        std::fs::hard_link(&cas, &chunk).expect("installed chunk should hardlink to CAS stand-in");
+
+        let patched = patch_legacy_vite_copies(
+            &aube_dir,
+            &graph,
+            aube_lockfile::dep_path_filename::DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH,
+            &global,
+        )
+        .expect("legacy Vite should be patched");
+        assert_eq!(patched, 1);
+        let output = std::fs::read_to_string(&chunk).expect("patched chunk should be readable");
+        assert!(output.starts_with(VITE_COMPAT_PREPEND));
+        assert!(output.contains(VITE_COMPAT_MARKER));
+        assert_eq!(
+            std::fs::read_to_string(&cas).expect("CAS stand-in should be readable"),
+            source,
+            "atomic replacement must not mutate the shared hardlink inode"
+        );
+
+        let second = patch_legacy_vite_copies(
+            &aube_dir,
+            &graph,
+            aube_lockfile::dep_path_filename::DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH,
+            &global,
+        )
+        .expect("second patch pass should succeed");
+        assert_eq!(second, 0);
+    }
+
+    #[test]
+    fn legacy_vite_patch_matches_vite_two_through_eight_bundles() {
+        let tmp = tempfile::tempdir().expect("tempdir should be created");
+        for (index, anchor) in VITE_COMPAT_ANCHORS.iter().enumerate() {
+            let chunk = tmp.path().join(format!("chunk-{index}.js"));
+            std::fs::write(&chunk, format!("{anchor}\n"))
+                .expect("synthetic Vite chunk should be written");
+            assert!(patch_vite_file(&chunk).expect("matching anchor should patch"));
+            let output = std::fs::read_to_string(&chunk).expect("patched chunk should be readable");
+            assert!(output.contains(VITE_COMPAT_MARKER));
+        }
     }
 }

--- a/crates/aube/src/commands/install/gvs.rs
+++ b/crates/aube/src/commands/install/gvs.rs
@@ -46,6 +46,42 @@ pub(super) fn planned_global_virtual_store(
         .unwrap_or_else(|| !env_snapshot.iter().any(|(k, _)| k == "CI"))
 }
 
+/// Write the pnpm-compatible metadata Vite 8.1+ uses to allow files
+/// served from a virtual store outside the workspace root.
+///
+/// `.modules.yaml` is not aube's install-state file — `.aube-state`
+/// remains authoritative. This is a narrow compatibility surface, and
+/// preserving unknown keys lets aube coexist with metadata left by
+/// pnpm or other tools.
+pub(super) fn write_modules_metadata(
+    workspace_root: &Path,
+    graph: &aube_lockfile::LockfileGraph,
+    modules_dir_name: &str,
+    virtual_store_dir: &Path,
+) -> std::io::Result<()> {
+    let virtual_store_dir = virtual_store_dir.to_string_lossy().into_owned();
+    for importer_path in graph.importers.keys() {
+        let project_dir =
+            super::workspace::importer_project_dir(workspace_root, importer_path.as_str());
+        let metadata_path = project_dir.join(modules_dir_name).join(".modules.yaml");
+        let mut metadata = match std::fs::read(&metadata_path) {
+            Ok(bytes) => {
+                serde_json::from_slice::<serde_json::Map<String, serde_json::Value>>(&bytes)
+                    .unwrap_or_default()
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => serde_json::Map::new(),
+            Err(err) => return Err(err),
+        };
+        metadata.insert(
+            "virtualStoreDir".to_string(),
+            serde_json::Value::String(virtual_store_dir.clone()),
+        );
+        let bytes = serde_json::to_vec_pretty(&metadata)?;
+        aube_util::fs_atomic::atomic_write(&metadata_path, &bytes)?;
+    }
+    Ok(())
+}
+
 pub(super) fn reset_on_mode_change(
     cwd: &Path,
     aube_dir: &Path,
@@ -91,5 +127,52 @@ fn remove_dir_all_if_exists(path: &Path) -> std::io::Result<()> {
         Ok(()) => Ok(()),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn writes_vite_metadata_for_each_importer_and_preserves_unknown_keys() {
+        let tmp = tempfile::tempdir().expect("tempdir should be created");
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("node_modules"))
+            .expect("root node_modules should be created");
+        std::fs::create_dir_all(root.join("packages/app/node_modules"))
+            .expect("member node_modules should be created");
+        std::fs::write(
+            root.join("node_modules/.modules.yaml"),
+            br#"{"packageManager":"pnpm@11.0.0","virtualStoreDir":".pnpm"}"#,
+        )
+        .expect("existing metadata should be written");
+
+        let mut graph = aube_lockfile::LockfileGraph::default();
+        graph.importers.insert(".".to_string(), Default::default());
+        graph
+            .importers
+            .insert("packages/app".to_string(), Default::default());
+        let store = root.join("shared/virtual-store");
+
+        write_modules_metadata(root, &graph, "node_modules", &store)
+            .expect("metadata should be written");
+
+        for project in [root.to_path_buf(), root.join("packages/app")] {
+            let bytes = std::fs::read(project.join("node_modules/.modules.yaml"))
+                .expect("metadata should exist");
+            let metadata: serde_json::Value =
+                serde_json::from_slice(&bytes).expect("metadata should be JSON-compatible YAML");
+            assert_eq!(
+                metadata["virtualStoreDir"],
+                store.to_string_lossy().as_ref()
+            );
+        }
+        let root_metadata: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(root.join("node_modules/.modules.yaml"))
+                .expect("root metadata should exist"),
+        )
+        .expect("root metadata should parse");
+        assert_eq!(root_metadata["packageManager"], "pnpm@11.0.0");
     }
 }

--- a/crates/aube/src/commands/install/gvs.rs
+++ b/crates/aube/src/commands/install/gvs.rs
@@ -1,6 +1,6 @@
 use crate::state;
 use miette::miette;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub(super) fn resolve_global_virtual_store_override(
     settings_ctx: &aube_settings::ResolveCtx<'_>,
@@ -120,7 +120,15 @@ fn upsert_virtual_store_dir(existing: &[u8], virtual_store_dir: &str) -> std::io
             (!content.is_empty()).then(|| content.starts_with('{'))
         })
         .unwrap_or(false);
-    if flow_mapping {
+    let block_scalar = source.lines().any(|line| {
+        let line = line.trim_end();
+        !line.chars().next().is_some_and(char::is_whitespace)
+            && line.split_once(':').is_some_and(|(key, value)| {
+                key.trim_matches([' ', '"', '\'']) == "virtualStoreDir"
+                    && matches!(value.trim_start().chars().next(), Some('|' | '>'))
+            })
+    });
+    if flow_mapping || block_scalar {
         let Some(mapping) = parsed.as_mapping_mut() else {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
@@ -232,6 +240,7 @@ pub(super) fn detect_existing_global_virtual_store(
     workspace_root: &Path,
     aube_dir: &Path,
     modules_dir_name: &str,
+    global_virtual_store: &Path,
 ) -> Option<bool> {
     let mut existing_gvs = super::settings::detect_aube_dir_gvs_mode(aube_dir)?;
     if !existing_gvs {
@@ -239,7 +248,20 @@ pub(super) fn detect_existing_global_virtual_store(
         existing_gvs = std::fs::read(metadata_path)
             .ok()
             .and_then(|bytes| metadata_virtual_store_dir(&bytes))
-            .is_some_and(|path| Path::new(&path) != aube_dir);
+            .map(PathBuf::from)
+            .map(|path| {
+                if path.is_absolute() {
+                    path
+                } else {
+                    workspace_root.join(modules_dir_name).join(path)
+                }
+            })
+            .is_some_and(|path| {
+                let actual = std::fs::canonicalize(&path).unwrap_or(path);
+                let expected = std::fs::canonicalize(global_virtual_store)
+                    .unwrap_or_else(|_| global_virtual_store.to_path_buf());
+                actual == expected
+            });
     }
     Some(existing_gvs)
 }
@@ -474,8 +496,17 @@ pub(super) fn reset_on_mode_change(
     modules_dir_name: &str,
     planned_gvs: bool,
 ) -> miette::Result<()> {
-    let Some(existing_gvs) = detect_existing_global_virtual_store(cwd, aube_dir, modules_dir_name)
+    let Some(global_virtual_store) =
+        aube_store::dirs::cache_dir().map(|dir| dir.join(aube_store::VIRTUAL_STORE_SUBDIR))
     else {
+        return Ok(());
+    };
+    let Some(existing_gvs) = detect_existing_global_virtual_store(
+        cwd,
+        aube_dir,
+        modules_dir_name,
+        &global_virtual_store,
+    ) else {
         return Ok(());
     };
     if existing_gvs == planned_gvs {
@@ -627,6 +658,30 @@ mod tests {
     }
 
     #[test]
+    fn rewrites_block_scalar_yaml_without_leaving_scalar_lines() {
+        let existing = b"virtualStoreDir: |-\n  .pnpm\nlayoutVersion: 5\nhoistPattern:\n  - '*'\n";
+        let updated =
+            upsert_virtual_store_dir(existing, "/shared/store").expect("metadata should update");
+        let parsed: yaml_serde::Value =
+            yaml_serde::from_slice(&updated).expect("updated metadata should remain valid YAML");
+        let mapping = parsed
+            .as_mapping()
+            .expect("updated metadata should remain a mapping");
+        assert_eq!(
+            mapping
+                .get(yaml_serde::Value::String("virtualStoreDir".to_string()))
+                .and_then(yaml_serde::Value::as_str),
+            Some("/shared/store")
+        );
+        assert_eq!(
+            mapping
+                .get(yaml_serde::Value::String("layoutVersion".to_string()))
+                .and_then(yaml_serde::Value::as_i64),
+            Some(5)
+        );
+    }
+
+    #[test]
     fn metadata_disambiguates_gvs_trees_with_only_local_packages() {
         let tmp = tempfile::tempdir().expect("tempdir should be created");
         let root = tmp.path();
@@ -644,10 +699,20 @@ mod tests {
         )
         .expect("metadata should be written");
 
-        reset_on_mode_change(root, &aube_dir, "node_modules", true)
-            .expect("matching GVS mode should be preserved");
-
-        assert!(aube_dir.join("vendor-dir@9.9.9").is_dir());
+        assert_eq!(
+            detect_existing_global_virtual_store(root, &aube_dir, "node_modules", &shared_store),
+            Some(true)
+        );
+        std::fs::write(
+            root.join("node_modules/.modules.yaml"),
+            "virtualStoreDir: .pnpm\n",
+        )
+        .expect("pnpm metadata should be written");
+        assert_eq!(
+            detect_existing_global_virtual_store(root, &aube_dir, "node_modules", &shared_store),
+            Some(false),
+            "pnpm's relative local store must not imply aube GVS mode"
+        );
     }
 
     #[test]

--- a/crates/aube/src/commands/install/gvs.rs
+++ b/crates/aube/src/commands/install/gvs.rs
@@ -113,6 +113,9 @@ fn upsert_virtual_store_dir(existing: &[u8], virtual_store_dir: &str) -> std::io
         .map(str::trim)
         .filter(|line| !line.is_empty() && !line.starts_with('#'))
         .find_map(|line| {
+            if line.starts_with('%') || line == "---" || line == "..." {
+                return None;
+            }
             let content = line
                 .strip_prefix("---")
                 .map(str::trim_start)
@@ -635,26 +638,30 @@ mod tests {
 
     #[test]
     fn rewrites_flow_style_yaml_as_a_valid_mapping() {
-        let existing = b"{virtualStoreDir: .pnpm, layoutVersion: 5}\n";
-        let updated =
-            upsert_virtual_store_dir(existing, "/shared/store").expect("metadata should update");
-        let parsed: yaml_serde::Value =
-            yaml_serde::from_slice(&updated).expect("updated metadata should remain valid YAML");
-        let mapping = parsed
-            .as_mapping()
-            .expect("updated metadata should remain a mapping");
-        assert_eq!(
-            mapping
-                .get(yaml_serde::Value::String("virtualStoreDir".to_string()))
-                .and_then(yaml_serde::Value::as_str),
-            Some("/shared/store")
-        );
-        assert_eq!(
-            mapping
-                .get(yaml_serde::Value::String("layoutVersion".to_string()))
-                .and_then(yaml_serde::Value::as_i64),
-            Some(5)
-        );
+        for existing in [
+            "{virtualStoreDir: .pnpm, layoutVersion: 5}\n",
+            "%YAML 1.2\n---\n{virtualStoreDir: .pnpm, layoutVersion: 5}\n",
+        ] {
+            let updated = upsert_virtual_store_dir(existing.as_bytes(), "/shared/store")
+                .expect("metadata should update");
+            let parsed: yaml_serde::Value = yaml_serde::from_slice(&updated)
+                .expect("updated metadata should remain valid YAML");
+            let mapping = parsed
+                .as_mapping()
+                .expect("updated metadata should remain a mapping");
+            assert_eq!(
+                mapping
+                    .get(yaml_serde::Value::String("virtualStoreDir".to_string()))
+                    .and_then(yaml_serde::Value::as_str),
+                Some("/shared/store")
+            );
+            assert_eq!(
+                mapping
+                    .get(yaml_serde::Value::String("layoutVersion".to_string()))
+                    .and_then(yaml_serde::Value::as_i64),
+                Some(5)
+            );
+        }
     }
 
     #[test]

--- a/crates/aube/src/commands/install/gvs.rs
+++ b/crates/aube/src/commands/install/gvs.rs
@@ -372,45 +372,60 @@ pub(super) fn patch_legacy_vite_copies(
     Ok(patched)
 }
 
-pub(super) fn legacy_vite_patches_are_current(
-    aube_dir: &Path,
-    graph: &aube_lockfile::LockfileGraph,
-    virtual_store_dir_max_length: usize,
-) -> bool {
-    for dep_path in legacy_vite_dep_paths(graph) {
-        let Some(pkg) = graph.packages.get(&dep_path) else {
-            return false;
+pub(super) fn legacy_vite_patches_are_current(aube_dir: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(aube_dir) else {
+        return false;
+    };
+    let mut inspected = std::collections::BTreeSet::new();
+    for entry in entries.flatten() {
+        let modules_dir = entry.path().join("node_modules");
+        let Ok(packages) = std::fs::read_dir(modules_dir) else {
+            continue;
         };
-        let entry = aube_lockfile::dep_path_filename::dep_path_to_filename(
-            &dep_path,
-            virtual_store_dir_max_length,
-        );
-        let dist_node = aube_dir
-            .join(entry)
-            .join("node_modules")
-            .join(&pkg.name)
-            .join("dist")
-            .join("node");
-        let mut files = Vec::new();
-        if collect_vite_js(&dist_node, &mut files, 0).is_err() {
-            return false;
-        }
-        let mut found_marker = false;
-        for file in files {
-            let Ok(source) = std::fs::read_to_string(file) else {
+        for package in packages.flatten() {
+            let package_dir = package.path();
+            let Ok(bytes) = std::fs::read(package_dir.join("package.json")) else {
+                continue;
+            };
+            let Ok(manifest) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
                 return false;
             };
-            if source.contains(VITE_COMPAT_MARKER) {
-                found_marker = true;
-            } else if VITE_COMPAT_ANCHORS
-                .iter()
-                .any(|anchor| source.contains(anchor))
+            if manifest.get("name").and_then(serde_json::Value::as_str) != Some("vite") {
+                continue;
+            }
+            let Some(version) = manifest.get("version").and_then(serde_json::Value::as_str) else {
+                return false;
+            };
+            if !vite_needs_modules_metadata_backport(version) {
+                continue;
+            }
+            let real_package_dir =
+                std::fs::canonicalize(&package_dir).unwrap_or_else(|_| package_dir.clone());
+            if !inspected.insert(real_package_dir.clone()) {
+                continue;
+            }
+            let mut files = Vec::new();
+            if collect_vite_js(&real_package_dir.join("dist").join("node"), &mut files, 0).is_err()
             {
                 return false;
             }
-        }
-        if !found_marker {
-            return false;
+            let mut found_marker = false;
+            for file in files {
+                let Ok(source) = std::fs::read_to_string(file) else {
+                    return false;
+                };
+                if source.contains(VITE_COMPAT_MARKER) {
+                    found_marker = true;
+                } else if VITE_COMPAT_ANCHORS
+                    .iter()
+                    .any(|anchor| source.contains(anchor))
+                {
+                    return false;
+                }
+            }
+            if !found_marker {
+                return false;
+            }
         }
     }
     true
@@ -735,6 +750,11 @@ mod tests {
         let global = tmp.path().join("global-virtual-store");
         std::fs::create_dir_all(&chunks).expect("Vite chunks should be created");
         std::fs::create_dir_all(&global).expect("global store should be created");
+        std::fs::write(
+            vite_dir.join("package.json"),
+            r#"{"name":"vite","version":"7.3.6"}"#,
+        )
+        .expect("Vite manifest should be written");
 
         let mut graph = aube_lockfile::LockfileGraph::default();
         graph.importers.insert(
@@ -787,18 +807,10 @@ mod tests {
         )
         .expect("second patch pass should succeed");
         assert_eq!(second, 0);
-        assert!(legacy_vite_patches_are_current(
-            &aube_dir,
-            &graph,
-            aube_lockfile::dep_path_filename::DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH,
-        ));
+        assert!(legacy_vite_patches_are_current(&aube_dir));
 
         std::fs::write(&chunk, source).expect("unpatched Vite chunk should be restored");
-        assert!(!legacy_vite_patches_are_current(
-            &aube_dir,
-            &graph,
-            aube_lockfile::dep_path_filename::DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH,
-        ));
+        assert!(!legacy_vite_patches_are_current(&aube_dir));
     }
 
     #[test]

--- a/crates/aube/src/commands/install/gvs.rs
+++ b/crates/aube/src/commands/install/gvs.rs
@@ -64,22 +64,114 @@ pub(super) fn write_modules_metadata(
         let project_dir =
             super::workspace::importer_project_dir(workspace_root, importer_path.as_str());
         let metadata_path = project_dir.join(modules_dir_name).join(".modules.yaml");
-        let mut metadata = match std::fs::read(&metadata_path) {
-            Ok(bytes) => {
-                serde_json::from_slice::<serde_json::Map<String, serde_json::Value>>(&bytes)
-                    .unwrap_or_default()
+        let bytes = match std::fs::read(&metadata_path) {
+            Ok(bytes) => upsert_virtual_store_dir(&bytes, &virtual_store_dir)?,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                let mut metadata = serde_json::Map::new();
+                metadata.insert(
+                    "virtualStoreDir".to_string(),
+                    serde_json::Value::String(virtual_store_dir.clone()),
+                );
+                serde_json::to_vec_pretty(&metadata)?
             }
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => serde_json::Map::new(),
             Err(err) => return Err(err),
         };
-        metadata.insert(
-            "virtualStoreDir".to_string(),
-            serde_json::Value::String(virtual_store_dir.clone()),
-        );
-        let bytes = serde_json::to_vec_pretty(&metadata)?;
         aube_util::fs_atomic::atomic_write(&metadata_path, &bytes)?;
     }
     Ok(())
+}
+
+fn upsert_virtual_store_dir(existing: &[u8], virtual_store_dir: &str) -> std::io::Result<Vec<u8>> {
+    if let Ok(mut metadata) =
+        serde_json::from_slice::<serde_json::Map<String, serde_json::Value>>(existing)
+    {
+        metadata.insert(
+            "virtualStoreDir".to_string(),
+            serde_json::Value::String(virtual_store_dir.to_string()),
+        );
+        return serde_json::to_vec_pretty(&metadata).map_err(std::io::Error::other);
+    }
+
+    let source = std::str::from_utf8(existing)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+    let parsed: yaml_serde::Value = yaml_serde::from_str(source)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+    if !parsed.is_mapping() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "node_modules/.modules.yaml must contain a mapping",
+        ));
+    }
+
+    let quoted = serde_json::to_string(virtual_store_dir).map_err(std::io::Error::other)?;
+    let replacement = format!("virtualStoreDir: {quoted}");
+    let mut output = String::with_capacity(source.len() + replacement.len() + 1);
+    let mut replaced = false;
+    for segment in source.split_inclusive('\n') {
+        let line = segment.strip_suffix('\n').unwrap_or(segment);
+        let line = line.strip_suffix('\r').unwrap_or(line);
+        let is_top_level_key = !line.chars().next().is_some_and(char::is_whitespace)
+            && line
+                .split_once(':')
+                .is_some_and(|(key, _)| key.trim_matches([' ', '"', '\'']) == "virtualStoreDir");
+        if is_top_level_key {
+            output.push_str(&replacement);
+            if segment.ends_with("\r\n") {
+                output.push_str("\r\n");
+            } else if segment.ends_with('\n') {
+                output.push('\n');
+            }
+            replaced = true;
+        } else {
+            output.push_str(segment);
+        }
+    }
+    if !replaced {
+        if !output.is_empty() && !output.ends_with('\n') {
+            output.push('\n');
+        }
+        output.push_str(&replacement);
+        output.push('\n');
+    }
+    Ok(output.into_bytes())
+}
+
+fn metadata_virtual_store_dir(bytes: &[u8]) -> Option<String> {
+    if let Ok(metadata) =
+        serde_json::from_slice::<serde_json::Map<String, serde_json::Value>>(bytes)
+    {
+        return metadata
+            .get("virtualStoreDir")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string);
+    }
+    let source = std::str::from_utf8(bytes).ok()?;
+    let metadata: yaml_serde::Value = yaml_serde::from_str(source).ok()?;
+    metadata
+        .as_mapping()?
+        .get(yaml_serde::Value::String("virtualStoreDir".to_string()))?
+        .as_str()
+        .map(str::to_string)
+}
+
+pub(super) fn modules_metadata_is_current<'a>(
+    workspace_root: &Path,
+    importer_paths: impl IntoIterator<Item = &'a str>,
+    modules_dir_name: &str,
+    expected_virtual_store_dir: Option<&Path>,
+) -> bool {
+    importer_paths.into_iter().all(|importer_path| {
+        let project_dir = super::workspace::importer_project_dir(workspace_root, importer_path);
+        let metadata_path = project_dir.join(modules_dir_name).join(".modules.yaml");
+        let Some(actual) = std::fs::read(metadata_path)
+            .ok()
+            .and_then(|bytes| metadata_virtual_store_dir(&bytes))
+        else {
+            return false;
+        };
+        expected_virtual_store_dir
+            .is_none_or(|expected| actual == expected.to_string_lossy().as_ref())
+    })
 }
 
 fn legacy_vite_dep_paths(
@@ -148,7 +240,8 @@ import{join as __aubeJoin,isAbsolute as __aubeIsAbs,resolve as __aubeResolve}fro
 const VITE_COMPAT_INSERT: &str = ";const __awr=searchForWorkspaceRoot(root);\
 if(!allowDirs)allowDirs=[__awr];\
 try{const __ac=__aubeRfs(__aubeJoin(__awr,\"node_modules\",\".modules.yaml\"),\"utf-8\");\
-const __av=JSON.parse(__ac).virtualStoreDir;\
+let __av;try{__av=JSON.parse(__ac).virtualStoreDir;}catch{const __am=__ac.match(/^virtualStoreDir:\\s*(.+?)\\s*(?:#.*)?$/m);\
+if(__am)try{__av=JSON.parse(__am[1]);}catch{__av=__am[1];}}\
 if(__av){if(__aubeIsAbs(__av))allowDirs.push(__av);\
 else if(__av.startsWith(\"..\"))allowDirs.push(__aubeResolve(__aubeJoin(__awr,\"node_modules\"),__av));}}catch{}";
 const VITE_COMPAT_ANCHORS: &[&str] = &[
@@ -310,6 +403,11 @@ mod tests {
             br#"{"packageManager":"pnpm@11.0.0","virtualStoreDir":".pnpm"}"#,
         )
         .expect("existing metadata should be written");
+        std::fs::write(
+            root.join("packages/app/node_modules/.modules.yaml"),
+            "layoutVersion: 5\n# preserve this comment\nvirtualStoreDir: .pnpm\nhoistPattern:\n  - '*'\n",
+        )
+        .expect("existing pnpm YAML should be written");
 
         let mut graph = aube_lockfile::LockfileGraph::default();
         graph.importers.insert(".".to_string(), Default::default());
@@ -324,11 +422,9 @@ mod tests {
         for project in [root.to_path_buf(), root.join("packages/app")] {
             let bytes = std::fs::read(project.join("node_modules/.modules.yaml"))
                 .expect("metadata should exist");
-            let metadata: serde_json::Value =
-                serde_json::from_slice(&bytes).expect("metadata should be JSON-compatible YAML");
             assert_eq!(
-                metadata["virtualStoreDir"],
-                store.to_string_lossy().as_ref()
+                metadata_virtual_store_dir(&bytes).as_deref(),
+                Some(store.to_string_lossy().as_ref())
             );
         }
         let root_metadata: serde_json::Value = serde_json::from_slice(
@@ -337,6 +433,30 @@ mod tests {
         )
         .expect("root metadata should parse");
         assert_eq!(root_metadata["packageManager"], "pnpm@11.0.0");
+        let member_metadata =
+            std::fs::read_to_string(root.join("packages/app/node_modules/.modules.yaml"))
+                .expect("member metadata should be readable");
+        assert!(member_metadata.contains("layoutVersion: 5"));
+        assert!(member_metadata.contains("# preserve this comment"));
+        assert!(member_metadata.contains("hoistPattern:\n  - '*'"));
+        assert_eq!(
+            metadata_virtual_store_dir(member_metadata.as_bytes()).as_deref(),
+            Some(store.to_string_lossy().as_ref())
+        );
+        assert!(modules_metadata_is_current(
+            root,
+            graph.importers.keys().map(String::as_str),
+            "node_modules",
+            Some(&store)
+        ));
+        std::fs::remove_file(root.join("packages/app/node_modules/.modules.yaml"))
+            .expect("member metadata should be removed");
+        assert!(!modules_metadata_is_current(
+            root,
+            graph.importers.keys().map(String::as_str),
+            "node_modules",
+            Some(&store)
+        ));
     }
 
     #[test]

--- a/crates/aube/src/commands/install/gvs.rs
+++ b/crates/aube/src/commands/install/gvs.rs
@@ -131,7 +131,8 @@ fn upsert_virtual_store_dir(existing: &[u8], virtual_store_dir: &str) -> std::io
                     && matches!(value.trim_start().chars().next(), Some('|' | '>'))
             })
     });
-    if flow_mapping || block_scalar {
+    let explicit_document_end = source.lines().any(|line| line.trim() == "...");
+    if flow_mapping || block_scalar || explicit_document_end {
         let Some(mapping) = parsed.as_mapping_mut() else {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
@@ -485,7 +486,7 @@ try{{const __ac=__aubeRfs(__aubeJoin(__awr,{modules_dir},\".modules.yaml\"),\"ut
 let __av;try{{__av=JSON.parse(__ac).virtualStoreDir;}}catch{{const __am=__ac.match(/^virtualStoreDir:\\s*(.+?)\\s*(?:#.*)?$/m);\
 if(__am)try{{__av=JSON.parse(__am[1]);}}catch{{__av=__am[1];}}}}\
 if(__av){{if(__aubeIsAbs(__av))allowDirs.push(__av);\
-else if(__av.startsWith(\"..\"))allowDirs.push(__aubeResolve(__aubeJoin(__awr,{modules_dir}),__av));}}}}catch{{}}"
+else if(__av.startsWith(\"..\"))allowDirs.push(__aubeResolve(__aubeJoin(__awr,{modules_dir}),__av));}}}}catch{{void 0;}}"
     );
     let patched = source.replacen(anchor, &format!("{anchor}{insert}"), 1);
     let patched = format!("{VITE_COMPAT_PREPEND}{patched}");
@@ -685,6 +686,24 @@ mod tests {
                 .get(yaml_serde::Value::String("layoutVersion".to_string()))
                 .and_then(yaml_serde::Value::as_i64),
             Some(5)
+        );
+    }
+
+    #[test]
+    fn inserts_metadata_before_an_explicit_document_end() {
+        let existing = b"layoutVersion: 5\nhoistPattern:\n  - '*'\n...\n";
+        let updated =
+            upsert_virtual_store_dir(existing, "/shared/store").expect("metadata should update");
+        let parsed: yaml_serde::Value =
+            yaml_serde::from_slice(&updated).expect("updated metadata should remain valid YAML");
+        let mapping = parsed
+            .as_mapping()
+            .expect("updated metadata should remain a mapping");
+        assert_eq!(
+            mapping
+                .get(yaml_serde::Value::String("virtualStoreDir".to_string()))
+                .and_then(yaml_serde::Value::as_str),
+            Some("/shared/store")
         );
     }
 

--- a/crates/aube/src/commands/install/gvs.rs
+++ b/crates/aube/src/commands/install/gvs.rs
@@ -98,7 +98,7 @@ fn upsert_virtual_store_dir(existing: &[u8], virtual_store_dir: &str) -> std::io
 
     let source = std::str::from_utf8(existing)
         .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
-    let parsed: yaml_serde::Value = yaml_serde::from_str(source)
+    let mut parsed: yaml_serde::Value = yaml_serde::from_str(source)
         .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
     if !parsed.is_mapping() {
         return Err(std::io::Error::new(
@@ -108,6 +108,34 @@ fn upsert_virtual_store_dir(existing: &[u8], virtual_store_dir: &str) -> std::io
     }
 
     let quoted = serde_json::to_string(virtual_store_dir).map_err(std::io::Error::other)?;
+    let flow_mapping = source
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .find_map(|line| {
+            let content = line
+                .strip_prefix("---")
+                .map(str::trim_start)
+                .unwrap_or(line);
+            (!content.is_empty()).then(|| content.starts_with('{'))
+        })
+        .unwrap_or(false);
+    if flow_mapping {
+        let Some(mapping) = parsed.as_mapping_mut() else {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "node_modules/.modules.yaml must contain a mapping",
+            ));
+        };
+        mapping.insert(
+            yaml_serde::Value::String("virtualStoreDir".to_string()),
+            yaml_serde::Value::String(virtual_store_dir.to_string()),
+        );
+        return yaml_serde::to_string(&parsed)
+            .map(String::into_bytes)
+            .map_err(std::io::Error::other);
+    }
+
     let replacement = format!("virtualStoreDir: {quoted}");
     let mut output = String::with_capacity(source.len() + replacement.len() + 1);
     let mut replaced = false;
@@ -309,6 +337,50 @@ pub(super) fn patch_legacy_vite_copies(
     Ok(patched)
 }
 
+pub(super) fn legacy_vite_patches_are_current(
+    aube_dir: &Path,
+    graph: &aube_lockfile::LockfileGraph,
+    virtual_store_dir_max_length: usize,
+) -> bool {
+    for dep_path in legacy_vite_dep_paths(graph) {
+        let Some(pkg) = graph.packages.get(&dep_path) else {
+            return false;
+        };
+        let entry = aube_lockfile::dep_path_filename::dep_path_to_filename(
+            &dep_path,
+            virtual_store_dir_max_length,
+        );
+        let dist_node = aube_dir
+            .join(entry)
+            .join("node_modules")
+            .join(&pkg.name)
+            .join("dist")
+            .join("node");
+        let mut files = Vec::new();
+        if collect_vite_js(&dist_node, &mut files, 0).is_err() {
+            return false;
+        }
+        let mut found_marker = false;
+        for file in files {
+            let Ok(source) = std::fs::read_to_string(file) else {
+                return false;
+            };
+            if source.contains(VITE_COMPAT_MARKER) {
+                found_marker = true;
+            } else if VITE_COMPAT_ANCHORS
+                .iter()
+                .any(|anchor| source.contains(anchor))
+            {
+                return false;
+            }
+        }
+        if !found_marker {
+            return false;
+        }
+    }
+    true
+}
+
 fn collect_vite_js(
     dir: &Path,
     out: &mut Vec<std::path::PathBuf>,
@@ -481,6 +553,30 @@ mod tests {
     }
 
     #[test]
+    fn rewrites_flow_style_yaml_as_a_valid_mapping() {
+        let existing = b"{virtualStoreDir: .pnpm, layoutVersion: 5}\n";
+        let updated =
+            upsert_virtual_store_dir(existing, "/shared/store").expect("metadata should update");
+        let parsed: yaml_serde::Value =
+            yaml_serde::from_slice(&updated).expect("updated metadata should remain valid YAML");
+        let mapping = parsed
+            .as_mapping()
+            .expect("updated metadata should remain a mapping");
+        assert_eq!(
+            mapping
+                .get(yaml_serde::Value::String("virtualStoreDir".to_string()))
+                .and_then(yaml_serde::Value::as_str),
+            Some("/shared/store")
+        );
+        assert_eq!(
+            mapping
+                .get(yaml_serde::Value::String("layoutVersion".to_string()))
+                .and_then(yaml_serde::Value::as_i64),
+            Some(5)
+        );
+    }
+
+    #[test]
     fn legacy_direct_vite_is_selected_but_modern_vite_is_not() {
         let mut graph = aube_lockfile::LockfileGraph::default();
         graph.importers.insert(
@@ -631,6 +727,18 @@ mod tests {
         )
         .expect("second patch pass should succeed");
         assert_eq!(second, 0);
+        assert!(legacy_vite_patches_are_current(
+            &aube_dir,
+            &graph,
+            aube_lockfile::dep_path_filename::DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH,
+        ));
+
+        std::fs::write(&chunk, source).expect("unpatched Vite chunk should be restored");
+        assert!(!legacy_vite_patches_are_current(
+            &aube_dir,
+            &graph,
+            aube_lockfile::dep_path_filename::DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH,
+        ));
     }
 
     #[test]

--- a/crates/aube/src/commands/install/gvs.rs
+++ b/crates/aube/src/commands/install/gvs.rs
@@ -310,13 +310,6 @@ fn vite_needs_modules_metadata_backport(version: &str) -> bool {
 
 const VITE_COMPAT_PREPEND: &str = "import{readFileSync as __aubeRfs}from\"node:fs\";\
 import{join as __aubeJoin,isAbsolute as __aubeIsAbs,resolve as __aubeResolve}from\"node:path\";\n";
-const VITE_COMPAT_INSERT: &str = ";const __awr=searchForWorkspaceRoot(root);\
-if(!allowDirs)allowDirs=[__awr];\
-try{const __ac=__aubeRfs(__aubeJoin(__awr,\"node_modules\",\".modules.yaml\"),\"utf-8\");\
-let __av;try{__av=JSON.parse(__ac).virtualStoreDir;}catch{const __am=__ac.match(/^virtualStoreDir:\\s*(.+?)\\s*(?:#.*)?$/m);\
-if(__am)try{__av=JSON.parse(__am[1]);}catch{__av=__am[1];}}\
-if(__av){if(__aubeIsAbs(__av))allowDirs.push(__av);\
-else if(__av.startsWith(\"..\"))allowDirs.push(__aubeResolve(__aubeJoin(__awr,\"node_modules\"),__av));}}catch{}";
 const VITE_COMPAT_ANCHORS: &[&str] = &[
     "let allowDirs = server.fs.allow;",
     "let allowDirs = server.fs?.allow;",
@@ -335,6 +328,7 @@ pub(super) fn patch_legacy_vite_copies(
     graph: &aube_lockfile::LockfileGraph,
     virtual_store_dir_max_length: usize,
     global_virtual_store: &Path,
+    modules_dir_name: &str,
 ) -> std::io::Result<usize> {
     let global_virtual_store = std::fs::canonicalize(global_virtual_store)
         .unwrap_or_else(|_| global_virtual_store.to_path_buf());
@@ -366,7 +360,7 @@ pub(super) fn patch_legacy_vite_copies(
         let mut files = Vec::new();
         collect_vite_js(&dist_node, &mut files, 0)?;
         for file in files {
-            patched += usize::from(patch_vite_file(&file)?);
+            patched += usize::from(patch_vite_file(&file, modules_dir_name)?);
         }
     }
     Ok(patched)
@@ -409,22 +403,17 @@ pub(super) fn legacy_vite_patches_are_current(aube_dir: &Path) -> bool {
             {
                 return false;
             }
-            let mut found_marker = false;
             for file in files {
                 let Ok(source) = std::fs::read_to_string(file) else {
                     return false;
                 };
-                if source.contains(VITE_COMPAT_MARKER) {
-                    found_marker = true;
-                } else if VITE_COMPAT_ANCHORS
-                    .iter()
-                    .any(|anchor| source.contains(anchor))
+                if !source.contains(VITE_COMPAT_MARKER)
+                    && VITE_COMPAT_ANCHORS
+                        .iter()
+                        .any(|anchor| source.contains(anchor))
                 {
                     return false;
                 }
-            }
-            if !found_marker {
-                return false;
             }
         }
     }
@@ -452,7 +441,7 @@ fn collect_vite_js(
     Ok(())
 }
 
-fn patch_vite_file(file: &Path) -> std::io::Result<bool> {
+fn patch_vite_file(file: &Path, modules_dir_name: &str) -> std::io::Result<bool> {
     let source = std::fs::read_to_string(file)?;
     if source.contains(VITE_COMPAT_MARKER) {
         return Ok(false);
@@ -463,7 +452,17 @@ fn patch_vite_file(file: &Path) -> std::io::Result<bool> {
     else {
         return Ok(false);
     };
-    let patched = source.replacen(anchor, &format!("{anchor}{VITE_COMPAT_INSERT}"), 1);
+    let modules_dir = serde_json::to_string(modules_dir_name).map_err(std::io::Error::other)?;
+    let insert = format!(
+        ";const __awr=searchForWorkspaceRoot(root);\
+if(!allowDirs)allowDirs=[__awr];\
+try{{const __ac=__aubeRfs(__aubeJoin(__awr,{modules_dir},\".modules.yaml\"),\"utf-8\");\
+let __av;try{{__av=JSON.parse(__ac).virtualStoreDir;}}catch{{const __am=__ac.match(/^virtualStoreDir:\\s*(.+?)\\s*(?:#.*)?$/m);\
+if(__am)try{{__av=JSON.parse(__am[1]);}}catch{{__av=__am[1];}}}}\
+if(__av){{if(__aubeIsAbs(__av))allowDirs.push(__av);\
+else if(__av.startsWith(\"..\"))allowDirs.push(__aubeResolve(__aubeJoin(__awr,{modules_dir}),__av));}}}}catch{{}}"
+    );
+    let patched = source.replacen(anchor, &format!("{anchor}{insert}"), 1);
     let patched = format!("{VITE_COMPAT_PREPEND}{patched}");
     aube_util::fs_atomic::atomic_write(file, patched.as_bytes())?;
     Ok(true)
@@ -787,12 +786,15 @@ mod tests {
             &graph,
             aube_lockfile::dep_path_filename::DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH,
             &global,
+            "vendor_modules",
         )
         .expect("legacy Vite should be patched");
         assert_eq!(patched, 1);
         let output = std::fs::read_to_string(&chunk).expect("patched chunk should be readable");
         assert!(output.starts_with(VITE_COMPAT_PREPEND));
         assert!(output.contains(VITE_COMPAT_MARKER));
+        assert!(output.contains(r#"__aubeJoin(__awr,"vendor_modules",".modules.yaml")"#));
+        assert!(!output.contains(r#"__aubeJoin(__awr,"node_modules",".modules.yaml")"#));
         assert_eq!(
             std::fs::read_to_string(&cas).expect("CAS stand-in should be readable"),
             source,
@@ -804,6 +806,7 @@ mod tests {
             &graph,
             aube_lockfile::dep_path_filename::DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH,
             &global,
+            "vendor_modules",
         )
         .expect("second patch pass should succeed");
         assert_eq!(second, 0);
@@ -811,6 +814,13 @@ mod tests {
 
         std::fs::write(&chunk, source).expect("unpatched Vite chunk should be restored");
         assert!(!legacy_vite_patches_are_current(&aube_dir));
+
+        std::fs::write(&chunk, "export const untouched = true;\n")
+            .expect("anchorless Vite chunk should be written");
+        assert!(
+            legacy_vite_patches_are_current(&aube_dir),
+            "an anchorless bundle is intentionally skipped by the patcher"
+        );
     }
 
     #[test]
@@ -820,7 +830,7 @@ mod tests {
             let chunk = tmp.path().join(format!("chunk-{index}.js"));
             std::fs::write(&chunk, format!("{anchor}\n"))
                 .expect("synthetic Vite chunk should be written");
-            assert!(patch_vite_file(&chunk).expect("matching anchor should patch"));
+            assert!(patch_vite_file(&chunk, "node_modules").expect("matching anchor should patch"));
             let output = std::fs::read_to_string(&chunk).expect("patched chunk should be readable");
             assert!(output.contains(VITE_COMPAT_MARKER));
         }

--- a/crates/aube/src/commands/install/gvs.rs
+++ b/crates/aube/src/commands/install/gvs.rs
@@ -60,7 +60,11 @@ pub(super) fn write_modules_metadata(
     virtual_store_dir: &Path,
 ) -> std::io::Result<()> {
     let virtual_store_dir = virtual_store_dir.to_string_lossy().into_owned();
-    for importer_path in graph.importers.keys() {
+    for importer_path in graph
+        .importers
+        .keys()
+        .filter(|path| aube_linker::is_physical_importer(path))
+    {
         let project_dir =
             super::workspace::importer_project_dir(workspace_root, importer_path.as_str());
         let metadata_path = project_dir.join(modules_dir_name).join(".modules.yaml");
@@ -160,18 +164,21 @@ pub(super) fn modules_metadata_is_current<'a>(
     modules_dir_name: &str,
     expected_virtual_store_dir: Option<&Path>,
 ) -> bool {
-    importer_paths.into_iter().all(|importer_path| {
-        let project_dir = super::workspace::importer_project_dir(workspace_root, importer_path);
-        let metadata_path = project_dir.join(modules_dir_name).join(".modules.yaml");
-        let Some(actual) = std::fs::read(metadata_path)
-            .ok()
-            .and_then(|bytes| metadata_virtual_store_dir(&bytes))
-        else {
-            return false;
-        };
-        expected_virtual_store_dir
-            .is_none_or(|expected| actual == expected.to_string_lossy().as_ref())
-    })
+    importer_paths
+        .into_iter()
+        .filter(|path| aube_linker::is_physical_importer(path))
+        .all(|importer_path| {
+            let project_dir = super::workspace::importer_project_dir(workspace_root, importer_path);
+            let metadata_path = project_dir.join(modules_dir_name).join(".modules.yaml");
+            let Some(actual) = std::fs::read(metadata_path)
+                .ok()
+                .and_then(|bytes| metadata_virtual_store_dir(&bytes))
+            else {
+                return false;
+            };
+            expected_virtual_store_dir
+                .is_none_or(|expected| actual == expected.to_string_lossy().as_ref())
+        })
 }
 
 fn legacy_vite_dep_paths(
@@ -197,6 +204,9 @@ pub(super) fn legacy_vite_project_local_closure(
     graph: &aube_lockfile::LockfileGraph,
 ) -> std::collections::BTreeSet<String> {
     let mut selected = legacy_vite_dep_paths(graph);
+    if selected.is_empty() {
+        return selected;
+    }
     loop {
         let mut added = false;
         for (parent_path, parent) in &graph.packages {
@@ -414,6 +424,10 @@ mod tests {
         graph
             .importers
             .insert("packages/app".to_string(), Default::default());
+        let synthetic_importer = "packages/app/node_modules/vite@5.4.21";
+        graph
+            .importers
+            .insert(synthetic_importer.to_string(), Default::default());
         let store = root.join("shared/virtual-store");
 
         write_modules_metadata(root, &graph, "node_modules", &store)
@@ -442,6 +456,13 @@ mod tests {
         assert_eq!(
             metadata_virtual_store_dir(member_metadata.as_bytes()).as_deref(),
             Some(store.to_string_lossy().as_ref())
+        );
+        assert!(
+            !root
+                .join(synthetic_importer)
+                .join("node_modules/.modules.yaml")
+                .exists(),
+            "synthetic peer-context importers must not get filesystem metadata"
         );
         assert!(modules_metadata_is_current(
             root,

--- a/crates/aube/src/commands/install/gvs.rs
+++ b/crates/aube/src/commands/install/gvs.rs
@@ -220,7 +220,7 @@ pub(super) fn modules_metadata_is_current<'a>(
                 return false;
             };
             let matches = expected_virtual_store_dir
-                .is_none_or(|expected| actual == expected.to_string_lossy());
+                .is_none_or(|expected| actual.as_str() == expected.to_string_lossy().as_ref());
             if !matches {
                 tracing::debug!(
                     "install warm path skipped: {} has virtualStoreDir={actual}, expected {}",

--- a/crates/aube/src/commands/install/link.rs
+++ b/crates/aube/src/commands/install/link.rs
@@ -1,7 +1,7 @@
 use super::bin_linking::{link_bin_entries, link_bins, link_bins_for_dep, link_dep_bins};
 use super::sweep::invalidate_changed_aube_entries;
 use super::{InstallPhaseTimings, lifecycle::resolve_link_strategy};
-use super::{bin_linking, delta};
+use super::{bin_linking, delta, gvs};
 use crate::commands::inject;
 use crate::state;
 use miette::{Context, IntoDiagnostic, miette};
@@ -137,6 +137,10 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
         .with_virtual_store_only(virtual_store_only)
         .with_modules_dir_name(modules_dir_name.to_string())
         .with_aube_dir_override(aube_dir.to_path_buf());
+    if planned_gvs && node_linker == aube_linker::NodeLinker::Isolated {
+        linker = linker
+            .with_project_local_dep_paths(gvs::legacy_vite_project_local_closure(graph_for_link));
+    }
     if let Some(enabled) = use_global_virtual_store_override {
         linker = linker.with_use_global_virtual_store(enabled);
     }

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1132,6 +1132,11 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
             };
             let lock_materialize_handle =
                 spawn_gvs_prewarm(lock_prewarm_inputs, lock_materialize_rx);
+            let lock_project_local_dep_paths = if planned_gvs {
+                gvs::legacy_vite_project_local_closure(&graph)
+            } else {
+                Default::default()
+            };
 
             let fetch_result = fetch_packages_with_root(
                 &graph.packages,
@@ -1146,6 +1151,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
                 &aube_dir,
                 Some(lock_materialize_tx),
                 /*skip_already_linked_shortcut=*/ has_workspace,
+                &lock_project_local_dep_paths,
                 virtual_store_dir_max_length,
                 opts.ignore_scripts,
                 network_concurrency_setting,
@@ -2169,6 +2175,11 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
                 let catchup_start = std::time::Instant::now();
                 let cwd_for_catchup_client = cwd.clone();
                 let catchup_network_mode = opts.network_mode;
+                let project_local_dep_paths = if planned_gvs {
+                    gvs::legacy_vite_project_local_closure(&graph)
+                } else {
+                    Default::default()
+                };
                 let (catchup_indices, catchup_cached, catchup_fetched, catchup_integrities) =
                     fetch_packages_with_root(
                         &missing_packages,
@@ -2184,6 +2195,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
                         &aube_dir,
                         /*materialize_tx=*/ None,
                         /*skip_already_linked_shortcut=*/ has_workspace,
+                        &project_local_dep_paths,
                         virtual_store_dir_max_length,
                         opts.ignore_scripts,
                         network_concurrency_setting,

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -2428,6 +2428,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
         jail_policy: &jail_policy,
         stats: &stats,
         node_linker,
+        planned_gvs,
         virtual_store_only,
         current_leaf_hashes,
         current_subtree_hashes,

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -193,13 +193,16 @@ pub(super) fn detect_aube_dir_gvs_mode(aube_dir: &std::path::Path) -> Option<boo
         // making a gvs-on entry indistinguishable from a per-project
         // real directory via the file-type bit. `read_link` succeeds on
         // both Unix symlinks and Windows junction reparse points, and
-        // returns `Err(InvalidInput)` on a regular directory — exactly
-        // the signal we need. Non-link IO errors just skip the entry
-        // and move on to the next candidate.
+        // may return different errors for regular directories across
+        // platforms, so fall back to the entry's directory bit after
+        // link detection fails.
         match std::fs::read_link(entry.path()) {
             Ok(_) => return Some(true),
-            Err(e) if e.kind() == std::io::ErrorKind::InvalidInput => saw_real_dir = true,
-            Err(_) => continue,
+            Err(_) => {
+                if entry.file_type().is_ok_and(|file_type| file_type.is_dir()) {
+                    saw_real_dir = true;
+                }
+            }
         }
     }
     saw_real_dir.then_some(false)

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -168,14 +168,15 @@ pub(super) fn find_gvs_incompatible_trigger<'a>(
 /// symlinks. Callers use this to detect the transition and wipe
 /// `node_modules/` before the linker runs.
 ///
-/// Assumes a consistent `.aube/` tree (every entry the same type),
-/// which is what a successful install produces. A crash mid-link
-/// during a transition could leave a mixed tree; we classify from the
-/// first entry `read_dir` yields and let the next install self-heal
-/// — worst case is one extra wipe, which is identical to the cost of
-/// the transition we're already handling.
+/// A GVS tree may contain a small number of deliberately project-local
+/// compatibility copies (for example Vite before 8.1), so a single
+/// real directory does not make the whole layout per-project. Any
+/// package symlink/junction classifies the tree as GVS; only a tree
+/// containing exclusively real package directories classifies as
+/// per-project.
 pub(super) fn detect_aube_dir_gvs_mode(aube_dir: &std::path::Path) -> Option<bool> {
     let entries = std::fs::read_dir(aube_dir).ok()?;
+    let mut saw_real_dir = false;
     for entry in entries.flatten() {
         let name = entry.file_name();
         let name_str = name.to_string_lossy();
@@ -197,11 +198,35 @@ pub(super) fn detect_aube_dir_gvs_mode(aube_dir: &std::path::Path) -> Option<boo
         // and move on to the next candidate.
         match std::fs::read_link(entry.path()) {
             Ok(_) => return Some(true),
-            Err(e) if e.kind() == std::io::ErrorKind::InvalidInput => return Some(false),
+            Err(e) if e.kind() == std::io::ErrorKind::InvalidInput => saw_real_dir = true,
             Err(_) => continue,
         }
     }
-    None
+    saw_real_dir.then_some(false)
+}
+
+#[cfg(test)]
+mod gvs_mode_tests {
+    use super::detect_aube_dir_gvs_mode;
+
+    #[test]
+    fn mixed_project_local_and_linked_entries_still_classify_as_gvs() {
+        let tmp = tempfile::tempdir().expect("tempdir should be created");
+        let aube_dir = tmp.path().join(".aube");
+        let global = tmp.path().join("global/foo");
+        std::fs::create_dir_all(aube_dir.join("vite@7.3.6"))
+            .expect("project-local entry should be created");
+        std::fs::create_dir_all(&global).expect("global entry should be created");
+        aube_linker::sys::create_dir_link(&global, &aube_dir.join("foo@1.0.0"))
+            .expect("global-store link should be created");
+
+        assert_eq!(detect_aube_dir_gvs_mode(&aube_dir), Some(true));
+
+        std::fs::remove_dir(aube_dir.join("foo@1.0.0"))
+            .or_else(|_| std::fs::remove_file(aube_dir.join("foo@1.0.0")))
+            .expect("global-store link should be removed");
+        assert_eq!(detect_aube_dir_gvs_mode(&aube_dir), Some(false));
+    }
 }
 
 /// Honor `cleanupUnusedCatalogs` by pruning declared-but-unreferenced

--- a/crates/aube/src/commands/install/startup.rs
+++ b/crates/aube/src/commands/install/startup.rs
@@ -110,18 +110,21 @@ fn compatibility_metadata_is_current(cwd: &Path) -> bool {
     let expected = match layout.linker {
         state::InstallLayoutMode::Hoisted => Some(aube_dir),
         state::InstallLayoutMode::Isolated => {
+            let Some(global_virtual_store) =
+                aube_store::dirs::cache_dir().map(|dir| dir.join(aube_store::VIRTUAL_STORE_SUBDIR))
+            else {
+                return false;
+            };
             match super::gvs::detect_existing_global_virtual_store(
                 cwd,
                 &aube_dir,
                 &modules_dir_name,
+                &global_virtual_store,
             ) {
                 Some(true) => {
-                    let Ok(store) = super::super::open_store(cwd) else {
-                        return false;
-                    };
                     legacy_vite_patches_current =
                         super::gvs::legacy_vite_patches_are_current(&aube_dir);
-                    Some(store.virtual_store_dir())
+                    Some(global_virtual_store)
                 }
                 Some(false) => Some(aube_dir),
                 None => None,

--- a/crates/aube/src/commands/install/startup.rs
+++ b/crates/aube/src/commands/install/startup.rs
@@ -106,6 +106,7 @@ fn compatibility_metadata_is_current(cwd: &Path) -> bool {
     };
     let modules_dir_name = super::super::resolve_modules_dir_name_for_cwd(cwd);
     let aube_dir = super::super::resolve_virtual_store_dir_for_cwd(cwd);
+    let mut legacy_vite_patches_current = true;
     let expected = match layout.linker {
         state::InstallLayoutMode::Hoisted => Some(aube_dir),
         state::InstallLayoutMode::Isolated => {
@@ -114,6 +115,18 @@ fn compatibility_metadata_is_current(cwd: &Path) -> bool {
                     let Ok(store) = super::super::open_store(cwd) else {
                         return false;
                     };
+                    let Ok(manifest) = super::super::load_manifest_or_default(cwd) else {
+                        return false;
+                    };
+                    let Ok((graph, _)) = aube_lockfile::parse_lockfile_with_kind(cwd, &manifest)
+                    else {
+                        return false;
+                    };
+                    legacy_vite_patches_current = super::gvs::legacy_vite_patches_are_current(
+                        &aube_dir,
+                        &graph,
+                        super::super::resolve_virtual_store_dir_max_length_for_cwd(cwd),
+                    );
                     Some(store.virtual_store_dir())
                 }
                 Some(false) => Some(aube_dir),
@@ -121,12 +134,13 @@ fn compatibility_metadata_is_current(cwd: &Path) -> bool {
             }
         }
     };
-    super::gvs::modules_metadata_is_current(
-        cwd,
-        layout.direct_entries.keys().map(String::as_str),
-        &modules_dir_name,
-        expected.as_deref(),
-    )
+    legacy_vite_patches_current
+        && super::gvs::modules_metadata_is_current(
+            cwd,
+            layout.direct_entries.keys().map(String::as_str),
+            &modules_dir_name,
+            expected.as_deref(),
+        )
 }
 
 fn trust_policy_requires_validation(cwd: &Path, opts: &InstallOptions) -> bool {

--- a/crates/aube/src/commands/install/startup.rs
+++ b/crates/aube/src/commands/install/startup.rs
@@ -119,18 +119,8 @@ fn compatibility_metadata_is_current(cwd: &Path) -> bool {
                     let Ok(store) = super::super::open_store(cwd) else {
                         return false;
                     };
-                    let Ok(manifest) = super::super::load_manifest_or_default(cwd) else {
-                        return false;
-                    };
-                    let Ok((graph, _)) = aube_lockfile::parse_lockfile_with_kind(cwd, &manifest)
-                    else {
-                        return false;
-                    };
-                    legacy_vite_patches_current = super::gvs::legacy_vite_patches_are_current(
-                        &aube_dir,
-                        &graph,
-                        super::super::resolve_virtual_store_dir_max_length_for_cwd(cwd),
-                    );
+                    legacy_vite_patches_current =
+                        super::gvs::legacy_vite_patches_are_current(&aube_dir);
                     Some(store.virtual_store_dir())
                 }
                 Some(false) => Some(aube_dir),

--- a/crates/aube/src/commands/install/startup.rs
+++ b/crates/aube/src/commands/install/startup.rs
@@ -92,12 +92,41 @@ fn install_fast_path_eligible(
     // consulted), leaving `aube install -v` silent on repeat-install loops
     // that originate from state drift rather than lockfile drift.
     match state::check_needs_install_with_flags(cwd, &opts.cli_flags) {
-        None => true,
+        None => compatibility_metadata_is_current(cwd),
         Some(reason) => {
             tracing::debug!("install warm path skipped: {reason}");
             false
         }
     }
+}
+
+fn compatibility_metadata_is_current(cwd: &Path) -> bool {
+    let Some(layout) = state::read_state_layout(cwd) else {
+        return false;
+    };
+    let modules_dir_name = super::super::resolve_modules_dir_name_for_cwd(cwd);
+    let aube_dir = super::super::resolve_virtual_store_dir_for_cwd(cwd);
+    let expected = match layout.linker {
+        state::InstallLayoutMode::Hoisted => Some(aube_dir),
+        state::InstallLayoutMode::Isolated => {
+            match super::settings::detect_aube_dir_gvs_mode(&aube_dir) {
+                Some(true) => {
+                    let Ok(store) = super::super::open_store(cwd) else {
+                        return false;
+                    };
+                    Some(store.virtual_store_dir())
+                }
+                Some(false) => Some(aube_dir),
+                None => None,
+            }
+        }
+    };
+    super::gvs::modules_metadata_is_current(
+        cwd,
+        layout.direct_entries.keys().map(String::as_str),
+        &modules_dir_name,
+        expected.as_deref(),
+    )
 }
 
 fn trust_policy_requires_validation(cwd: &Path, opts: &InstallOptions) -> bool {

--- a/crates/aube/src/commands/install/startup.rs
+++ b/crates/aube/src/commands/install/startup.rs
@@ -127,7 +127,12 @@ fn compatibility_metadata_is_current(cwd: &Path) -> bool {
                     Some(global_virtual_store)
                 }
                 Some(false) => Some(aube_dir),
-                None => None,
+                None => {
+                    tracing::debug!(
+                        "install warm path skipped: unable to detect virtual-store layout"
+                    );
+                    return false;
+                }
             }
         }
     };

--- a/crates/aube/src/commands/install/startup.rs
+++ b/crates/aube/src/commands/install/startup.rs
@@ -110,7 +110,11 @@ fn compatibility_metadata_is_current(cwd: &Path) -> bool {
     let expected = match layout.linker {
         state::InstallLayoutMode::Hoisted => Some(aube_dir),
         state::InstallLayoutMode::Isolated => {
-            match super::settings::detect_aube_dir_gvs_mode(&aube_dir) {
+            match super::gvs::detect_existing_global_virtual_store(
+                cwd,
+                &aube_dir,
+                &modules_dir_name,
+            ) {
                 Some(true) => {
                     let Ok(store) = super::super::open_store(cwd) else {
                         return false;
@@ -134,13 +138,20 @@ fn compatibility_metadata_is_current(cwd: &Path) -> bool {
             }
         }
     };
-    legacy_vite_patches_current
-        && super::gvs::modules_metadata_is_current(
-            cwd,
-            layout.direct_entries.keys().map(String::as_str),
-            &modules_dir_name,
-            expected.as_deref(),
-        )
+    if !legacy_vite_patches_current {
+        tracing::debug!("install warm path skipped: legacy Vite patch is missing");
+        return false;
+    }
+    let metadata_current = super::gvs::modules_metadata_is_current(
+        cwd,
+        layout.direct_entries.keys().map(String::as_str),
+        &modules_dir_name,
+        expected.as_deref(),
+    );
+    if !metadata_current {
+        tracing::debug!("install warm path skipped: .modules.yaml metadata is stale");
+    }
+    metadata_current
 }
 
 fn trust_policy_requires_validation(cwd: &Path, opts: &InstallOptions) -> bool {

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -770,6 +770,14 @@ pub fn read_state_package_content_hashes(project_dir: &Path) -> Option<BTreeMap<
     Some(state.package_content_hashes)
 }
 
+/// Read the installed layout snapshot used by the install warm path.
+///
+/// Missing layout state means the install predates layout tracking and
+/// should take the normal path once to refresh derived metadata.
+pub fn read_state_layout(project_dir: &Path) -> Option<InstallLayoutState> {
+    read_state(&state_dir(project_dir))?.layout
+}
+
 /// Read the LtHash accumulator digest the last install wrote, if
 /// any. Empty string on fresh state or pre-lthash aube versions.
 pub fn read_state_graph_lthash(project_dir: &Path) -> Option<String> {

--- a/docs/package-manager/global-virtual-store.md
+++ b/docs/package-manager/global-virtual-store.md
@@ -120,13 +120,17 @@ default trigger list is:
 
 - `next`
 - `nuxt`
-- `vite`
-- `vitepress`
 - `parcel`
 
 When that happens, install still succeeds and aube prints a warning. Repeat
 installs of that project just won't share materialized package directories
 across projects.
+
+Vite 8.1 and newer supports shared virtual stores. aube writes the effective
+store location to `node_modules/.modules.yaml`, including in linked workspace
+importers, so Vite can add the directory to its development-server filesystem
+allow-list. The file is pnpm-compatible integration metadata; aube continues to
+use `node_modules/.aube-state` as its own install state.
 
 To add a package to the trigger list, append entries to
 `disableGlobalVirtualStoreForPackages` in `.npmrc`:

--- a/docs/package-manager/global-virtual-store.md
+++ b/docs/package-manager/global-virtual-store.md
@@ -132,6 +132,11 @@ importers, so Vite can add the directory to its development-server filesystem
 allow-list. The file is pnpm-compatible integration metadata; aube continues to
 use `node_modules/.aube-state` as its own install state.
 
+For older Vite versions, aube materializes the legacy Vite dependency and its
+framework ancestry in the project-local virtual store, then backports Vite
+8.1's metadata lookup into that local copy. Unrelated dependency branches stay
+in the global virtual store, and aube never modifies the shared Vite package.
+
 To add a package to the trigger list, append entries to
 `disableGlobalVirtualStoreForPackages` in `.npmrc`:
 

--- a/docs/pnpm-users.md
+++ b/docs/pnpm-users.md
@@ -59,6 +59,8 @@ aube also writes the effective virtual-store path to
 `node_modules/.modules.yaml` for tools such as Vite that use pnpm's metadata as
 a filesystem-compatibility signal. This does not make it aube's install state;
 freshness and layout data remain in `node_modules/.aube-state`.
+Vite versions before 8.1 receive the equivalent lookup in a project-local copy,
+leaving the shared store immutable.
 
 aube never touches pnpm's `node_modules/.pnpm/` or `~/.pnpm-store/`. The two
 virtual stores can coexist under `node_modules`. For the lockfile and

--- a/docs/pnpm-users.md
+++ b/docs/pnpm-users.md
@@ -55,6 +55,11 @@ aube reads pnpm v11 YAML files for compatibility. `aube-lock.yaml` and
 `aube-workspace.yaml` use pnpm-compatible shapes today but are the long-term
 contract and may diverge over time.
 
+aube also writes the effective virtual-store path to
+`node_modules/.modules.yaml` for tools such as Vite that use pnpm's metadata as
+a filesystem-compatibility signal. This does not make it aube's install state;
+freshness and layout data remain in `node_modules/.aube-state`.
+
 aube never touches pnpm's `node_modules/.pnpm/` or `~/.pnpm-store/`. The two
 virtual stores can coexist under `node_modules`. For the lockfile and
 workspace YAML, aube reads and writes whichever file already exists on disk

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -1117,7 +1117,7 @@ Examples:
 Package names whose presence in any importer forces per-project materialization.
 
 - Type: `list<string>`
-- Default: `["next", "nuxt", "vite", "vitepress", "parcel"]`
+- Default: `["next", "nuxt", "parcel"]`
 - Environment: `npm_config_disable_global_virtual_store_for_packages`, `NPM_CONFIG_DISABLE_GLOBAL_VIRTUAL_STORE_FOR_PACKAGES`, `AUBE_DISABLE_GLOBAL_VIRTUAL_STORE_FOR_PACKAGES`
 - .npmrc keys: `disableGlobalVirtualStoreForPackages`, `disable-global-virtual-store-for-packages`
 - Workspace YAML keys: `disableGlobalVirtualStoreForPackages`
@@ -1134,12 +1134,14 @@ When `aube install` finds one of these names in any importer's
 forces per-project materialization for that install and prints a
 one-line warning naming the trigger.
 
-The default list — `next`, `nuxt`, `vite`, `vitepress`, `parcel` —
+The default list — `next`, `nuxt`, `parcel` —
 covers the tools with concrete walk-up failures: Next.js's Turbopack
-canonicalizes through symlinks and walks up for app-router/monorepo
-detection, Vite/VitePress/Nuxt plugins walk up for config discovery
-(see [jdx/mise#9261](https://github.com/jdx/mise/pull/9261) for the
-VitePress case), and Parcel's resolver walks up for `.parcelrc`.
+canonicalizes through symlinks and walks up for app-router/monorepo detection,
+Nuxt plugins walk up for config discovery, and Parcel's resolver walks up for
+`.parcelrc`. Vite and VitePress are compatible with the global virtual store:
+aube writes `node_modules/.modules.yaml` with the store location, which Vite
+8.1+ reads when constructing its filesystem allow-list.
+
 Webpack and Rollup are *not* on the default list: plain Webpack
 resolves via the sibling symlinks aube already places inside
 `.aube/<pkg>/node_modules/`, and Rollup is rarely a direct dep (it's

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -1140,7 +1140,10 @@ canonicalizes through symlinks and walks up for app-router/monorepo detection,
 Nuxt plugins walk up for config discovery, and Parcel's resolver walks up for
 `.parcelrc`. Vite and VitePress are compatible with the global virtual store:
 aube writes `node_modules/.modules.yaml` with the store location, which Vite
-8.1+ reads when constructing its filesystem allow-list.
+8.1+ reads when constructing its filesystem allow-list. For older Vite
+versions, aube materializes only the Vite dependency path locally and backports
+the same allow-list lookup into that project-local copy; unrelated dependencies
+remain in the shared store.
 
 Webpack and Rollup are *not* on the default list: plain Webpack
 resolves via the sibling symlinks aube already places inside

--- a/test/nextjs_gvs_autodisable.bats
+++ b/test/nextjs_gvs_autodisable.bats
@@ -2,11 +2,12 @@
 
 # Auto-disable of the global virtual store when any package listed in
 # `disableGlobalVirtualStoreForPackages` is present in an importer's
-# deps. Default list is `["next"]` — Next.js's Turbopack canonicalizes
-# every `node_modules/<pkg>` symlink and rejects targets outside the
-# project root, which aube's gvs layout produces by default. The
-# setting is the extension point: add any tool with the same
-# restriction, or set to `[]` to disable the heuristic.
+# deps. Next.js's Turbopack canonicalizes every `node_modules/<pkg>`
+# symlink and rejects targets outside the project root, which aube's
+# gvs layout produces by default. Vite is deliberately absent because
+# 8.1+ reads the `.modules.yaml` metadata aube writes. The setting is
+# the extension point: add any tool with the same restriction, or set
+# to `[]` to disable the heuristic.
 #
 # These tests use a `link:` local dep so detection fires without
 # needing a real tarball — the scan only reads dependency names, not
@@ -92,6 +93,48 @@ JSON
 	assert_success
 	refute_output --partial "disableGlobalVirtualStoreForPackages"
 	refute_output --partial "disabling global virtual store"
+}
+
+@test "vite keeps global virtual store enabled and receives compatibility metadata" {
+	_make_fake_dep vite
+	mkdir -p app
+	cd app
+	cat >package.json <<'JSON'
+{"name":"app","version":"0.0.0","devDependencies":{"vite":"link:../fake-vite","is-odd":"3.0.1"}}
+JSON
+
+	run aube install
+	assert_success
+	refute_output --partial "disableGlobalVirtualStoreForPackages"
+	[ -L node_modules/.aube/is-odd@3.0.1 ]
+
+	run sed -n 's/.*"virtualStoreDir": "\(.*\)".*/\1/p' node_modules/.modules.yaml
+	assert_success
+	[[ "$output" == /*/aube/virtual-store ]]
+}
+
+@test "vite compatibility metadata is written for nested workspace importers" {
+	_make_fake_dep vite
+	cat >package.json <<'JSON'
+{"name":"workspace","version":"0.0.0","private":true}
+JSON
+	cat >aube-workspace.yaml <<'YAML'
+packages:
+  - packages/*
+YAML
+	mkdir -p packages/app
+	cat >packages/app/package.json <<'JSON'
+{"name":"app","version":"0.0.0","devDependencies":{"vite":"link:../../fake-vite","is-odd":"3.0.1"}}
+JSON
+
+	run aube install
+	assert_success
+	refute_output --partial "disableGlobalVirtualStoreForPackages"
+	[ -L node_modules/.aube/is-odd@3.0.1 ]
+
+	run sed -n 's/.*"virtualStoreDir": "\(.*\)".*/\1/p' packages/app/node_modules/.modules.yaml
+	assert_success
+	[[ "$output" == /*/aube/virtual-store ]]
 }
 
 @test "disableGlobalVirtualStoreForPackages=[] opts out of the auto-disable" {

--- a/test/nextjs_gvs_autodisable.bats
+++ b/test/nextjs_gvs_autodisable.bats
@@ -111,6 +111,11 @@ JSON
 	run sed -n 's/.*"virtualStoreDir": "\(.*\)".*/\1/p' node_modules/.modules.yaml
 	assert_success
 	[[ "$output" == /*/aube/virtual-store ]]
+
+	rm node_modules/.modules.yaml
+	run aube install
+	assert_success
+	[ -f node_modules/.modules.yaml ]
 }
 
 @test "vite compatibility metadata is written for nested workspace importers" {


### PR DESCRIPTION
## Summary

- write pnpm-compatible `node_modules/.modules.yaml` metadata with aube's effective virtual-store path for every linked workspace importer
- keep GVS enabled by default for Vite and VitePress
- use Vite 8.1+'s native metadata support directly
- for older Vite releases, materialize only Vite and the framework ancestry needed to reach it, then backport the same allow-list lookup into that project-local copy
- leave unrelated packages in the global store and protect shared CAS/GVS bytes with atomic local replacement

## Root cause

Aube still classified every Vite and VitePress release as incompatible with the global virtual store. Vite 8.1 added native support for external virtual stores by reading `virtualStoreDir` from `node_modules/.modules.yaml`, but aube did not expose that metadata. Older Vite releases lack that lookup and therefore still need a narrowly scoped compatibility path.

## Impact

Vite and VitePress projects keep aube's shared GVS fast path without manual `server.fs.allow` configuration. Vite 8.1+ works natively; older Vite versions receive the equivalent behavior from a project-local compatibility copy while unrelated dependency branches stay shared. Nested aube workspaces receive importer-local metadata as well.

## Validation

- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `mise run test:bats test/nextjs_gvs_autodisable.bats`
- `mise run docs:build` (VitePress 1.6.4 / Vite 5.4.21 production build, with Vite and VitePress local and unrelated PostCSS still linked to GVS)

*This pull request was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install/linking layout, warm-path skipping, and mutates legacy Vite files on disk; mistakes could break dev-server FS allow-listing or shared-store safety, though guards and tests target those cases.
> 
> **Overview**
> **Vite/VitePress no longer disable the global virtual store by default** — only `next`, `nuxt`, and `parcel` remain on `disableGlobalVirtualStoreForPackages`. GVS stays on for typical Vite projects.
> 
> **pnpm-compatible `node_modules/.modules.yaml`** is written (or updated) per physical importer with `virtualStoreDir`, so Vite 8.1+ can allow-list the shared store. Finalize also runs a **legacy Vite backport** when GVS is planned: packages on Vite &lt; 8.1 plus graph ancestors that must resolve to them are **materialized locally** via new linker `with_project_local_dep_paths`, while everything else still symlinks into GVS.
> 
> The linker treats those dep paths as **real directories** under `.aube/` (not GVS symlinks) so install can **patch Vite’s `dist/node` bundles** to read `.modules.yaml` without mutating shared CAS bytes (atomic writes; refuses patching inside the global store).
> 
> **Warm-path and layout detection** now require current `.modules.yaml`, legacy patch markers, and mixed trees (some local dirs + GVS links) to still count as GVS. Fetch skips the “already linked” shortcut for forced project-local dep paths so indices stay available for rematerialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12f8e6aa38c93286c7f8b1746e096b3861fbac14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration to materialize selected dependencies as real project-local directories while keeping the rest on the global virtual store.
  * Improved global virtual store finalization by writing pnpm-compatible `node_modules/.modules.yaml` and applying legacy Vite backports when needed.
* **Bug Fixes**
  * Correctly handles mixed local/shared `.aube/` layouts and ensures warm-cache eligibility only when compatibility metadata is current.
  * Ensures selected local entries bypass shared-store rematerialization.
* **Documentation**
  * Updated global virtual store settings defaults and clarified Vite/pnpm `.modules.yaml` behavior.
* **Tests**
  * Added/expanded coverage for selective local materialization, `.modules.yaml` upserts, legacy Vite patching, nested workspaces, and mixed layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->