### PR TITLE
fix(resolver): exclude @hono/node-server from no-downgrade by default

### DIFF
--- a/crates/aube-resolver/src/trust.rs
+++ b/crates/aube-resolver/src/trust.rs
@@ -257,6 +257,12 @@ pub const DEFAULT_TRUST_POLICY_EXCLUDES: &[&str] = &[
     // @octokit/endpoint@9.0.6) is published after an attested newer major
     // (10.1.0), so the no-downgrade check flags the legitimate older release.
     "@octokit/endpoint",
+    // @hono/node-server keeps a 1.x line alive alongside 2.x. The 2.x releases
+    // are published from CI with SLSA provenance, but 1.x backports are
+    // hand-published by the maintainer without attestation — e.g.
+    // @hono/node-server@1.19.15 (2026-07-24) came after the attested
+    // 2.0.10 (2026-07-15), so no-downgrade flags the legitimate backport.
+    "@hono/node-server",
     "chokidar",
     "eslint-config-prettier",
     "eslint-import-resolver-typescript",
@@ -1148,6 +1154,23 @@ mod tests {
             "@octokit/core",
             &node_semver::Version::parse("9.0.6").unwrap()
         ));
+    }
+
+    #[test]
+    fn default_excludes_scoped_hono_node_server_backport() {
+        // Regression: @hono/node-server publishes 2.x from CI with provenance
+        // but hand-publishes 1.x backports without it, so 1.19.15 (released
+        // after the attested 2.0.10) tripped no-downgrade.
+        let r = TrustExcludeRules::default();
+        assert!(r.matches(
+            "@hono/node-server",
+            &node_semver::Version::parse("1.19.15").unwrap()
+        ));
+        assert!(r.matches(
+            "@hono/node-server",
+            &node_semver::Version::parse("2.0.10").unwrap()
+        ));
+        assert!(!r.matches("hono", &node_semver::Version::parse("1.19.15").unwrap()));
     }
 
     #[test]


### PR DESCRIPTION
`@hono/node-server` maintains a 1.x line alongside 2.x. The 2.x releases are published from CI with SLSA provenance, but 1.x backports are hand-published by the maintainer without attestation, so `no-downgrade` rejects a legitimate backport:

```
trust downgrade for @hono/node-server@1.19.15 (trustPolicy=no-downgrade):
earlier published version 2.0.10 had trusted publisher but this version has no trust evidence
```

Same shape as `@octokit/endpoint` in #1088 — parallel major lines with unattested backports to the older one.

## Verification

Checked against the npm registry:

| | 2.0.10 | 1.19.15 |
|---|---|---|
| publisher | `GitHub Actions` | `yusukebe` (manual) |
| SLSA provenance | yes | **none** |
| registry signature | yes | yes |
| published | 2026-07-15 | 2026-07-24 |

`yusukebe` is the sole maintainer, and 1.19.15 is a 1.x backport published after the 2.x line shipped. Legitimate maintainer, real provenance regression, no indication of tampering.

## Impact

This surfaced as an opaque `heroku` install failure in mise, which depends on `@hono/node-server` transitively — the tool is currently uninstallable through mise's npm backend without a manual `trust_policy_excludes` entry.

## Tests

Added `default_excludes_scoped_hono_node_server_backport`, mirroring the existing `@octokit/endpoint` regression test. `cargo test -p aube-resolver trust::` — 40 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-package addition to the default exclude list with a targeted unit test; no change to trust-check logic beyond which packages skip no-downgrade.
> 
> **Overview**
> Adds **`@hono/node-server`** to the built-in **`trustPolicyExclude`** list so the **no-downgrade** trust check no longer fails on legitimate **1.x backports** published after attested **2.x** releases (same pattern as **`@octokit/endpoint`**).
> 
> A regression test **`default_excludes_scoped_hono_node_server_backport`** asserts default rules cover **`@hono/node-server`** at **1.19.15** and **2.0.10** but not the unrelated **`hono`** package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1654474bd518f55bb922d92df493113b7dc040bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->