### PR TITLE
perf: track startup cost with tak

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -59,8 +59,10 @@ jobs:
       # precise enough to detect anything.
       - name: Install valgrind
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends valgrind
+          command -v valgrind || {
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends valgrind
+          }
           valgrind --version
 
       - name: Measure and record

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   measure:
-    name: Measure startup
+    name: Measure
     # Pinned to one runner class on purpose. Absolute instruction counts shift
     # between machine types by more than a real regression does, so a series
     # that wanders between runners is unreadable.
@@ -72,7 +72,14 @@ jobs:
       # pattern as bench-refresh.yml: re-point origin rather than pushing to a
       # one-shot URL, so tak's retry path has a remote to fetch from when it
       # loses a race.
+      #
+      # Only main publishes. workflow_dispatch can be pointed at any branch or
+      # tag, and refs/notes/tak is a shared baseline that should hold main's
+      # history and nothing else. Gating the push rather than the whole job
+      # means a dispatch on a branch still measures and still prints its
+      # numbers in the summary — it just keeps them local.
       - name: Push measurements
+        if: github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,82 @@
+name: perf
+
+# Records aube's startup cost for every commit that lands on main, into the
+# git-notes ref `refs/notes/tak`. The data lives in this repository — there is
+# no external service holding it, and `git fetch origin refs/notes/tak:refs/notes/tak`
+# gets you the whole history.
+#
+# Only runs post-merge. A PR-time gate is the eventual goal, but a gate needs a
+# baseline series to compare against, and right now there is none. This builds
+# that baseline.
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions: {}
+
+# Never two at once. Concurrent runs race the notes push; tak retries with a
+# cat_sort_uniq merge so nothing is lost, but serialising avoids the churn.
+# cancel-in-progress is off deliberately: every commit gets a measurement, and
+# a cancelled run is a hole in the series.
+concurrency:
+  group: perf
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+
+jobs:
+  measure:
+    name: Measure startup
+    # Pinned to one runner class on purpose. Absolute instruction counts shift
+    # between machine types by more than a real regression does, so a series
+    # that wanders between runners is unreadable.
+    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
+    timeout-minutes: 30
+    permissions:
+      contents: write # pushing refs/notes/tak is a write to this repository
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
+        with:
+          cache: rust
+
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          cache: false
+        env:
+          MISE_LOCKED: "1"
+
+      # cachegrind is the whole point: it counts instructions, which reproduce
+      # to ~0.02% run-to-run where wall clock on this same hardware moves by
+      # 4-20%. Without it tak still records timing, but the series stops being
+      # precise enough to detect anything.
+      - name: Install valgrind
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends valgrind
+          valgrind --version
+
+      - name: Measure and record
+        run: mise run perf:record
+
+      # persist-credentials: false means the push needs its own auth. Same
+      # pattern as bench-refresh.yml: re-point origin rather than pushing to a
+      # one-shot URL, so tak's retry path has a remote to fetch from when it
+      # loses a race.
+      - name: Push measurements
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
+          tak push
+
+      - name: Summary
+        run: tak history >> "$GITHUB_STEP_SUMMARY"

--- a/mise.lock
+++ b/mise.lock
@@ -179,6 +179,52 @@ checksum = "sha256:e437443331865218763d44089680f4d36547353e8c3c8b394c24859203e6c
 url = "https://github.com/foresterre/cargo-msrv/releases/download/v0.19.3/cargo-msrv-x86_64-pc-windows-msvc-v0.19.3.zip"
 url_api = "https://api.github.com/repos/foresterre/cargo-msrv/releases/assets/380851496"
 
