### PR TITLE
perf: seed history from published releases

### DIFF
--- a/.github/workflows/perf-backfill.yml
+++ b/.github/workflows/perf-backfill.yml
@@ -149,6 +149,54 @@ jobs:
         with:
           name: tak-notes
 
+      # The measure job runs 64 downloaded executables in a writable checkout,
+      # so anything it hands over is untrusted input crossing into a job that
+      # can write to the repository. Two checks before the write token is used.
+      #
+      # What this defends is the shape of the data, not its truthfulness: a
+      # subject that lies about its own performance cannot be caught here, and
+      # no arrangement of jobs could catch it, because the subject *is* the
+      # measurement. What it stops is a tampered bundle carrying extra refs or
+      # arbitrary blobs into this repository.
+      - name: Verify the bundle carries only measurements
+        run: |
+          git bundle verify notes.bundle
+
+          refs=$(git bundle list-heads notes.bundle | awk '{print $2}')
+          if [ "$refs" != "refs/notes/tak" ]; then
+            echo "::error::bundle carries unexpected refs:"
+            printf '%s\n' "$refs"
+            exit 1
+          fi
+
+          git fetch notes.bundle 'refs/notes/tak:refs/notes/tak'
+
+          # Every line of every note must be a tak record. A note holding
+          # anything else means the ref was written by something other than tak.
+          git notes --ref=tak list | awk '{print $2}' > /tmp/tak-commits
+          : > /tmp/tak-records
+          while IFS= read -r commit; do
+            git notes --ref=tak show "$commit" >> /tmp/tak-records
+          done < /tmp/tak-commits
+
+          bad=0
+          count=0
+          while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            count=$((count + 1))
+            printf '%s' "$line" | jq -e '
+              type == "object" and has("v") and has("bench")
+              and (.metrics | type == "object")
+            ' > /dev/null 2>&1 || { echo "::error::not a tak record: $line"; bad=1; }
+          done < /tmp/tak-records
+
+          if [ "$bad" -ne 0 ]; then exit 1; fi
+          if [ "$count" -eq 0 ]; then
+            echo "::error::the bundle contains no measurements"
+            exit 1
+          fi
+          echo "verified $count records across $(wc -l < /tmp/tak-commits) commits"
+
       # `tak push` rather than a plain `git push`: it re-fetches and merges with
       # cat_sort_uniq when it loses a race, which it can against perf.yml.
       #
@@ -156,11 +204,10 @@ jobs:
       # pattern as perf.yml and bench-refresh.yml: re-point origin rather than
       # pushing to a one-shot URL, so tak's retry path has a remote to fetch
       # from.
-      - name: Import and push measurements
+      - name: Push measurements
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          git fetch notes.bundle 'refs/notes/tak:refs/notes/tak'
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
           tak push

--- a/.github/workflows/perf-backfill.yml
+++ b/.github/workflows/perf-backfill.yml
@@ -180,11 +180,18 @@ jobs:
 
           git fetch notes.bundle 'refs/notes/tak:refs/notes/tak'
 
-          # Notes may only attach to something a release tag points at. Backfill
-          # measures published releases and nothing else, so a note anywhere
-          # else was not written by the run we asked for. Both the tag object
-          # and its peeled commit are accepted.
-          git for-each-ref refs/tags --format='%(objectname)%0a%(*objectname)' \
+          # Notes may only attach to a commit a release tag resolves to.
+          # Backfill measures published releases and nothing else, so a note
+          # anywhere else was not written by the run we asked for.
+          #
+          # Peeled commits only. tak resolves a tag with `rev-parse tag^{commit}`
+          # and records against that, so an annotated tag's own object is
+          # somewhere tak never writes — accepting it would leave a slot for a
+          # valid-looking record on an object the measurement never touched.
+          # The %(if) picks the peeled commit for annotated tags and the object
+          # itself for lightweight ones, where they are the same thing.
+          git for-each-ref refs/tags \
+            --format='%(if)%(*objectname)%(then)%(*objectname)%(else)%(objectname)%(end)' \
             | grep -v '^$' | sort -u > /tmp/tag-objects
 
           git notes --ref=tak list > /tmp/note-list

