### PR TITLE
fix(install): restore animated progress bar in interactive terminals

### DIFF
--- a/crates/aube/src/progress/mod.rs
+++ b/crates/aube/src/progress/mod.rs
@@ -2,22 +2,24 @@
 //!
 //! Two modes live behind one API so call sites in `install::run` stay the same:
 //!
-//! * **TTY** — an animated clx bar, kept as an internal fallback for callers
-//!   that explicitly opt into an in-place display. It redraws by moving the
-//!   cursor and clearing the previous frame.
-//! * **Append-only** — lines safe for terminals, GitHub Actions, and plain
-//!   pipes: a single repeating pnpm-style `Progress:` line emitted on a ~2s
+//! * **TTY** — an animated clx bar: a root row with overall counts plus
+//!   transient child rows for in-flight tarball fetches. Children collapse on
+//!   completion, so the display stays bounded even though the pipeline
+//!   resolves → fetches → links concurrently.
+//! * **Append-only** — lines safe for GitHub Actions and plain pipes: a
+//!   single repeating pnpm-style `Progress:` line emitted on a ~2s
 //!   heartbeat, showing `resolved` / `reused` / `downloaded` plus the byte
 //!   total for the downloaded set. The heartbeat only prints when something
 //!   actually advanced, so a fast install stays quiet and a slow one shows
 //!   exactly *why* it's slow (network-bound vs linker-bound). No phase noise,
 //!   no child rows, no redraws.
 //!
-//! `try_new` picks the append-only mode by default. The clx TTY renderer
-//! clears the previous frame on every redraw; that makes installs look like
-//! the screen is blinking right before the post-install package summary lands.
-//! Set `AUBE_TTY_PROGRESS=1` to use the in-place renderer while it remains
-//! useful for local debugging.
+//! `try_new` picks the mode: TTY on an interactive stderr, append-only on a
+//! pipe, or append-only when `is_ci::cached()` detects a known CI environment
+//! (Buildkite, GitHub Actions, etc.) even if stderr looks like a TTY — those
+//! systems allocate a PTY so tools emit colors, but their log capturers strip
+//! cursor-control escapes and each animation frame lands as its own log line.
+//! The ~2s heartbeat is the right shape for that.
 //! It returns `None` only when clx has been forced into text mode
 //! (`--silent`, `-v`, `--reporter=append-only|ndjson`) — those modes own
 //! their own output and we stay out of the way.
@@ -80,15 +82,6 @@ fn clamp_reused_to(reused: &AtomicUsize, downloaded: &AtomicUsize, total: usize)
     let _ = reused.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |cur| {
         (cur > cap).then_some(cap)
     });
-}
-
-fn env_truthy(name: &str) -> bool {
-    std::env::var(name).is_ok_and(|value| {
-        !matches!(
-            value.trim().to_ascii_lowercase().as_str(),
-            "" | "0" | "false" | "no" | "off"
-        )
-    })
 }
 
 /// Whether the vendor attribution (`by jdx.dev`) may render into the banner.
@@ -304,12 +297,16 @@ impl InstallProgress {
         if clx::progress::output() == ProgressOutput::Text {
             return None;
         }
-        // The animated TTY renderer redraws via cursor movement plus
-        // clear-to-end-of-screen. That is fine for a standalone progress bar,
-        // but it looks like a screen wipe when followed by the post-install
-        // dependency summary. Default to append-only progress everywhere and
-        // leave the in-place renderer behind an explicit debugging opt-in.
-        if std::io::stderr().is_terminal() && !is_ci::cached() && env_truthy("AUBE_TTY_PROGRESS") {
+        // Prefer append-only mode whenever we're in a known CI environment
+        // (`is_ci` checks `CI`, `BUILDKITE`, `GITHUB_ACTIONS`, and friends),
+        // even when stderr looks like a TTY. Most CI runners allocate a PTY
+        // so child processes emit colors, which makes `is_terminal()` return
+        // true — but the log capturer then strips cursor-control escapes and
+        // each animation frame becomes its own log line, flooding the build
+        // log with thousands of near-duplicate spinner rows. The 2s heartbeat
+        // is the right shape there. `--reporter=append-only` forces the same
+        // mode on demand in an interactive terminal.
+        if std::io::stderr().is_terminal() && !is_ci::cached() {
             Some(Self::new_tty())
         } else {
             Some(Self::new_ci())


### PR DESCRIPTION
Fixes the report in https://github.com/jdx/aube/discussions/1115: install progress advances in ~2s chunks (`0% → 83% → 100%`) instead of animating. Reported under ghostty + tmux, but neither is involved — it reproduces in a bare terminal.

## What happened

`8c44e63` (#559, `feat(install): show post-install dependency summary`, v1.10.0) added `&& env_truthy("AUBE_TTY_PROGRESS")` to the renderer selection in `progress/mod.rs`:

```rust
// before
if std::io::stderr().is_terminal() && !is_ci::cached() {
// after
if std::io::stderr().is_terminal() && !is_ci::cached() && env_truthy("AUBE_TTY_PROGRESS") {
```

Every interactive terminal then fell through to the append-only heartbeat intended for CI logs, which writes one line per `CI_HEARTBEAT_INTERVAL` (2s) and suppresses byte-identical repeats — precisely the reported chunking.

The gate was a workaround for the in-place renderer's clear-to-end-of-screen redraw looking like a screen wipe ahead of the then-new dependency summary. But **the same commit already fixed that** properly:

- `ProgressJobDoneBehavior::Hide` → `Collapse`
- `finish()`: `clx::progress::stop_clear()` → `stop()`
- a `finished: AtomicBool` so `Drop` won't clear a display the success path preserved

Only the workaround remained load-bearing. The animated bar has been unreachable for 76 days and 36 releases (v1.10.1 … v1.33.0), behind an env var documented nowhere outside a module comment.

## Change

Restores the pre-v1.10.0 condition and drops the now-unused `env_truthy` helper. CI detection is untouched — CI runners allocate a PTY, so `!is_ci::cached()` still routes them to the heartbeat. No new setting: `--reporter=append-only` already forces line-oriented output on demand, so nothing is lost.

## Verification

The TTY path was unreachable by default, so its teardown needed manual checking in a real terminal. Confirmed in ghostty, with and without tmux:

- bar animates smoothly; final row collapses at `377/377 pkgs`
- scrollback above the install survives the redraws
- hand-off to the dependency summary shows no blink or wipe
- `ctrl-c` mid-install returns the cursor on a clean line
- a resolver error renders below the bar, not on top of a live frame

`cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `cargo test` (704 unit + full suite), and `test/install.bats` (75/75) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to progress UI mode selection with CI and `--reporter=append-only` behavior unchanged.
> 
> **Overview**
> **Restores the animated clx progress bar** for local installs by removing the `AUBE_TTY_PROGRESS` gate that had forced every interactive terminal onto the append-only ~2s heartbeat (the behavior reported as chunky `0% → 83% → 100%` updates).
> 
> `InstallProgress::try_new` again picks **TTY mode** when `stderr` is a terminal and `!is_ci::cached()`; pipes and known CI environments still use the heartbeat. The unused `env_truthy` helper is deleted.
> 
> Module docs are updated to describe TTY vs append-only selection (including why CI uses append-only even when stderr looks like a TTY) instead of documenting the removed env opt-in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a62c2ee351a731f8de93388c2ef5238014c83b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->