+[[tools."github:jdx/tak"]]
+version = "0.0.2"
+backend = "github:jdx/tak"
+
+[tools."github:jdx/tak"."platforms.linux-arm64"]
+checksum = "sha256:cc7c611b5d4bf57066ca141e415f8fee457d3bee41395c04a9464cfacaa38b57"
+url = "https://github.com/jdx/tak/releases/download/v0.0.2/tak-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/489776888"
+provenance = "github-attestations"
+
+[tools."github:jdx/tak"."platforms.linux-arm64-musl"]
+checksum = "sha256:b552c5020911f2978e37aa7b82158e49d8e799efe52eb2f729ec4102920a96a3"
+url = "https://github.com/jdx/tak/releases/download/v0.0.2/tak-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/489776889"
+provenance = "github-attestations"
+
+[tools."github:jdx/tak"."platforms.linux-x64"]
+checksum = "sha256:13827cc448824cf821490fa02ba109ecbf4fb5edfa23d4eb06f8f7abe39c63a5"
+url = "https://github.com/jdx/tak/releases/download/v0.0.2/tak-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/489776900"
+provenance = "github-attestations"
+
+[tools."github:jdx/tak"."platforms.linux-x64-musl"]
+checksum = "sha256:994efac9c7a199e48e8736bbde4cf1280c1af1657fe0a8243c9ff63a004c16b1"
+url = "https://github.com/jdx/tak/releases/download/v0.0.2/tak-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/489776899"
+provenance = "github-attestations"
+
+[tools."github:jdx/tak"."platforms.macos-arm64"]
+checksum = "sha256:8500112b24d4aef2f5c133178c9ca2a3367dfa820cd50a6320a3ce890963ca9e"
+url = "https://github.com/jdx/tak/releases/download/v0.0.2/tak-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/489776890"
+provenance = "github-attestations"
+
+[tools."github:jdx/tak"."platforms.macos-x64"]
+checksum = "sha256:1c2a6b7e151d5e9e21bb3c846814e4184ed5880a3c4c9cc828d82ea0d54a454e"
+url = "https://github.com/jdx/tak/releases/download/v0.0.2/tak-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/489776897"
+provenance = "github-attestations"
+
+[tools."github:jdx/tak"."platforms.windows-x64"]
+checksum = "sha256:20afc9690859822b26e78a29d615c3936dffd77ddc1ced5cedace96cb83a5d66"
+url = "https://github.com/jdx/tak/releases/download/v0.0.2/tak-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/489776898"
+provenance = "github-attestations"
+
 [[tools.hk]]
 version = "1.44.3"
 backend = "aqua:jdx/hk"

--- a/mise.toml
+++ b/mise.toml
@@ -109,12 +109,23 @@ run = [
   "node benchmarks/update-readme.mts",
 ]
 
-# Measure startup cost and print it. Instruction counts need valgrind; without
-# it tak reports wall clock only and says so, so this is still useful on macOS.
+# Instruction-counted benchmarks (see tak.toml). Needs valgrind for counts;
+# without it tak reports wall clock only and says so, so this still works on
+# macOS.
+#
+# GVS is pinned for the same reason benchmarks/bench.sh pins it: aube's default
+# flips based on the inherited CI=true, so without this a laptop and a CI runner
+# would be measuring different code paths and the series would be meaningless.
+#
+# The store warm-up is the one networked step. It has to happen before tak runs
+# because the install benchmark uses --offline, and it is outside the
+# measurement on purpose — nothing tak times ever touches the registry.
 [tasks.perf]
 dir = "{{config_root}}"
+env = { npm_config_enable_global_virtual_store = "true" }
 run = [
   "cargo build --release",
+  "./target/release/aube -C fixtures/medium install --frozen-lockfile",
   "tak run",
 ]
 