--- a/.github/workflows/perf-backfill.yml
+++ b/.github/workflows/perf-backfill.yml
@@ -137,6 +137,11 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # Tags, so the validation below can check that every note attaches to
+          # a commit some release tag points at. Fetched here rather than
+          # trusted from the measure job's checkout, which untrusted binaries
+          # ran inside.
+          fetch-depth: 0
           persist-credentials: false
 
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
@@ -151,14 +156,18 @@ jobs:
 
       # The measure job runs 64 downloaded executables in a writable checkout,
       # so anything it hands over is untrusted input crossing into a job that
-      # can write to the repository. Two checks before the write token is used.
+      # can write to the repository. Everything below runs before the write
+      # token is in scope.
       #
-      # What this defends is the shape of the data, not its truthfulness: a
-      # subject that lies about its own performance cannot be caught here, and
-      # no arrangement of jobs could catch it, because the subject *is* the
-      # measurement. What it stops is a tampered bundle carrying extra refs or
-      # arbitrary blobs into this repository.
+      # What this defends is the shape and placement of the data, not its
+      # truthfulness. A subject that lies about its own performance cannot be
+      # caught here, and no arrangement of jobs could catch it, because the
+      # subject *is* the measurement. What it stops is a tampered bundle
+      # carrying extra refs, notes on unrelated objects, records for another
+      # benchmark, or non-numeric metrics into this repository.
       - name: Verify the bundle carries only measurements
+        env:
+          EXPECTED_BENCH: release-graph
         run: |
           git bundle verify notes.bundle
 
@@ -171,31 +180,47 @@ jobs:
 
           git fetch notes.bundle 'refs/notes/tak:refs/notes/tak'
 
-          # Every line of every note must be a tak record. A note holding
-          # anything else means the ref was written by something other than tak.
-          git notes --ref=tak list | awk '{print $2}' > /tmp/tak-commits
-          : > /tmp/tak-records
-          while IFS= read -r commit; do
-            git notes --ref=tak show "$commit" >> /tmp/tak-records
-          done < /tmp/tak-commits
+          # Notes may only attach to something a release tag points at. Backfill
+          # measures published releases and nothing else, so a note anywhere
+          # else was not written by the run we asked for. Both the tag object
+          # and its peeled commit are accepted.
+          git for-each-ref refs/tags --format='%(objectname)%0a%(*objectname)' \
+            | grep -v '^$' | sort -u > /tmp/tag-objects
 
+          git notes --ref=tak list > /tmp/note-list
           bad=0
-          count=0
-          while IFS= read -r line; do
-            [ -z "$line" ] && continue
-            count=$((count + 1))
-            printf '%s' "$line" | jq -e '
-              type == "object" and has("v") and has("bench")
-              and (.metrics | type == "object")
-            ' > /dev/null 2>&1 || { echo "::error::not a tak record: $line"; bad=1; }
-          done < /tmp/tak-records
+          notes=0
+          records=0
+          while read -r _blob target; do
+            notes=$((notes + 1))
+            if ! grep -qx "$target" /tmp/tag-objects; then
+              echo "::error::note on $target, which no release tag points at"
+              bad=1
+              continue
+            fi
+            # Shape alone would accept a forged record, so this also pins the
+            # schema version, the benchmark name, and that metrics are numbers.
+            git notes --ref=tak show "$target" > /tmp/note-body
+            while IFS= read -r line; do
+              [ -z "$line" ] && continue
+              records=$((records + 1))
+              printf '%s' "$line" | jq -e --arg want "$EXPECTED_BENCH" '
+                type == "object"
+                and .v == 1
+                and .bench == $want
+                and (.metrics | type == "object")
+                and (.metrics | length > 0)
+                and ([.metrics[] | type] | all(. == "number"))
+              ' > /dev/null 2>&1 || { echo "::error::rejected on $target: $line"; bad=1; }
+            done < /tmp/note-body
+          done < /tmp/note-list
 
           if [ "$bad" -ne 0 ]; then exit 1; fi
