### PR TITLE
feat(run): complete package.json scripts in shell completions

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -1617,6 +1617,9 @@ cmd root help="Print the path to `node_modules`" {
 }
 cmd run help="Run a script defined in package.json" {
     alias run-script hide=#true
+    flag --complete help="Print the nearest `package.json`'s scripts for shell completion" hide=#true {
+        long_help "Print the nearest `package.json`'s scripts for shell completion.\n\nConsumed by the `complete \"script\"` node in the usage spec, not meant to be typed by hand."
+    }
     flag --if-present help="Don't error if the script is missing from package.json"
     flag --inspect help="Forward `--inspect` to a Node-backed script or local binary" {
         arg "[[HOST:]PORT]" required=#false
@@ -2201,3 +2204,5 @@ cmd why help="Print reverse dependency chains explaining why a package is instal
     arg <PACKAGE> help="Package name to search for (exact match against package names)"
 }
 
+// `aube run <TAB>` offers the nearest package.json's scripts.
+complete "script" run="aube run --complete" descriptions=#true

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -2204,5 +2204,14 @@ cmd why help="Print reverse dependency chains explaining why a package is instal
     arg <PACKAGE> help="Package name to search for (exact match against package names)"
 }
 
-// `aube run <TAB>` offers the nearest package.json's scripts.
+// `aube run <TAB>` offers the scripts from the package.json nearest the
+// shell's cwd.
+//
+// The command is fixed, so a `-C` on the line being completed is not
+// forwarded and `aube -C packages/api run <TAB>` still offers the outer
+// project's scripts. usage's only channel for the typed words is tera
+// interpolation into a `sh -c` string, with no shell-quoting filter, so
+// forwarding it would mean pasting user input into a shell command. The
+// helper itself honors `-C` for direct invocation, ready for a safer
+// channel upstream.
 complete "script" run="aube run --complete" descriptions=#true

--- a/crates/aube-codes/src/errors.rs
+++ b/crates/aube-codes/src/errors.rs
@@ -87,6 +87,7 @@ pub const ERR_AUBE_RECURSIVE_NOT_SUPPORTED: &str = "ERR_AUBE_RECURSIVE_NOT_SUPPO
 pub const ERR_AUBE_UNKNOWN_COMMAND: &str = "ERR_AUBE_UNKNOWN_COMMAND";
 pub const ERR_AUBE_NPM_ONLY_COMMAND: &str = "ERR_AUBE_NPM_ONLY_COMMAND";
 pub const ERR_AUBE_COMPLETION_FAILED: &str = "ERR_AUBE_COMPLETION_FAILED";
+pub const ERR_AUBE_USAGE_SPEC_WRITE_FAILED: &str = "ERR_AUBE_USAGE_SPEC_WRITE_FAILED";
 pub const ERR_AUBE_REMOVE_PRIOR_INSTALL_DIR: &str = "ERR_AUBE_REMOVE_PRIOR_INSTALL_DIR";
 pub const ERR_AUBE_CONFIG_NESTED_AUBE_KEY: &str = "ERR_AUBE_CONFIG_NESTED_AUBE_KEY";
 pub const ERR_AUBE_CONFLICTING_BUILD_FLAGS: &str = "ERR_AUBE_CONFLICTING_BUILD_FLAGS";
