### PR TITLE
feat: replace `node-semver` with `nodejs-semver`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -202,7 +202,7 @@ dependencies = [
  "http",
  "reqwest",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
  "tower-service",
 ]
 
@@ -273,7 +273,7 @@ dependencies = [
  "libc",
  "miette",
  "mimalloc",
- "node-semver",
+ "nodejs-semver",
  "pathdiff",
  "pluralizer",
  "predicates",
@@ -341,7 +341,7 @@ dependencies = [
  "sha2 0.11.0",
  "strum",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "xx",
 ]
@@ -360,7 +360,7 @@ dependencies = [
  "glob",
  "memchr",
  "miette",
- "node-semver",
+ "nodejs-semver",
  "proptest",
  "serde",
  "serde_json",
@@ -368,7 +368,7 @@ dependencies = [
  "smallvec",
  "sonic-rs",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "yaml_serde",
 ]
@@ -385,7 +385,7 @@ dependencies = [
  "serde_yaml",
  "sonic-rs",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "yaml_serde",
  "yamlpatch",
  "yamlpath",
@@ -420,7 +420,7 @@ dependencies = [
  "bytes",
  "flate2",
  "miette",
- "node-semver",
+ "nodejs-semver",
  "proptest",
  "reqwest",
  "serde",
@@ -429,7 +429,7 @@ dependencies = [
  "sonic-rs",
  "tar",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "wiremock",
@@ -450,7 +450,7 @@ dependencies = [
  "criterion",
  "flate2",
  "miette",
- "node-semver",
+ "nodejs-semver",
  "pathdiff",
  "rkyv",
  "serde",
@@ -460,7 +460,7 @@ dependencies = [
  "sonic-rs",
  "tar",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "zstd",
@@ -476,14 +476,14 @@ dependencies = [
  "base64",
  "flate2",
  "hex",
- "node-semver",
+ "nodejs-semver",
  "reqwest",
  "serde",
  "serde_json",
  "sha2 0.11.0",
  "tar",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "xx",
@@ -502,7 +502,7 @@ dependencies = [
  "miette",
  "regex",
  "seccompiler",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "windows-sys 0.61.2",
@@ -542,7 +542,7 @@ dependencies = [
  "sonic-rs",
  "tar",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "xx",
  "zstd",
 ]
@@ -562,7 +562,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "webpki-root-certs",
@@ -578,7 +578,7 @@ dependencies = [
  "miette",
  "pathdiff",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
@@ -945,7 +945,7 @@ dependencies = [
  "serde_json",
  "strum",
  "tera",
- "thiserror 2.0.18",
+ "thiserror",
  "unicode-width 0.2.2",
 ]
 
@@ -1374,7 +1374,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -1960,7 +1960,7 @@ dependencies = [
  "ipnet",
  "jni",
  "rand 0.10.2",
- "thiserror 2.0.18",
+ "thiserror",
  "tinyvec",
  "tokio",
  "tracing",
@@ -1981,7 +1981,7 @@ dependencies = [
  "prefix-trie",
  "rand 0.10.2",
  "ring",
- "thiserror 2.0.18",
+ "thiserror",
  "tinyvec",
  "tracing",
  "url",
@@ -2008,7 +2008,7 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "system-configuration",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
 ]
@@ -2450,7 +2450,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror",
  "walkdir",
  "windows-link 0.2.1",
 ]
@@ -2526,7 +2526,7 @@ checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -2548,7 +2548,7 @@ checksum = "635839550ae8b90d9fd2571460a6645dc0aec070225956ca7a2831ed31d2795d"
 dependencies = [
  "enumflags2",
  "libc",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -2741,12 +2741,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2894,16 +2888,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "node-semver"
-version = "2.2.0"
+name = "nodejs-semver"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b1a233ea5dc37d2cfba31cfc87a5a56cc2a9c04e3672c15d179ca118dae40a7"
+checksum = "364dd919c4d6feef8c3a3f3e2b64af729187902156e17481618622cbbf1353a1"
 dependencies = [
  "bytecount",
  "miette",
- "nom 7.1.3",
- "serde",
- "thiserror 1.0.69",
+ "smallvec",
+ "thiserror",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -2911,16 +2905,6 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
 
 [[package]]
 name = "nom"
@@ -3364,7 +3348,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -3387,7 +3371,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3535,7 +3519,7 @@ dependencies = [
  "palette",
  "serde",
  "strum",
- "thiserror 2.0.18",
+ "thiserror",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.2",
@@ -4219,7 +4203,7 @@ dependencies = [
  "sigstore-rekor",
  "sigstore-tsa",
  "sigstore-types",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -4239,7 +4223,7 @@ dependencies = [
  "signature",
  "sigstore-types",
  "spki",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "x509-cert",
 ]
@@ -4257,7 +4241,7 @@ dependencies = [
  "sigstore-crypto",
  "sigstore-oidc",
  "sigstore-types",
- "thiserror 2.0.18",
+ "thiserror",
  "url",
 ]
 
@@ -4271,7 +4255,7 @@ dependencies = [
  "hex",
  "sigstore-crypto",
  "sigstore-types",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -4289,7 +4273,7 @@ dependencies = [
  "serde_json",
  "sigstore-crypto",
  "sigstore-types",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "url",
 ]
@@ -4308,7 +4292,7 @@ dependencies = [
  "sigstore-crypto",
  "sigstore-merkle",
  "sigstore-types",
- "thiserror 2.0.18",
+ "thiserror",
  "url",
 ]
 
@@ -4328,7 +4312,7 @@ dependencies = [
  "sigstore-trust-root",
  "sigstore-tsa",
  "sigstore-types",
- "thiserror 2.0.18",
+ "thiserror",
  "x509-cert",
 ]
 
@@ -4347,7 +4331,7 @@ dependencies = [
  "sigstore-crypto",
  "sigstore-tuf",
  "sigstore-types",
- "thiserror 2.0.18",
+ "thiserror",
  "x509-cert",
 ]
 
@@ -4371,7 +4355,7 @@ dependencies = [
  "rustls-webpki",
  "sigstore-crypto",
  "sigstore-types",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "x509-cert",
  "x509-tsp",
@@ -4393,7 +4377,7 @@ dependencies = [
  "sigstore-crypto",
  "sigstore-types",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "url",
@@ -4410,7 +4394,7 @@ dependencies = [
  "pem",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -4486,7 +4470,7 @@ dependencies = [
  "simdutf8",
  "sonic-number",
  "sonic-simd",
- "thiserror 2.0.18",
+ "thiserror",
  "zmij",
 ]
 
@@ -4726,31 +4710,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -5218,7 +5182,7 @@ dependencies = [
  "shell-words",
  "strum",
  "tera",
- "thiserror 2.0.18",
+ "thiserror",
  "versions",
  "xx",
 ]
@@ -5265,7 +5229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80a7e511ce1795821207a837b7b1c8d8aca0c648810966ad200446ae58f6667f"
 dependencies = [
  "itertools 0.14.0",
- "nom 8.0.0",
+ "nom",
 ]
 
 [[package]]
@@ -5831,6 +5795,15 @@ dependencies = [
 
 [[package]]
 name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
@@ -5923,7 +5896,7 @@ dependencies = [
  "regex",
  "sha2 0.11.0",
  "strsim",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -5949,7 +5922,7 @@ dependencies = [
  "line-index",
  "serde_json",
  "subfeature",
- "thiserror 2.0.18",
+ "thiserror",
  "yaml_serde",
  "yamlpath",
 ]
@@ -5963,7 +5936,7 @@ dependencies = [
  "line-index",
  "self_cell",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
  "tree-sitter",
  "tree-sitter-iter",
  "tree-sitter-yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,7 @@ zstd = { version = "0.13", default-features = false }
 zip = { version = "8", default-features = false, features = ["deflate"] }
 
 # Semver
-node-semver = "2"
+nodejs-semver = "5"
 
 # Diff/patch
 diffy = "0.5"

--- a/crates/aube-lockfile/Cargo.toml
+++ b/crates/aube-lockfile/Cargo.toml
@@ -18,7 +18,7 @@ aube-util = { workspace = true }
 base64 = { workspace = true }
 glob = { workspace = true }
 miette = { workspace = true }
-node-semver = { workspace = true }
+nodejs-semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sonic-rs = { workspace = true }

--- a/crates/aube-lockfile/src/io.rs
+++ b/crates/aube-lockfile/src/io.rs
@@ -561,7 +561,7 @@ fn dep_path_has_registry_version(dep_path: &str, name: &str) -> bool {
         return false;
     };
     let version = tail.split('(').next().unwrap_or(tail);
-    node_semver::Version::parse(version).is_ok()
+    nodejs_semver::Version::parse(version).is_ok()
 }
 
 #[cfg(test)]

--- a/crates/aube-lockfile/src/merge.rs
+++ b/crates/aube-lockfile/src/merge.rs
@@ -450,8 +450,8 @@ fn existing_version_from_dep_path(dep: &DirectDep) -> &str {
 /// never panics.
 fn prefer_higher_version(a: &str, b: &str) -> bool {
     match (
-        node_semver::Version::parse(a),
-        node_semver::Version::parse(b),
+        nodejs_semver::Version::parse(a),
+        nodejs_semver::Version::parse(b),
     ) {
         (Ok(va), Ok(vb)) => va >= vb,
         _ => a >= b,

--- a/crates/aube-lockfile/src/override_match.rs
+++ b/crates/aube-lockfile/src/override_match.rs
@@ -228,7 +228,7 @@ fn range_could_satisfy(task_range: &str, req: &str) -> bool {
             // Probe just above the exclusive boundary: `>3.0.5` covers
             // every version above 3.0.5, so use 3.0.5 + minimum patch
             // bump as the representative point.
-            v.patch += 1;
+            v.patch() += 1;
         }
         return v.satisfies(&r);
     }

--- a/crates/aube-lockfile/src/override_match.rs
+++ b/crates/aube-lockfile/src/override_match.rs
@@ -211,10 +211,10 @@ fn parse_segment(seg: &str) -> Option<(String, Option<String>)> {
 /// for two ranges with empty intersection. The caller signals the
 /// exclusive form via a separate try with `bumped_lower_bound` first.
 fn range_could_satisfy(task_range: &str, req: &str) -> bool {
-    let Ok(r) = node_semver::Range::parse(req) else {
+    let Ok(r) = nodejs_semver::Range::parse(req) else {
         return true;
     };
-    if let Ok(v) = node_semver::Version::parse(task_range)
+    if let Ok(v) = nodejs_semver::Version::parse(task_range)
         && v.satisfies(&r)
     {
         return true;
@@ -222,7 +222,7 @@ fn range_could_satisfy(task_range: &str, req: &str) -> bool {
     let trimmed = task_range.trim();
     let exclusive = trimmed.starts_with('>') && !trimmed.starts_with(">=");
     if let Some(candidate) = lower_bound_version(trimmed)
-        && let Ok(mut v) = node_semver::Version::parse(&candidate)
+        && let Ok(mut v) = nodejs_semver::Version::parse(&candidate)
     {
         if exclusive {
             // Probe just above the exclusive boundary: `>3.0.5` covers

--- a/crates/aube-lockfile/src/override_match.rs
+++ b/crates/aube-lockfile/src/override_match.rs
@@ -228,7 +228,14 @@ fn range_could_satisfy(task_range: &str, req: &str) -> bool {
             // Probe just above the exclusive boundary: `>3.0.5` covers
             // every version above 3.0.5, so use 3.0.5 + minimum patch
             // bump as the representative point.
-            v.patch() += 1;
+            let vp = v.into_parts();
+            v = nodejs_semver::Version::new(
+                vp.major,
+                vp.minor,
+                vp.patch + 1,
+                vp.pre_release,
+                vp.build,
+            );
         }
         return v.satisfies(&r);
     }

--- a/crates/aube-registry/Cargo.toml
+++ b/crates/aube-registry/Cargo.toml
@@ -16,7 +16,7 @@ aube-manifest = { workspace = true }
 aube-settings = { workspace = true }
 aube-store = { workspace = true }
 aube-util = { workspace = true }
-node-semver = { workspace = true }
+nodejs-semver = { workspace = true }
 miette = { workspace = true }
 blake3 = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/aube-registry/src/osv_bloom_client.rs
+++ b/crates/aube-registry/src/osv_bloom_client.rs
@@ -222,10 +222,10 @@ impl Bloom {
 /// `osv_bloom::bucket` — keep in sync with the published wire format.
 fn bucket_of(version: &str) -> Option<String> {
     let v = nodejs_semver::Version::parse(version).ok()?;
-    if v.major == 0 {
-        Some(format!("0.{}", v.minor))
+    if v.major() == 0 {
+        Some(format!("0.{}", v.minor()))
     } else {
-        Some(v.major.to_string())
+        Some(v.major().to_string())
     }
 }
 

--- a/crates/aube-registry/src/osv_bloom_client.rs
+++ b/crates/aube-registry/src/osv_bloom_client.rs
@@ -221,7 +221,7 @@ impl Bloom {
 /// Bucket a concrete semver as the upstream builder does. Mirrors
 /// `osv_bloom::bucket` — keep in sync with the published wire format.
 fn bucket_of(version: &str) -> Option<String> {
-    let v = node_semver::Version::parse(version).ok()?;
+    let v = nodejs_semver::Version::parse(version).ok()?;
     if v.major == 0 {
         Some(format!("0.{}", v.minor))
     } else {

--- a/crates/aube-resolver/Cargo.toml
+++ b/crates/aube-resolver/Cargo.toml
@@ -17,7 +17,7 @@ aube-manifest = { workspace = true }
 aube-lockfile = { workspace = true }
 aube-store = { workspace = true }
 aube-util = { workspace = true }
-node-semver = { workspace = true }
+nodejs-semver = { workspace = true }
 smallvec = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/aube-resolver/benches/locked_lookup.rs
+++ b/crates/aube-resolver/benches/locked_lookup.rs
@@ -119,12 +119,12 @@ fn indexed(
 
 // Local copies of the resolver's predicates so the bench links without
 // reaching into the crate's private modules. `version_satisfies` mirrors
-// `semver_util::version_satisfies` (node-semver Range::satisfies);
+// `semver_util::version_satisfies` (nodejs-semver Range::satisfies);
 // `is_vulnerable` mirrors `resolve::vulnerable::is_vulnerable`.
 fn version_satisfies(version: &str, range_str: &str) -> bool {
     let (Ok(v), Ok(r)) = (
-        node_semver::Version::parse(version),
-        node_semver::Range::parse(range_str),
+        nodejs_semver::Version::parse(version),
+        nodejs_semver::Range::parse(range_str),
     ) else {
         return false;
     };
@@ -135,12 +135,12 @@ fn is_vulnerable(name: &str, version: &str, vuln: &BTreeMap<String, Vec<String>>
     let Some(ranges) = vuln.get(name) else {
         return false;
     };
-    let Ok(v) = node_semver::Version::parse(version) else {
+    let Ok(v) = nodejs_semver::Version::parse(version) else {
         return false;
     };
     ranges
         .iter()
-        .filter_map(|r| node_semver::Range::parse(r).ok())
+        .filter_map(|r| nodejs_semver::Range::parse(r).ok())
         .any(|r| v.satisfies(&r))
 }
 

--- a/crates/aube-resolver/src/direct_dep_info.rs
+++ b/crates/aube-resolver/src/direct_dep_info.rs
@@ -86,7 +86,7 @@ impl Resolver {
 /// (rare, but possible) still surfaces as an upgrade hint.
 fn is_prerelease(version: &str) -> bool {
     nodejs_semver::Version::parse(version)
-        .map(|v| !v.pre_release.is_empty())
+        .map(|v| !v.pre_release().is_empty())
         .unwrap_or(false)
 }
 

--- a/crates/aube-resolver/src/direct_dep_info.rs
+++ b/crates/aube-resolver/src/direct_dep_info.rs
@@ -85,7 +85,7 @@ impl Resolver {
 /// as non-prerelease so a registry returning a non-semver `latest`
 /// (rare, but possible) still surfaces as an upgrade hint.
 fn is_prerelease(version: &str) -> bool {
-    node_semver::Version::parse(version)
+    nodejs_semver::Version::parse(version)
         .map(|v| !v.pre_release.is_empty())
         .unwrap_or(false)
 }

--- a/crates/aube-resolver/src/error.rs
+++ b/crates/aube-resolver/src/error.rs
@@ -197,7 +197,7 @@ pub(crate) fn build_no_match(task: &ResolveTask, packument: &Packument) -> NoMat
         let Ok(parsed) = nodejs_semver::Version::parse(v) else {
             continue;
         };
-        if parsed.pre_release.is_empty() {
+        if parsed.pre_release().is_empty() {
             stable.push((parsed, v.as_str()));
         } else {
             prerelease.push((parsed, v.as_str()));

--- a/crates/aube-resolver/src/error.rs
+++ b/crates/aube-resolver/src/error.rs
@@ -191,10 +191,10 @@ fn format_trust_missing_time_help(d: &MissingTimeDetails) -> String {
 /// alias), and a sample of the highest non-prerelease versions so the
 /// diagnostic can tell the user how close they were.
 pub(crate) fn build_no_match(task: &ResolveTask, packument: &Packument) -> NoMatchDetails {
-    let mut stable: Vec<(node_semver::Version, &str)> = Vec::new();
-    let mut prerelease: Vec<(node_semver::Version, &str)> = Vec::new();
+    let mut stable: Vec<(nodejs_semver::Version, &str)> = Vec::new();
+    let mut prerelease: Vec<(nodejs_semver::Version, &str)> = Vec::new();
     for v in packument.versions.keys() {
-        let Ok(parsed) = node_semver::Version::parse(v) else {
+        let Ok(parsed) = nodejs_semver::Version::parse(v) else {
             continue;
         };
         if parsed.pre_release.is_empty() {
@@ -261,11 +261,11 @@ pub(crate) fn build_age_gate(
     // fails silently and the help text drops the "blocked by age gate"
     // line entirely, losing the most useful diagnostic.
     let effective = resolve_dist_tag_range(packument, &task.range);
-    let range = node_semver::Range::parse(&effective).ok();
-    let mut gated: Vec<(node_semver::Version, String)> = Vec::new();
+    let range = nodejs_semver::Range::parse(&effective).ok();
+    let mut gated: Vec<(nodejs_semver::Version, String)> = Vec::new();
     if let Some(r) = range {
         for ver in packument.versions.keys() {
-            let Ok(v) = node_semver::Version::parse(ver) else {
+            let Ok(v) = nodejs_semver::Version::parse(ver) else {
                 continue;
             };
             if !v.satisfies(&r) {

--- a/crates/aube-resolver/src/override_rule.rs
+++ b/crates/aube-resolver/src/override_rule.rs
@@ -311,10 +311,10 @@ fn match_from_right(parents: &[Segment], anc: &[AncestorFrame<'_>]) -> bool {
 }
 
 fn version_in_req(version: &str, req: &str) -> bool {
-    let Ok(v) = node_semver::Version::parse(version) else {
+    let Ok(v) = nodejs_semver::Version::parse(version) else {
         return false;
     };
-    let Ok(r) = node_semver::Range::parse(req) else {
+    let Ok(r) = nodejs_semver::Range::parse(req) else {
         return false;
     };
     v.satisfies(&r)
@@ -339,16 +339,16 @@ fn version_in_req(version: &str, req: &str) -> bool {
 /// return `true` (overridden too aggressively beats silently
 /// ignoring) so users at least see the override take effect.
 fn range_could_satisfy(task_range: &str, req: &str) -> bool {
-    let Ok(r) = node_semver::Range::parse(req) else {
+    let Ok(r) = nodejs_semver::Range::parse(req) else {
         return true;
     };
-    if let Ok(v) = node_semver::Version::parse(task_range)
+    if let Ok(v) = nodejs_semver::Version::parse(task_range)
         && v.satisfies(&r)
     {
         return true;
     }
     if let Some(candidate) = lower_bound_version(task_range)
-        && let Ok(v) = node_semver::Version::parse(&candidate)
+        && let Ok(v) = nodejs_semver::Version::parse(&candidate)
     {
         let hit = v.satisfies(&r);
         if !hit {

--- a/crates/aube-resolver/src/peer_context.rs
+++ b/crates/aube-resolver/src/peer_context.rs
@@ -174,7 +174,7 @@ pub fn hoist_auto_installed_peers(mut graph: LockfileGraph) -> LockfileGraph {
                         .values()
                         .filter(|p| p.name == *peer_name)
                         .filter_map(|p| {
-                            node_semver::Version::parse(&p.version)
+                            nodejs_semver::Version::parse(&p.version)
                                 .ok()
                                 .map(|v| (v, p.version.clone()))
                         })
@@ -1683,7 +1683,7 @@ fn visit_peer_context<'g>(
                         .strip_prefix(&format!("{}@", p.name))
                         .map(|s| s.to_string())
                         .unwrap_or_else(|| p.version.clone());
-                    node_semver::Version::parse(&p.version)
+                    nodejs_semver::Version::parse(&p.version)
                         .ok()
                         .map(|ver| (ver, tail))
                 })

--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -585,10 +585,10 @@ impl<'a> ResolveDriver<'a> {
             .minimum_release_age
             .as_ref()
             .map(|m| &m.exclude);
-        let is_age_exempt = |ver: &str, parsed: Option<&node_semver::Version>| {
+        let is_age_exempt = |ver: &str, parsed: Option<&nodejs_semver::Version>| {
             mra_exclude.is_some_and(|ex| match parsed {
                 Some(v) => ex.matches(&registry_name, v),
-                None => match node_semver::Version::parse(ver) {
+                None => match nodejs_semver::Version::parse(ver) {
                     Ok(v) => ex.matches(&registry_name, &v),
                     Err(_) => ex.matches_name_only(&registry_name),
                 },

--- a/crates/aube-resolver/src/resolve/vulnerable.rs
+++ b/crates/aube-resolver/src/resolve/vulnerable.rs
@@ -9,12 +9,12 @@ pub(crate) fn is_vulnerable(
     let Some(ranges) = vulnerable_ranges.get(package_name) else {
         return false;
     };
-    let Ok(version) = node_semver::Version::parse(version) else {
+    let Ok(version) = nodejs_semver::Version::parse(version) else {
         return false;
     };
     ranges
         .iter()
-        .filter_map(|range| node_semver::Range::parse(range).ok())
+        .filter_map(|range| nodejs_semver::Range::parse(range).ok())
         .any(|range| version.satisfies(&range))
 }
 
@@ -28,12 +28,12 @@ pub(super) fn prefer_non_vulnerable_pick<'a>(
     cutoff: Option<&str>,
     exempt_cutoff: Option<&str>,
     vulnerable_ranges: &BTreeMap<String, Vec<String>>,
-    is_age_exempt: impl Fn(&str, Option<&node_semver::Version>) -> bool,
+    is_age_exempt: impl Fn(&str, Option<&nodejs_semver::Version>) -> bool,
 ) -> &'a aube_registry::VersionMetadata {
     if !is_vulnerable(package_name, &fallback.version, vulnerable_ranges) {
         return fallback;
     }
-    let Ok(range) = node_semver::Range::parse(crate::semver_util::normalize_range(range_str))
+    let Ok(range) = nodejs_semver::Range::parse(crate::semver_util::normalize_range(range_str))
     else {
         return fallback;
     };
@@ -42,7 +42,7 @@ pub(super) fn prefer_non_vulnerable_pick<'a>(
     // subject to `exempt_cutoff`, the time-based wall), otherwise the
     // re-pick could discard the exempt safe version and keep the
     // vulnerable one.
-    let passes_cutoff = |ver: &str, parsed: Option<&node_semver::Version>| -> bool {
+    let passes_cutoff = |ver: &str, parsed: Option<&nodejs_semver::Version>| -> bool {
         let effective = if is_age_exempt(ver, parsed) {
             exempt_cutoff
         } else {
@@ -54,9 +54,9 @@ pub(super) fn prefer_non_vulnerable_pick<'a>(
             None => true,
         }
     };
-    let mut best: Option<(node_semver::Version, &'a aube_registry::VersionMetadata)> = None;
+    let mut best: Option<(nodejs_semver::Version, &'a aube_registry::VersionMetadata)> = None;
     for (ver_str, meta) in &packument.versions {
-        let Ok(version) = node_semver::Version::parse(ver_str) else {
+        let Ok(version) = nodejs_semver::Version::parse(ver_str) else {
             continue;
         };
         if !version.satisfies(&range)

--- a/crates/aube-resolver/src/semver_util.rs
+++ b/crates/aube-resolver/src/semver_util.rs
@@ -335,7 +335,7 @@ pub(crate) fn highest_stable_version(packument: &Packument) -> Option<String> {
         // Skip prereleases so we match npm semantics. Registry
         // with only prereleases returns None and caller gets
         // NoMatch, same as before.
-        if !v.pre_release.is_empty() {
+        if !v.pre_release().is_empty() {
             continue;
         }
         match &best {

--- a/crates/aube-resolver/src/semver_util.rs
+++ b/crates/aube-resolver/src/semver_util.rs
@@ -57,10 +57,10 @@ pub fn pick_version_for_add<'a>(
     };
     let strict = minimum_release_age.is_some_and(|m| m.strict);
     let exclude = minimum_release_age.map(|m| &m.exclude);
-    let is_age_exempt = |ver: &str, parsed: Option<&node_semver::Version>| {
+    let is_age_exempt = |ver: &str, parsed: Option<&nodejs_semver::Version>| {
         exclude.is_some_and(|ex| match parsed {
             Some(v) => ex.matches(registry_name, v),
-            None => match node_semver::Version::parse(ver) {
+            None => match nodejs_semver::Version::parse(ver) {
                 Ok(v) => ex.matches(registry_name, &v),
                 Err(_) => ex.matches_name_only(registry_name),
             },
@@ -119,7 +119,7 @@ pub(crate) fn pick_version<'a>(
     cutoff: Option<&str>,
     exempt_cutoff: Option<&str>,
     strict: bool,
-    is_age_exempt: impl Fn(&str, Option<&node_semver::Version>) -> bool,
+    is_age_exempt: impl Fn(&str, Option<&nodejs_semver::Version>) -> bool,
 ) -> PickResult<'a> {
     // Handle dist-tag references. If the requested range is a tag
     // name and the packument has that tag, use the tagged version
@@ -132,7 +132,7 @@ pub(crate) fn pick_version<'a>(
     // npm and pnpm fall back to the highest non-prerelease version.
     // Do the same so `aube install foo` does not silently fail on a
     // packument that just happens to lack the tag.
-    let range = match node_semver::Range::parse(normalize_range(range_str)) {
+    let range = match nodejs_semver::Range::parse(normalize_range(range_str)) {
         Ok(r) => r,
         Err(_) => {
             // Reject protocol-prefixed ranges that survived workspace /
@@ -156,7 +156,7 @@ pub(crate) fn pick_version<'a>(
             } else {
                 return PickResult::NoMatch;
             };
-            match node_semver::Range::parse(normalize_range(&effective_range)) {
+            match nodejs_semver::Range::parse(normalize_range(&effective_range)) {
                 Ok(r) => r,
                 Err(_) => return PickResult::NoMatch,
             }
@@ -178,7 +178,7 @@ pub(crate) fn pick_version<'a>(
     // A version's effective cutoff: exempt versions answer to the
     // time-based wall (`exempt_cutoff`) only; everyone else answers to
     // the merged `cutoff`.
-    let passes_cutoff = |ver: &str, parsed: Option<&node_semver::Version>| -> bool {
+    let passes_cutoff = |ver: &str, parsed: Option<&nodejs_semver::Version>| -> bool {
         let effective = if is_age_exempt(ver, parsed) {
             exempt_cutoff
         } else {
@@ -189,7 +189,7 @@ pub(crate) fn pick_version<'a>(
 
     // Prefer locked version if it satisfies and clears the cutoff.
     if let Some(locked_ver) = locked
-        && let Ok(v) = node_semver::Version::parse(locked_ver)
+        && let Ok(v) = nodejs_semver::Version::parse(locked_ver)
         && v.satisfies(&range)
         && passes_cutoff(locked_ver, Some(&v))
         && let Some(meta) = packument.versions.get(locked_ver)
@@ -207,7 +207,7 @@ pub(crate) fn pick_version<'a>(
     // not the publisher's preferred build).
     if !pick_lowest
         && let Some(latest_ver) = packument.dist_tags.get("latest")
-        && let Ok(v) = node_semver::Version::parse(latest_ver)
+        && let Ok(v) = nodejs_semver::Version::parse(latest_ver)
         && v.satisfies(&range)
         && passes_cutoff(latest_ver, Some(&v))
         && let Some(meta) = packument.versions.get(latest_ver)
@@ -220,12 +220,12 @@ pub(crate) fn pick_version<'a>(
     // related, not a real "no match in range".
     let mut had_satisfying_but_age_gated = false;
 
-    let mut best: Option<(node_semver::Version, &'a aube_registry::VersionMetadata)> = None;
-    let mut fallback_lowest: Option<(node_semver::Version, &'a aube_registry::VersionMetadata)> =
+    let mut best: Option<(nodejs_semver::Version, &'a aube_registry::VersionMetadata)> = None;
+    let mut fallback_lowest: Option<(nodejs_semver::Version, &'a aube_registry::VersionMetadata)> =
         None;
 
     for (ver_str, meta) in &packument.versions {
-        let Ok(v) = node_semver::Version::parse(ver_str) else {
+        let Ok(v) = nodejs_semver::Version::parse(ver_str) else {
             continue;
         };
         if !v.satisfies(&range) {
@@ -327,9 +327,9 @@ fn looks_like_protocol_range(range_str: &str) -> bool {
 
 #[inline]
 pub(crate) fn highest_stable_version(packument: &Packument) -> Option<String> {
-    let mut best: Option<(node_semver::Version, String)> = None;
+    let mut best: Option<(nodejs_semver::Version, String)> = None;
     for key in packument.versions.keys() {
-        let Ok(v) = node_semver::Version::parse(key) else {
+        let Ok(v) = nodejs_semver::Version::parse(key) else {
             continue;
         };
         // Skip prereleases so we match npm semantics. Registry
@@ -374,7 +374,7 @@ pub(crate) fn version_satisfies(version: &str, range_str: &str) -> bool {
 }
 
 /// npm / pnpm / yarn all treat an empty or whitespace-only version
-/// range as equivalent to `"*"` (match any). `node_semver` rejects it
+/// range as equivalent to `"*"` (match any). `nodejs_semver` rejects it
 /// with `No valid ranges could be parsed`. Normalize here so the
 /// resolver and every `version_satisfies` caller agree with the
 /// upstream registry semantics. Real-world case: `hashring@0.0.8`
@@ -387,7 +387,7 @@ pub(crate) fn normalize_range(range_str: &str) -> &str {
     }
 }
 
-/// Thread-local `node_semver::Range` parse cache.
+/// Thread-local `nodejs_semver::Range` parse cache.
 ///
 /// Resolver hot loops (sibling dedupe, lockfile-reuse scan,
 /// peer-context fixed-point, catalog pick) call `version_satisfies`
@@ -399,15 +399,15 @@ pub(crate) fn normalize_range(range_str: &str) -> &str {
 /// slice of ranges, lock contention would erase the parse savings.
 /// Two workers parsing the same range twice is cheaper than one
 /// lock round-trip.
-fn with_cached_range<R>(range_str: &str, f: impl FnOnce(Option<&node_semver::Range>) -> R) -> R {
+fn with_cached_range<R>(range_str: &str, f: impl FnOnce(Option<&nodejs_semver::Range>) -> R) -> R {
     thread_local! {
-        static CACHE: std::cell::RefCell<crate::FxHashMap<String, Option<node_semver::Range>>> =
+        static CACHE: std::cell::RefCell<crate::FxHashMap<String, Option<nodejs_semver::Range>>> =
             std::cell::RefCell::default();
     }
     CACHE.with(|cell| {
         let mut map = cell.borrow_mut();
         if !map.contains_key(range_str) {
-            let parsed = node_semver::Range::parse(range_str).ok();
+            let parsed = nodejs_semver::Range::parse(range_str).ok();
             map.insert(range_str.to_string(), parsed);
         }
         f(map.get(range_str).and_then(Option::as_ref))
@@ -417,15 +417,15 @@ fn with_cached_range<R>(range_str: &str, f: impl FnOnce(Option<&node_semver::Ran
 // Mirrors with_cached_range. Locked-version side hits same string
 // thousands of times across peer-context + dedupe passes. Hit rate
 // trends to 1.0 after first BFS layer.
-fn with_cached_version<R>(version: &str, f: impl FnOnce(Option<&node_semver::Version>) -> R) -> R {
+fn with_cached_version<R>(version: &str, f: impl FnOnce(Option<&nodejs_semver::Version>) -> R) -> R {
     thread_local! {
-        static CACHE: std::cell::RefCell<crate::FxHashMap<String, Option<node_semver::Version>>> =
+        static CACHE: std::cell::RefCell<crate::FxHashMap<String, Option<nodejs_semver::Version>>> =
             std::cell::RefCell::default();
     }
     CACHE.with(|cell| {
         let mut map = cell.borrow_mut();
         if !map.contains_key(version) {
-            let parsed = node_semver::Version::parse(version).ok();
+            let parsed = nodejs_semver::Version::parse(version).ok();
             map.insert(version.to_string(), parsed);
         }
         f(map.get(version).and_then(Option::as_ref))

--- a/crates/aube-resolver/src/trust.rs
+++ b/crates/aube-resolver/src/trust.rs
@@ -187,7 +187,7 @@ pub fn check_no_downgrade(
     // block a stable that omits attestation.
     let exclude_prereleases = picked_parsed
         .as_ref()
-        .map(|v| v.pre_release.is_empty())
+        .map(|v| v.pre_release().is_empty())
         .unwrap_or(false);
 
     let mut best: Option<(TrustEvidence, &str)> = None;
@@ -203,7 +203,7 @@ pub fn check_no_downgrade(
         }
         if exclude_prereleases
             && let Ok(parsed) = nodejs_semver::Version::parse(other_ver)
-            && !parsed.pre_release.is_empty()
+            && !parsed.pre_release().is_empty()
         {
             continue;
         }

--- a/crates/aube-resolver/src/trust.rs
+++ b/crates/aube-resolver/src/trust.rs
@@ -144,7 +144,7 @@ pub fn check_no_downgrade(
     exclude: &TrustExcludeRules,
     ignore_after_minutes: Option<u64>,
 ) -> Result<(), TrustCheckError> {
-    let picked_parsed = node_semver::Version::parse(picked_version).ok();
+    let picked_parsed = nodejs_semver::Version::parse(picked_version).ok();
 
     if let Some(ref pv) = picked_parsed {
         if exclude.matches(&packument.name, pv) {
@@ -202,7 +202,7 @@ pub fn check_no_downgrade(
             continue;
         }
         if exclude_prereleases
-            && let Ok(parsed) = node_semver::Version::parse(other_ver)
+            && let Ok(parsed) = nodejs_semver::Version::parse(other_ver)
             && !parsed.pre_release.is_empty()
         {
             continue;
@@ -324,7 +324,7 @@ struct TrustExcludeRule {
     name_matcher: NameMatcher,
     /// `None` → rule matches every version of any name match.
     /// `Some(ranges)` → rule matches any version satisfying one range.
-    version_ranges: Option<Vec<node_semver::Range>>,
+    version_ranges: Option<Vec<nodejs_semver::Range>>,
 }
 
 #[derive(Debug, Clone)]
@@ -421,7 +421,7 @@ impl TrustExcludeRules {
         (Self { rules }, errors)
     }
 
-    pub(crate) fn matches(&self, name: &str, version: &node_semver::Version) -> bool {
+    pub(crate) fn matches(&self, name: &str, version: &nodejs_semver::Version) -> bool {
         for rule in &self.rules {
             if !rule.name_matcher.matches(name) {
                 continue;
@@ -483,7 +483,7 @@ fn parse_one(pattern: &str) -> Result<TrustExcludeRule, TrustExcludeParseError> 
                         pattern: pattern.to_string(),
                     });
                 }
-                let r = node_semver::Range::parse(trimmed).map_err(|_| {
+                let r = nodejs_semver::Range::parse(trimmed).map_err(|_| {
                     TrustExcludeParseError::InvalidVersionUnion {
                         pattern: pattern.to_string(),
                     }
@@ -1125,9 +1125,9 @@ mod tests {
     #[test]
     fn exclude_parses_name_only() {
         let r = TrustExcludeRules::parse(["foo"]).unwrap();
-        assert!(r.matches("foo", &node_semver::Version::parse("1.0.0").unwrap()));
-        assert!(r.matches("foo", &node_semver::Version::parse("99.0.0").unwrap()));
-        assert!(!r.matches("bar", &node_semver::Version::parse("1.0.0").unwrap()));
+        assert!(r.matches("foo", &nodejs_semver::Version::parse("1.0.0").unwrap()));
+        assert!(r.matches("foo", &nodejs_semver::Version::parse("99.0.0").unwrap()));
+        assert!(!r.matches("bar", &nodejs_semver::Version::parse("1.0.0").unwrap()));
     }
 
     #[test]
@@ -1144,11 +1144,11 @@ mod tests {
                 continue;
             }
             assert!(
-                r.matches(name, &node_semver::Version::parse("1.0.0").unwrap()),
+                r.matches(name, &nodejs_semver::Version::parse("1.0.0").unwrap()),
                 "{name} should be globally excluded"
             );
         }
-        assert!(!r.matches("left-pad", &node_semver::Version::parse("1.0.0").unwrap()));
+        assert!(!r.matches("left-pad", &nodejs_semver::Version::parse("1.0.0").unwrap()));
     }
 
     #[test]
@@ -1161,15 +1161,15 @@ mod tests {
         let r = TrustExcludeRules::default();
         assert!(r.matches(
             "@octokit/endpoint",
-            &node_semver::Version::parse("9.0.6").unwrap()
+            &nodejs_semver::Version::parse("9.0.6").unwrap()
         ));
         assert!(r.matches(
             "@octokit/endpoint",
-            &node_semver::Version::parse("10.1.0").unwrap()
+            &nodejs_semver::Version::parse("10.1.0").unwrap()
         ));
         assert!(!r.matches(
             "@octokit/core",
-            &node_semver::Version::parse("9.0.6").unwrap()
+            &nodejs_semver::Version::parse("9.0.6").unwrap()
         ));
     }
 
@@ -1181,35 +1181,35 @@ mod tests {
         let r = TrustExcludeRules::default();
         assert!(r.matches(
             "@hono/node-server",
-            &node_semver::Version::parse("1.19.15").unwrap()
+            &nodejs_semver::Version::parse("1.19.15").unwrap()
         ));
         // Every version, not just the 1.x line — the exclusion is
         // intentionally package-wide (see DEFAULT_TRUST_POLICY_EXCLUDES).
         assert!(r.matches(
             "@hono/node-server",
-            &node_semver::Version::parse("2.0.10").unwrap()
+            &nodejs_semver::Version::parse("2.0.10").unwrap()
         ));
         assert!(r.matches(
             "@hono/node-server",
-            &node_semver::Version::parse("2.1.0").unwrap()
+            &nodejs_semver::Version::parse("2.1.0").unwrap()
         ));
-        assert!(!r.matches("hono", &node_semver::Version::parse("1.19.15").unwrap()));
+        assert!(!r.matches("hono", &nodejs_semver::Version::parse("1.19.15").unwrap()));
     }
 
     #[test]
     fn exclude_parses_name_at_version() {
         let r = TrustExcludeRules::parse(["foo@1.0.0"]).unwrap();
-        assert!(r.matches("foo", &node_semver::Version::parse("1.0.0").unwrap()));
-        assert!(!r.matches("foo", &node_semver::Version::parse("1.0.1").unwrap()));
+        assert!(r.matches("foo", &nodejs_semver::Version::parse("1.0.0").unwrap()));
+        assert!(!r.matches("foo", &nodejs_semver::Version::parse("1.0.1").unwrap()));
     }
 
     #[test]
     fn exclude_parses_version_union() {
         let r = TrustExcludeRules::parse(["foo@1.0.0 || 2.0.0 || 3.0.0"]).unwrap();
-        assert!(r.matches("foo", &node_semver::Version::parse("1.0.0").unwrap()));
-        assert!(r.matches("foo", &node_semver::Version::parse("2.0.0").unwrap()));
-        assert!(r.matches("foo", &node_semver::Version::parse("3.0.0").unwrap()));
-        assert!(!r.matches("foo", &node_semver::Version::parse("4.0.0").unwrap()));
+        assert!(r.matches("foo", &nodejs_semver::Version::parse("1.0.0").unwrap()));
+        assert!(r.matches("foo", &nodejs_semver::Version::parse("2.0.0").unwrap()));
+        assert!(r.matches("foo", &nodejs_semver::Version::parse("3.0.0").unwrap()));
+        assert!(!r.matches("foo", &nodejs_semver::Version::parse("4.0.0").unwrap()));
     }
 
     #[test]
@@ -1217,11 +1217,11 @@ mod tests {
         let r = TrustExcludeRules::parse(["@babel/core@7.20.0"]).unwrap();
         assert!(r.matches(
             "@babel/core",
-            &node_semver::Version::parse("7.20.0").unwrap()
+            &nodejs_semver::Version::parse("7.20.0").unwrap()
         ));
         assert!(!r.matches(
             "@babel/core",
-            &node_semver::Version::parse("7.20.1").unwrap()
+            &nodejs_semver::Version::parse("7.20.1").unwrap()
         ));
     }
 
@@ -1230,32 +1230,32 @@ mod tests {
         let r = TrustExcludeRules::parse(["@babel/core"]).unwrap();
         assert!(r.matches(
             "@babel/core",
-            &node_semver::Version::parse("9.9.9").unwrap()
+            &nodejs_semver::Version::parse("9.9.9").unwrap()
         ));
     }
 
     #[test]
     fn exclude_parses_glob() {
         let r = TrustExcludeRules::parse(["is-*"]).unwrap();
-        assert!(r.matches("is-odd", &node_semver::Version::parse("1.0.0").unwrap()));
-        assert!(r.matches("is-even", &node_semver::Version::parse("1.0.0").unwrap()));
-        assert!(!r.matches("lodash", &node_semver::Version::parse("1.0.0").unwrap()));
+        assert!(r.matches("is-odd", &nodejs_semver::Version::parse("1.0.0").unwrap()));
+        assert!(r.matches("is-even", &nodejs_semver::Version::parse("1.0.0").unwrap()));
+        assert!(!r.matches("lodash", &nodejs_semver::Version::parse("1.0.0").unwrap()));
     }
 
     #[test]
     fn exclude_parses_star_matches_all() {
         let r = TrustExcludeRules::parse(["*"]).unwrap();
-        assert!(r.matches("anything", &node_semver::Version::parse("0.0.1").unwrap()));
+        assert!(r.matches("anything", &nodejs_semver::Version::parse("0.0.1").unwrap()));
     }
 
     #[test]
     fn exclude_parses_version_ranges() {
         let r = TrustExcludeRules::parse(["foo@^1.0.0 || ~2.1.0 || >=3.0.0 <4.0.0"]).unwrap();
-        assert!(r.matches("foo", &node_semver::Version::parse("1.2.3").unwrap()));
-        assert!(r.matches("foo", &node_semver::Version::parse("2.1.9").unwrap()));
-        assert!(r.matches("foo", &node_semver::Version::parse("3.5.0").unwrap()));
-        assert!(!r.matches("foo", &node_semver::Version::parse("2.2.0").unwrap()));
-        assert!(!r.matches("foo", &node_semver::Version::parse("4.0.0").unwrap()));
+        assert!(r.matches("foo", &nodejs_semver::Version::parse("1.2.3").unwrap()));
+        assert!(r.matches("foo", &nodejs_semver::Version::parse("2.1.9").unwrap()));
+        assert!(r.matches("foo", &nodejs_semver::Version::parse("3.5.0").unwrap()));
+        assert!(!r.matches("foo", &nodejs_semver::Version::parse("2.2.0").unwrap()));
+        assert!(!r.matches("foo", &nodejs_semver::Version::parse("4.0.0").unwrap()));
     }
 
     #[test]
@@ -1285,10 +1285,10 @@ mod tests {
             "is-*@nope",
         ]);
         // Two valid rules survive; two invalid surface as separate errors.
-        assert!(rules.matches("good", &node_semver::Version::parse("1.0.0").unwrap()));
+        assert!(rules.matches("good", &nodejs_semver::Version::parse("1.0.0").unwrap()));
         assert!(rules.matches(
             "@scope/also-good",
-            &node_semver::Version::parse("1.0.0").unwrap()
+            &nodejs_semver::Version::parse("1.0.0").unwrap()
         ));
         assert_eq!(errors.len(), 2, "two malformed entries reported");
     }
@@ -1297,6 +1297,6 @@ mod tests {
     fn exclude_skips_empty_patterns() {
         // npm config arrays sometimes include empty entries; ignore them.
         let r = TrustExcludeRules::parse(["", "foo", ""]).unwrap();
-        assert!(r.matches("foo", &node_semver::Version::parse("1.0.0").unwrap()));
+        assert!(r.matches("foo", &nodejs_semver::Version::parse("1.0.0").unwrap()));
     }
 }

--- a/crates/aube-runtime/Cargo.toml
+++ b/crates/aube-runtime/Cargo.toml
@@ -17,7 +17,7 @@ aube-util = { workspace = true }
 base64 = { workspace = true }
 flate2 = { workspace = true }
 hex = { workspace = true }
-node-semver = { workspace = true }
+nodejs-semver = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/aube-runtime/src/discover.rs
+++ b/crates/aube-runtime/src/discover.rs
@@ -24,7 +24,7 @@ impl InstallOrigin {
 /// A validated on-disk Node install.
 #[derive(Debug, Clone)]
 pub struct InstalledNode {
-    pub version: node_semver::Version,
+    pub version: nodejs_semver::Version,
     pub install_dir: PathBuf,
     /// The directory to prepend to PATH: `<dir>/bin` on unix, the
     /// install dir itself on Windows (node.exe sits at the root).
@@ -37,7 +37,7 @@ pub struct InstalledNode {
 /// and mise's installs dir. When both have the same version, aube's
 /// copy wins (deterministic, and it's the copy aube can manage).
 pub fn list_installed() -> Vec<InstalledNode> {
-    let mut by_version: BTreeMap<node_semver::Version, InstalledNode> = BTreeMap::new();
+    let mut by_version: BTreeMap<nodejs_semver::Version, InstalledNode> = BTreeMap::new();
     // Insert mise first so aube entries overwrite on version collision.
     if let Some(dir) = mise_node_installs_dir() {
         for node in scan_install_dir(&dir, InstallOrigin::Mise) {
@@ -96,7 +96,7 @@ fn scan_install_dir(root: &Path, origin: InstallOrigin) -> Vec<InstalledNode> {
         let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
             continue;
         };
-        let Ok(version) = node_semver::Version::parse(name.trim_start_matches('v')) else {
+        let Ok(version) = nodejs_semver::Version::parse(name.trim_start_matches('v')) else {
             continue;
         };
         if let Some(node) = validate_install(&path, version, origin) {
@@ -111,7 +111,7 @@ fn scan_install_dir(root: &Path, origin: InstallOrigin) -> Vec<InstalledNode> {
 /// (or one mise just created) through the exact same rules.
 pub(crate) fn validate_install(
     dir: &Path,
-    version: node_semver::Version,
+    version: nodejs_semver::Version,
     origin: InstallOrigin,
 ) -> Option<InstalledNode> {
     if dir.join("incomplete").exists() {
@@ -179,13 +179,13 @@ pub(crate) fn node_paths_in(dir: &Path) -> (PathBuf, PathBuf) {
 /// Find `node` on PATH and probe its version (`node --version`).
 /// Memoized for the process: one spawn no matter how many resolution
 /// calls happen.
-pub fn probe_path_node() -> Option<(node_semver::Version, PathBuf)> {
-    static PROBED: std::sync::OnceLock<Option<(node_semver::Version, PathBuf)>> =
+pub fn probe_path_node() -> Option<(nodejs_semver::Version, PathBuf)> {
+    static PROBED: std::sync::OnceLock<Option<(nodejs_semver::Version, PathBuf)>> =
         std::sync::OnceLock::new();
     PROBED.get_or_init(probe_path_node_uncached).clone()
 }
 
-fn probe_path_node_uncached() -> Option<(node_semver::Version, PathBuf)> {
+fn probe_path_node_uncached() -> Option<(nodejs_semver::Version, PathBuf)> {
     let exe = find_on_path(node_exe_name())?;
     let output = std::process::Command::new(&exe)
         .arg("--version")
@@ -195,7 +195,7 @@ fn probe_path_node_uncached() -> Option<(node_semver::Version, PathBuf)> {
         return None;
     }
     let raw = String::from_utf8(output.stdout).ok()?;
-    let version = node_semver::Version::parse(raw.trim().trim_start_matches('v')).ok()?;
+    let version = nodejs_semver::Version::parse(raw.trim().trim_start_matches('v')).ok()?;
     Some((version, exe))
 }
 

--- a/crates/aube-runtime/src/index.rs
+++ b/crates/aube-runtime/src/index.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 pub struct IndexEntry {
     /// `"v22.1.0"` in the raw feed; exposed parsed.
     #[serde(with = "v_prefixed_version")]
-    pub version: node_semver::Version,
+    pub version: nodejs_semver::Version,
     /// `false`, or the LTS codename (`"Jod"`).
     #[serde(default)]
     pub lts: LtsField,
@@ -52,13 +52,13 @@ impl LtsField {
 mod v_prefixed_version {
     use serde::{Deserialize, Deserializer, Serializer};
 
-    pub fn serialize<S: Serializer>(v: &node_semver::Version, ser: S) -> Result<S::Ok, S::Error> {
+    pub fn serialize<S: Serializer>(v: &nodejs_semver::Version, ser: S) -> Result<S::Ok, S::Error> {
         ser.serialize_str(&format!("v{v}"))
     }
 
-    pub fn deserialize<'de, D: Deserializer<'de>>(de: D) -> Result<node_semver::Version, D::Error> {
+    pub fn deserialize<'de, D: Deserializer<'de>>(de: D) -> Result<nodejs_semver::Version, D::Error> {
         let raw = String::deserialize(de)?;
-        node_semver::Version::parse(raw.trim_start_matches('v'))
+        nodejs_semver::Version::parse(raw.trim_start_matches('v'))
             .map_err(|e| serde::de::Error::custom(format!("bad version {raw:?}: {e}")))
     }
 }

--- a/crates/aube-runtime/src/installer.rs
+++ b/crates/aube-runtime/src/installer.rs
@@ -28,7 +28,7 @@ pub(crate) struct DownloadSpec {
 /// version is already present and valid.
 pub(crate) async fn install(
     http: &Http,
-    version: &node_semver::Version,
+    version: &nodejs_semver::Version,
     spec: &DownloadSpec,
     progress: &dyn DownloadProgress,
 ) -> Result<InstalledNode, Error> {
@@ -81,7 +81,7 @@ pub(crate) async fn install(
 
 async fn download_verify_extract(
     http: &Http,
-    version: &node_semver::Version,
+    version: &nodejs_semver::Version,
     spec: &DownloadSpec,
     dest: &Path,
     progress: &dyn DownloadProgress,

--- a/crates/aube-runtime/src/lib.rs
+++ b/crates/aube-runtime/src/lib.rs
@@ -122,7 +122,7 @@ impl RuntimeConfig {
 /// `aube_lockfile::RuntimePin`).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PinnedNode {
-    pub version: node_semver::Version,
+    pub version: nodejs_semver::Version,
     pub variants: Vec<PinnedVariant>,
 }
 

--- a/crates/aube-runtime/src/mise.rs
+++ b/crates/aube-runtime/src/mise.rs
@@ -26,7 +26,7 @@ pub fn mise_on_path() -> Option<PathBuf> {
 /// `install_tool_via_mise`).
 pub(crate) async fn install_via_mise(
     mise_bin: &std::path::Path,
-    version: &node_semver::Version,
+    version: &nodejs_semver::Version,
     progress: &dyn crate::progress::DownloadProgress,
 ) -> Result<InstalledNode, Error> {
     install_tool_via_mise(mise_bin, "node", version, progress).await?;
@@ -60,7 +60,7 @@ pub(crate) async fn install_via_mise(
 pub(crate) async fn install_tool_via_mise(
     mise_bin: &std::path::Path,
     tool: &str,
-    version: &node_semver::Version,
+    version: &nodejs_semver::Version,
     progress: &dyn crate::progress::DownloadProgress,
 ) -> Result<(), Error> {
     let spec = format!("{tool}@{version}");
@@ -96,7 +96,7 @@ pub(crate) async fn install_tool_via_mise(
 }
 
 /// Look up one exact version in mise's installs dir.
-pub(crate) fn find_mise_install(version: &node_semver::Version) -> Option<InstalledNode> {
+pub(crate) fn find_mise_install(version: &nodejs_semver::Version) -> Option<InstalledNode> {
     let dir = discover::mise_node_installs_dir()?.join(version.to_string());
     discover::validate_install(&dir, version.clone(), InstallOrigin::Mise)
 }

--- a/crates/aube-runtime/src/paths.rs
+++ b/crates/aube-runtime/src/paths.rs
@@ -35,7 +35,7 @@ pub fn runtime_dir() -> Option<PathBuf> {
 }
 
 /// The install dir for an exact version: `<runtime_dir>/24.1.0/`.
-pub fn install_dir(version: &node_semver::Version) -> Option<PathBuf> {
+pub fn install_dir(version: &nodejs_semver::Version) -> Option<PathBuf> {
     runtime_dir().map(|d| d.join(version.to_string()))
 }
 
@@ -82,7 +82,7 @@ pub(crate) fn index_cache_path(mirror_base: &str) -> Option<PathBuf> {
 /// `$XDG_CACHE_HOME/aube/node-shasums/origin-<sha256-16>/v24.1.0.txt`.
 pub(crate) fn shasums_cache_path(
     mirror_base: &str,
-    version: &node_semver::Version,
+    version: &nodejs_semver::Version,
 ) -> Option<PathBuf> {
     cache_dir().map(|d| {
         d.join("node-shasums")

--- a/crates/aube-runtime/src/platform.rs
+++ b/crates/aube-runtime/src/platform.rs
@@ -129,7 +129,7 @@ fn detect_musl() -> bool {
 
 /// The artifact filename for `version` on `platform`:
 /// `node-v22.1.0-darwin-arm64.tar.gz`.
-pub fn artifact_filename(version: &node_semver::Version, platform: &Platform) -> String {
+pub fn artifact_filename(version: &nodejs_semver::Version, platform: &Platform) -> String {
     format!(
         "node-v{version}-{}.{}",
         platform.dist_slug(),
@@ -139,7 +139,7 @@ pub fn artifact_filename(version: &node_semver::Version, platform: &Platform) ->
 
 /// The top-level directory inside an artifact:
 /// `node-v22.1.0-darwin-arm64`.
-pub fn artifact_top_dir(version: &node_semver::Version, platform: &Platform) -> String {
+pub fn artifact_top_dir(version: &nodejs_semver::Version, platform: &Platform) -> String {
     format!("node-v{version}-{}", platform.dist_slug())
 }
 
@@ -203,7 +203,7 @@ mod tests {
 
     #[test]
     fn artifact_names() {
-        let v: node_semver::Version = "22.1.0".parse().unwrap();
+        let v: nodejs_semver::Version = "22.1.0".parse().unwrap();
         assert_eq!(
             artifact_filename(&v, &plat("win32", "x64", None)),
             "node-v22.1.0-win-x64.zip"

--- a/crates/aube-runtime/src/progress.rs
+++ b/crates/aube-runtime/src/progress.rs
@@ -13,7 +13,7 @@ pub enum InstallPhase {
 pub trait DownloadProgress: Send + Sync {
     /// `version` is `None` during [`InstallPhase::Resolving`] — the
     /// exact version isn't known until resolution finishes.
-    fn on_phase(&self, _version: Option<&node_semver::Version>, _phase: InstallPhase) {}
+    fn on_phase(&self, _version: Option<&nodejs_semver::Version>, _phase: InstallPhase) {}
     fn on_download_start(&self, _total_bytes: Option<u64>) {}
     fn on_download_chunk(&self, _bytes: u64) {}
     fn on_done(&self) {}

--- a/crates/aube-runtime/src/resolver.rs
+++ b/crates/aube-runtime/src/resolver.rs
@@ -33,7 +33,7 @@ pub enum ResolvedFrom {
 /// A successfully resolved runtime.
 #[derive(Debug, Clone)]
 pub struct Resolution {
-    pub version: node_semver::Version,
+    pub version: nodejs_semver::Version,
     /// Directory to prepend to PATH. `None` for [`ResolvedFrom::PathEnv`].
     pub bin_dir: Option<PathBuf>,
     pub node_bin: PathBuf,
@@ -251,7 +251,7 @@ impl NodeRuntime {
 
     async fn install(
         &self,
-        version: &node_semver::Version,
+        version: &nodejs_semver::Version,
         download: &DownloadSpec,
         progress: &dyn DownloadProgress,
     ) -> Result<InstalledNode, Error> {
@@ -320,7 +320,7 @@ impl NodeRuntime {
     /// configured mirror's checksums, plus — when running against the
     /// default official mirror — unofficial-builds' musl checksums,
     /// best-effort (older releases have no musl builds).
-    async fn build_full_pin(&self, version: &node_semver::Version) -> Result<PinnedNode, Error> {
+    async fn build_full_pin(&self, version: &nodejs_semver::Version) -> Result<PinnedNode, Error> {
         let base = self.cfg.mirror_base();
         let sums = shasums::load_shasums(&self.http, &self.cfg, &base, version).await?;
         let mut variants = variants_from_shasums(&base, version, sums.iter());
@@ -387,7 +387,7 @@ fn local_resolution(target: &NodeSpec) -> Option<Resolution> {
 /// `win` → `win32`, bin paths per OS, `prefix` set for zips.
 fn variants_from_shasums<'a>(
     base: &str,
-    version: &node_semver::Version,
+    version: &nodejs_semver::Version,
     entries: impl Iterator<Item = (&'a String, &'a [u8; 32])>,
 ) -> Vec<PinnedVariant> {
     let prefix = format!("node-v{version}-");
@@ -455,7 +455,7 @@ mod tests {
 
     #[test]
     fn shasums_variant_mapping() {
-        let version: node_semver::Version = "24.4.1".parse().unwrap();
+        let version: nodejs_semver::Version = "24.4.1".parse().unwrap();
         let entries: Vec<(String, [u8; 32])> = vec![
             ("node-v24.4.1-darwin-arm64.tar.gz".into(), [1; 32]),
             ("node-v24.4.1-linux-x64.tar.gz".into(), [2; 32]),

--- a/crates/aube-runtime/src/self_install.rs
+++ b/crates/aube-runtime/src/self_install.rs
@@ -46,7 +46,7 @@ const VERSION_URL: &str = "https://aube.jdx.dev/VERSION";
 /// A validated on-disk aube install.
 #[derive(Debug, Clone)]
 pub struct InstalledAube {
-    pub version: node_semver::Version,
+    pub version: nodejs_semver::Version,
     pub install_dir: PathBuf,
     /// The `aube` executable. `aubr` / `aubx` siblings live next to it.
     pub exe: PathBuf,
@@ -74,7 +74,7 @@ pub fn self_dir() -> Option<PathBuf> {
 /// self dir. Same collision rule as Node: aube's own copy of a
 /// version wins over mise's.
 pub fn list_installed_aube() -> Vec<InstalledAube> {
-    let mut by_version: std::collections::BTreeMap<node_semver::Version, InstalledAube> =
+    let mut by_version: std::collections::BTreeMap<nodejs_semver::Version, InstalledAube> =
         Default::default();
     if let Some(dir) = discover::mise_tool_installs_dir("aube") {
         for install in scan_aube_dir(&dir, InstallOrigin::Mise) {
@@ -91,7 +91,7 @@ pub fn list_installed_aube() -> Vec<InstalledAube> {
 
 /// Look up one exact installed version (mise first, then self dir —
 /// the self-dir copy wins, mirroring `list_installed_aube`).
-pub fn find_installed_aube(version: &node_semver::Version) -> Option<InstalledAube> {
+pub fn find_installed_aube(version: &nodejs_semver::Version) -> Option<InstalledAube> {
     let from_self = self_dir()
         .map(|d| d.join(version.to_string()))
         .and_then(|d| validate_aube_install(&d, version.clone(), InstallOrigin::Aube));
@@ -119,7 +119,7 @@ fn scan_aube_dir(root: &Path, origin: InstallOrigin) -> Vec<InstalledAube> {
         let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
             continue;
         };
-        let Ok(version) = node_semver::Version::parse(name.trim_start_matches('v')) else {
+        let Ok(version) = nodejs_semver::Version::parse(name.trim_start_matches('v')) else {
             continue;
         };
         if let Some(install) = validate_aube_install(&path, version, origin) {
@@ -135,7 +135,7 @@ fn scan_aube_dir(root: &Path, origin: InstallOrigin) -> Vec<InstalledAube> {
 /// alternative packagings).
 fn validate_aube_install(
     dir: &Path,
-    version: node_semver::Version,
+    version: nodejs_semver::Version,
     origin: InstallOrigin,
 ) -> Option<InstalledAube> {
     if dir.join("incomplete").exists() {
@@ -232,14 +232,14 @@ fn versions_host() -> String {
 /// plaintext list — CDN-cached, no rate limits; the
 /// `aube.jdx.dev/VERSION` latest-only announcement is the fallback,
 /// degrading range resolution to "newest release" rather than failing.
-pub async fn available_aube_versions(retries: u32) -> Result<Vec<node_semver::Version>, Error> {
+pub async fn available_aube_versions(retries: u32) -> Result<Vec<nodejs_semver::Version>, Error> {
     let http = Http::new(retries);
     let list_url = format!("{}/aube", versions_host());
     match fetch_text(&http, &list_url).await {
         Ok(text) => {
-            let versions: Vec<node_semver::Version> = text
+            let versions: Vec<nodejs_semver::Version> = text
                 .lines()
-                .filter_map(|l| node_semver::Version::parse(l.trim().trim_start_matches('v')).ok())
+                .filter_map(|l| nodejs_semver::Version::parse(l.trim().trim_start_matches('v')).ok())
                 .collect();
             if !versions.is_empty() {
                 return Ok(versions);
@@ -255,7 +255,7 @@ pub async fn available_aube_versions(retries: u32) -> Result<Vec<node_semver::Ve
         .filter(|s| !s.trim().is_empty())
         .unwrap_or_else(|| VERSION_URL.to_string());
     let text = fetch_text(&http, &url).await?;
-    let latest = node_semver::Version::parse(text.trim().trim_start_matches('v')).map_err(|e| {
+    let latest = nodejs_semver::Version::parse(text.trim().trim_start_matches('v')).map_err(|e| {
         Error::DownloadFailed {
             url,
             reason: format!("unparseable version announcement: {e}"),
@@ -281,7 +281,7 @@ async fn fetch_text(http: &Http, url: &str) -> Result<String, Error> {
 /// users), self-download from GitHub releases otherwise.
 pub async fn install_aube(
     cfg: &RuntimeConfig,
-    version: &node_semver::Version,
+    version: &nodejs_semver::Version,
     progress: &dyn DownloadProgress,
 ) -> Result<InstalledAube, Error> {
     if let Some(existing) = find_installed_aube(version) {
@@ -317,7 +317,7 @@ pub async fn install_aube(
 
 async fn delegate_to_mise(
     mise_bin: &Path,
-    version: &node_semver::Version,
+    version: &nodejs_semver::Version,
     progress: &dyn DownloadProgress,
 ) -> Result<InstalledAube, Error> {
     mise::install_tool_via_mise(mise_bin, "aube", version, progress).await?;
@@ -338,7 +338,7 @@ async fn delegate_to_mise(
 /// archive root — and atomically publish.
 async fn self_download(
     cfg: &RuntimeConfig,
-    version: &node_semver::Version,
+    version: &nodejs_semver::Version,
     progress: &dyn DownloadProgress,
 ) -> Result<InstalledAube, Error> {
     let root = self_dir().ok_or_else(|| {
@@ -468,7 +468,7 @@ async fn self_download(
 /// failing a download GitHub itself already served over TLS.
 async fn fetch_release_digest(
     http: &Http,
-    version: &node_semver::Version,
+    version: &nodejs_semver::Version,
     archive_name: &str,
 ) -> Option<[u8; 32]> {
     let api_override = aube_util::env::embedder_env("SELF_API_BASE")
@@ -525,7 +525,7 @@ async fn digest_from_release_json(
     http: &Http,
     url: &str,
     bearer: Option<&str>,
-    version: &node_semver::Version,
+    version: &nodejs_semver::Version,
     archive_name: &str,
 ) -> Option<[u8; 32]> {
     let resp = http

--- a/crates/aube-runtime/src/shasums.rs
+++ b/crates/aube-runtime/src/shasums.rs
@@ -65,7 +65,7 @@ pub(crate) async fn load_shasums(
     http: &Http,
     cfg: &RuntimeConfig,
     base: &str,
-    version: &node_semver::Version,
+    version: &nodejs_semver::Version,
 ) -> Result<Shasums, Error> {
     let cache_path = paths::shasums_cache_path(base, version);
     if let Some(text) = cache_path

--- a/crates/aube-runtime/src/spec.rs
+++ b/crates/aube-runtime/src/spec.rs
@@ -7,8 +7,8 @@ use crate::error::Error;
 /// A parsed Node version request.
 #[derive(Debug, Clone, PartialEq)]
 pub enum NodeSpec {
-    Exact(node_semver::Version),
-    Range(node_semver::Range),
+    Exact(nodejs_semver::Version),
+    Range(nodejs_semver::Range),
     /// Newest LTS release (`lts`, `lts/*`).
     Lts,
     /// Newest release of any kind (`latest`, `current`, `node`).
@@ -39,10 +39,10 @@ impl NodeSpec {
             });
         }
         let unprefixed = s.strip_prefix('v').unwrap_or(s);
-        if let Ok(v) = node_semver::Version::parse(unprefixed) {
+        if let Ok(v) = nodejs_semver::Version::parse(unprefixed) {
             return Ok(NodeSpec::Exact(v));
         }
-        if let Ok(r) = node_semver::Range::parse(unprefixed) {
+        if let Ok(r) = nodejs_semver::Range::parse(unprefixed) {
             return Ok(NodeSpec::Range(r));
         }
         // Bare alphabetic word → treat as an LTS codename (`jod`,
@@ -61,7 +61,7 @@ impl NodeSpec {
     /// vocabulary that are decidable without the dist index. `Lts` /
     /// `Latest` / codenames return `None` — satisfaction depends on
     /// index data the caller may not have.
-    pub fn satisfied_by(&self, version: &node_semver::Version) -> Option<bool> {
+    pub fn satisfied_by(&self, version: &nodejs_semver::Version) -> Option<bool> {
         match self {
             NodeSpec::Exact(v) => Some(v == version),
             NodeSpec::Range(r) => Some(version.satisfies(r)),
@@ -181,7 +181,7 @@ mod tests {
 
     #[test]
     fn local_satisfaction() {
-        let v: node_semver::Version = "22.3.0".parse().unwrap();
+        let v: nodejs_semver::Version = "22.3.0".parse().unwrap();
         assert_eq!(parse("^22").satisfied_by(&v), Some(true));
         assert_eq!(parse("^20").satisfied_by(&v), Some(false));
         assert_eq!(parse("22.3.0").satisfied_by(&v), Some(true));
@@ -192,7 +192,7 @@ mod tests {
     #[test]
     fn bare_number_is_a_range() {
         // "22" must match every 22.x.y, not just 22.0.0.
-        let v: node_semver::Version = "22.9.1".parse().unwrap();
+        let v: nodejs_semver::Version = "22.9.1".parse().unwrap();
         assert_eq!(parse("22").satisfied_by(&v), Some(true));
     }
 }

--- a/crates/aube/Cargo.toml
+++ b/crates/aube/Cargo.toml
@@ -91,7 +91,7 @@ tracing-subscriber = { workspace = true }
 flate2 = { workspace = true, features = ["zlib-ng"] }
 glob = { workspace = true }
 ignore = { workspace = true }
-node-semver = { workspace = true }
+nodejs-semver = { workspace = true }
 rayon = { workspace = true }
 tar = { workspace = true }
 tempfile = "3"

--- a/crates/aube/src/commands/add/manifest.rs
+++ b/crates/aube/src/commands/add/manifest.rs
@@ -219,8 +219,8 @@ pub(super) async fn update_manifest_for_add(
             // dist-tag never blocks a workspace match.
             if spec.has_explicit_range
                 && let (Ok(parsed_version), Ok(parsed_range)) = (
-                    node_semver::Version::parse(version),
-                    node_semver::Range::parse(&spec.range),
+                    nodejs_semver::Version::parse(version),
+                    nodejs_semver::Range::parse(&spec.range),
                 )
                 && !parsed_version.satisfies(&parsed_range)
             {

--- a/crates/aube/src/commands/add/supply_chain.rs
+++ b/crates/aube/src/commands/add/supply_chain.rs
@@ -133,7 +133,7 @@ fn is_full_exact_version(range: &str) -> bool {
     [major, minor, patch]
         .into_iter()
         .all(|part| !part.is_empty() && part.bytes().all(|b| b.is_ascii_digit()))
-        && node_semver::Version::parse(range).is_ok()
+        && nodejs_semver::Version::parse(range).is_ok()
 }
 
 #[cfg(test)]

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -929,10 +929,10 @@ fn spec_range(spec: &str) -> &str {
 }
 
 fn spec_satisfies_version(spec: &str, version: &str) -> bool {
-    let Ok(version) = node_semver::Version::parse(version) else {
+    let Ok(version) = nodejs_semver::Version::parse(version) else {
         return false;
     };
-    node_semver::Range::parse(spec_range(spec))
+    nodejs_semver::Range::parse(spec_range(spec))
         .ok()
         .is_some_and(|range| version.satisfies(&range))
 }
@@ -989,24 +989,24 @@ fn resolved_versions_by_name(
 }
 
 fn version_is_vulnerable(version: &str, vulnerable_versions: &[String]) -> bool {
-    let Ok(version) = node_semver::Version::parse(version) else {
+    let Ok(version) = nodejs_semver::Version::parse(version) else {
         return false;
     };
     vulnerable_versions
         .iter()
-        .filter_map(|range| node_semver::Range::parse(range).ok())
+        .filter_map(|range| nodejs_semver::Range::parse(range).ok())
         .any(|range| version.satisfies(&range))
 }
 
 /// Atomic package.json write via tempfile + rename. Crash or Ctrl+C
 fn best_non_vulnerable(packument: &Packument, vulnerable_versions: &[String]) -> Option<String> {
-    let vulnerable: Vec<node_semver::Range> = vulnerable_versions
+    let vulnerable: Vec<nodejs_semver::Range> = vulnerable_versions
         .iter()
-        .filter_map(|range| node_semver::Range::parse(range).ok())
+        .filter_map(|range| nodejs_semver::Range::parse(range).ok())
         .collect();
-    let mut best: Option<(&str, node_semver::Version)> = None;
+    let mut best: Option<(&str, nodejs_semver::Version)> = None;
     for ver_str in packument.versions.keys() {
-        let Ok(version) = node_semver::Version::parse(ver_str) else {
+        let Ok(version) = nodejs_semver::Version::parse(ver_str) else {
             continue;
         };
         if !version.pre_release.is_empty() {

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -1009,7 +1009,7 @@ fn best_non_vulnerable(packument: &Packument, vulnerable_versions: &[String]) ->
         let Ok(version) = nodejs_semver::Version::parse(ver_str) else {
             continue;
         };
-        if !version.pre_release.is_empty() {
+        if !version.pre_release().is_empty() {
             continue;
         }
         if vulnerable.iter().any(|range| version.satisfies(range)) {

--- a/crates/aube/src/commands/cache.rs
+++ b/crates/aube/src/commands/cache.rs
@@ -328,7 +328,7 @@ fn highest_semver<'a, I: IntoIterator<Item = &'a str>>(versions: I) -> Option<St
     let all: Vec<&str> = versions.into_iter().collect();
     let parsed_max = all
         .iter()
-        .filter_map(|v| node_semver::Version::parse(v).ok().map(|p| (p, *v)))
+        .filter_map(|v| nodejs_semver::Version::parse(v).ok().map(|p| (p, *v)))
         .max_by(|a, b| a.0.cmp(&b.0))
         .map(|(_, s)| s.to_string());
     parsed_max.or_else(|| all.iter().max().map(|s| s.to_string()))

--- a/crates/aube/src/commands/catalogs.rs
+++ b/crates/aube/src/commands/catalogs.rs
@@ -109,10 +109,10 @@ pub(crate) fn range_compatible(
     if user_range == catalog_range {
         return true;
     }
-    let Ok(catalog_parsed) = node_semver::Range::parse(catalog_range) else {
+    let Ok(catalog_parsed) = nodejs_semver::Range::parse(catalog_range) else {
         return false;
     };
-    let Ok(version) = node_semver::Version::parse(resolved_version) else {
+    let Ok(version) = nodejs_semver::Version::parse(resolved_version) else {
         return false;
     };
     version.satisfies(&catalog_parsed)

--- a/crates/aube/src/commands/deprecate.rs
+++ b/crates/aube/src/commands/deprecate.rs
@@ -97,13 +97,13 @@ pub async fn apply(
         .and_then(Value::as_object_mut)
         .ok_or_else(|| miette!("registry response for {name} has no `versions` field"))?;
 
-    let range_parsed = node_semver::Range::parse(range)
+    let range_parsed = nodejs_semver::Range::parse(range)
         .into_diagnostic()
         .wrap_err_with(|| format!("invalid version range {range:?}"))?;
 
     let mut matched: Vec<String> = Vec::new();
     for (version_str, entry) in versions_obj.iter_mut() {
-        let Ok(v) = node_semver::Version::parse(version_str) else {
+        let Ok(v) = nodejs_semver::Version::parse(version_str) else {
             continue;
         };
         if !range_parsed.satisfies(&v) {

--- a/crates/aube/src/commands/doctor.rs
+++ b/crates/aube/src/commands/doctor.rs
@@ -238,8 +238,8 @@ fn project_section(anchor: &Path, report: &mut Report) -> Section {
                 && let Some(node) = crate::engines::effective_node_version(None)
             {
                 match (
-                    node_semver::Version::parse(&node),
-                    node_semver::Range::parse(range),
+                    nodejs_semver::Version::parse(&node),
+                    nodejs_semver::Range::parse(range),
                 ) {
                     (Ok(v), Ok(r)) if !v.satisfies(&r) => {
                         report.errors.push(format!(

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -1128,7 +1128,7 @@ impl PeerDependencyRules {
             self.allowed_versions.get(&scoped_key),
             self.allowed_versions.get(peer),
         ];
-        let Ok(found_v) = node_semver::Version::parse(found) else {
+        let Ok(found_v) = nodejs_semver::Version::parse(found) else {
             return false;
         };
         candidates
@@ -1138,8 +1138,8 @@ impl PeerDependencyRules {
     }
 }
 
-fn matches_range(range: &str, found: &node_semver::Version) -> bool {
-    match node_semver::Range::parse(range) {
+fn matches_range(range: &str, found: &nodejs_semver::Version) -> bool {
+    match nodejs_semver::Range::parse(range) {
         Ok(r) => r.satisfies(found),
         Err(_) => false,
     }

--- a/crates/aube/src/commands/outdated.rs
+++ b/crates/aube/src/commands/outdated.rs
@@ -544,10 +544,10 @@ fn colorize_diff(current: &str, target: &str, width: usize) -> String {
     if current == target {
         return plain;
     }
-    let Ok(cur) = node_semver::Version::parse(current) else {
+    let Ok(cur) = nodejs_semver::Version::parse(current) else {
         return plain;
     };
-    let Ok(new) = node_semver::Version::parse(target) else {
+    let Ok(new) = nodejs_semver::Version::parse(target) else {
         return plain;
     };
     let trailing_pad = " ".repeat(width.saturating_sub(target.len()));

--- a/crates/aube/src/commands/outdated.rs
+++ b/crates/aube/src/commands/outdated.rs
@@ -555,18 +555,18 @@ fn colorize_diff(current: &str, target: &str, width: usize) -> String {
     // every component to the right is also "new" and gets the same
     // color so a `1.2.3 → 2.0.0` major bump highlights the whole
     // tail, not just the leading `2`.
-    let head_color = if cur.major != new.major {
+    let head_color = if cur.major() != new.major() {
         SemverDiff::Major
-    } else if cur.minor != new.minor {
+    } else if cur.minor() != new.minor() {
         SemverDiff::Minor
-    } else if cur.patch != new.patch {
+    } else if cur.patch() != new.patch() {
         SemverDiff::Patch
     } else {
         SemverDiff::Prerelease
     };
-    let core = format!("{}.{}.{}", new.major, new.minor, new.patch);
-    let prerelease = if !new.pre_release.is_empty() {
-        let parts: Vec<String> = new.pre_release.iter().map(|p| p.to_string()).collect();
+    let core = format!("{}.{}.{}", new.major(), new.minor(), new.patch());
+    let prerelease = if !new.pre_release().is_empty() {
+        let parts: Vec<String> = new.pre_release().iter().map(|p| p.to_string()).collect();
         format!("-{}", parts.join("."))
     } else {
         String::new()
@@ -577,8 +577,8 @@ fn colorize_diff(current: &str, target: &str, width: usize) -> String {
     // `MAJOR.MINOR.PATCH` plain and color the `-rc.x` tail.
     let split_at = match head_color {
         SemverDiff::Major => 0,
-        SemverDiff::Minor => format!("{}.", new.major).len(),
-        SemverDiff::Patch => format!("{}.{}.", new.major, new.minor).len(),
+        SemverDiff::Minor => format!("{}.", new.major()).len(),
+        SemverDiff::Patch => format!("{}.{}.", new.major(), new.minor()).len(),
         SemverDiff::Prerelease => core.len(),
     };
     let (head, tail_in_core) = core.split_at(split_at.min(core.len()));

--- a/crates/aube/src/commands/package_spec.rs
+++ b/crates/aube/src/commands/package_spec.rs
@@ -11,10 +11,10 @@ pub(crate) fn max_satisfying_version(
     packument: &aube_registry::Packument,
     range_str: &str,
 ) -> Option<String> {
-    let range = node_semver::Range::parse(range_str).ok()?;
-    let mut best: Option<(&str, node_semver::Version)> = None;
+    let range = nodejs_semver::Range::parse(range_str).ok()?;
+    let mut best: Option<(&str, nodejs_semver::Version)> = None;
     for ver_str in packument.versions.keys() {
-        let Ok(v) = node_semver::Version::parse(ver_str) else {
+        let Ok(v) = nodejs_semver::Version::parse(ver_str) else {
             continue;
         };
         if !v.satisfies(&range) {
@@ -59,11 +59,11 @@ pub(crate) fn resolve_version(packument: &serde_json::Value, spec: Option<&str>)
         return Some(spec.to_string());
     }
 
-    let range: node_semver::Range = spec.parse().ok()?;
+    let range: nodejs_semver::Range = spec.parse().ok()?;
     versions
         .keys()
         .filter_map(|v| {
-            v.parse::<node_semver::Version>()
+            v.parse::<nodejs_semver::Version>()
                 .ok()
                 .filter(|parsed| parsed.satisfies(&range))
                 .map(|parsed| (v.clone(), parsed))

--- a/crates/aube/src/commands/peers.rs
+++ b/crates/aube/src/commands/peers.rs
@@ -132,8 +132,8 @@ fn collect_issues(graph: &LockfileGraph) -> Vec<Issue> {
                 Some(tail) => {
                     let version_str = tail.split_once('(').map(|(v, _)| v).unwrap_or(tail);
                     match (
-                        node_semver::Version::parse(version_str),
-                        node_semver::Range::parse(peer_range),
+                        nodejs_semver::Version::parse(version_str),
+                        nodejs_semver::Range::parse(peer_range),
                     ) {
                         (Ok(v), Ok(r)) if v.satisfies(&r) => {}
                         (Ok(_), Ok(_)) => out.push(Issue {

--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -623,7 +623,7 @@ fn build_archive_for_publish(pkg_dir: &Path) -> miette::Result<BuiltArchive> {
 }
 
 fn normalize_publish_version(version: &str) -> String {
-    node_semver::Version::parse(version)
+    nodejs_semver::Version::parse(version)
         .map(|v| v.to_string())
         .unwrap_or_else(|_| version.to_string())
 }

--- a/crates/aube/src/commands/runtime.rs
+++ b/crates/aube/src/commands/runtime.rs
@@ -186,7 +186,7 @@ async fn run_set_global(
 
     // aube-managed global install: fetch into the runtime dir and tell
     // the user how to reach it directly or through opt-in activation.
-    let version: node_semver::Version = resolved.parse().into_diagnostic()?;
+    let version: nodejs_semver::Version = resolved.parse().into_diagnostic()?;
     let cfg = aube_runtime::RuntimeConfig {
         installer: aube_runtime::InstallerMode::Aube,
         mirror: settings.mirror.clone(),

--- a/crates/aube/src/commands/unpublish.rs
+++ b/crates/aube/src/commands/unpublish.rs
@@ -419,7 +419,7 @@ fn highest_semver(versions: &[String]) -> Option<String> {
     versions
         .iter()
         .filter_map(|v| {
-            node_semver::Version::parse(v)
+            nodejs_semver::Version::parse(v)
                 .ok()
                 .map(|parsed| (parsed, v))
         })

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -392,11 +392,11 @@ pub async fn run(
             // `latest`: the manifest pin (if exact) and the locked version
             // (if any). Either tipping above latest is enough to preserve.
             let manifest_pin =
-                exact_pin_version(original).and_then(|p| node_semver::Version::parse(p).ok());
+                exact_pin_version(original).and_then(|p| nodejs_semver::Version::parse(p).ok());
             let locked_pin = existing
                 .as_ref()
                 .and_then(|g| lookup_pkg(g, &existing_importers, key, &real_name))
-                .and_then(|p| node_semver::Version::parse(&p.version).ok());
+                .and_then(|p| nodejs_semver::Version::parse(&p.version).ok());
             if manifest_pin.is_none() && locked_pin.is_none() {
                 continue;
             }
@@ -421,7 +421,7 @@ pub async fn run(
                     }
                 };
                 let latest_v = packument.dist_tags.get("latest")?;
-                let Ok(parsed_latest) = node_semver::Version::parse(latest_v) else {
+                let Ok(parsed_latest) = nodejs_semver::Version::parse(latest_v) else {
                     tracing::warn!(
                         code = aube_codes::warnings::WARN_AUBE_PRERELEASE_CHECK_SKIPPED,
                         "skipping prerelease-preservation check for {real_name}: \

--- a/crates/aube/src/commands/version.rs
+++ b/crates/aube/src/commands/version.rs
@@ -327,13 +327,13 @@ fn compute_new_version(current: &str, bump: &str, preid: Option<&str>) -> miette
         // prerelease instead of incrementing. Going through those helpers
         // would leave e.g. `premajor` of `2.0.0-rc.0` as `2.0.0-0` rather
         // than the npm-matching `3.0.0-0`.
-        "premajor" => prerelease_of(Version::new(current_ver.major + 1, 0, 0), preid),
+        "premajor" => prerelease_of(Version::new(current_ver.major() + 1, 0, 0), preid),
         "preminor" => prerelease_of(
-            Version::new(current_ver.major, current_ver.minor + 1, 0),
+            Version::new(current_ver.major(), current_ver.minor() + 1, 0),
             preid,
         ),
         "prepatch" => prerelease_of(
-            Version::new(current_ver.major, current_ver.minor, current_ver.patch + 1),
+            Version::new(current_ver.major(), current_ver.minor(), current_ver.patch() + 1),
             preid,
         ),
         "prerelease" => bump_prerelease(&current_ver, preid),
@@ -348,32 +348,32 @@ fn bump_major(v: &Version) -> Version {
     // If the current version has a prerelease and the core is already
     // bumped (minor=0, patch=0), the release drops the prerelease without
     // advancing the major. Mirrors npm's `inc('major')`.
-    if v.minor == 0 && v.patch == 0 && v.is_prerelease() {
-        Version::new(v.major, 0, 0)
+    if v.minor() == 0 && v.patch() == 0 && v.is_prerelease() {
+        Version::new(v.major(), 0, 0)
     } else {
-        Version::new(v.major + 1, 0, 0)
+        Version::new(v.major() + 1, 0, 0)
     }
 }
 
 fn bump_minor(v: &Version) -> Version {
-    if v.patch == 0 && v.is_prerelease() {
-        Version::new(v.major, v.minor, 0)
+    if v.patch() == 0 && v.is_prerelease() {
+        Version::new(v.major(), v.minor(), 0)
     } else {
-        Version::new(v.major, v.minor + 1, 0)
+        Version::new(v.major(), v.minor() + 1, 0)
     }
 }
 
 fn bump_patch(v: &Version) -> Version {
     if v.is_prerelease() {
-        Version::new(v.major, v.minor, v.patch)
+        Version::new(v.major(), v.minor(), v.patch())
     } else {
-        Version::new(v.major, v.minor, v.patch + 1)
+        Version::new(v.major(), v.minor(), v.patch() + 1)
     }
 }
 
 fn prerelease_of(core: Version, preid: Option<&str>) -> Version {
     let mut out = core;
-    out.pre_release = initial_prerelease(preid);
+    out.pre_release() = initial_prerelease(preid);
     out
 }
 
@@ -395,37 +395,37 @@ fn bump_prerelease(current: &Version, preid: Option<&str>) -> Version {
         if let Some(id) = preid
             && !id.is_empty()
         {
-            let current_preid = current.pre_release.first().and_then(|ident| match ident {
+            let current_preid = current.pre_release().first().and_then(|ident| match ident {
                 Identifier::AlphaNumeric(s) => Some(s.as_str()),
                 Identifier::Numeric(_) => None,
             });
             if current_preid != Some(id) {
                 return Version {
-                    major: current.major,
-                    minor: current.minor,
-                    patch: current.patch,
+                    major: current.major(),
+                    minor: current.minor(),
+                    patch: current.patch(),
                     build: Vec::new(),
                     pre_release: initial_prerelease(Some(id)),
                 };
             }
         }
         let mut out = Version {
-            major: current.major,
-            minor: current.minor,
-            patch: current.patch,
+            major: current.major(),
+            minor: current.minor(),
+            patch: current.patch(),
             build: Vec::new(),
-            pre_release: current.pre_release.clone(),
+            pre_release: current.pre_release().clone(),
         };
-        if let Some(Identifier::Numeric(n)) = out.pre_release.last().cloned() {
-            *out.pre_release.last_mut().unwrap() = Identifier::Numeric(n + 1);
+        if let Some(Identifier::Numeric(n)) = out.pre_release().last().cloned() {
+            *out.pre_release().last_mut().unwrap() = Identifier::Numeric(n + 1);
         } else {
-            out.pre_release.push(Identifier::Numeric(0));
+            out.pre_release().push(Identifier::Numeric(0));
         }
         return out;
     }
     // Not yet a prerelease — bump patch and add `-<preid>.0` / `-0`.
-    let mut out = Version::new(current.major, current.minor, current.patch + 1);
-    out.pre_release = initial_prerelease(preid);
+    let mut out = Version::new(current.major(), current.minor(), current.patch() + 1);
+    out.pre_release() = initial_prerelease(preid);
     out
 }
 

--- a/crates/aube/src/commands/version.rs
+++ b/crates/aube/src/commands/version.rs
@@ -8,7 +8,7 @@
 
 use clap::Args;
 use miette::{Context, IntoDiagnostic, miette};
-use node_semver::{Identifier, Version};
+use nodejs_semver::{Identifier, Version};
 use std::path::Path;
 use std::process::Command;
 

--- a/crates/aube/src/commands/version.rs
+++ b/crates/aube/src/commands/version.rs
@@ -8,7 +8,7 @@
 
 use clap::Args;
 use miette::{Context, IntoDiagnostic, miette};
-use nodejs_semver::{Identifier, Version};
+use nodejs_semver::{Identifier, Version, VersionParts};
 use std::path::Path;
 use std::process::Command;
 
@@ -327,13 +327,13 @@ fn compute_new_version(current: &str, bump: &str, preid: Option<&str>) -> miette
         // prerelease instead of incrementing. Going through those helpers
         // would leave e.g. `premajor` of `2.0.0-rc.0` as `2.0.0-0` rather
         // than the npm-matching `3.0.0-0`.
-        "premajor" => prerelease_of(Version::new(current_ver.major() + 1, 0, 0), preid),
+        "premajor" => prerelease_of(Version::new(current_ver.major() + 1, 0, 0, vec![], vec![]), preid),
         "preminor" => prerelease_of(
-            Version::new(current_ver.major(), current_ver.minor() + 1, 0),
+            Version::new(current_ver.major(), current_ver.minor() + 1, 0, vec![], vec![]),
             preid,
         ),
         "prepatch" => prerelease_of(
-            Version::new(current_ver.major(), current_ver.minor(), current_ver.patch() + 1),
+            Version::new(current_ver.major(), current_ver.minor(), current_ver.patch() + 1, vec![], vec![]),
             preid,
         ),
         "prerelease" => bump_prerelease(&current_ver, preid),
@@ -349,32 +349,43 @@ fn bump_major(v: &Version) -> Version {
     // bumped (minor=0, patch=0), the release drops the prerelease without
     // advancing the major. Mirrors npm's `inc('major')`.
     if v.minor() == 0 && v.patch() == 0 && v.is_prerelease() {
-        Version::new(v.major(), 0, 0)
+        Version::new(v.major(), 0, 0, vec![], vec![])
     } else {
-        Version::new(v.major() + 1, 0, 0)
+        Version::new(v.major() + 1, 0, 0, vec![], vec![])
     }
 }
 
 fn bump_minor(v: &Version) -> Version {
     if v.patch() == 0 && v.is_prerelease() {
-        Version::new(v.major(), v.minor(), 0)
+        Version::new(v.major(), v.minor(), 0, vec![], vec![])
     } else {
-        Version::new(v.major(), v.minor() + 1, 0)
+        Version::new(v.major(), v.minor() + 1, 0, vec![], vec![])
     }
 }
 
 fn bump_patch(v: &Version) -> Version {
     if v.is_prerelease() {
-        Version::new(v.major(), v.minor(), v.patch())
+        Version::new(v.major(), v.minor(), v.patch(), vec![], vec![])
     } else {
-        Version::new(v.major(), v.minor(), v.patch() + 1)
+        Version::new(v.major(), v.minor(), v.patch() + 1, vec![], vec![])
     }
 }
 
 fn prerelease_of(core: Version, preid: Option<&str>) -> Version {
-    let mut out = core;
-    out.pre_release() = initial_prerelease(preid);
-    out
+    let VersionParts {
+        major,
+        minor,
+        patch,
+        pre_release: _,
+        build,
+    } = core.into_parts();
+    Version::new(
+        major,
+        minor,
+        patch,
+        initial_prerelease(preid),
+        build,
+    )
 }
 
 fn initial_prerelease(preid: Option<&str>) -> Vec<Identifier> {
@@ -400,33 +411,37 @@ fn bump_prerelease(current: &Version, preid: Option<&str>) -> Version {
                 Identifier::Numeric(_) => None,
             });
             if current_preid != Some(id) {
-                return Version {
-                    major: current.major(),
-                    minor: current.minor(),
-                    patch: current.patch(),
-                    build: Vec::new(),
-                    pre_release: initial_prerelease(Some(id)),
-                };
+                return Version::new(
+                    current.major(),
+                    current.minor(),
+                    current.patch(),
+                    Vec::new(),
+                    initial_prerelease(Some(id)),
+                );
             }
         }
-        let mut out = Version {
-            major: current.major(),
-            minor: current.minor(),
-            patch: current.patch(),
-            build: Vec::new(),
-            pre_release: current.pre_release().clone(),
-        };
-        if let Some(Identifier::Numeric(n)) = out.pre_release().last().cloned() {
-            *out.pre_release().last_mut().unwrap() = Identifier::Numeric(n + 1);
+        let VersionParts {
+            major,
+            minor,
+            patch,
+            mut pre_release,
+            build,
+        } = current.to_owned().into_parts();
+        if let Some(Identifier::Numeric(n)) = pre_release.last().cloned() {
+            *pre_release.last_mut().unwrap() = Identifier::Numeric(n + 1);
         } else {
-            out.pre_release().push(Identifier::Numeric(0));
+            pre_release.push(Identifier::Numeric(0));
         }
-        return out;
+        return Version::new(
+        major,
+        minor,
+        patch,
+        pre_release,
+        build,
+    );
     }
     // Not yet a prerelease — bump patch and add `-<preid>.0` / `-0`.
-    let mut out = Version::new(current.major(), current.minor(), current.patch() + 1);
-    out.pre_release() = initial_prerelease(preid);
-    out
+    prerelease_of(Version::new(current.major(), current.minor(), current.patch() + 1, vec![], vec![]), preid)
 }
 
 fn is_git_repo(cwd: &Path) -> bool {

--- a/crates/aube/src/commands/version.rs
+++ b/crates/aube/src/commands/version.rs
@@ -415,8 +415,8 @@ fn bump_prerelease(current: &Version, preid: Option<&str>) -> Version {
                     current.major(),
                     current.minor(),
                     current.patch(),
-                    Vec::new(),
                     initial_prerelease(Some(id)),
+                    Vec::new(),
                 );
             }
         }

--- a/crates/aube/src/engines.rs
+++ b/crates/aube/src/engines.rs
@@ -150,10 +150,10 @@ fn probe_node_version(program: &std::path::Path) -> Option<String> {
 /// fields or unusual binaries that report non-standard version strings
 /// (e.g. nightly builds, custom forks).
 fn version_satisfies(version: &str, range: &str) -> bool {
-    let Ok(v) = node_semver::Version::parse(version) else {
+    let Ok(v) = nodejs_semver::Version::parse(version) else {
         return true;
     };
-    let Ok(r) = node_semver::Range::parse(range) else {
+    let Ok(r) = nodejs_semver::Range::parse(range) else {
         return true;
     };
     v.satisfies(&r)

--- a/crates/aube/src/runtime.rs
+++ b/crates/aube/src/runtime.rs
@@ -903,7 +903,7 @@ fn release_mirror(ctx: &ResolveCtx<'_>) -> Option<String> {
 fn pinned_from_lockfile(
     pin: &aube_lockfile::RuntimePin,
 ) -> Result<aube_runtime::PinnedNode, aube_runtime::Error> {
-    let version = node_semver::Version::parse(&pin.version).map_err(|e| {
+    let version = nodejs_semver::Version::parse(&pin.version).map_err(|e| {
         aube_runtime::Error::NoMatchingVersion {
             requested: format!("lockfile pin {}: {e}", pin.version),
             platform_note: String::new(),
@@ -1124,7 +1124,7 @@ impl CliProgress {
 }
 
 impl aube_runtime::DownloadProgress for CliProgress {
-    fn on_phase(&self, version: Option<&node_semver::Version>, phase: aube_runtime::InstallPhase) {
+    fn on_phase(&self, version: Option<&nodejs_semver::Version>, phase: aube_runtime::InstallPhase) {
         use aube_runtime::InstallPhase;
         let mut state = self.state.lock().unwrap();
         if let Some(v) = version {

--- a/crates/aube/src/self_version.rs
+++ b/crates/aube/src/self_version.rs
@@ -56,7 +56,7 @@ pub(crate) async fn maybe_switch(settings: &crate::startup::StartupSettings) -> 
         return Ok(());
     };
 
-    let current = node_semver::Version::parse(running_version().trim_end_matches("-DEBUG")).ok();
+    let current = nodejs_semver::Version::parse(running_version().trim_end_matches("-DEBUG")).ok();
     if let Some(current) = &current
         && pin.spec.satisfied_by(current) == Some(true)
     {
@@ -235,7 +235,7 @@ fn extract_pin(manifest: &aube_manifest::PackageJson) -> Option<SelfPin> {
     // Strip a corepack `+<hash>` suffix.
     let version = version.split_once('+').map_or(version, |(v, _)| v);
     let version = version.trim().trim_end_matches("-DEBUG");
-    let exact = node_semver::Version::parse(version).ok()?;
+    let exact = nodejs_semver::Version::parse(version).ok()?;
     Some(SelfPin {
         spec: aube_runtime::NodeSpec::Exact(exact),
         raw: version.to_string(),

--- a/crates/aube/src/update_check.rs
+++ b/crates/aube/src/update_check.rs
@@ -146,8 +146,8 @@ fn unix_now() -> u64 {
 
 fn is_newer(latest: &str, current: &str) -> bool {
     match (
-        node_semver::Version::parse(latest),
-        node_semver::Version::parse(current),
+        nodejs_semver::Version::parse(latest),
+        nodejs_semver::Version::parse(current),
     ) {
         (Ok(l), Ok(c)) => l > c,
         _ => false,


### PR DESCRIPTION
Supports dependency versions like ~~`">=0.60.0<1"` and~~ `""`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Migrated version parsing and comparison across dependency resolution, runtime management, lockfiles, auditing, publishing, and CLI commands to a new SemVer implementation.
  * Preserved existing version matching, prerelease handling, vulnerability filtering, and fallback behavior.
  * Updated runtime and package version APIs to use the new SemVer representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->