-          if [ "$count" -eq 0 ]; then
+          if [ "$records" -eq 0 ]; then
             echo "::error::the bundle contains no measurements"
             exit 1
           fi
-          echo "verified $count records across $(wc -l < /tmp/tak-commits) commits"
+          echo "verified $records records across $notes tagged commits"
 
       # `tak push` rather than a plain `git push`: it re-fetches and merges with
       # cat_sort_uniq when it loses a race, which it can against perf.yml.

--- a/.github/workflows/perf-backfill.yml
+++ b/.github/workflows/perf-backfill.yml
@@ -11,6 +11,11 @@ name: perf-backfill
 # Dispatch-only, and effectively idempotent: release binaries are immutable, so
 # a second run produces byte-identical records that cat_sort_uniq collapses on
 # merge. Re-running is harmless, just pointless.
+#
+# Split into two jobs so the repository-write token is never present while
+# downloaded binaries are executing. `measure` runs 64 historical executables
+# and holds only a read token; `publish` holds the write token and runs nothing
+# but git.
 
 on:
   workflow_dispatch:
@@ -28,15 +33,15 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  backfill:
-    name: Backfill
+  measure:
+    name: Measure released binaries
     # Same runner class as perf.yml. Absolute instruction counts shift between
     # machine types by more than a real regression does, so the backfilled
     # series and the ongoing one have to come from the same kind of machine.
     runs-on: namespace-profile-endev-linux-amd64
     timeout-minutes: 60
     permissions:
-      contents: write # pushing refs/notes/tak is a write to this repository
+      contents: read # listing releases and downloading assets; no write here
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -76,6 +81,10 @@ jobs:
       #
       # The fixture path is absolute so it does not depend on the working
       # directory tak happens to run each downloaded binary from.
+      #
+      # This step executes 64 binaries downloaded from the releases API. The
+      # token in scope is read-only, so what they inherit is worth nothing
+      # beyond what a public clone already grants.
       - name: Backfill from published releases
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -84,26 +93,74 @@ jobs:
           tak backfill --bench release-graph --limit "$LIMIT" -- \
             -C "$GITHUB_WORKSPACE/fixtures/medium" sbom
 
-      # persist-credentials: false means the push needs its own auth. Same
-      # pattern as perf.yml and bench-refresh.yml: re-point origin rather than
-      # pushing to a one-shot URL, so tak's retry path has a remote to fetch
-      # from when it loses a race.
-      - name: Push measurements
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPOSITORY: ${{ github.repository }}
+      # A bundle is how the notes reach the publish job: it carries the ref and
+      # its object closure in one file, and `git fetch` restores it exactly.
+      # Passing the records as text would mean re-deriving the ref on the far
+      # side and getting the cat_sort_uniq byte-ordering right by hand.
+      - name: Bundle the notes
         run: |
-          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
-          tak push
+          git bundle create notes.bundle refs/notes/tak
+          git bundle verify notes.bundle
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: tak-notes
+          path: notes.bundle
+          retention-days: 1
+          if-no-files-found: error
 
       - name: Summary
