### PR TITLE
fix(install): bootstrap node-gyp in-process instead of re-execing aube

### DIFF
--- a/crates/aube/src/commands/install/node_gyp_bootstrap.rs
+++ b/crates/aube/src/commands/install/node_gyp_bootstrap.rs
@@ -17,17 +17,26 @@
 //! dir is prepended to the lifecycle script's `PATH` *after* the
 //! dep's own `.bin`.
 //!
-//! The install is performed by recursively invoking the current aube
-//! binary with `install --ignore-scripts` inside a freshly-written
-//! `package.json` that pins node-gyp. The outer project's `.npmrc`
-//! (if any) is copied into the tool dir as its own project-level
-//! `.npmrc` so private-registry URLs and auth tokens configured by
-//! monorepo / enterprise setups flow through to the recursive
-//! install — the subprocess's cwd is the tool dir, which would
-//! otherwise only pick up `~/.npmrc`. An `xx::fslock` lock keyed
-//! off the tool dir serializes concurrent bootstraps across
-//! processes; the fast-path existence check short-circuits every
-//! subsequent invocation.
+//! The install runs in-process against a freshly-written
+//! `package.json` that pins node-gyp, via
+//! [`super::run_with_project_lock`] with `ignore_scripts` set. It
+//! deliberately does *not* shell out to the aube binary: an embedder
+//! links this crate into its own executable, so
+//! `std::env::current_exe` would name the host program and the
+//! recursive `install --ignore-scripts --silent` would be parsed as
+//! host arguments.
+//!
+//! The outer project's `.npmrc` (if any) is copied into the tool dir
+//! as its own project-level `.npmrc` so private-registry URLs and
+//! auth tokens configured by monorepo / enterprise setups flow
+//! through to the bootstrap install, which resolves against the tool
+//! dir and would otherwise only pick up `~/.npmrc`.
+//!
+//! The tool dir is its own single-package project (stub workspace
+//! yaml), so its project lock is keyed off the tool dir and both
+//! serializes concurrent bootstraps across processes and stays
+//! disjoint from the outer install's lock. The fast-path existence
+//! check short-circuits every subsequent invocation.
 use miette::{IntoDiagnostic, WrapErr, miette};
 use std::path::{Path, PathBuf};
 
@@ -94,21 +103,50 @@ pub async fn ensure_cached(project_dir: &Path) -> miette::Result<PathBuf> {
     if node_gyp_bin_exists(&bin_dir) {
         return Ok(bin_dir);
     }
-    let lock_key = root.join(format!("{BUCKET}.lock"));
     let tool_dir_blocking = tool_dir.clone();
-    let bin_dir_blocking = bin_dir.clone();
     let project_npmrc = project_dir.join(".npmrc");
     tokio::task::spawn_blocking(move || {
-        bootstrap_blocking(
-            &lock_key,
-            &tool_dir_blocking,
-            &bin_dir_blocking,
-            &project_npmrc,
-        )
+        write_bootstrap_project(&tool_dir_blocking, &project_npmrc)
     })
     .await
     .into_diagnostic()
     .wrap_err("node-gyp bootstrap task panicked")??;
+
+    // The tool dir is its own single-package project (see the stub workspace
+    // yaml written above), so this lock is keyed on `tool_dir` and cannot
+    // contend with the outer install's lock on the real project.
+    let lock = crate::commands::take_project_lock(&tool_dir)?;
+    // Re-check under the lock: another process may have raced us between the
+    // check above and acquisition.
+    if node_gyp_bin_exists(&bin_dir) {
+        return Ok(bin_dir);
+    }
+
+    tracing::info!("bootstrapping node-gyp {SPEC} into {}", tool_dir.display());
+    let mut opts = super::InstallOptions::with_mode(super::FrozenMode::Prefer);
+    // Equivalent of the `install --ignore-scripts --silent` this used to shell
+    // out for. node-gyp's own dependency tree needs no build scripts, and
+    // running them here would recurse straight back into this bootstrap.
+    opts.ignore_scripts = true;
+    opts.control = super::InstallControl::silent();
+    super::run_with_project_lock(opts, &lock)
+        .await
+        .wrap_err_with(|| {
+            format!(
+                "failed to bootstrap node-gyp {SPEC} into {} — \
+                 pre-populate it or run `{}` once while online",
+                tool_dir.display(),
+                aube_util::cmd("install")
+            )
+        })?;
+
+    if !node_gyp_bin_exists(&bin_dir) {
+        return Err(miette!(
+            "node-gyp bootstrap into {} reported success but left no node-gyp binary in {}",
+            tool_dir.display(),
+            bin_dir.display()
+        ));
+    }
     Ok(bin_dir)
 }
 
