### PR TITLE
perf(install): prioritize opencode-ai builds

### DIFF
--- a/crates/aube/src/commands/install/critical_path.rs
+++ b/crates/aube/src/commands/install/critical_path.rs
@@ -28,6 +28,7 @@ pub(super) fn is_likely_native_build(registry_name: &str) -> bool {
         "node-gyp",
         "prebuild-install",
         "node-gyp-build",
+        "opencode-ai",
     ];
     if EXACT.contains(&registry_name) {
         return true;
@@ -51,20 +52,6 @@ pub(super) fn is_likely_native_build(registry_name: &str) -> bool {
 #[cfg(test)]
 mod critical_path_tests {
     use super::is_likely_native_build;
-
-    #[test]
-    fn flags_exact_native_packages() {
-        for name in [
-            "sharp",
-            "esbuild",
-            "fsevents",
-            "node-gyp",
-            "better-sqlite3",
-            "sodium-native",
-        ] {
-            assert!(is_likely_native_build(name), "{name} should match");
-        }
-    }
 
     #[test]
     fn flags_scoped_native_prefixes() {


### PR DESCRIPTION
## Summary

- add `opencode-ai` to the curated native-build critical-path allowlist
- remove the exact-package test that duplicated implementation entries

## Impact

`opencode-ai` downloads are now prioritized with other likely build-heavy packages so its install step can overlap with remaining package fetches. The remaining tests cover prefix matching, negative classification, and stable fetch ordering without mirroring the exact allowlist.

## Validation

- `cargo test -p aube critical_path_tests`
- `cargo fmt --check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single allowlist entry plus test cleanup; only affects fetch ordering heuristics, not install correctness or security.
> 
> **Overview**
> Adds **`opencode-ai`** to the install **critical-path** exact-match allowlist in `is_likely_native_build`, so its tarball is fetched earlier alongside other likely native/build-heavy packages and install work can overlap with remaining downloads.
> 
> Removes the **`flags_exact_native_packages`** unit test that asserted several exact allowlist names (e.g. `sharp`, `esbuild`); scoped-prefix, pure-JS negative, and stable-sort tests are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b863d560a676fd236d243e2a989432f084571e17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native-build detection for the `opencode-ai` package, ensuring it is correctly identified as potentially requiring native compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->