### PR TITLE
fix(resolver): make versioned entries in the trust-exclude defaults work

### DIFF
--- a/crates/aube-resolver/src/trust.rs
+++ b/crates/aube-resolver/src/trust.rs
@@ -262,6 +262,10 @@ pub const DEFAULT_TRUST_POLICY_EXCLUDES: &[&str] = &[
     // hand-published by the maintainer without attestation — e.g.
     // @hono/node-server@1.19.15 (2026-07-24) came after the attested
     // 2.0.10 (2026-07-15), so no-downgrade flags the legitimate backport.
+    // Deliberately package-wide rather than scoped to `^1`: this publisher
+    // has already shipped one line without attestation, and we are not
+    // betting on 2.x holding its CI-published discipline. Do not narrow
+    // this to a version range on the theory that only 1.x is affected.
     "@hono/node-server",
     "chokidar",
     "eslint-config-prettier",
@@ -300,7 +304,18 @@ pub struct TrustExcludeRules {
 
 impl Default for TrustExcludeRules {
     fn default() -> Self {
-        Self::from_name_excludes(DEFAULT_TRUST_POLICY_EXCLUDES)
+        // Parse the entries rather than assuming each is a bare name, so a
+        // future `name@range` default actually works. The previous
+        // `from_name_excludes` hardcoded `version_ranges: None`, which would
+        // have compiled such an entry into a name matcher for the literal
+        // string `"name@range"` — silently matching nothing and dropping the
+        // exemption rather than erroring. Every current entry is a bare name,
+        // for which this is behavior-identical. The list is a compile-time
+        // constant, so a malformed entry is an authoring bug;
+        // `default_excludes_known_provenance_churn_packages` asserts each one
+        // parses.
+        Self::parse(DEFAULT_TRUST_POLICY_EXCLUDES)
+            .expect("DEFAULT_TRUST_POLICY_EXCLUDES must be valid exclude patterns")
     }
 }
 
@@ -356,18 +371,6 @@ impl TrustExcludeRules {
 
     pub fn len(&self) -> usize {
         self.rules.len()
-    }
-
-    fn from_name_excludes(names: &[&str]) -> Self {
-        Self {
-            rules: names
-                .iter()
-                .map(|name| TrustExcludeRule {
-                    name_matcher: NameMatcher::compile(name),
-                    version_ranges: None,
-                })
-                .collect(),
-        }
     }
 
     pub fn with_defaults_and_user_rules(user_rules: Self) -> Self {
@@ -446,18 +449,23 @@ impl TrustExcludeRules {
     }
 }
 
-fn parse_one(pattern: &str) -> Result<TrustExcludeRule, TrustExcludeParseError> {
-    let scoped = pattern.starts_with('@');
-    let at_index = if scoped {
-        pattern[1..].find('@').map(|i| i + 1)
-    } else {
-        pattern.find('@')
+/// Split `<name>[@<versions>]` on the separator that isn't a scope marker,
+/// so a scoped name's leading `@` isn't mistaken for a version selector.
+fn split_name_and_versions(pattern: &str) -> (&str, Option<&str>) {
+    let at_index = match pattern.strip_prefix('@') {
+        // Scoped name: the leading `@` is the scope marker, so the version
+        // separator is the next `@`, offset back past the one we stripped.
+        Some(rest) => rest.find('@').map(|i| i + 1),
+        None => pattern.find('@'),
     };
-
-    let (name_part, versions_part) = match at_index {
+    match at_index {
         Some(i) => (&pattern[..i], Some(&pattern[i + 1..])),
         None => (pattern, None),
-    };
+    }
+}
+
+fn parse_one(pattern: &str) -> Result<TrustExcludeRule, TrustExcludeParseError> {
+    let (name_part, versions_part) = split_name_and_versions(pattern);
 
     let version_ranges = match versions_part {
         None => None,
@@ -1125,10 +1133,19 @@ mod tests {
     #[test]
     fn default_excludes_known_provenance_churn_packages() {
         let r = TrustExcludeRules::default();
+        // Every entry parses into exactly one rule — a malformed default
+        // would otherwise silently drop protection or panic at first use.
+        assert_eq!(r.len(), DEFAULT_TRUST_POLICY_EXCLUDES.len());
         for package in DEFAULT_TRUST_POLICY_EXCLUDES {
+            let (name, versions) = split_name_and_versions(package);
+            // Bare-name entries exempt every version. Version-scoped entries
+            // deliberately do not, so they get their own targeted tests.
+            if versions.is_some() {
+                continue;
+            }
             assert!(
-                r.matches(package, &node_semver::Version::parse("1.0.0").unwrap()),
-                "{package} should be globally excluded"
+                r.matches(name, &node_semver::Version::parse("1.0.0").unwrap()),
+                "{name} should be globally excluded"
             );
         }
         assert!(!r.matches("left-pad", &node_semver::Version::parse("1.0.0").unwrap()));
@@ -1166,9 +1183,15 @@ mod tests {
             "@hono/node-server",
             &node_semver::Version::parse("1.19.15").unwrap()
         ));
+        // Every version, not just the 1.x line — the exclusion is
+        // intentionally package-wide (see DEFAULT_TRUST_POLICY_EXCLUDES).
         assert!(r.matches(
             "@hono/node-server",
             &node_semver::Version::parse("2.0.10").unwrap()
+        ));
+        assert!(r.matches(
+            "@hono/node-server",
+            &node_semver::Version::parse("2.1.0").unwrap()
         ));
         assert!(!r.matches("hono", &node_semver::Version::parse("1.19.15").unwrap()));
     }


### PR DESCRIPTION
Follow-up to #1113. **Not** the scoping change Greptile asked for there — see below.

## The actual bug

`DEFAULT_TRUST_POLICY_EXCLUDES` went through `from_name_excludes`, which hardcodes `version_ranges: None`. So a `name@range` entry in that list would compile into a name matcher for the *literal string* `"name@range"` and match nothing — silently dropping the exemption rather than failing. The list looks like it supports version selectors (the parser certainly does) but doesn't.

`Default` now goes through `parse`. Every current entry is a bare name, for which this is behavior-identical.

## On Greptile's comment

Greptile flagged `@hono/node-server` as over-broad and suggested scoping it to `^1`, since only the 1.x line is hand-published. I initially did that — then @jdx overruled it, and I think correctly: the publisher has already shipped one line without attestation, and scoping to `^1` bets that 2.x keeps its CI-published discipline. If that bet loses, `no-downgrade` silently starts failing on a package people depend on transitively, and additive user config can't pre-empt it.

So the entry stays package-wide, and there's now a comment saying so explicitly — the next reviewer (human or bot) shouldn't narrow it on the same reasoning without a deliberate decision.

That leaves the parse fix worth landing on its own: whenever a future entry *does* want a range, it should work rather than fail silently.

## Tests

`cargo test -p aube-resolver` — 243 passed, 0 failed.

- `default_excludes_known_provenance_churn_packages` now asserts every entry parses into a rule, so a malformed constant fails here instead of panicking at first use through `Default`'s `expect`.
- `default_excludes_scoped_hono_node_server_backport` pins the intended breadth: 1.19.15, 2.0.10 and 2.1.0 all excluded.

Supporting cleanup: `split_name_and_versions` extracted from `parse_one` so it and its callers share the "second `@`" rule instead of duplicating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is unchanged for current bare-name defaults; the change closes a silent mis-parse footgun and documents intentional breadth of one exclude.
> 
> **Overview**
> **Default trust-policy excludes** are now built via `TrustExcludeRules::parse` instead of a name-only helper, so entries like `pkg@^1` in `DEFAULT_TRUST_POLICY_EXCLUDES` would actually apply version ranges instead of matching a bogus literal name and silently dropping the exemption. Today’s list is still all bare names, so runtime behavior is unchanged.
> 
> **Parsing** pulls scoped `name@versions` splitting into `split_name_and_versions` (shared by `parse_one` and tests). **`@hono/node-server`** gets an explicit comment that the exclude stays **package-wide**, not narrowed to `^1`.
> 
> **Tests** assert every default entry parses (`len` match), use proper name splitting in the churn-package test, and pin that `@hono/node-server` 1.x and 2.x versions are all excluded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85bcd5d8b09416eeac99d4b4e2e2f1518dce282f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->