### PR TITLE
fix(runtime): keep activated shims stable across upgrades

### DIFF
--- a/crates/aube/src/argv.rs
+++ b/crates/aube/src/argv.rs
@@ -45,6 +45,7 @@ pub(crate) fn extract_config_overrides(args: &mut Vec<OsString>) -> Vec<(String,
 /// rewrite the argv so clap sees the equivalent `aube run …` / `aube dlx …`.
 pub(crate) fn rewrite_multicall_argv(mut args: Vec<OsString>) -> Vec<OsString> {
     normalize_npm_interpreter_shim_argv(&mut args);
+    normalize_dispatcher_shim_argv(&mut args);
     let Some(argv0) = args.first() else {
         return args;
     };
@@ -60,6 +61,20 @@ pub(crate) fn rewrite_multicall_argv(mut args: Vec<OsString>) -> Vec<OsString> {
         _ => args,
     };
     protect_node_subcommand_args(rewritten)
+}
+
+fn normalize_dispatcher_shim_argv(args: &mut Vec<OsString>) {
+    if args.get(1).and_then(|arg| arg.to_str()) != Some(crate::tool_shims::DISPATCH_ARG) {
+        return;
+    }
+    let Some(tool) = args.get(2).and_then(|arg| arg.to_str()) else {
+        return;
+    };
+    if !crate::tool_shims::TOOL_SHIMS.contains(&tool) {
+        return;
+    }
+    args[0] = OsString::from(tool);
+    args.drain(1..=2);
 }
 
 fn rewrite_simple_multicall(mut args: Vec<OsString>, subcommand: &str) -> Vec<OsString> {

--- a/crates/aube/src/commands/activate.rs
+++ b/crates/aube/src/commands/activate.rs
@@ -59,7 +59,7 @@ fn ensure_shims(shim_dir: &Path) -> miette::Result<()> {
 fn write_shim(shim_dir: &Path, name: &str) -> miette::Result<()> {
     let dest = shim_dir.join(name);
     let _ = std::fs::remove_file(&dest);
-    write_dispatcher_shim(&dest, name).map_err(|e| {
+    write_dispatcher_shim(&dest, name, aube_util::prog()).map_err(|e| {
         miette!(
             code = aube_codes::errors::ERR_AUBE_SHIM_CREATE_FAILED,
             "failed to create shim {}: {e}",
@@ -69,11 +69,12 @@ fn write_shim(shim_dir: &Path, name: &str) -> miette::Result<()> {
 }
 
 #[cfg(unix)]
-fn write_dispatcher_shim(dest: &Path, name: &str) -> std::io::Result<()> {
+fn write_dispatcher_shim(dest: &Path, name: &str, program: &str) -> std::io::Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
+    let program = shell_double_quote(program);
     let script = format!(
-        "#!/bin/sh\n# aube-tool-shim v1\nexec aube {} {name} \"$@\"\n",
+        "#!/bin/sh\n# aube-tool-shim v1\nexec {program} {} {name} \"$@\"\n",
         crate::tool_shims::DISPATCH_ARG
     );
     std::fs::write(dest, script)?;
@@ -195,7 +196,19 @@ mod tests {
         );
         assert_eq!(
             std::fs::read_to_string(&node).expect("node shim should be readable after creation"),
-            "#!/bin/sh\n# aube-tool-shim v1\nexec aube __aube-shim node \"$@\"\n"
+            "#!/bin/sh\n# aube-tool-shim v1\nexec \"aube\" __aube-shim node \"$@\"\n"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dispatcher_shim_uses_embedder_program() {
+        let dir = tempfile::tempdir().expect("shim tempdir should be created");
+        let node = dir.path().join("node");
+        write_dispatcher_shim(&node, "node", "nublike").expect("embedder shim should be created");
+        assert_eq!(
+            std::fs::read_to_string(node).expect("embedder shim should be readable"),
+            "#!/bin/sh\n# aube-tool-shim v1\nexec \"nublike\" __aube-shim node \"$@\"\n"
         );
     }
 }

--- a/crates/aube/src/commands/activate.rs
+++ b/crates/aube/src/commands/activate.rs
@@ -37,47 +37,66 @@ fn ensure_shims(shim_dir: &Path) -> miette::Result<()> {
             shim_dir.display()
         )
     })?;
+    #[cfg(not(unix))]
     let exe = std::env::current_exe().map_err(|e| {
         miette!(
             code = aube_codes::errors::ERR_AUBE_SHIM_CREATE_FAILED,
             "failed to locate current executable for shim creation: {e}"
         )
     })?;
+    #[cfg(unix)]
+    for name in crate::tool_shims::TOOL_SHIMS {
+        write_shim(shim_dir, &crate::tool_shims::shim_file_name(name))?;
+    }
+    #[cfg(not(unix))]
     for name in crate::tool_shims::TOOL_SHIMS {
         write_shim(shim_dir, &crate::tool_shims::shim_file_name(name), &exe)?;
     }
     Ok(())
 }
 
-fn write_shim(shim_dir: &Path, name: &str, exe: &Path) -> miette::Result<()> {
+#[cfg(unix)]
+fn write_shim(shim_dir: &Path, name: &str) -> miette::Result<()> {
     let dest = shim_dir.join(name);
     let _ = std::fs::remove_file(&dest);
-    create_executable_alias(exe, &dest).map_err(|e| {
+    write_dispatcher_shim(&dest, name).map_err(|e| {
         miette!(
             code = aube_codes::errors::ERR_AUBE_SHIM_CREATE_FAILED,
-            "failed to create shim {} -> {}: {e}",
+            "failed to create shim {}: {e}",
             dest.display(),
-            exe.display()
         )
     })
 }
 
 #[cfg(unix)]
-fn create_executable_alias(exe: &Path, dest: &Path) -> std::io::Result<()> {
-    std::os::unix::fs::symlink(exe, dest).or_else(|_| {
-        std::fs::hard_link(exe, dest).or_else(|_| {
-            std::fs::copy(exe, dest)?;
-            Ok(())
-        })
-    })
+fn write_dispatcher_shim(dest: &Path, name: &str) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let script = format!(
+        "#!/bin/sh\n# aube-tool-shim v1\nexec aube {} {name} \"$@\"\n",
+        crate::tool_shims::DISPATCH_ARG
+    );
+    std::fs::write(dest, script)?;
+    std::fs::set_permissions(dest, std::fs::Permissions::from_mode(0o755))
 }
 
 #[cfg(not(unix))]
-fn create_executable_alias(exe: &Path, dest: &Path) -> std::io::Result<()> {
-    std::fs::hard_link(exe, dest).or_else(|_| {
-        std::fs::copy(exe, dest)?;
-        Ok(())
-    })
+fn write_shim(shim_dir: &Path, name: &str, exe: &Path) -> miette::Result<()> {
+    let dest = shim_dir.join(name);
+    let _ = std::fs::remove_file(&dest);
+    std::fs::hard_link(exe, &dest)
+        .or_else(|_| {
+            std::fs::copy(exe, &dest)?;
+            Ok(())
+        })
+        .map_err(|e| {
+            miette!(
+                code = aube_codes::errors::ERR_AUBE_SHIM_CREATE_FAILED,
+                "failed to create shim {} -> {}: {e}",
+                dest.display(),
+                exe.display()
+            )
+        })
 }
 
 fn render_activation(shell: ActivateShell, shim_dir: &Path) -> String {
@@ -154,6 +173,29 @@ mod tests {
         assert_eq!(
             shell_double_quote(r#"/tmp/a"b$c\d`e"#),
             r#""/tmp/a\"b\$c\\d\`e""#
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn writes_path_resolved_dispatcher_shims() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("shim tempdir should be created");
+        ensure_shims(dir.path()).expect("shims should be created");
+        let node = dir.path().join("node");
+        assert!(!node.is_symlink());
+        assert_ne!(
+            std::fs::metadata(&node)
+                .expect("node shim should have metadata")
+                .permissions()
+                .mode()
+                & 0o111,
+            0
+        );
+        assert_eq!(
+            std::fs::read_to_string(&node).expect("node shim should be readable after creation"),
+            "#!/bin/sh\n# aube-tool-shim v1\nexec aube __aube-shim node \"$@\"\n"
         );
     }
 }

--- a/crates/aube/src/commands/activate.rs
+++ b/crates/aube/src/commands/activate.rs
@@ -86,10 +86,7 @@ fn write_shim(shim_dir: &Path, name: &str, exe: &Path) -> miette::Result<()> {
     let dest = shim_dir.join(name);
     let _ = std::fs::remove_file(&dest);
     std::fs::hard_link(exe, &dest)
-        .or_else(|_| {
-            std::fs::copy(exe, &dest)?;
-            Ok(())
-        })
+        .or_else(|_| std::fs::copy(exe, &dest).map(|_| ()))
         .map_err(|e| {
             miette!(
                 code = aube_codes::errors::ERR_AUBE_SHIM_CREATE_FAILED,

--- a/crates/aube/src/lib.rs
+++ b/crates/aube/src/lib.rs
@@ -1570,6 +1570,10 @@ mod multicall_tests {
             rewrite_multicall_argv(os(&["aube", "node", "--version"])),
             os(&["aube", "node", "--", "--version"])
         );
+        assert_eq!(
+            rewrite_multicall_argv(os(&["aube", "__aube-shim", "node", "--version"])),
+            os(&["aube", "node", "--", "--version"])
+        );
     }
 
     #[test]
@@ -1601,6 +1605,24 @@ mod multicall_tests {
         assert_eq!(
             rewrite_multicall_argv(os(&["pnpx", "cowsay", "hi"])),
             os(&["aube", "dlx", "cowsay", "hi"])
+        );
+        assert_eq!(
+            rewrite_multicall_argv(os(&[
+                "aube",
+                "__aube-shim",
+                "pnpm",
+                "install",
+                "--frozen-lockfile",
+            ])),
+            os(&["aube", "install", "--frozen-lockfile"])
+        );
+    }
+
+    #[test]
+    fn dispatcher_marker_rejects_unknown_tool_names() {
+        assert_eq!(
+            rewrite_multicall_argv(os(&["aube", "__aube-shim", "shell", "arg"])),
+            os(&["aube", "__aube-shim", "shell", "arg"])
         );
     }
 

--- a/crates/aube/src/tool_shims.rs
+++ b/crates/aube/src/tool_shims.rs
@@ -3,6 +3,8 @@ use std::path::{Component, Path, PathBuf};
 
 pub(crate) const SHIM_DIR_ENV: &str = "AUBE_SHIM_DIR";
 
+pub(crate) const DISPATCH_ARG: &str = "__aube-shim";
+
 pub(crate) const TOOL_SHIMS: &[&str] = &["node", "npm", "npx", "pnpm", "pnpx", "yarn", "yarnpkg"];
 
 pub(crate) fn shim_file_name(name: &str) -> String {

--- a/docs/package-manager/node-runtime.md
+++ b/docs/package-manager/node-runtime.md
@@ -76,9 +76,11 @@ aube activate fish | source
 ```
 
 Activation creates shims under aube's data directory and prepends that
-directory to PATH for the current shell. The `node` shim resolves the
-project runtime and execs the selected Node. The `npm`, `npx`, `pnpm`,
-`pnpx`, `yarn`, and `yarnpkg` shims route common package-manager
+directory to PATH for the current shell. On Unix these are dispatcher
+scripts that resolve the current `aube` from PATH, so upgrading aube does
+not leave them pointing at a removed version. The `node` shim resolves
+the project runtime and execs the selected Node. The `npm`, `npx`,
+`pnpm`, `pnpx`, `yarn`, and `yarnpkg` shims route common package-manager
 commands to aube, so an accidental `pnpm install` in a project with a
 different existing lockfile still lets aube preserve that lockfile kind.
 

--- a/test/runtime.bats
+++ b/test/runtime.bats
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# shellcheck disable=SC2030,SC2031
 # Node runtime switching: version sources (.nvmrc / .node-version /
 # devEngines.runtime), install discovery (aube dir + mise dir), onFail
 # policies, and `aube runtime` CLI surface. Hermetic — no network:

--- a/test/runtime.bats
+++ b/test/runtime.bats
@@ -260,6 +260,29 @@ _basic_project() {
 	assert_output --partial "v1.2.3"
 }
 
+@test "activated shims survive removal of the aube version that created them" {
+	local real_aube v1 v2
+	real_aube="$(command -v aube)"
+	v1="$TEST_TEMP_DIR/aube-v1"
+	v2="$TEST_TEMP_DIR/aube-v2"
+	mkdir -p "$v1" "$v2"
+	cp "$real_aube" "$v1/aube"
+	cp "$real_aube" "$v2/aube"
+	chmod +x "$v1/aube" "$v2/aube"
+	export PATH="$v1:$PATH"
+
+	run aube activate bash
+	assert_success
+	eval "$output"
+	refute [ -L "$AUBE_SHIM_DIR/pnpm" ]
+	rm "$v1/aube"
+	export PATH="${PATH/$v1/$v2}"
+
+	run pnpm --version
+	assert_success
+	assert_output --regexp '^[0-9]+\.[0-9]+\.[0-9]+'
+}
+
 @test "pnpm shim routes install through aube without changing lockfile kind" {
 	_basic_project
 	cat >yarn.lock <<-'YAML'


### PR DESCRIPTION
## Summary

- replace Unix activation symlinks to the creating executable with small dispatcher scripts
- resolve the current `aube` from `PATH`, then reuse the existing multicall routing through a validated internal marker
- document the upgrade-stable behavior and cover removing the creating aube version

The former absolute symlink captured a version-managed executable path. Removing that version left every activated tool shim dangling. The dispatcher model preserves the stable indirection property used by mise while keeping Windows behavior unchanged.

Related: #1125

## Validation

- `cargo fmt --check`
- `cargo clippy -p aube --all-targets -- -D warnings`
- focused dispatcher and multicall unit tests
- targeted runtime BATS tests (4/4), including removal of the creating executable
- full `test/runtime.bats`: 22/24; the two unrelated failures occur before activation because the host mise installation has an invalid ambient Node shim

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shell activation and argv dispatch on Unix—high-touch PATH/shim behavior—but Windows is unchanged and routing is gated on a validated tool list.
> 
> **Overview**
> On **Unix**, `aube activate` no longer symlinks/hardlinks tool shims to the binary that created them. It writes executable **dispatcher scripts** that `exec` the current `aube` from `PATH` (via embedder program name) with an internal `__aube-shim <tool>` marker.
> 
> **Argv rewriting** strips that marker for known tools (`node`, `pnpm`, etc.) before existing multicall routing, so behavior matches direct shim invocation; unknown tool names are left alone. **Windows** activation still hard-links/copies the executable.
> 
> Docs note upgrade-stable shims; tests cover script contents, multicall paths, and a BATS case where the creating `aube` binary is removed but activated `pnpm` still works.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ca015b8a4e852b4b24d8553d4a54da8dda35f41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->