### PR TITLE
fix(packaging): include assets/ in the published aube tarball

### DIFF
--- a/crates/aube/Cargo.toml
+++ b/crates/aube/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 readme.workspace = true
-include = ["src/**/*.rs", "src/**/*.mjs", "build.rs"]
+include = ["src/**/*.rs", "src/**/*.mjs", "assets/**", "build.rs"]
 
 # The command layer is a library so it can be embedded (construct
 # `commands::install::InstallOptions`, call `commands::install::run`)


### PR DESCRIPTION
`aube` 1.33.0 is not on crates.io. The [release-plz run for v1.33.0](https://github.com/jdx/aube/actions/runs/30171684534) published all 12 library crates and then failed verifying the `aube` tarball:

```
error: couldn't read `src/../assets/extra.usage.kdl`: No such file or directory (os error 2)
  --> src/main.rs:57:9
error: failed to verify package tarball
```

`crates/aube/Cargo.toml`'s `include` list was `["src/**/*.rs", "src/**/*.mjs", "build.rs"]`. `assets/extra.usage.kdl` arrived in #1108 and was never added, so the file `main.rs:57` `include_str!`s is absent from the packaged tarball. Ordinary CI never sees this — it builds the working tree, where the file is always there.

This widens the list to `assets/**`. Same bug class as f21d6e2 (`security_scanner_js/*.mjs`), hence the glob rather than naming the one file.

## Verification

```
cargo package --workspace --locked   # before: exit 101, same error as the release run
                                     # after:  all 14 crates verify
```

## Downstream

mise pins `aube = "1.32"` / `aube-registry = "1.32"`. It can't move to 1.33 while the split exists — the sub-crates' `^1.32.0` reqs resolve to 1.33.0, but `aube-scripts` 1.33 renamed `ScriptSettings::node_exe` to `node_program`/`node_execpath`, so `aube` 1.32 no longer compiles against it:

```
error[E0560]: struct `ScriptSettings` has no field named `node_exe`
  --> aube-1.32.0/src/commands/script_settings.rs:41:9
```

Once this merges and release-plz publishes `aube` 1.33.0, the mise bump is a one-liner.

## Not included

A `package` CI job running `cargo package --workspace --locked` (~20s warm, ~3min cold) would catch the next omission at PR time. I couldn't push it — the token lacks the `workflow` scope. Patch is ready to apply separately.

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only manifest change; no runtime logic or dependency changes.
> 
> **Overview**
> **Fixes `cargo package` / crates.io publish verification** for the `aube` binary crate by adding `assets/**` to the `[package] include` whitelist in `crates/aube/Cargo.toml`.
> 
> `src/main.rs` embeds `assets/extra.usage.kdl` via `include_str!` for the usage spec; that path was missing from the tarball, so release-plz failed with “couldn't read `src/../assets/extra.usage.kdl`” even though normal CI builds from the full working tree. The change mirrors an earlier fix for omitted `security_scanner_js/*.mjs` files—use a glob so future assets under `assets/` are packaged too.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3ecea5d0d3c90c5bb2377bce1b8fa961199f913. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->