@@ -213,37 +251,25 @@ if not defined AUBE_REAL_NODE_GYP exit /b 1
     Ok(())
 }
 
-fn bootstrap_blocking(
-    lock_key: &Path,
-    tool_dir: &Path,
-    bin_dir: &Path,
-    project_npmrc: &Path,
-) -> miette::Result<()> {
+/// Materialize the synthetic single-package project that the bootstrap
+/// install runs against. Writes are atomic and idempotent, so racing
+/// processes converge on the same content; serialization is the caller's
+/// project lock on `tool_dir`.
+fn write_bootstrap_project(tool_dir: &Path, project_npmrc: &Path) -> miette::Result<()> {
     std::fs::create_dir_all(tool_dir).into_diagnostic()?;
-    let _lock = xx::fslock::FSLock::new(lock_key)
-        .with_callback(|_| {
-            tracing::info!("waiting for another aube process to finish bootstrapping node-gyp");
-        })
-        .lock()
-        .map_err(|e| miette!("failed to acquire node-gyp bootstrap lock: {e}"))?;
-    // Re-check under the lock: another process may have raced us.
-    if node_gyp_bin_exists(bin_dir) {
-        return Ok(());
-    }
     let manifest = format!(
         r#"{{"name":"aube-tool-node-gyp","private":true,"dependencies":{{"node-gyp":"{SPEC}"}}}}"#
     );
     aube_util::fs_atomic::atomic_write(&tool_dir.join("package.json"), manifest.as_bytes())
         .into_diagnostic()?;
-    // Pin the recursive `aube install` invocation below to `tool_dir`
-    // so its workspace-root walk-up stops here instead of escaping
-    // upward. `tool_dir` lives under `$XDG_CACHE_HOME/aube/tools/` —
+    // Pin the bootstrap install to `tool_dir` so its workspace-root
+    // walk-up stops here instead of escaping upward. `tool_dir` lives under `$XDG_CACHE_HOME/aube/tools/` —
     // i.e. inside the user's HOME and inside any test temp dir set
     // via `HOME=$TEST_TEMP_DIR`. Without this stub yaml,
     // `find_workspace_root` would walk past `$XDG_CACHE_HOME`,
     // discover the outer project's `pnpm-workspace.yaml`, and run
-    // the recursive install against the *outer* tree — deadlocking
-    // on the outer process's project lock. Any `pnpm-workspace.yaml`
+    // the bootstrap install against the *outer* tree — taking, and
+    // deadlocking on, the project lock the outer install already holds. Any `pnpm-workspace.yaml`
     // is a hard boundary, so the empty stub hits the first marker
     // check at the start of the walk, returns `tool_dir`, and the
     // install runs as a single-package install (`workspace_packages`
@@ -257,9 +283,8 @@ fn bootstrap_blocking(
     aube_util::fs_atomic::atomic_write(&tool_dir.join(marker), b"").into_diagnostic()?;
     // Forward the outer project's `.npmrc` so private registries and
     // auth tokens configured at project scope carry through to the
-    // recursive install. The subprocess's cwd is `tool_dir`, so
-    // without this copy its `.npmrc` walk would only ever see
-    // `~/.npmrc`. Overwrite on every bootstrap so a user updating
+    // bootstrap install. It resolves against `tool_dir`, so without
+    // this copy its `.npmrc` walk would only ever see `~/.npmrc`. Overwrite on every bootstrap so a user updating
     // their project `.npmrc` between runs picks up fresh config;
     // delete the stale copy if the project no longer has one.
     let tool_npmrc = tool_dir.join(".npmrc");
@@ -274,35 +299,6 @@ fn bootstrap_blocking(
             })?;
     } else if tool_npmrc.exists() {
         let _ = std::fs::remove_file(&tool_npmrc);
-    }
-    let exe = std::env::current_exe()
-        .into_diagnostic()
-        .wrap_err("could not locate current aube executable for node-gyp bootstrap")?;
-    tracing::info!("bootstrapping node-gyp {SPEC} into {}", tool_dir.display());
-    let status = std::process::Command::new(&exe)
-        .args(["install", "--ignore-scripts", "--silent"])
-        .current_dir(tool_dir)
-        .status()
-        .into_diagnostic()
-        .wrap_err(format!(
-            "failed to spawn recursive {} for node-gyp bootstrap",
-            aube_util::cmd("install")
-        ))?;
-    if !status.success() {
-        return Err(miette!(
-            "recursive {} failed while bootstrapping node-gyp (exit {:?}) — \
-             pre-populate {} or run `{}` once while online",
-            aube_util::cmd("install"),
-            status.code(),
-            tool_dir.display(),
-            aube_util::cmd("install")
-        ));
-    }
-    if !node_gyp_bin_exists(bin_dir) {
-        return Err(miette!(
-            "node-gyp bootstrap completed but no shim found under {}",
-            bin_dir.display()
-        ));
     }
     Ok(())
 }


