### PR TITLE
fix(resolver): explain trust downgrade failures

### DIFF
--- a/crates/aube-resolver/src/error.rs
+++ b/crates/aube-resolver/src/error.rs
@@ -147,9 +147,23 @@ impl miette::Diagnostic for Error {
 
 fn format_trust_downgrade_help(d: &TrustDowngradeDetails) -> String {
     format!(
-        "a trust downgrade may indicate a supply-chain incident — the publisher's previous releases carried {evidence} but {name}@{ver} does not.\n\
-         to bypass: pin a version that retains evidence, set `trustPolicy = off` in .npmrc / pnpm-workspace.yaml, \
-         or add `{name}` (or `{name}@{ver}`) to `trustPolicyExclude`.",
+        "this is a supply-chain trust failure, not an ordinary version-resolution error. \
+         An earlier release carried {evidence}, but {name}@{ver} does not.\n\
+         \n\
+         This can signal a compromised publisher or tampered release. It can also be benign \
+         release-process drift: a maintainer manually published, backported outside the trusted \
+         workflow, skipped provenance for convenience, or used a registry that stripped metadata.\n\
+         \n\
+         Before bypassing:\n\
+         1. Inspect the package's npm release, source tag/commit, publisher identity, and tarball; \
+         confirm the change is expected and nothing appears tampered with.\n\
+         2. Report the downgrade upstream. The package's release process failed to preserve its \
+         previous trust evidence, and the maintainer should restore the trusted publishing path.\n\
+         3. Only after review, pin a version that retains evidence or add the narrow \
+         `{name}@{ver}` exception to `trustPolicyExclude`. A bare `{name}` exempts every version; \
+         `trustPolicy = off` disables this protection for the entire install.\n\
+         \n\
+         Details and known built-in exceptions: https://aube.jdx.dev/trust-policy-exceptions",
         evidence = d.prior_evidence.label(),
         name = d.name,
         ver = d.picked_version,
@@ -496,5 +510,29 @@ pub(crate) fn classify_registry_error(msg: &str) -> RegistryErrorKind {
         RegistryErrorKind::ResolverBug
     } else {
         RegistryErrorKind::Generic
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::trust::TrustEvidence;
+
+    #[test]
+    fn trust_downgrade_help_prioritizes_investigation_and_upstream_reporting() {
+        let help = format_trust_downgrade_help(&TrustDowngradeDetails {
+            name: "@scope/pkg".into(),
+            picked_version: "2.0.0".into(),
+            current_evidence: None,
+            prior_evidence: TrustEvidence::TrustedPublisher,
+            prior_version: "1.9.0".into(),
+        });
+
+        assert!(help.contains("not an ordinary version-resolution error"));
+        assert!(help.contains("confirm the change is expected and nothing appears tampered with"));
+        assert!(help.contains("Report the downgrade upstream"));
+        assert!(help.contains("`@scope/pkg@2.0.0` exception"));
+        assert!(help.contains("A bare `@scope/pkg` exempts every version"));
+        assert!(help.contains("https://aube.jdx.dev/trust-policy-exceptions"));
     }
 }

--- a/crates/aube-resolver/src/error.rs
+++ b/crates/aube-resolver/src/error.rs
@@ -148,7 +148,7 @@ impl miette::Diagnostic for Error {
 fn format_trust_downgrade_help(d: &TrustDowngradeDetails) -> String {
     format!(
         "this is a supply-chain trust failure, not an ordinary version-resolution error. \
-         An earlier release carried {evidence}, but {name}@{ver} does not.\n\
+         An earlier release carried {prior_evidence}, but {name}@{ver} carries {current_evidence}.\n\
          \n\
          This can signal a compromised publisher or tampered release. It can also be benign \
          release-process drift: a maintainer manually published, backported outside the trusted \
@@ -156,15 +156,20 @@ fn format_trust_downgrade_help(d: &TrustDowngradeDetails) -> String {
          \n\
          Before bypassing:\n\
          1. Inspect the package's npm release, source tag/commit, publisher identity, and tarball; \
-         confirm the change is expected and nothing appears tampered with.\n\
-         2. Report the downgrade upstream. The package's release process failed to preserve its \
-         previous trust evidence, and the maintainer should restore the trusted publishing path.\n\
+         compare the metadata with npmjs.org, and confirm the change is expected and nothing \
+         appears tampered with.\n\
+         2. Report inconsistent evidence to the relevant upstream owner. Package-release drift \
+         belongs with the maintainer; metadata present on npmjs.org but missing from a proxy or \
+         mirror belongs with that registry operator.\n\
          3. Only after review, pin a version that retains evidence or add the narrow \
          `{name}@{ver}` exception to `trustPolicyExclude`. A bare `{name}` exempts every version; \
          `trustPolicy = off` disables this protection for the entire install.\n\
          \n\
          Details and known built-in exceptions: https://aube.jdx.dev/trust-policy-exceptions",
-        evidence = d.prior_evidence.label(),
+        prior_evidence = d.prior_evidence.label(),
+        current_evidence = d
+            .current_evidence
+            .map_or("no trust evidence", |e| e.label()),
         name = d.name,
         ver = d.picked_version,
     )
@@ -529,8 +534,10 @@ mod tests {
         });
 
         assert!(help.contains("not an ordinary version-resolution error"));
+        assert!(help.contains("carries no trust evidence"));
         assert!(help.contains("confirm the change is expected and nothing appears tampered with"));
-        assert!(help.contains("Report the downgrade upstream"));
+        assert!(help.contains("Report inconsistent evidence to the relevant upstream owner"));
+        assert!(help.contains("belongs with that registry operator"));
         assert!(help.contains("`@scope/pkg@2.0.0` exception"));
         assert!(help.contains("A bare `@scope/pkg` exempts every version"));
         assert!(help.contains("https://aube.jdx.dev/trust-policy-exceptions"));

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -121,6 +121,7 @@ export default defineConfig({
         text: "Security",
         items: [
           { text: "Overview", link: "/security" },
+          { text: "Trust policy downgrades", link: "/trust-policy-exceptions" },
           { text: "Jailed builds", link: "/package-manager/jailed-builds" },
           { text: "Security scanner", link: "/package-manager/security-scanner" },
         ],

--- a/docs/security.md
+++ b/docs/security.md
@@ -175,6 +175,10 @@ maintaining multiple major-version lines and backporting to older ones without
 attestation), so common installs don't fail on a known-benign downgrade. Your
 own `trustPolicyExclude` entries are added on top of these defaults.
 
+See [Trust policy downgrades](/trust-policy-exceptions) for an investigation
+checklist, guidance for reporting packaging failures upstream, and the
+dynamically generated list of built-in exceptions.
+
 Settings: [`trustPolicy`](/settings/#setting-trustpolicy),
 [`trustPolicyExclude`](/settings/#setting-trustpolicyexclude),
 [`trustPolicyIgnoreAfter`](/settings/#setting-trustpolicyignoreafter).

--- a/docs/trust-policy-exceptions.data.ts
+++ b/docs/trust-policy-exceptions.data.ts
@@ -11,41 +11,39 @@ const TRUST_SOURCE_PATH = path.resolve(
 declare const data: string[]
 export { data }
 
+export function parseTrustPolicyExcludes(source: string): string[] {
+  const block = source.match(
+    /pub const DEFAULT_TRUST_POLICY_EXCLUDES:[\s\S]*?=\s*&\[(?<entries>[\s\S]*?)\];/,
+  )?.groups?.entries
+
+  if (!block) {
+    throw new Error('could not find DEFAULT_TRUST_POLICY_EXCLUDES in trust.rs')
+  }
+
+  const uncommented = block
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '')
+
+  const entries = uncommented.split('\n').flatMap((line, index) => {
+    const trimmed = line.trim()
+    if (!trimmed) return []
+
+    const match = trimmed.match(/^"([^"]+)"\s*,?$/)
+    if (!match) {
+      throw new Error(
+        `unrecognized DEFAULT_TRUST_POLICY_EXCLUDES entry on line ${index + 1}: ${trimmed}`,
+      )
+    }
+    return [match[1]]
+  })
+
+  return entries.sort((a, b) => a.localeCompare(b))
+}
+
 export default {
   watch: ['../crates/aube-resolver/src/trust.rs'],
   load(): string[] {
     const source = fs.readFileSync(TRUST_SOURCE_PATH, 'utf8')
-    const block = source.match(
-      /pub const DEFAULT_TRUST_POLICY_EXCLUDES:[\s\S]*?=\s*&\[(?<entries>[\s\S]*?)\];/,
-    )?.groups?.entries
-
-    if (!block) {
-      throw new Error('could not find DEFAULT_TRUST_POLICY_EXCLUDES in trust.rs')
-    }
-
-    const entries = block.split('\n').flatMap((line, index) => {
-      const trimmed = line.trim()
-      if (
-        !trimmed ||
-        trimmed.startsWith('//') ||
-        trimmed.startsWith('/*') ||
-        trimmed.startsWith('*') ||
-        trimmed === '*/'
-      ) {
-        return []
-      }
-
-      const match = trimmed.match(
-        /^"([^"]+)"\s*,?\s*(?:(?:\/\/.*)|(?:\/\*.*\*\/))?$/,
-      )
-      if (!match) {
-        throw new Error(
-          `unrecognized DEFAULT_TRUST_POLICY_EXCLUDES entry on line ${index + 1}: ${trimmed}`,
-        )
-      }
-      return [match[1]]
-    })
-
-    return entries.sort((a, b) => a.localeCompare(b))
+    return parseTrustPolicyExcludes(source)
   },
 }

--- a/docs/trust-policy-exceptions.data.ts
+++ b/docs/trust-policy-exceptions.data.ts
@@ -1,0 +1,30 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const TRUST_SOURCE_PATH = path.resolve(
+  __dirname,
+  '../crates/aube-resolver/src/trust.rs',
+)
+
+declare const data: string[]
+export { data }
+
+export default {
+  watch: ['../crates/aube-resolver/src/trust.rs'],
+  load(): string[] {
+    const source = fs.readFileSync(TRUST_SOURCE_PATH, 'utf8')
+    const block = source.match(
+      /pub const DEFAULT_TRUST_POLICY_EXCLUDES:[\s\S]*?=\s*&\[(?<entries>[\s\S]*?)\];/,
+    )?.groups?.entries
+
+    if (!block) {
+      throw new Error('could not find DEFAULT_TRUST_POLICY_EXCLUDES in trust.rs')
+    }
+
+    return [...block.matchAll(/^\s*"([^"]+)",\s*$/gm)]
+      .map((match) => match[1])
+      .sort((a, b) => a.localeCompare(b))
+  },
+}

--- a/docs/trust-policy-exceptions.data.ts
+++ b/docs/trust-policy-exceptions.data.ts
@@ -23,8 +23,29 @@ export default {
       throw new Error('could not find DEFAULT_TRUST_POLICY_EXCLUDES in trust.rs')
     }
 
-    return [...block.matchAll(/^\s*"([^"]+)",\s*$/gm)]
-      .map((match) => match[1])
-      .sort((a, b) => a.localeCompare(b))
+    const entries = block.split('\n').flatMap((line, index) => {
+      const trimmed = line.trim()
+      if (
+        !trimmed ||
+        trimmed.startsWith('//') ||
+        trimmed.startsWith('/*') ||
+        trimmed.startsWith('*') ||
+        trimmed === '*/'
+      ) {
+        return []
+      }
+
+      const match = trimmed.match(
+        /^"([^"]+)"\s*,?\s*(?:(?:\/\/.*)|(?:\/\*.*\*\/))?$/,
+      )
+      if (!match) {
+        throw new Error(
+          `unrecognized DEFAULT_TRUST_POLICY_EXCLUDES entry on line ${index + 1}: ${trimmed}`,
+        )
+      }
+      return [match[1]]
+    })
+
+    return entries.sort((a, b) => a.localeCompare(b))
   },
 }

--- a/docs/trust-policy-exceptions.md
+++ b/docs/trust-policy-exceptions.md
@@ -22,9 +22,10 @@ There are also less dramatic explanations:
 - parallel major-version lines use inconsistent release automation;
 - a registry proxy or mirror omitted trust metadata.
 
-Those explanations may be benign, but they are still packaging failures. Once
+Release-process drift may be benign, but it is still a packaging failure. Once
 a project establishes a trusted publishing path, every release should preserve
-it.
+it. Metadata lost only by a proxy or mirror is instead a registry-operator
+failure.
 
 ## What to do before adding an exception
 
@@ -36,9 +37,10 @@ it.
    that the release was tampered with.
 4. Check the upstream repository and advisories for a compromised account,
    workflow outage, or intentional manual publish.
-5. Report the downgrade to the package maintainer. Ask them to restore the
-   trusted publishing workflow and publish a corrected release when
-   appropriate.
+5. Report inconsistent evidence to the relevant upstream owner. Ask the package
+   maintainer to restore a drifted publishing workflow, or ask the registry
+   operator to restore metadata that exists on npmjs.org but is missing from its
+   proxy or mirror.
 
 Do not treat an allowlist entry as proof that a package is safe. It only records
 that someone chose to bypass this particular signal.

--- a/docs/trust-policy-exceptions.md
+++ b/docs/trust-policy-exceptions.md
@@ -1,0 +1,89 @@
+# Trust policy downgrades
+
+<script setup>
+import { data as packages } from './trust-policy-exceptions.data.ts'
+</script>
+
+`trustPolicy = no-downgrade` stops an install when the selected package
+version has weaker publishing evidence than an earlier release. This is a
+signal to investigate, not just another version-resolution error.
+
+## What the failure means
+
+An earlier-published version had npm staged-publish approval, trusted-publisher
+identity, or provenance metadata that the selected version no longer has. That
+can indicate a compromised publisher, stolen token, malicious co-maintainer, or
+a release built outside the repository's expected CI workflow.
+
+There are also less dramatic explanations:
+
+- a maintainer manually published a release or backport;
+- a release shortcut skipped the trusted-publisher or provenance-enabled job;
+- parallel major-version lines use inconsistent release automation;
+- a registry proxy or mirror omitted trust metadata.
+
+Those explanations may be benign, but they are still packaging failures. Once
+a project establishes a trusted publishing path, every release should preserve
+it.
+
+## What to do before adding an exception
+
+1. Confirm the package name and selected version are the ones you expected.
+2. Compare the npm publish time, publisher identity, source tag, commit, and
+   release notes with the last trusted release.
+3. Inspect the tarball contents and integrity metadata. Look for unexpected
+   files, generated code, install scripts, dependency changes, or other signs
+   that the release was tampered with.
+4. Check the upstream repository and advisories for a compromised account,
+   workflow outage, or intentional manual publish.
+5. Report the downgrade to the package maintainer. Ask them to restore the
+   trusted publishing workflow and publish a corrected release when
+   appropriate.
+
+Do not treat an allowlist entry as proof that a package is safe. It only records
+that someone chose to bypass this particular signal.
+
+## Choosing the narrowest workaround
+
+Prefer these options in order:
+
+1. Pin a release that still carries trust evidence.
+2. After reviewing the release, exempt only the affected version:
+
+   ```yaml
+   trustPolicyExclude:
+     - "package-name@1.2.3"
+   ```
+
+3. Exempt every version only when the package's release model is inherently
+   inconsistent and you are willing to review future releases without this
+   protection:
+
+   ```yaml
+   trustPolicyExclude:
+     - "package-name"
+   ```
+
+Setting `trustPolicy = off` disables the check for the entire install and
+should be a last resort.
+
+## Wall of shame
+
+The following {{ packages.length }} packages are built into aube's default
+exception list because their published metadata has triggered legitimate
+`no-downgrade` failures:
+
+<ul>
+  <li v-for="packageName in packages" :key="packageName">
+    <a :href="`https://www.npmjs.com/package/${packageName}`">{{ packageName }}</a>
+  </li>
+</ul>
+
+This list is generated directly from
+[`DEFAULT_TRUST_POLICY_EXCLUDES`](https://github.com/jdx/aube/blob/main/crates/aube-resolver/src/trust.rs)
+at documentation build time, so it cannot drift from the resolver. Inclusion
+is not an accusation of malware; it records inconsistent publishing evidence
+that weakens the protection for every aube user.
+
+If a package restores consistent trusted publishing, remove its built-in
+exception so future regressions are blocked again.


### PR DESCRIPTION
## Summary

- expand `ERR_AUBE_TRUST_DOWNGRADE` help with investigation steps, upstream-reporting guidance, and narrow remediation advice
- add a dedicated trust-policy downgrade guide with a packaging triage checklist
- add a "Wall of shame" generated at VitePress build time from `DEFAULT_TRUST_POLICY_EXCLUDES`
- link the new guide from the security overview and sidebar

## Why

A trust downgrade currently looks too much like a routine resolver failure and moves quickly to bypass instructions. Users should first treat lost trusted-publisher or provenance evidence as a possible supply-chain incident, inspect the release for tampering, and report inconsistent publishing evidence to the package maintainer. Benign manual publishes and backports are still packaging failures worth fixing upstream.

The built-in exception list also had no user-facing inventory. The new page reads the resolver constant directly, so the published list updates whenever the allowlist changes and cannot drift from runtime behavior.

## Validation

- `cargo fmt --check`
- `cargo test -p aube-resolver trust_downgrade`
- `mise run docs:build`
- `mise run lint-fix`
- verified the rendered page lists all 11 current built-in exceptions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing diagnostics and documentation only; trust enforcement behavior is unchanged.
> 
> **Overview**
> **Trust downgrade errors** now read as supply-chain signals instead of quick bypass hints. `ERR_AUBE_TRUST_DOWNGRADE` help in `aube-resolver` names prior vs current evidence, walks through inspection and upstream reporting, ranks narrow `trustPolicyExclude` vs global `off`, and links to the new docs page. A unit test locks in that messaging.
> 
> **New docs:** A **Trust policy downgrades** guide covers what `no-downgrade` means, a pre-exception checklist, and workaround ordering. A VitePress data loader parses `DEFAULT_TRUST_POLICY_EXCLUDES` from `trust.rs` at build time so a **Wall of shame** list stays in sync with the resolver. The security overview and sidebar link to `/trust-policy-exceptions`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0ccc91da11d400b253a6b5577d4fe7c141d8bf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a dedicated “Trust policy downgrades” guide with investigation steps, reporting guidance, and exception recommendations.
  * Documented the risks of disabling trust checks and recommended narrower package-specific workarounds.
  * Added the guide to the Security documentation navigation.
  * Added a dynamically maintained list of built-in trust-policy exceptions.

* **Bug Fixes**
  * Expanded trust downgrade guidance with clearer supply-chain warnings and a structured checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->