### PR TITLE
fix(run): start script picker in search mode and prevent wrapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -145,7 +145,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1421,9 +1421,9 @@ dependencies = [
 
 [[package]]
 name = "demand"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96e17936c1a2340dde9999f89a2f749020a3dd3f8bcf5c321741047b15ca024"
+checksum = "5439b2dab1b826af399f3b21a84538f52102a4b32f0dd59b0c69b40725e20fdd"
 dependencies = [
  "console",
  "fuzzy-matcher",
@@ -1628,7 +1628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2607,7 +2607,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006"
 dependencies = [
  "scopeguard",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3035,7 +3035,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3189,7 +3189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3585,7 +3585,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4010,7 +4010,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4067,7 +4067,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4678,7 +4678,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4892,7 +4892,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4942,7 +4942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5685,7 +5685,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -304,14 +304,18 @@ fn prompt_for_script() -> miette::Result<Option<String>> {
         .description("package.json scripts")
         .filterable(true)
         .filtering(true);
-    let name_column = scripts
+    let terminal = terminal_width();
+    let widest_name = scripts
         .iter()
         .map(|(name, _)| console::measure_text_width(name))
         .max()
         .unwrap_or(0);
-    let command_column = command_column_width(name_column, terminal_width());
+    let name_column = name_column_width(widest_name, terminal);
+    let command_column = command_column_width(name_column, terminal);
     for (name, cmd) in &scripts {
-        let mut option = demand::DemandOption::new(name.clone());
+        let ellipsis = if name_column > 0 { "…" } else { "" };
+        let label = console::truncate_str(name, name_column, ellipsis);
+        let mut option = demand::DemandOption::new(name.clone()).label(&label);
         if command_column > 0 {
             let cmd = single_line(cmd);
             option = option.description(&console::truncate_str(&cmd, command_column, "…"));
@@ -330,9 +334,18 @@ fn prompt_for_script() -> miette::Result<Option<String>> {
     }
 }
 
+/// How many columns the picker's name text may occupy.
+///
+/// A name-only `demand` row still has a one-column cursor and a space
+/// before its label. Truncating only commands would therefore leave long
+/// script names able to wrap on their own.
+fn name_column_width(widest_name: usize, terminal: usize) -> usize {
+    widest_name.min(terminal.saturating_sub(2))
+}
+
 /// How many columns the picker's command text may occupy, or `0` when
 /// there's no room worth spending on it (very narrow terminal, very long
-/// script names) and the rows should show script names alone.
+/// script names) and the rows should show truncated script names alone.
 ///
 /// `demand` renders each row as `❯ ` + the name padded to the widest
 /// name + two spaces + the description, and clears the previous frame by
@@ -1337,7 +1350,7 @@ async fn exec_script_status_with_node_args(
 mod tests {
     use super::{
         RecursiveOpts, command_column_width, completion_line, effective_concurrency,
-        inject_node_args, node_args_from_run_flags, order_matched_packages,
+        inject_node_args, name_column_width, node_args_from_run_flags, order_matched_packages,
     };
     use aube_manifest::PackageJson;
     use aube_workspace::selector::SelectedPackage;
@@ -1552,5 +1565,14 @@ mod tests {
         // rather than rows that wrap and corrupt the redraw.
         assert_eq!(command_column_width(60, 64), 0);
         assert_eq!(command_column_width(6, 12), 0);
+    }
+
+    #[test]
+    fn name_column_stays_inside_the_terminal() {
+        // The option value remains the full script name; only its label is
+        // truncated to leave room for demand's cursor and separating space.
+        assert_eq!(name_column_width(100, 64), 62);
+        assert_eq!(name_column_width(6, 64), 6);
+        assert_eq!(name_column_width(6, 2), 0);
     }
 }

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -302,7 +302,8 @@ fn prompt_for_script() -> miette::Result<Option<String>> {
     }
     let mut picker = demand::Select::new("Select a script to run")
         .description("package.json scripts")
-        .filterable(true);
+        .filterable(true)
+        .filtering(true);
     let name_column = scripts
         .iter()
         .map(|(name, _)| console::measure_text_width(name))

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -303,9 +303,19 @@ fn prompt_for_script() -> miette::Result<Option<String>> {
     let mut picker = demand::Select::new("Select a script to run")
         .description("package.json scripts")
         .filterable(true);
+    let name_column = scripts
+        .iter()
+        .map(|(name, _)| console::measure_text_width(name))
+        .max()
+        .unwrap_or(0);
+    let command_column = command_column_width(name_column, terminal_width());
     for (name, cmd) in &scripts {
-        let label = format!("{name}: {cmd}");
-        picker = picker.option(demand::DemandOption::new(name.clone()).label(&label));
+        let mut option = demand::DemandOption::new(name.clone());
+        if command_column > 0 {
+            let cmd = single_line(cmd);
+            option = option.description(&console::truncate_str(&cmd, command_column, "…"));
+        }
+        picker = picker.option(option);
     }
     match picker.run() {
         Ok(name) => Ok(Some(name)),
@@ -317,6 +327,49 @@ fn prompt_for_script() -> miette::Result<Option<String>> {
             .into_diagnostic()
             .wrap_err("failed to read script selection"),
     }
+}
+
+/// How many columns the picker's command text may occupy, or `0` when
+/// there's no room worth spending on it (very narrow terminal, very long
+/// script names) and the rows should show script names alone.
+///
+/// `demand` renders each row as `❯ ` + the name padded to the widest
+/// name + two spaces + the description, and clears the previous frame by
+/// counting *logical* lines. A row wider than the terminal wraps into
+/// physical rows the clear never erases, so every keypress stacks another
+/// copy of the frame on screen. Keeping rows inside the width is what
+/// makes the picker usable, not just tidy.
+fn command_column_width(name_column: usize, terminal: usize) -> usize {
+    /// Below this a truncated command is all ellipsis and no information.
+    const MIN_COMMAND_COLUMN: usize = 12;
+    // `❯ ` before the name, two spaces between the columns.
+    let row_overhead = 2 + name_column + 2;
+    match terminal.saturating_sub(row_overhead) {
+        w if w >= MIN_COMMAND_COLUMN => w,
+        _ => 0,
+    }
+}
+
+/// Width of the terminal the picker draws on, falling back to 80 when
+/// stderr isn't a TTY or the size can't be read. `$COLUMNS` wins because
+/// it's what the user's shell reports for the current window.
+fn terminal_width() -> usize {
+    std::env::var("COLUMNS")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .or_else(|| {
+            console::Term::stderr()
+                .size_checked()
+                .map(|(_rows, cols)| cols as usize)
+        })
+        .filter(|cols| *cols > 0)
+        .unwrap_or(80)
+}
+
+/// Collapse every run of whitespace to a single space so a multi-line
+/// script command still occupies exactly one row.
+fn single_line(cmd: &str) -> String {
+    cmd.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 /// Print the nearest `package.json`'s scripts for the `complete "script"`
@@ -386,8 +439,8 @@ pub(crate) fn print_script_completions(dir: Option<&Path>) {
 /// Format one `name:command` completion line. `usage` splits each line on
 /// its first *unescaped* colon, so colons inside the name are escaped —
 /// without this a `test:unit` script completes as `test` described by
-/// `unit:vitest …`. Newlines and tabs in the command are folded to spaces
-/// so a multi-line script stays on one line.
+/// `unit:vitest …`. The command is folded onto one line so a multi-line
+/// script doesn't turn into several bogus completion candidates.
 ///
 /// A name that ends in a backslash gets no description at all. The
 /// separator immediately after it would read as escaped, and `usage` would
@@ -397,14 +450,10 @@ pub(crate) fn print_script_completions(dir: Option<&Path>) {
 /// the one form that still yields the right name.
 fn completion_line(name: &str, cmd: &str) -> String {
     let name = name.replace(':', "\\:");
-    let cmd: String = cmd
-        .chars()
-        .map(|c| if c.is_whitespace() { ' ' } else { c })
-        .collect();
     if name.ends_with('\\') {
         return name;
     }
-    format!("{name}:{}", cmd.trim())
+    format!("{name}:{}", single_line(cmd))
 }
 
 /// Read `package.json` and return its `scripts` entries in the order
@@ -1281,8 +1330,8 @@ async fn exec_script_status_with_node_args(
 #[cfg(test)]
 mod tests {
     use super::{
-        RecursiveOpts, completion_line, effective_concurrency, inject_node_args,
-        node_args_from_run_flags, order_matched_packages,
+        RecursiveOpts, command_column_width, completion_line, effective_concurrency,
+        inject_node_args, node_args_from_run_flags, order_matched_packages,
     };
     use aube_manifest::PackageJson;
     use aube_workspace::selector::SelectedPackage;
@@ -1481,7 +1530,21 @@ mod tests {
     fn completion_line_folds_a_multiline_command_onto_one_line() {
         assert_eq!(
             completion_line("deploy", "node deploy.mjs \\\n  --yes\n"),
-            "deploy:node deploy.mjs \\   --yes"
+            "deploy:node deploy.mjs \\ --yes"
         );
+    }
+
+    #[test]
+    fn command_column_takes_what_the_name_column_leaves() {
+        // "❯ " + 6-wide name column + "  " = 10 columns of overhead.
+        assert_eq!(command_column_width(6, 80), 70);
+    }
+
+    #[test]
+    fn command_column_collapses_when_the_row_would_wrap() {
+        // Nothing useful fits, so the picker shows script names alone
+        // rather than rows that wrap and corrupt the redraw.
+        assert_eq!(command_column_width(60, 64), 0);
+        assert_eq!(command_column_width(6, 12), 0);
     }
 }

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -350,17 +350,22 @@ fn command_column_width(name_column: usize, terminal: usize) -> usize {
     }
 }
 
-/// Width of the terminal the picker draws on, falling back to 80 when
-/// stderr isn't a TTY or the size can't be read. `$COLUMNS` wins because
-/// it's what the user's shell reports for the current window.
+/// Width of the terminal the picker draws on.
+///
+/// Queried from stderr, because that's where `demand` renders and what it
+/// sizes itself against — budgeting rows against anything else is how they
+/// end up disagreeing. `$COLUMNS` is only a fallback for when the size
+/// can't be read: it's an inherited value that goes stale on resize, and
+/// trusting it over a live `ioctl` would put rows past the real edge and
+/// bring the wrapping right back. 80 when neither is available.
 fn terminal_width() -> usize {
-    std::env::var("COLUMNS")
-        .ok()
-        .and_then(|s| s.parse::<usize>().ok())
+    console::Term::stderr()
+        .size_checked()
+        .map(|(_rows, cols)| cols as usize)
         .or_else(|| {
-            console::Term::stderr()
-                .size_checked()
-                .map(|(_rows, cols)| cols as usize)
+            std::env::var("COLUMNS")
+                .ok()
+                .and_then(|s| s.parse::<usize>().ok())
         })
         .filter(|cols| *cols > 0)
         .unwrap_or(80)


### PR DESCRIPTION
Second half of https://github.com/jdx/aube/discussions/1107. The reporter described the `aube run` picker as showing script bodies that are "long enough to make it look ugly", and moving or searching within the list as "completely broken as it scrambles the output, repeating lines and cursors".

Both come from one cause: every row was built as `format!("{name}: {cmd}")` with no regard for the terminal width. The picker now also starts in filtering mode, so typing searches script names immediately.

## What actually happens

`demand` sizes its redraw from `output.lines().count()` — *logical* lines — and clears the previous frame with `clear_last_lines(height)`. A row wider than the terminal wraps into physical rows that the clear never erases, so each keypress stacks another copy of the frame on screen.

Driving the picker through a pty at 80 columns, two ↓ presses, rendered through a terminal emulator — before:

```
 0 |Select a script to run
 1 |package.json scripts
 2 |❯ build: tsc -p tsconfig.build.json && rollup -c rollup.config.mjs --environment
 3 |Select a script to run          ← stale row
 4 |package.json scripts
 5 |  build: tsc -p tsconfig.build.json && rollup -c rollup.config.mjs --environment
 6 |Select a script to run          ← stale row
 7 |package.json scripts
 8 |  build: …
```

After:

```
 0 |Select a script to run
 1 |package.json scripts
 2 |  build      tsc -p tsconfig.build.json && rollup -c rollup.config.mjs --enviro…
 3 |  test       vitest run --coverage --reporter=verbose --pool=threads --poolOpti…
 4 |❯ lint       eslint . --ext .ts,.tsx --max-warnings 0 --cache --cache-location …
 5 |  dev        vite --host 0.0.0.0 --port 3000
 6 |  test:unit  vitest run --dir test/unit
 7 |  deploy     node scripts/deploy.mjs --yes
 8 |↑/↓/k/j up/down • / filter • enter confirm
```

Filtering is clean too — and active immediately. Typing `te` narrows the list in place instead of requiring `/` first or scrambling the output.

## The change

The script name becomes the label and the command moves to `demand`'s description column, budgeted against the real terminal width (`Term::stderr().size_checked()`, else `$COLUMNS`, else 80) and truncated with an ellipsis. When the name column leaves under 12 usable columns the command is dropped entirely; script-name labels are also truncated to leave room for `demand`'s cursor, while the selected value remains the complete name. Multi-line commands are folded onto one line — `single_line` is now shared with the completion path. The picker remains filterable and now starts with filtering active, so the first printable key begins the search.

Aligning the command into its own column also answers the "hide it" half of the request without losing the information: the names line up, and the command reads as secondary.

## Upstream

This PR includes `demand` 2.0.4, which contains [jdx/demand#190](https://github.com/jdx/demand/pull/190). The picker now re-reads the terminal height on every frame and clears wrapped physical rows correctly, including after a terminal resize. Aube still budgets script descriptions to the initial terminal width because `demand::Select` takes options by value, but narrowing the terminal no longer leaves duplicated or scrambled frames.

## Tests

Unit tests for the column budget, including the collapse-to-names-only path. All 19 focused `run` tests, `cargo clippy --all-targets -- -D warnings`, `cargo check --locked -p aube`, and `cargo fmt --check` are clean.


*This PR was generated by Claude and updated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the interactive TTY script-picker path and completion string formatting; no install, exec, or auth behavior.
> 
> **Overview**
> Fixes the interactive **`aube run`** script picker when rows were wider than the terminal: **`demand`** redraws by logical line count, so wrapped rows stacked duplicate frames on every keypress.
> 
> The picker now uses **script name as the label** and the **command as the description**, with widths derived from **stderr terminal size** (then **`$COLUMNS`**, else 80). Names and commands are truncated with ellipsis; if fewer than 12 columns remain for the command, descriptions are omitted so rows stay single-line. **`.filtering(true)`** starts search immediately (still **`.filterable(true)`**).
> 
> **`single_line`** collapses multi-line script bodies and is shared with shell **completion** formatting (replacing the previous per-char whitespace fold). Unit tests cover column budgeting and completion folding.
> 
> **`Cargo.lock`** bumps **`demand`** to **2.0.4** (upstream redraw/resize fixes) plus transitive **`windows-sys`** pin adjustments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43fca71c6b1a7d8fc2d02bf8682c2ecc7c1283f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