@@ -471,6 +472,12 @@ pub const ALL: &[CodeMeta] = &[
         name: ERR_AUBE_COMPLETION_FAILED,
         category: category::ENGINE_CLI,
         description: "`aube completion` couldn't invoke `usage` to render the shell completions.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: ERR_AUBE_USAGE_SPEC_WRITE_FAILED,
+        category: category::ENGINE_CLI,
+        description: "`aube usage` couldn't write the CLI spec to stdout; the output would have been truncated.",
         exit_code: None,
     },
     CodeMeta {

--- a/crates/aube/assets/extra.usage.kdl
+++ b/crates/aube/assets/extra.usage.kdl
@@ -1,0 +1,2 @@
+// `aube run <TAB>` offers the nearest package.json's scripts.
+complete "script" run="{bin} run --complete" descriptions=#true

--- a/crates/aube/assets/extra.usage.kdl
+++ b/crates/aube/assets/extra.usage.kdl
@@ -1,2 +1,11 @@
-// `aube run <TAB>` offers the nearest package.json's scripts.
+// `aube run <TAB>` offers the scripts from the package.json nearest the
+// shell's cwd.
+//
+// The command is fixed, so a `-C` on the line being completed is not
+// forwarded and `aube -C packages/api run <TAB>` still offers the outer
+// project's scripts. usage's only channel for the typed words is tera
+// interpolation into a `sh -c` string, with no shell-quoting filter, so
+// forwarding it would mean pasting user input into a shell command. The
+// helper itself honors `-C` for direct invocation, ready for a safer
+// channel upstream.
 complete "script" run="{bin} run --complete" descriptions=#true

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -16,6 +16,12 @@ pub struct RunArgs {
     /// Arguments to pass to the script
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub args: Vec<String>,
+    /// Print the nearest `package.json`'s scripts for shell completion.
+    ///
+    /// Consumed by the `complete "script"` node in the usage spec, not
+    /// meant to be typed by hand.
+    #[arg(long, hide = true)]
+    pub complete: bool,
     /// Don't error if the script is missing from package.json
     #[arg(long)]
     pub if_present: bool,
@@ -131,12 +137,21 @@ pub async fn run(
     run_args: RunArgs,
     filter: aube_workspace::selector::EffectiveFilter,
 ) -> miette::Result<Option<i32>> {
+    // Completion probe: answer from package.json alone, before any setting
+    // override, install check, or runtime resolution runs. A TAB press must
+    // stay cheap and must never fail — outside a project there is simply
+    // nothing to offer.
+    if run_args.complete {
+        print_script_completions();
+        return Ok(Some(0));
+    }
     run_args.network.install_overrides();
     run_args.lockfile.install_overrides();
     run_args.virtual_store.install_overrides();
     let RunArgs {
         script,
         args,
+        complete: _,
         no_install,
         no_sort,
         if_present,
@@ -310,6 +325,44 @@ fn prompt_for_script() -> miette::Result<Option<String>> {
             .into_diagnostic()
             .wrap_err("failed to read script selection"),
     }
+}
+
+/// Print the nearest `package.json`'s scripts for the `complete "script"`
+/// node in the usage spec, one `name:command` line each.
+///
+/// Best-effort by design: a missing, unreadable, or malformed
+/// `package.json` prints nothing rather than erroring, because the caller
+/// is a TAB press and completion noise is worse than no completions.
+fn print_script_completions() {
+    let Some(root) = crate::dirs::cwd()
+        .ok()
+        .and_then(|cwd| crate::dirs::find_project_root(&cwd))
+    else {
+        return;
+    };
+    let Ok(scripts) = read_scripts_in_order(&root) else {
+        return;
+    };
+    let mut out = String::new();
+    for (name, cmd) in &scripts {
+        out.push_str(&completion_line(name, cmd));
+        out.push('\n');
+    }
+    print!("{out}");
+}
+
+/// Format one `name:command` completion line. `usage` splits each line on
+/// its first *unescaped* colon, so colons inside the name are escaped —
+/// without this a `test:unit` script completes as `test` described by
+/// `unit:vitest …`. Newlines and tabs in the command are folded to spaces
+/// so a multi-line script stays on one line.
+fn completion_line(name: &str, cmd: &str) -> String {
+    let name = name.replace(':', "\\:");
+    let cmd: String = cmd
+        .chars()
+        .map(|c| if c.is_whitespace() { ' ' } else { c })
+        .collect();
+    format!("{name}:{}", cmd.trim())
 }
 
 /// Read `package.json` and return its `scripts` entries in the order
@@ -1186,8 +1239,8 @@ async fn exec_script_status_with_node_args(
 #[cfg(test)]
 mod tests {
     use super::{
-        RecursiveOpts, effective_concurrency, inject_node_args, node_args_from_run_flags,
-        order_matched_packages,
+        RecursiveOpts, completion_line, effective_concurrency, inject_node_args,
+        node_args_from_run_flags, order_matched_packages,
     };
     use aube_manifest::PackageJson;
     use aube_workspace::selector::SelectedPackage;
@@ -1345,6 +1398,24 @@ mod tests {
         assert_eq!(
             inject_node_args("node-gyp rebuild", &args),
             "node-gyp rebuild"
+        );
+    }
+
+    #[test]
+    fn completion_line_escapes_colons_in_the_script_name() {
+        // usage splits on the first unescaped colon, so only the name is
+        // escaped — a colon in the command is part of the description.
+        assert_eq!(
+            completion_line("test:unit", "vitest run --reporter=x:y"),
+            "test\\:unit:vitest run --reporter=x:y"
+        );
+    }
+
+    #[test]
+    fn completion_line_folds_a_multiline_command_onto_one_line() {
+        assert_eq!(
+            completion_line("deploy", "node deploy.mjs \\\n  --yes\n"),
+            "deploy:node deploy.mjs \\   --yes"
         );
     }
 }

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -333,9 +333,16 @@ pub(crate) fn print_script_completions(dir: Option<&Path>) {
         return;
     };
     // `-C` is resolved against the cwd, matching what the later chdir
-    // would do with a relative path.
+    // would do with a relative path. Canonicalized for the same reason:
+    // a real run chdirs and then reads the cwd back, which resolves
+    // symlinks, so the ancestor walk has to start from the target's
+    // hierarchy rather than the link's. A path that doesn't resolve falls
+    // back to the literal one and simply finds nothing.
     let start = match dir {
-        Some(dir) => cwd.join(dir),
+        Some(dir) => {
+            let joined = cwd.join(dir);
+            joined.canonicalize().unwrap_or(joined)
+        }
         None => cwd,
     };
     let Some(root) = crate::dirs::find_project_root(&start) else {

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -137,14 +137,6 @@ pub async fn run(
     run_args: RunArgs,
     filter: aube_workspace::selector::EffectiveFilter,
 ) -> miette::Result<Option<i32>> {
-    // Completion probe: answer from package.json alone, before any setting
-    // override, install check, or runtime resolution runs. A TAB press must
-    // stay cheap and must never fail — outside a project there is simply
-    // nothing to offer.
-    if run_args.complete {
-        print_script_completions();
-        return Ok(Some(0));
-    }
     run_args.network.install_overrides();
     run_args.lockfile.install_overrides();
     run_args.virtual_store.install_overrides();
@@ -333,7 +325,7 @@ fn prompt_for_script() -> miette::Result<Option<String>> {
 /// Best-effort by design: a missing, unreadable, or malformed
 /// `package.json` prints nothing rather than erroring, because the caller
 /// is a TAB press and completion noise is worse than no completions.
-fn print_script_completions() {
+pub(crate) fn print_script_completions() {
     let Some(root) = crate::dirs::cwd()
         .ok()
         .and_then(|cwd| crate::dirs::find_project_root(&cwd))
@@ -348,7 +340,10 @@ fn print_script_completions() {
         out.push_str(&completion_line(name, cmd));
         out.push('\n');
     }
-    print!("{out}");
+    // `write_all` rather than `print!`: the latter panics if stdout is
+    // gone, and a completion helper whose reader closed the pipe should
+    // just stop, not abort with a panic message.
+    let _ = std::io::Write::write_all(&mut std::io::stdout(), out.as_bytes());
 }
 
 /// Format one `name:command` completion line. `usage` splits each line on

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -332,16 +332,23 @@ pub(crate) fn print_script_completions(dir: Option<&Path>) {
     let Ok(cwd) = crate::dirs::cwd() else {
         return;
     };
-    // `-C` is resolved against the cwd, matching what the later chdir
-    // would do with a relative path. Canonicalized for the same reason:
-    // a real run chdirs and then reads the cwd back, which resolves
-    // symlinks, so the ancestor walk has to start from the target's
-    // hierarchy rather than the link's. A path that doesn't resolve falls
-    // back to the literal one and simply finds nothing.
+    // `-C` is resolved against the cwd, the way the later chdir treats a
+    // relative path, and canonicalized for the same reason: a real run
+    // chdirs and reads the cwd back, which resolves symlinks, so the
+    // ancestor walk has to start from the target's hierarchy rather than
+    // the link's.
+    //
+    // A path that won't resolve is a path the real chdir would reject, so
+    // there's nothing to offer. Falling back to the literal path would be
+    // worse than useless: `find_project_root` walks ancestors lexically,
+    // so `-C does-not-exist` would surface the *parent* project's scripts
+    // and complete a command that can't run.
     let start = match dir {
         Some(dir) => {
-            let joined = cwd.join(dir);
-            joined.canonicalize().unwrap_or(joined)
+            let Ok(resolved) = cwd.join(dir).canonicalize() else {
+                return;
+            };
+            resolved
         }
         None => cwd,
     };

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -367,12 +367,22 @@ pub(crate) fn print_script_completions(dir: Option<&Path>) {
 /// without this a `test:unit` script completes as `test` described by
 /// `unit:vitest …`. Newlines and tabs in the command are folded to spaces
 /// so a multi-line script stays on one line.
+///
+/// A name that ends in a backslash gets no description at all. The
+/// separator immediately after it would read as escaped, and `usage` would
+/// swallow the whole line into the candidate — `weird\:echo hi` completes
+/// as the script `weird:echo hi`. Escaping the backslash doesn't help,
+/// since the escape grammar only covers `\:`. Dropping the description is
+/// the one form that still yields the right name.
 fn completion_line(name: &str, cmd: &str) -> String {
     let name = name.replace(':', "\\:");
     let cmd: String = cmd
         .chars()
         .map(|c| if c.is_whitespace() { ' ' } else { c })
         .collect();
+    if name.ends_with('\\') {
+        return name;
+    }
     format!("{name}:{}", cmd.trim())
 }
 
@@ -1419,6 +1429,20 @@ mod tests {
         assert_eq!(
             completion_line("test:unit", "vitest run --reporter=x:y"),
             "test\\:unit:vitest run --reporter=x:y"
+        );
+    }
+
+    #[test]
+    fn completion_line_drops_the_description_after_a_trailing_backslash() {
+        // The separator would look escaped and usage would fold the
+        // command into the candidate. Verified against usage 3.2 and 3.5:
+        // the bare name is the only form that round-trips.
+        assert_eq!(completion_line("weird\\", "echo hi"), "weird\\");
+        // A backslash anywhere else is fine — the split still lands on the
+        // first unescaped colon.
+        assert_eq!(
+            completion_line("mid\\slash", "echo mid"),
+            "mid\\slash:echo mid"
         );
     }
 

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -329,27 +329,25 @@ fn prompt_for_script() -> miette::Result<Option<String>> {
 /// `package.json` prints nothing rather than erroring, because the caller
 /// is a TAB press and completion noise is worse than no completions.
 pub(crate) fn print_script_completions(dir: Option<&Path>) {
-    let Ok(cwd) = crate::dirs::cwd() else {
+    // Perform the same chdir a real run would rather than trying to
+    // predict it. Every way `-C` can be unusable — missing, not a
+    // directory, no search permission — is a way `chdir` already fails,
+    // and completing a command that can't run is worse than completing
+    // nothing: `find_project_root` walks ancestors lexically, so any
+    // approximation that guesses wrong offers the *parent* project's
+    // scripts. Safe to change the process cwd here because this probe
+    // prints and exits; nothing downstream observes it.
+    if let Some(dir) = dir
+        && std::env::set_current_dir(dir).is_err()
+    {
         return;
-    };
-    // `-C` is resolved against the cwd, the way the later chdir treats a
-    // relative path, and canonicalized for the same reason: a real run
-    // chdirs and reads the cwd back, which resolves symlinks, so the
-    // ancestor walk has to start from the target's hierarchy rather than
-    // the link's.
-    //
-    // Anything the real chdir would reject — a path that doesn't resolve,
-    // or one that isn't a directory — offers nothing. Searching from it
-    // anyway is worse than staying quiet, because `find_project_root`
-    // walks ancestors lexically: `-C does-not-exist` or `-C README.md`
-    // would surface the *parent* project's scripts and complete a command
-    // that can't run.
-    let start = match dir {
-        Some(dir) => match cwd.join(dir).canonicalize() {
-            Ok(resolved) if resolved.is_dir() => resolved,
-            _ => return,
-        },
-        None => cwd,
+    }
+    // Read the cwd back instead of reusing the argument: `getcwd` returns
+    // the resolved path, so a symlinked `-C` searches the target's
+    // hierarchy the way a real run does. Deliberately not
+    // `crate::dirs::cwd()`, whose memoized value predates the chdir.
+    let Ok(start) = std::env::current_dir() else {
+        return;
     };
     let Some(root) = crate::dirs::find_project_root(&start) else {
         return;

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -329,25 +329,26 @@ fn prompt_for_script() -> miette::Result<Option<String>> {
 /// `package.json` prints nothing rather than erroring, because the caller
 /// is a TAB press and completion noise is worse than no completions.
 pub(crate) fn print_script_completions(dir: Option<&Path>) {
-    // Perform the same chdir a real run would rather than trying to
-    // predict it. Every way `-C` can be unusable — missing, not a
-    // directory, no search permission — is a way `chdir` already fails,
-    // and completing a command that can't run is worse than completing
-    // nothing: `find_project_root` walks ancestors lexically, so any
-    // approximation that guesses wrong offers the *parent* project's
-    // scripts. Safe to change the process cwd here because this probe
-    // prints and exits; nothing downstream observes it.
-    if let Some(dir) = dir
-        && std::env::set_current_dir(dir).is_err()
-    {
+    let Ok(cwd) = crate::dirs::cwd() else {
         return;
-    }
-    // Read the cwd back instead of reusing the argument: `getcwd` returns
-    // the resolved path, so a symlinked `-C` searches the target's
-    // hierarchy the way a real run does. Deliberately not
-    // `crate::dirs::cwd()`, whose memoized value predates the chdir.
-    let Ok(start) = std::env::current_dir() else {
-        return;
+    };
+    // Establish where to search *without* chdir'ing. `cli_main` is a
+    // library entry point, so an embedding host is driving this in-process
+    // and would keep any cwd change we made.
+    //
+    // Getting this wrong is worse than declining to answer: a real run
+    // chdirs into `-C`, and `find_project_root` walks ancestors lexically,
+    // so a target the chdir would reject still surfaces the *parent*
+    // project's scripts and completes a command that can't run. Hence all
+    // three checks — resolvable (also resolving symlinks, so the walk
+    // starts in the target's hierarchy the way `getcwd` would report it),
+    // a directory, and readable.
+    let start = match dir {
+        Some(dir) => match cwd.join(dir).canonicalize() {
+            Ok(resolved) if resolved.is_dir() && std::fs::read_dir(&resolved).is_ok() => resolved,
+            _ => return,
+        },
+        None => cwd,
     };
     let Some(root) = crate::dirs::find_project_root(&start) else {
         return;
@@ -1434,6 +1435,16 @@ mod tests {
             completion_line("test:unit", "vitest run --reporter=x:y"),
             "test\\:unit:vitest run --reporter=x:y"
         );
+    }
+
+    /// `cli_main` is a library entry point, so an embedding host is
+    /// driving the probe in-process. Resolving `-C` must not leave the
+    /// host's working directory somewhere else.
+    #[test]
+    fn completion_probe_leaves_the_working_directory_alone() {
+        let before = std::env::current_dir().unwrap();
+        super::print_script_completions(Some(std::path::Path::new("..")));
+        assert_eq!(std::env::current_dir().unwrap(), before);
     }
 
     #[test]

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -339,13 +339,22 @@ pub(crate) fn print_script_completions(dir: Option<&Path>) {
     // Getting this wrong is worse than declining to answer: a real run
     // chdirs into `-C`, and `find_project_root` walks ancestors lexically,
     // so a target the chdir would reject still surfaces the *parent*
-    // project's scripts and completes a command that can't run. Hence all
-    // three checks — resolvable (also resolving symlinks, so the walk
-    // starts in the target's hierarchy the way `getcwd` would report it),
-    // a directory, and readable.
+    // project's scripts and completes a command that can't run.
+    //
+    // Resolving also collapses symlinks, so the walk starts in the
+    // target's hierarchy the way `getcwd` would report it after a real
+    // chdir. The `try_exists` probe stands in for the permission half:
+    // it stats a path *inside* the directory, so it needs the same search
+    // bit `chdir` does, and reports `Err` exactly when that bit is
+    // missing. (`read_dir` would test the read bit instead and reject
+    // execute-only directories a real run handles fine.)
     let start = match dir {
         Some(dir) => match cwd.join(dir).canonicalize() {
-            Ok(resolved) if resolved.is_dir() && std::fs::read_dir(&resolved).is_ok() => resolved,
+            Ok(resolved)
+                if resolved.is_dir() && resolved.join("package.json").try_exists().is_ok() =>
+            {
+                resolved
+            }
             _ => return,
         },
         None => cwd,
@@ -358,6 +367,13 @@ pub(crate) fn print_script_completions(dir: Option<&Path>) {
     };
     let mut out = String::new();
     for (name, cmd) in &scripts {
+        // JSON keys can hold a newline, and the protocol is one candidate
+        // per line — such a name would split into several bogus
+        // candidates, none of which names a real script. Nothing sane can
+        // be offered for it, so skip it.
+        if name.contains(['\n', '\r']) {
+            continue;
+        }
         out.push_str(&completion_line(name, cmd));
         out.push('\n');
     }

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -322,14 +322,23 @@ fn prompt_for_script() -> miette::Result<Option<String>> {
 /// Print the nearest `package.json`'s scripts for the `complete "script"`
 /// node in the usage spec, one `name:command` line each.
 ///
+/// Searches upward from `dir` when the invocation carried `-C`, and from
+/// the process cwd otherwise.
+///
 /// Best-effort by design: a missing, unreadable, or malformed
 /// `package.json` prints nothing rather than erroring, because the caller
 /// is a TAB press and completion noise is worse than no completions.
-pub(crate) fn print_script_completions() {
-    let Some(root) = crate::dirs::cwd()
-        .ok()
-        .and_then(|cwd| crate::dirs::find_project_root(&cwd))
-    else {
+pub(crate) fn print_script_completions(dir: Option<&Path>) {
+    let Ok(cwd) = crate::dirs::cwd() else {
+        return;
+    };
+    // `-C` is resolved against the cwd, matching what the later chdir
+    // would do with a relative path.
+    let start = match dir {
+        Some(dir) => cwd.join(dir),
+        None => cwd,
+    };
+    let Some(root) = crate::dirs::find_project_root(&start) else {
         return;
     };
     let Ok(scripts) = read_scripts_in_order(&root) else {

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -338,18 +338,17 @@ pub(crate) fn print_script_completions(dir: Option<&Path>) {
     // ancestor walk has to start from the target's hierarchy rather than
     // the link's.
     //
-    // A path that won't resolve is a path the real chdir would reject, so
-    // there's nothing to offer. Falling back to the literal path would be
-    // worse than useless: `find_project_root` walks ancestors lexically,
-    // so `-C does-not-exist` would surface the *parent* project's scripts
-    // and complete a command that can't run.
+    // Anything the real chdir would reject — a path that doesn't resolve,
+    // or one that isn't a directory — offers nothing. Searching from it
+    // anyway is worse than staying quiet, because `find_project_root`
+    // walks ancestors lexically: `-C does-not-exist` or `-C README.md`
+    // would surface the *parent* project's scripts and complete a command
+    // that can't run.
     let start = match dir {
-        Some(dir) => {
-            let Ok(resolved) = cwd.join(dir).canonicalize() else {
-                return;
-            };
-            resolved
-        }
+        Some(dir) => match cwd.join(dir).canonicalize() {
+            Ok(resolved) if resolved.is_dir() => resolved,
+            _ => return,
+        },
         None => cwd,
     };
     let Some(root) = crate::dirs::find_project_root(&start) else {

--- a/crates/aube/src/lib.rs
+++ b/crates/aube/src/lib.rs
@@ -682,10 +682,14 @@ fn inner_main() -> miette::Result<i32> {
     //     that pins a different package manager.
     //
     // None of those are things a completion helper should do.
+    //
+    // `-C` is honored explicitly, since the chdir that normally applies it
+    // happens further down: completing `aube -C packages/api run <TAB>`
+    // has to offer that package's scripts, not the shell's cwd's.
     if let Some(Commands::Run(args)) = cli.command.as_ref()
         && args.complete
     {
-        commands::run::print_script_completions();
+        commands::run::print_script_completions(cli.dir.as_deref());
         return Ok(0);
     }
 

--- a/crates/aube/src/lib.rs
+++ b/crates/aube/src/lib.rs
@@ -668,6 +668,27 @@ fn inner_main() -> miette::Result<i32> {
         Cli::from_arg_matches(&matches).unwrap_or_else(|e| e.exit())
     };
 
+    // `run --complete` is the shell-completion probe behind
+    // `complete "script"` in the usage spec. It answers from the nearest
+    // `package.json` and nothing else, so it returns here — ahead of
+    // every piece of startup that would either cost a TAB press real time
+    // or swallow the candidate list outright:
+    //
+    //   - `useStderr` dup2s stdout onto stderr, and `usage` reads the
+    //     child's stdout, so the completions would vanish;
+    //   - `self_version::maybe_switch` can download and re-exec a
+    //     different aube for a keypress;
+    //   - `enforce_package_manager_guardrails` hard-errors in a project
+    //     that pins a different package manager.
+    //
+    // None of those are things a completion helper should do.
+    if let Some(Commands::Run(args)) = cli.command.as_ref()
+        && args.complete
+    {
+        commands::run::print_script_completions();
+        return Ok(0);
+    }
+
     // `--color` / `--no-color` take effect before anything else touches
     // color state: we translate the flags into the env vars that miette,
     // clx, `supports-color`, and spawned child processes all already

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -69,8 +69,13 @@ fn print_usage_spec(embedder: &'static aube_util::Embedder) -> i32 {
         Ok(()) => 0,
         Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => 0,
         Err(e) => {
-            eprintln!("{}: failed to write usage spec: {e}", embedder.name);
-            1
+            // This path never reaches miette — the usage branch returns
+            // before `cli_main` — so the stable code is printed here and
+            // the exit status comes from the same `EXIT_TABLE` lookup the
+            // diagnostic path uses.
+            let code = aube_codes::errors::ERR_AUBE_USAGE_SPEC_WRITE_FAILED;
+            eprintln!("{}: {code}: failed to write usage spec: {e}", embedder.name);
+            aube_codes::exit::exit_code_for(code).unwrap_or(aube_codes::exit::EXIT_GENERIC)
         }
     }
 }

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -32,30 +32,47 @@ fn main() {
     // before `cli_main` rather than carried as a subcommand in the lib. Only
     // the standalone `aube` invocation reaches it: multicall shims rewrite
     // argv before clap, so their `usage` tokens belong to the wrapped tool.
-    if is_usage_invocation() {
-        let mut cmd = aube::command();
-        let mut spec = Vec::new();
-        clap_usage::generate(&mut cmd, embedder.name, &mut spec);
-        let mut out = std::io::stdout();
-        let _ = std::io::Write::write_all(&mut out, &spec);
-        // `clap_usage` only sees the clap tree, which has no way to express a
-        // dynamic completer, so the `complete` nodes come from a hand-written
-        // fragment. usage merges top-level nodes, so appending the text is
-        // enough (`mise usage` does the same). `{bin}` carries the embedder's
-        // binary name into the shell snippet the completer runs.
-        let _ = std::io::Write::write_all(
-            &mut out,
-            include_str!("../assets/extra.usage.kdl")
-                .replace("{bin}", embedder.name)
-                .as_bytes(),
-        );
-        return;
-    }
-
     // The binary owns the single `std::process::exit`: `cli_main` returns the
     // code so the library stays embed-safe (a host driving it in-process is
     // never hard-killed), and the standalone binary terminates with it here.
-    std::process::exit(aube::cli_main(embedder));
+    let code = if is_usage_invocation() {
+        print_usage_spec(embedder)
+    } else {
+        aube::cli_main(embedder)
+    };
+    std::process::exit(code);
+}
+
+/// Print the usage.jdx.dev KDL spec for the CLI and return an exit code.
+fn print_usage_spec(embedder: &'static aube_util::Embedder) -> i32 {
+    let mut cmd = aube::command();
+    let mut spec = Vec::new();
+    clap_usage::generate(&mut cmd, embedder.name, &mut spec);
+    // `clap_usage` only sees the clap tree, which has no way to express a
+    // dynamic completer, so the `complete` nodes come from a hand-written
+    // fragment. usage merges top-level nodes, so appending the text is
+    // enough (`mise usage` does the same). `{bin}` carries the embedder's
+    // binary name into the shell snippet the completer runs.
+    spec.extend_from_slice(
+        include_str!("../assets/extra.usage.kdl")
+            .replace("{bin}", embedder.name)
+            .as_bytes(),
+    );
+
+    // `mise render` redirects this into `aube.usage.kdl`, so a short write
+    // must not pass for success — a truncated spec would become the
+    // checked-in one, and the completions built from it. A reader that
+    // hung up (`aube usage | head`) is not a failure.
+    use std::io::Write;
+    let mut out = std::io::stdout();
+    match out.write_all(&spec).and_then(|()| out.flush()) {
+        Ok(()) => 0,
+        Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => 0,
+        Err(e) => {
+            eprintln!("{}: failed to write usage spec: {e}", embedder.name);
+            1
+        }
+    }
 }
 
 /// True for a standalone `aube usage` invocation: argv[0] resolves to the

--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -34,7 +34,21 @@ fn main() {
     // argv before clap, so their `usage` tokens belong to the wrapped tool.
     if is_usage_invocation() {
         let mut cmd = aube::command();
-        clap_usage::generate(&mut cmd, embedder.name, &mut std::io::stdout());
+        let mut spec = Vec::new();
+        clap_usage::generate(&mut cmd, embedder.name, &mut spec);
+        let mut out = std::io::stdout();
+        let _ = std::io::Write::write_all(&mut out, &spec);
+        // `clap_usage` only sees the clap tree, which has no way to express a
+        // dynamic completer, so the `complete` nodes come from a hand-written
+        // fragment. usage merges top-level nodes, so appending the text is
+        // enough (`mise usage` does the same). `{bin}` carries the embedder's
+        // binary name into the shell snippet the completer runs.
+        let _ = std::io::Write::write_all(
+            &mut out,
+            include_str!("../assets/extra.usage.kdl")
+                .replace("{bin}", embedder.name)
+                .as_bytes(),
+        );
         return;
     }
 

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -9376,6 +9376,19 @@
         ],
         "flags": [
           {
+            "name": "complete",
+            "usage": "--complete",
+            "help": "Print the nearest `package.json`'s scripts for shell completion",
+            "help_long": "Print the nearest `package.json`'s scripts for shell completion.\n\nConsumed by the `complete \"script\"` node in the usage spec, not meant to be typed by hand.",
+            "help_first_line": "Print the nearest `package.json`'s scripts for shell completion",
+            "short": [],
+            "long": [
+              "complete"
+            ],
+            "hide": true,
+            "global": false
+          },
+          {
             "name": "if-present",
             "usage": "--if-present",
             "help": "Don't error if the script is missing from package.json",
@@ -13265,6 +13278,12 @@
   },
   "version": "1.32.0",
   "usage": "Usage: aube [OPTIONS] [COMMAND]",
-  "complete": {},
+  "complete": {
+    "script": {
+      "name": "script",
+      "run": "aube run --complete",
+      "descriptions": true
+    }
+  },
   "about": "A fast Node.js package manager"
 }

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -325,6 +325,12 @@
       "exit_code": null
     },
     {
+      "name": "ERR_AUBE_USAGE_SPEC_WRITE_FAILED",
+      "category": "Engine / CLI",
+      "description": "`aube usage` couldn't write the CLI spec to stdout; the output would have been truncated.",
+      "exit_code": null
+    },
+    {
       "name": "ERR_AUBE_REMOVE_PRIOR_INSTALL_DIR",
       "category": "Engine / CLI",
       "description": "Couldn't clean up a prior global install dir before re-installing.",

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -179,3 +179,6 @@ aube completion bash   > /etc/bash_completion.d/aube
 aube completion zsh    > "${fpath[1]}/_aube"
 aube completion fish   > ~/.config/fish/completions/aube.fish
 ```
+
+`aube run <TAB>` completes the scripts declared in the nearest
+`package.json`, with each script's command shown as the description.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -180,5 +180,7 @@ aube completion zsh    > "${fpath[1]}/_aube"
 aube completion fish   > ~/.config/fish/completions/aube.fish
 ```
 
-`aube run <TAB>` completes the scripts declared in the nearest
-`package.json`, with each script's command shown as the description.
+`aube run <TAB>` completes the scripts declared in the `package.json`
+nearest your current directory, with each script's command shown as the
+description. A `-C` earlier on the line isn't taken into account — the
+scripts offered are always the current directory's.

--- a/test/run.bats
+++ b/test/run.bats
@@ -608,3 +608,22 @@ JSON
 	assert_success
 	assert_output ""
 }
+
+@test "aube run --complete answers before the useStderr redirect and guards" {
+	# `useStderr=true` dup2s stdout onto stderr at startup, and a foreign
+	# `packageManager` pin trips the guardrail — both before command
+	# dispatch. The completion probe has to return ahead of both, or
+	# `usage` reads an empty stdout.
+	cat >package.json <<'JSON'
+{
+  "name": "guarded",
+  "version": "1.0.0",
+  "packageManager": "pnpm@9.0.0",
+  "scripts": { "build": "tsc -p ." }
+}
+JSON
+	echo "useStderr=true" >.npmrc
+	run --separate-stderr aube run --complete
+	assert_success
+	assert_output "build:tsc -p ."
+}

--- a/test/run.bats
+++ b/test/run.bats
@@ -650,3 +650,21 @@ JSON
 	assert_success
 	assert_output "root-build:echo root"
 }
+
+@test "aube run --complete resolves a symlinked -C to its target" {
+	# A real run chdirs and reads the cwd back, which resolves symlinks, so
+	# the ancestor walk starts from the target's hierarchy. The probe has to
+	# match or it searches the link's parents instead.
+	mkdir -p real/nested outer
+	cat >real/package.json <<'JSON'
+{ "name": "real", "version": "1.0.0", "scripts": { "real-build": "echo real" } }
+JSON
+	cat >outer/package.json <<'JSON'
+{ "name": "outer", "version": "1.0.0", "scripts": { "outer-build": "echo outer" } }
+JSON
+	ln -s "$PWD/real/nested" outer/deep
+
+	run aube -C outer/deep run --complete
+	assert_success
+	assert_output "real-build:echo real"
+}

--- a/test/run.bats
+++ b/test/run.bats
@@ -669,7 +669,7 @@ JSON
 	assert_output "real-build:echo real"
 }
 
-@test "aube run --complete stays quiet when -C names a missing directory" {
+@test "aube run --complete stays quiet when -C is not a usable directory" {
 	# The ancestor walk is lexical, so falling back to the unresolved path
 	# would surface the parent project's scripts and complete a command
 	# that can't run — the real chdir rejects the directory.
@@ -677,6 +677,12 @@ JSON
 { "name": "root", "version": "1.0.0", "scripts": { "root-build": "echo root" } }
 JSON
 	run aube -C does-not-exist run --complete
+	assert_success
+	assert_output ""
+
+	# Same for a target that exists but isn't a directory.
+	touch README.md
+	run aube -C README.md run --complete
 	assert_success
 	assert_output ""
 }

--- a/test/run.bats
+++ b/test/run.bats
@@ -571,3 +571,40 @@ JSON
 	assert_success
 	assert_output --partial "cli-bin"
 }
+
+@test "aube run --complete lists package.json scripts for shell completion" {
+	cat >package.json <<'JSON'
+{
+  "name": "complete-scripts",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc -p .",
+    "test:unit": "vitest run"
+  }
+}
+JSON
+	run aube run --complete
+	assert_success
+	assert_line "build:tsc -p ."
+	# usage splits each line on the first unescaped colon, so a colon in the
+	# script name has to survive as `\:`.
+	assert_line 'test\:unit:vitest run'
+}
+
+@test "aube run --complete finds the project root from a subdirectory" {
+	cat >package.json <<'JSON'
+{ "name": "root", "version": "1.0.0", "scripts": { "build": "echo hi" } }
+JSON
+	mkdir -p src/deep
+	run aube -C src/deep run --complete
+	assert_success
+	assert_line "build:echo hi"
+}
+
+@test "aube run --complete stays quiet outside a project" {
+	mkdir -p empty
+	run aube -C empty run --complete
+	assert_success
+	assert_output ""
+}

--- a/test/run.bats
+++ b/test/run.bats
@@ -627,3 +627,26 @@ JSON
 	assert_success
 	assert_output "build:tsc -p ."
 }
+
+@test "aube run --complete honors -C" {
+	# The chdir that normally applies `-C` runs after the completion probe
+	# returns, so the probe resolves the directory itself.
+	cat >package.json <<'JSON'
+{ "name": "root", "version": "1.0.0", "scripts": { "root-build": "echo root" } }
+JSON
+	mkdir -p packages/api
+	cat >packages/api/package.json <<'JSON'
+{ "name": "api", "version": "1.0.0", "scripts": { "api-serve": "node server.js" } }
+JSON
+	run aube -C packages/api run --complete
+	assert_success
+	assert_output "api-serve:node server.js"
+
+	run aube --dir "$PWD/packages/api" run --complete
+	assert_success
+	assert_output "api-serve:node server.js"
+
+	run aube run --complete
+	assert_success
+	assert_output "root-build:echo root"
+}

--- a/test/run.bats
+++ b/test/run.bats
@@ -668,3 +668,15 @@ JSON
 	assert_success
 	assert_output "real-build:echo real"
 }
+
+@test "aube run --complete stays quiet when -C names a missing directory" {
+	# The ancestor walk is lexical, so falling back to the unresolved path
+	# would surface the parent project's scripts and complete a command
+	# that can't run — the real chdir rejects the directory.
+	cat >package.json <<'JSON'
+{ "name": "root", "version": "1.0.0", "scripts": { "root-build": "echo root" } }
+JSON
+	run aube -C does-not-exist run --complete
+	assert_success
+	assert_output ""
+}

--- a/test/run.bats
+++ b/test/run.bats
@@ -685,4 +685,14 @@ JSON
 	run aube -C README.md run --complete
 	assert_success
 	assert_output ""
+
+	# ...and for one the process can't enter. root ignores the mode bits.
+	if [ "$(id -u)" -ne 0 ]; then
+		mkdir -p locked
+		chmod 000 locked
+		run aube -C locked run --complete
+		chmod 755 locked
+		assert_success
+		assert_output ""
+	fi
 }

--- a/test/run.bats
+++ b/test/run.bats
@@ -694,5 +694,24 @@ JSON
 		chmod 755 locked
 		assert_success
 		assert_output ""
+
+		# An execute-only directory is enterable, though, so a real run
+		# would work there and completion must not decline it.
+		mkdir -p searchable
+		echo '{ "name": "s", "scripts": { "s-build": "echo s" } }' >searchable/package.json
+		chmod 111 searchable
+		run aube -C searchable run --complete
+		chmod 755 searchable
+		assert_success
+		assert_output "s-build:echo s"
 	fi
+}
+
+@test "aube run --complete skips a script name containing a newline" {
+	# The protocol is one candidate per line, so such a name would split
+	# into several candidates, none of which names a real script.
+	printf '{ "name": "nl", "scripts": { "ok": "echo ok", "bad\\nname": "echo bad" } }' >package.json
+	run aube run --complete
+	assert_success
+	assert_output "ok:echo ok"
 }


### PR DESCRIPTION
Closes the feature request in https://github.com/jdx/aube/discussions/1107 — `aube run <TAB>` now completes the scripts declared in the nearest `package.json`.

## Why it didn't work before

`aube.usage.kdl` is generated by `clap_usage`, which only sees the clap tree and has no way to express a dynamic completer. So `run`'s `[SCRIPT]` positional had no completion source and the generated bash/zsh/fish script only knew the static CLI grammar. Regenerating completions never helped.

## How

Same shape `mise` uses: a hand-written spec fragment concatenated onto the generated spec.

- `crates/aube/assets/extra.usage.kdl` declares `complete "script" run="{bin} run --complete" descriptions=#true`. `{bin}` is substituted with the active embedder's binary name.
- `main.rs` buffers the `clap_usage` output and appends the fragment. usage merges top-level nodes, so plain concatenation is enough.
- `run` gains a hidden `--complete` flag that prints `name:command` lines from the nearest `package.json`.

This needs no change to how completions are installed. `aube completion <shell>` already passes `--usage-cmd "aube usage"`, so the generated script re-derives the spec from the binary and runs the completer per-project at TAB time.

The probe answers immediately after clap parsing in `inner_main`, ahead of the rest of startup. That isn't just about speed — three things in that window would otherwise break it outright: `useStderr` dup2s stdout onto stderr (and `usage` reads the child's stdout, so completions vanish), `self_version::maybe_switch` can download and re-exec a different aube for a keypress, and `enforce_package_manager_guardrails` hard-errors in a project pinning another package manager. Verified against a fixture with `useStderr=true` and `packageManager: pnpm@9.0.0`: empty before, correct after.

Colons in script names are escaped as `\:`, because usage splits each line on the first unescaped colon. Without it a `test:unit` script completes as `test` described by `unit:vitest run`. Verified against usage 3.2.0 and 3.5.2:

```
$ usage complete-word --shell zsh -f aube.spec -- aube run "test"
test        vitest run --coverage --reporter=verbose    test
test:unit   vitest run --dir test/unit                  test:unit
```

A name that *ends* in a backslash gets no description at all — the separator would read as escaped and the command would be swallowed into the candidate. Escaping the backslash doesn't help, since usage's grammar only covers `\:`; the bare name is the one form that round-trips.

## Known limitations

- **`-C` on the line being completed is ignored.** `aube -C packages/api run <TAB>` offers the current directory's scripts. usage's only channel for the typed words is tera interpolation into a `sh -c` string with no shell-quoting filter, so forwarding it would mean pasting user input into a shell command. The helper itself honors `-C` for direct invocation, ready for a safer channel upstream. Documented in the spec fragment and in `docs/installation.md`.
- **`aubr <TAB>` is not covered.** The shim rewrites argv before clap, so `aubr completion` / `aubr usage` are read as script names and there's no `aubr` spec to register. Supporting it needs a root-level spec for the shim plus a way to emit it — a separate change.
- Implicit script invocation (`aube build` with no `run`) still completes as a subcommand only.

## Tests

- Unit tests for the colon escaping, trailing-backslash handling, multi-line-command folding, and the probe leaving the process cwd untouched (`cli_main` is a library entry point, so an embedding host would keep any chdir).
- Seven bats tests: script listing, project-root discovery from a subdirectory, quiet success outside a project, answering ahead of the `useStderr` redirect and the guards, `-C` handling, symlinked `-C`, and staying quiet when `-C` isn't a usable directory.

`cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` are clean.

*This PR was generated by Claude.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI/completion-only changes with best-effort, no-error completion behavior; no install, auth, or data-path impact.
> 
> **Overview**
> **`aube run <TAB>`** now completes script names from the nearest `package.json`, with each script’s command as the description.
> 
> Because `clap_usage` cannot express dynamic completers, the PR adds a hand-written **`extra.usage.kdl`** fragment (merged when `aube usage` runs) that registers `complete "script"` → `{bin} run --complete`. **`run`** gains a hidden **`--complete`** flag that prints one `name:command` line per script, with colon escaping and other formatting tuned for the usage protocol. **`cli_main`** handles `run --complete` immediately after parsing—before `useStderr`, self-update re-exec, or package-manager guardrails—so completions stay on stdout. Direct **`aube run --complete`** honors **`-C`/`--dir`** without changing the process cwd.
> 
> **`aube usage`** now buffers the generated spec, appends the fragment, and treats truncated writes as failure via **`ERR_AUBE_USAGE_SPEC_WRITE_FAILED`**. Docs note that **`-C` on the line being completed** is not forwarded to the completer (usage limitation). Unit and bats tests cover listing, `-C`, symlinks, guards, and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d823f4a1a82471f00fbb0d54e75eac49dc1c93b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->