### PR TITLE
fix(runtime): replace activated shims atomically

### DIFF
--- a/crates/aube/src/commands/activate.rs
+++ b/crates/aube/src/commands/activate.rs
@@ -58,7 +58,6 @@ fn ensure_shims(shim_dir: &Path) -> miette::Result<()> {
 #[cfg(unix)]
 fn write_shim(shim_dir: &Path, name: &str) -> miette::Result<()> {
     let dest = shim_dir.join(name);
-    let _ = std::fs::remove_file(&dest);
     write_dispatcher_shim(&dest, name, aube_util::prog()).map_err(|e| {
         miette!(
             code = aube_codes::errors::ERR_AUBE_SHIM_CREATE_FAILED,
@@ -70,6 +69,7 @@ fn write_shim(shim_dir: &Path, name: &str) -> miette::Result<()> {
 
 #[cfg(unix)]
 fn write_dispatcher_shim(dest: &Path, name: &str, program: &str) -> std::io::Result<()> {
+    use std::io::Write as _;
     use std::os::unix::fs::PermissionsExt;
 
     let program = shell_double_quote(program);
@@ -77,8 +77,24 @@ fn write_dispatcher_shim(dest: &Path, name: &str, program: &str) -> std::io::Res
         "#!/bin/sh\n# aube-tool-shim v1\nexec {program} {} {name} \"$@\"\n",
         crate::tool_shims::DISPATCH_ARG
     );
-    std::fs::write(dest, script)?;
-    std::fs::set_permissions(dest, std::fs::Permissions::from_mode(0o755))
+    let tmp = aube_util::fs_atomic::sibling_tempdir(dest);
+    let result = (|| {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp)?;
+        file.write_all(script.as_bytes())?;
+        file.set_permissions(std::fs::Permissions::from_mode(0o755))?;
+        drop(file);
+        // The temp file lives beside the destination, so Unix rename replaces
+        // the old executable atomically. Readers see either complete shim,
+        // never the remove/write/chmod window activation previously exposed.
+        std::fs::rename(&tmp, dest)
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&tmp);
+    }
+    result
 }
 
 #[cfg(not(unix))]
@@ -207,5 +223,32 @@ mod tests {
             std::fs::read_to_string(node).expect("embedder shim should be readable"),
             "#!/bin/sh\n# aube-tool-shim v1\nexec \"nublike\" __aube-shim node \"$@\"\n"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dispatcher_shim_atomically_replaces_existing_file() {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+        let dir = tempfile::tempdir().expect("shim tempdir should be created");
+        let node = dir.path().join("node");
+        std::fs::write(&node, "old shim").expect("old shim should be created");
+        let old_inode = std::fs::metadata(&node)
+            .expect("old shim should have metadata")
+            .ino();
+
+        write_dispatcher_shim(&node, "node", "aube").expect("shim should be replaced");
+
+        let metadata = std::fs::metadata(&node).expect("new shim should have metadata");
+        assert_ne!(metadata.ino(), old_inode);
+        assert_ne!(metadata.permissions().mode() & 0o111, 0);
+        assert_eq!(
+            std::fs::read_to_string(&node).expect("new shim should be complete"),
+            "#!/bin/sh\n# aube-tool-shim v1\nexec \"aube\" __aube-shim node \"$@\"\n"
+        );
+        let entries = std::fs::read_dir(dir.path())
+            .expect("shim dir should be readable")
+            .count();
+        assert_eq!(entries, 1, "temporary shim should be renamed away");
     }
 }

--- a/crates/aube/src/commands/activate.rs
+++ b/crates/aube/src/commands/activate.rs
@@ -77,12 +77,19 @@ fn write_dispatcher_shim(dest: &Path, name: &str, program: &str) -> std::io::Res
         "#!/bin/sh\n# aube-tool-shim v1\nexec {program} {} {name} \"$@\"\n",
         crate::tool_shims::DISPATCH_ARG
     );
-    let tmp = aube_util::fs_atomic::sibling_tempdir(dest);
-    let result = (|| {
-        let mut file = std::fs::OpenOptions::new()
+    let (tmp, mut file) = loop {
+        let tmp = aube_util::fs_atomic::sibling_tempdir(dest);
+        match std::fs::OpenOptions::new()
             .write(true)
             .create_new(true)
-            .open(&tmp)?;
+            .open(&tmp)
+        {
+            Ok(file) => break (tmp, file),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
+        }
+    };
+    let result = (|| {
         file.write_all(script.as_bytes())?;
         file.set_permissions(std::fs::Permissions::from_mode(0o755))?;
         drop(file);


### PR DESCRIPTION
## Summary

- prepare Unix dispatcher shims in unique sibling temporary files
- apply executable permissions before publishing the replacement
- atomically rename the completed shim over the live path and clean up failures
- cover replacement completeness, executable mode, inode replacement, and temp cleanup

## Why

Follow-up to #1129 and its final review feedback. Activation previously removed the live shim before writing and chmodding its replacement, exposing an ENOENT/EACCES window to concurrent commands and leaving no working shim when preparation failed.

## Validation

- `cargo fmt --check`
- `cargo test -p aube commands::activate::tests`
- `cargo clippy --all-targets -- -D warnings`
- `test/bats/bin/bats --filter "activate|activated" test/runtime.bats`

The full `test/runtime.bats` file also ran: all shim tests passed; two unrelated ambient-runtime cases failed because this machine has a stale mise-managed `node` shim.

*This pull request was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Unix activation shim I/O with clearer concurrency behavior; non-Unix paths are unchanged.
> 
> **Overview**
> **Unix `aube activate` shim updates no longer delete the live shim before writing the replacement.** `write_dispatcher_shim` builds the script in a unique sibling temp file (`aube_util::fs_atomic::sibling_tempdir`), sets **0755** on that file, then **renames** it over the destination so concurrent PATH lookups always see either the previous shim or a complete new one—not a missing or half-written executable.
> 
> `write_shim` on Unix drops the upfront `remove_file` on the destination; failed writes remove the temp file only. A new unit test asserts inode change, executable bits, full script content, and no leftover temp files after replacing an existing shim.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1124a40d12add3a72905b629ecbaa4e9d87cd1b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->