### PR DESCRIPTION
`node_gyp_bootstrap::bootstrap_blocking` shelled out to `std::env::current_exe` to install node-gyp into its cache dir:

```rust
let exe = std::env::current_exe()?;
std::process::Command::new(&exe)
    .args(["install", "--ignore-scripts", "--silent"])
```

That holds only when the running program *is* aube. An embedder links this crate into its own binary, so `current_exe` names the host and the recursive install is parsed as host arguments.

## Impact

Every npm package whose enabled build scripts reach node-gyp is uninstallable through mise:

```
error: unexpected argument '--ignore-scripts' found
Usage: mise install [OPTIONS] [TOOL@VERSION]...
```

Six registry tools hit this (gemini-cli, vercel, wrangler, orval, jules, nub) — all entries that set `allow_builds`, which is what enables lifecycle scripts and reaches `ensure`.

Reproducible on any machine, cold cache required:

```bash
XDG_CACHE_HOME=$(mktemp -d) mise install vercel@latest
```

A warm `~/.cache/aube/tools/node-gyp/` hides it entirely — `ensure_cached` short-circuits before the bootstrap — so anyone who has installed such a package before will not see this.

## Approach

Run the bootstrap install **in-process** via `run_with_project_lock`, dropping the subprocess.

The subprocess was only ever buying lock and config isolation, and the synthetic tool dir already provides both. The stub workspace yaml stops the workspace-root walk at `tool_dir`, so its project lock is keyed there and stays disjoint from the outer install's lock — the deadlock the old comment warned about is what that stub already prevents. `run_with_project_lock` exists for exactly this "reuse a lock owned by an outer command" case, and `run_scoped` stacks fresh runtime/scripts/dep-chain scopes, so the nested install gets isolated slots. That nesting is not new: `PER_CALL_RUNTIME`'s doc comment describes `dlx`'s transient install and `run`/`exec` auto-install doing the same thing.

Also replaces the bespoke `xx::fslock` bootstrap lock with that project lock — one lock instead of two over the same window. Writes are atomic and idempotent and the post-lock re-check still short-circuits a race.

**This supersedes my first attempt on this branch**, which added a `set_embedder_self_exe` override for hosts to register a real aube binary. That approach was wrong: mise has no aube binary to hand over. Its npm backend lists only `["node"]` among install dependencies — *"Embedded aube — no external package-manager binary required"* — with `aube` appearing solely in `get_optional_dependencies`. Satisfying an exe override would have meant making aube a hard dependency of every npm install, downloading the binary that embedding exists to avoid. Details in the comment below.

## Verification

Control vs treatment, `XDG_CACHE_HOME` redirected so the node-gyp cache is genuinely cold, mise built against each:

| | result |
|---|---|
| stock aube | `error: unexpected argument '--ignore-scripts' found` / `Usage: mise-stock-133 install …` |
| this branch | `mise vercel@57.0.0 ✓ installed`, exit 0 |

The binary name in the control's usage line is the `current_exe` re-exec landing on the host. On the treatment run node-gyp is genuinely bootstrapped — `<cold-cache>/aube/tools/node-gyp/v12/node_modules/.bin/node-gyp` exists afterward, confirming the fixed path executed rather than being skipped.

Also installs clean on this branch: `gemini-cli@0.52.0`, `wrangler@4.114.0`, `orval@8.22.0`.

`cargo test -p aube` — 719 passed, 0 failed.

No new unit test: the bug is only observable when a real install drives a cold bootstrap, which needs network and a node runtime. If you'd like it covered in-repo, point me at the right integration harness and I'll add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