@@ -123,8 +134,10 @@ run = [
 # Safe to run locally — nothing leaves the machine until `tak push`.
 [tasks."perf:record"]
 dir = "{{config_root}}"
+env = { npm_config_enable_global_virtual_store = "true" }
 run = [
   "cargo build --release",
+  "./target/release/aube -C fixtures/medium install --frozen-lockfile",
   "tak run --record",
 ]
 

--- a/mise.toml
+++ b/mise.toml
@@ -7,6 +7,13 @@ cargo-binstall = "latest"
 communique = "latest"
 "github:bnjbvr/cargo-machete" = "latest"
 "github:foresterre/cargo-msrv" = "latest"
+# Pinned rather than "latest" because tak is the measuring instrument: an
+# upgrade that changes how it samples would land in the series as a step
+# change in aube's numbers, indistinguishable from a real regression. Bump
+# deliberately, on a commit that does nothing else.
+# TODO: switch to plain `tak = "0.0.2"` once jdx/mise#11307 adds the registry
+# entry and the shorthand exists.
+"github:jdx/tak" = "0.0.2"
 hk = "latest"
 node = "24"
 pitchfork = "latest"
@@ -100,6 +107,25 @@ run = [
   "cargo build --release",
   "mise x aqua:sharkdp/hyperfine@latest github:pnpm/pnpm@latest npm:@yarnpkg/cli-dist@latest bun@latest deno@latest npm:vlt@latest node@24 -- bash benchmarks/bench.sh",
   "node benchmarks/update-readme.mts",
+]
+
+# Measure startup cost and print it. Instruction counts need valgrind; without
+# it tak reports wall clock only and says so, so this is still useful on macOS.
+[tasks.perf]
+dir = "{{config_root}}"
+run = [
+  "cargo build --release",
+  "tak run",
+]
+
+# Same measurement, appended to refs/notes/tak for this commit. Run by the
+# `perf` workflow on every push to main; the notes are what the history is.
+# Safe to run locally — nothing leaves the machine until `tak push`.
+[tasks."perf:record"]
+dir = "{{config_root}}"
+run = [
+  "cargo build --release",
+  "tak run --record",
 ]
 
 [tasks."build:pgo"]

--- a/tak.toml
+++ b/tak.toml
@@ -1,0 +1,25 @@
+# Startup cost, measured by tak (https://github.com/jdx/tak).
+#
+# Deliberately narrow. This tracks what every `aube` invocation pays before it
+# does any work — process start, dynamic linking, clap construction, settings
+# load. That is the part instruction counting measures exactly, and the part
+# the hyperfine matrix in `benchmarks/` cannot see: those scenarios are
+# dominated by network and filesystem work whose variance is orders of
+# magnitude larger than a startup regression.
+#
+# The two suites answer different questions and neither replaces the other.
+# `benchmarks/bench.sh` asks "is aube faster than pnpm at installing?".  This
+# asks "did today's commit make `aube` slower to start than yesterday's?", and
+# it can answer that to ~0.02% because cachegrind counts instructions rather
+# than timing them.
+
+[bench.version]
+cmd = ["./target/release/aube", "--version"]
+
+# `--help` costs more than `--version`: clap has to build and render the whole
+# command tree, so a subcommand added with an expensive default shows up here
+# first. Fewer runs because it is the slower of the two under cachegrind's ~50x
+# slowdown, and instruction counts do not need samples to converge.
+[bench.help]
+cmd = ["./target/release/aube", "--help"]
+runs = 10

--- a/tak.toml
+++ b/tak.toml
@@ -1,25 +1,38 @@
-# Startup cost, measured by tak (https://github.com/jdx/tak).
+# Instruction-counted benchmarks, measured by tak (https://github.com/jdx/tak).
 #
-# Deliberately narrow. This tracks what every `aube` invocation pays before it
-# does any work — process start, dynamic linking, clap construction, settings
-# load. That is the part instruction counting measures exactly, and the part
-# the hyperfine matrix in `benchmarks/` cannot see: those scenarios are
-# dominated by network and filesystem work whose variance is orders of
-# magnitude larger than a startup regression.
+# These complement the hyperfine matrix in `benchmarks/`, which measures
+# installs — network and filesystem work whose variance is orders of magnitude
+# larger than any CPU regression. Everything here is pure CPU against a
+# committed fixture: no registry access, no writes, no clock, so cachegrind can
+# count it to ~0.02% where wall clock on the same hardware moves 4-20%.
 #
-# The two suites answer different questions and neither replaces the other.
-# `benchmarks/bench.sh` asks "is aube faster than pnpm at installing?".  This
-# asks "did today's commit make `aube` slower to start than yesterday's?", and
-# it can answer that to ~0.02% because cachegrind counts instructions rather
-# than timing them.
+# Hermeticity was checked by running each of these with the registry pointed at
+# a dead port; all three succeed unchanged. `aube --version` deliberately is not
+# here: it is documented as "print version and check for updates", and a command
+# that talks to the network retires a different number of instructions depending
+# on conditions that have nothing to do with the code under test.
+#
+# `startup` is the control. It does no package work, so it measures the fixed
+# cost every invocation pays — process start, settings load, workspace
+# discovery. The other two are that same cost plus real graph work. When all
+# three move together the regression is in startup; when only one moves it is in
+# that command's path. Reading them without the control tells you much less.
+#
+# `fixtures/medium` is a 10-dependency, 28KB lockfile — small, but it separates
+# well: measured against a debug build, `startup` is 6.7ms where `graph` and
+# `tree` are 11.8ms and 11.1ms, so the package work is around 40% of each. A
+# larger fixture would raise that fraction if this ever feels blunt.
 
-[bench.version]
-cmd = ["./target/release/aube", "--version"]
+# Fixed cost of any invocation: startup, settings, workspace discovery.
+[bench.startup]
+cmd = ["./target/release/aube", "-C", "fixtures/medium", "prefix"]
 
-# `--help` costs more than `--version`: clap has to build and render the whole
-# command tree, so a subcommand added with an expensive default shows up here
-# first. Fewer runs because it is the slower of the two under cachegrind's ~50x
-# slowdown, and instruction counts do not need samples to converge.
-[bench.help]
-cmd = ["./target/release/aube", "--help"]
-runs = 10
+# Parse the lockfile, walk the whole dependency graph, serialize every package.
+# Output is byte-identical run to run.
+[bench.graph]
+cmd = ["./target/release/aube", "-C", "fixtures/medium", "sbom"]
+
+# The other major read path over the same graph: resolve and render the tree.
+# `--depth 20` is past the fixture's real depth, so nothing is truncated.
+[bench.tree]
+cmd = ["./target/release/aube", "-C", "fixtures/medium", "list", "--depth", "20"]

--- a/tak.toml
+++ b/tak.toml
@@ -36,3 +36,33 @@ cmd = ["./target/release/aube", "-C", "fixtures/medium", "sbom"]
 # `--depth 20` is past the fixture's real depth, so nothing is truncated.
 [bench.tree]
 cmd = ["./target/release/aube", "-C", "fixtures/medium", "list", "--depth", "20"]
+
+# Install, on the path people actually hit most: everything is already present
+# and aube has to prove it. Every CI job with a warm cache and every redundant
+# `aube install` a developer types pays exactly this, and at ~106ms it is the
+# heaviest thing here.
+#
+# `--offline` is what makes it measurable. Plain `install --frozen-lockfile`
+# contacts the registry even when nothing needs fetching — verified by pointing
+# it at a dead port, where it spends 70s retrying before failing. `--offline`
+# against the same dead port succeeds unchanged, so no measurement here can be
+# perturbed by the network.
+#
+# The store must already hold the fixture's packages; `mise run perf` warms it
+# with one networked install before handing over to tak.
+#
+# Not covered: the fresh-link path, where node_modules is deleted first — that
+# is the 571ms number in `benchmarks/results.json`. It cannot be repeated
+# without resetting the directory between runs, and tak has no per-benchmark
+# setup hook. `aube ci` looked like the answer since it deletes node_modules
+# itself, but it takes neither `--offline` nor `npm_config_offline`, so it
+# cannot be made hermetic. A setup hook in tak is the real fix.
+[bench.install]
+cmd = [
+  "./target/release/aube",
+  "-C",
+  "fixtures/medium",
+  "install",
+  "--frozen-lockfile",
+  "--offline",
+]


### PR DESCRIPTION
Adds a second, narrower benchmark suite alongside the hyperfine matrix. **It does not replace or touch `benchmarks/`** — the two answer different questions.

| | `benchmarks/bench.sh` | `tak.toml` (new) |
|---|---|---|
| asks | is aube faster than pnpm? | did this commit make aube slower? |
| measures | wall clock, network + filesystem | cachegrind instruction counts |
| noise floor | ~7% CV on `gvs-warm` | ~0.02% |
| runs | nightly refresh + PR comparison | every push to main |

The install matrix is dominated by work whose variance is orders of magnitude larger than a CPU regression — `gvs-warm` is 571ms ± 42ms — so a few hundred thousand extra instructions are invisible there. That is the gap this fills.

## The benchmarks

Four, all against the committed `fixtures/medium` lockfile, all hermetic.

| name | command | debug timing |
|---|---|---|
| `startup` | `aube -C fixtures/medium prefix` | 6.8ms |
| `graph` | `aube -C fixtures/medium sbom` | 11.9ms |
| `tree` | `aube -C fixtures/medium list --depth 20` | 11.3ms |
| `install` | `aube -C fixtures/medium install --frozen-lockfile --offline` | 102ms |

**`startup` is the control.** It does no package work, so it measures the fixed cost every invocation pays — process start, settings load, workspace discovery. Everything else is that cost plus real work. When all four move together the regression is in startup; when one moves it is in that command's path. Reading them without the control tells you much less.

**`install` is the interesting one.** It measures the path people hit most: everything already present and aube has to prove it — every CI job with a warm cache, every redundant `aube install` a developer types. At ~102ms it dominates, with 93% of the measurement above the startup floor.

## Hermeticity, checked rather than assumed

Every benchmark was run with the registry pointed at a dead port (`npm_config_registry=http://127.0.0.1:1/`). This turned up something that would have quietly ruined the series:

- **`aube install --frozen-lockfile` contacts the registry even when nothing needs fetching** — against the dead port it spends 70s retrying before failing. With `--offline` it succeeds unchanged and at the same speed.
- **`aube --version` is documented as "print version and check for updates".** It is deliberately not benchmarked. A command that talks to the network retires a varying instruction count for reasons unrelated to the code under test — exactly what an instruction-counted series must not contain. `--help` is gone too: it measured clap, not aube.
- `sbom` output is byte-identical across runs.

The store is warmed by one networked install inside the mise task, before tak starts. Nothing that gets measured touches the network.

## What is not covered, and why

The **fresh-link path** — node_modules deleted first, the 571ms `gvs-warm` number. It cannot be repeated without resetting the directory between runs, and tak has no per-benchmark setup hook. `aube ci` looked like the answer since it deletes node_modules itself, but it accepts neither `--offline` nor `npm_config_offline`, so it cannot be made hermetic. **A setup hook in tak is the real fix** and is the obvious follow-up.

## What else lands

- **`.github/workflows/perf.yml`** — on push to main: build, warm store, `mise run perf:record`, `tak push`. Pinned to one runner class, because absolute instruction counts shift between machine types by more than a real regression does.
- **`mise.toml`** — `github:jdx/tak` pinned to `0.0.2`, plus `perf` and `perf:record` tasks. Both pin GVS on, for the same reason `bench.sh` does: aube's default flips on the inherited `CI=true`, so without it a laptop and a CI runner measure different code paths.
- **`mise.lock`** — regenerated. Three workflows run `MISE_LOCKED=1` and would have failed on a stale lockfile.

## Where the data lives

Git notes, in this repository. No external service:

```bash
git fetch origin refs/notes/tak:refs/notes/tak
git notes --ref=tak show HEAD
```

The notes tree is keyed by commit SHA as a path, so one shallow fetch of that ref returns the whole history rather than a round trip per commit.

## Why tak is pinned

It is the measuring instrument. An upgrade that changes how it samples would land in the series as a step change indistinguishable from a real regression. Bump it deliberately. There's a TODO to switch to the plain `tak` shorthand once [jdx/mise#11307](https://github.com/jdx/mise/pull/11307) adds the registry entry.

## Notes

- **valgrind** is absent from GitHub's `ubuntu-24.04` manifest and Namespace's image contents are not publicly documented, so the install step is guarded with `command -v valgrind ||` and costs nothing if the image already has it.
- **No gate yet.** This only records. A PR-time gate needs a baseline to compare against and there isn't one — this builds it.
- **Not yet verified:** instruction-count *stability* for these commands. This machine has no valgrind, so the numbers above are wall clock. tak samples three times and warns above 0.5% spread, so the first CI run will say if anything here is less deterministic than it looks. `install` is the one to watch — it is the most parallel of the four.
- actionlint, `hk check`, and zizmor at `--persona=pedantic` are clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Added automated benchmarks for startup, graph, and tree reads, plus installation workflow measurement.
  - Benchmarks run in a consistent, hermetic environment using a fixed medium fixture for reliable comparisons.
  - Added automated recording and publishing of performance results for changes merged to the main branch.

- **Chores**
  - Pinned the benchmarking tool version to reduce measurement noise and improve stability.
  - Added a dedicated performance GitHub Actions workflow with controlled execution and summarized results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and dev-tooling only; no runtime or application code changes. Workflow uses scoped `contents: write` only on the measure job for git-notes pushes.
> 
> **Overview**
> Adds an **instruction-counted** benchmark suite (via **tak** + **valgrind/cachegrind**) alongside the existing hyperfine install matrix, aimed at detecting per-commit CPU regressions that wall-clock benches cannot see.
> 
> **`tak.toml`** defines four hermetic benchmarks on `fixtures/medium`: `startup` (control), `graph` (`sbom`), `tree` (`list`), and warm **`install --offline`** (store warmed outside the timed run). **`mise.toml`** pins `github:jdx/tak` at `0.0.2`, adds `perf` / `perf:record` tasks (release build, GVS pinned, one networked warm-up install before `tak run`), and **`mise.lock`** is updated for locked CI installs.
> 
> **`.github/workflows/perf.yml`** runs on every push to `main` (and `workflow_dispatch`): fixed runner class, optional valgrind install, `mise run perf:record`, then **`tak push`** to `refs/notes/tak` on main only; job summary gets `tak history`. Recording only—no PR gate yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7783d3671cec564cba342a3ecbd723e2abbdcea7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->