+        env:
+          LIMIT: ${{ inputs.limit }}
         run: |
           {
-            echo "Backfilled up to ${LIMIT} releases into \`refs/notes/tak\` as \`release-graph\`."
+            echo "Measured up to ${LIMIT} releases as \`release-graph\`."
             echo
             echo '```'
             tak history 2>&1 | head -40
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+  publish:
+    name: Publish measurements
+    needs: measure
+    # Only main publishes. workflow_dispatch can be pointed at any branch or
+    # tag, and refs/notes/tak is a shared baseline. A dispatch from a branch
+    # still measures and still prints its numbers in the summary above — it
+    # just keeps them out of the shared series, which matters because a branch
+    # may have changed the fixture or the subject while keeping the bench name.
+    if: github.ref == 'refs/heads/main'
+    runs-on: namespace-profile-endev-linux-amd64
+    timeout-minutes: 10
+    permissions:
+      contents: write # pushing refs/notes/tak is a write to this repository
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          cache: false
         env:
-          LIMIT: ${{ inputs.limit }}
+          MISE_LOCKED: "1"
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: tak-notes
+
+      # `tak push` rather than a plain `git push`: it re-fetches and merges with
+      # cat_sort_uniq when it loses a race, which it can against perf.yml.
+      #
+      # persist-credentials: false means the push needs its own auth. Same
+      # pattern as perf.yml and bench-refresh.yml: re-point origin rather than
+      # pushing to a one-shot URL, so tak's retry path has a remote to fetch
+      # from.
+      - name: Import and push measurements
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          git fetch notes.bundle 'refs/notes/tak:refs/notes/tak'
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
+          tak push

--- a/.github/workflows/perf-backfill.yml
+++ b/.github/workflows/perf-backfill.yml
@@ -1,0 +1,109 @@
+name: perf-backfill
+
+# Seeds refs/notes/tak with measurements of already-published aube binaries, so
+# the performance history starts with a real series instead of one point.
+#
+# The alternative is rebuilding aube at 64 historical commits, which is hours of
+# compute and fails outright on old commits whose dependencies no longer
+# resolve. Downloading what was already published takes minutes and measures the
+# exact artifact users installed.
+#
+# Dispatch-only, and effectively idempotent: release binaries are immutable, so
+# a second run produces byte-identical records that cat_sort_uniq collapses on
+# merge. Re-running is harmless, just pointless.
+
+on:
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: Most recent releases to measure
+        required: false
+        default: "64"
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: perf-backfill
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    name: Backfill
+    # Same runner class as perf.yml. Absolute instruction counts shift between
+    # machine types by more than a real regression does, so the backfilled
+    # series and the ongoing one have to come from the same kind of machine.
+    runs-on: namespace-profile-endev-linux-amd64
+    timeout-minutes: 60
+    permissions:
+      contents: write # pushing refs/notes/tak is a write to this repository
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # tak resolves each release tag to the commit it points at, so a
+          # measurement lands on the commit that produced it rather than on
+          # HEAD. That needs the tags, and a shallow checkout has none.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          cache: false
+        env:
+          MISE_LOCKED: "1"
+
+      - name: Install valgrind
+        run: |
+          command -v valgrind || {
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends valgrind
+          }
+          valgrind --version
+
+      # `sbom` rather than tak's default of `--version`. aube's `-V` is
+      # documented as "print version and check for updates", and a subject that
+      # talks to the network cannot hold a stable instruction count.
+      #
+      # `sbom` reads only the committed lockfile — no node_modules, no store, no
+      # registry — so it needs no setup and cannot be perturbed. It was checked
+      # against releases sampled across the whole range, back to v1.0.0-beta.1,
+      # and works on all of them; `prefix` does not exist that far back.
+      #
+      # Separate bench name from the CI series on purpose. These are release
+      # artifacts built by the release pipeline; perf.yml measures a plain
+      # `cargo build --release`. Plotting them on one axis would compare build
+      # configurations, not commits.
+      #
+      # The fixture path is absolute so it does not depend on the working
+      # directory tak happens to run each downloaded binary from.
+      - name: Backfill from published releases
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LIMIT: ${{ inputs.limit }}
+        run: |
+          tak backfill --bench release-graph --limit "$LIMIT" -- \
+            -C "$GITHUB_WORKSPACE/fixtures/medium" sbom
+
+      # persist-credentials: false means the push needs its own auth. Same
+      # pattern as perf.yml and bench-refresh.yml: re-point origin rather than
+      # pushing to a one-shot URL, so tak's retry path has a remote to fetch
+      # from when it loses a race.
+      - name: Push measurements
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
+          tak push
+
+      - name: Summary
+        run: |
+          {
+            echo "Backfilled up to ${LIMIT} releases into \`refs/notes/tak\` as \`release-graph\`."
+            echo
+            echo '```'
+            tak history 2>&1 | head -40
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          LIMIT: ${{ inputs.limit }}


### PR DESCRIPTION
The performance chart currently has one point. usage.sh says so plainly:

> 4 measurements recorded, but no series has enough points to chart yet — two per benchmark and runner.

Waiting for main to accumulate commits means weeks before it shows anything. aube has **64 published releases**; measuring those binaries gives a real series today.

## Why download rather than rebuild

Rebuilding aube at 64 historical commits is hours of compute, and fails outright on old commits whose dependencies no longer resolve. Downloading what was already published takes minutes — and measures the exact artifact users installed.

## What it measures, and why not `--version`

`aube -C fixtures/medium sbom`, not tak's default of `--version`.

`-V` is documented as *"print version and check for updates"*. A subject that talks to the network cannot hold a stable instruction count, which would make the whole series decorative.

`sbom` reads only the committed lockfile — no `node_modules`, no store, no registry — so it needs no setup and cannot be perturbed by anything outside the repo.

## Verified before writing it

Downloaded real release binaries and ran them against the fixture with the registry pointed at a dead port:

| release | `list` | `sbom` | `prefix` |
|---|---|---|---|
| v1.33.0 | ✅ | ✅ | — |
| v1.21.0 | ✅ | ✅ | — |
| v1.11.0 | ✅ | ✅ | — |
| v1.3.0 | ✅ | ✅ | — |
| v1.0.0-beta.1 | ✅ | ✅ | ❌ `unknown command: prefix` |

**`prefix` does not exist that far back** — which is exactly why it is not the subject here, and why this was worth checking rather than assuming the current CLI surface held for 64 releases.

## Two details that would have broken it

- **`fetch-depth: 0`.** tak resolves each release tag to the commit it points at, so a measurement lands on the commit that produced it rather than on HEAD. A shallow checkout has no tags and every record would have piled onto one commit.
- **Separate bench name** (`release-graph`). These are release-pipeline artifacts; `perf.yml` measures a plain `cargo build --release`. On one axis that compares build configurations, not commits.

## Notes

- Dispatch-only, and effectively idempotent: release binaries are immutable, so a second run produces byte-identical records that `cat_sort_uniq` collapses on merge.
- Same runner class as `perf.yml`, since absolute instruction counts shift between machine types by more than a real regression does.
- actionlint and zizmor at `--persona=pedantic` are clean.
- Not yet run — it is `workflow_dispatch`, so it needs a manual trigger after merge.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The publish job writes to `refs/notes/tak` on main after validation, but it still trusts measurement content from downloaded binaries; misconfiguration or bypass of checks could pollute shared perf history.
> 
> **Overview**
> Adds a **manual** `perf-backfill` workflow that seeds `refs/notes/tak` with performance measurements from already-published release binaries, so charts get a multi-point `release-graph` series without waiting on main or rebuilding old commits.
> 
> The **`measure`** job (read-only token) checks out with full history, runs `tak backfill --bench release-graph` against `fixtures/medium` with subject `sbom` (not network-touching `--version`), bundles `refs/notes/tak`, and uploads it. The **`publish`** job (write token, **main only**) downloads the bundle, validates refs/note targets (release-tag commits only) and JSON record shape (`v:1`, bench name, numeric metrics), then **`tak push`** merges into the shared notes ref.
> 
> Security is split so downloaded executables never run in a job that can write to the repo; dispatch from non-main branches can still measure and show a summary but does not publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d947e2af03fe24fc8a0e97bc01ea7144c690a0c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->