### PR TITLE
fix(install): clear progress row for no-op installs

### DIFF
--- a/crates/aube/src/commands/install/finalize.rs
+++ b/crates/aube/src/commands/install/finalize.rs
@@ -101,7 +101,12 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
     // block and the branded line as redundant twins.
     let install_is_noop = stats.packages_linked == 0 && stats.top_level_linked == 0;
     if let Some(p) = prog_ref {
-        p.finish(!install_is_noop);
+        let tty_behavior = if install_is_noop {
+            crate::progress::TtyFinishBehavior::Clear
+        } else {
+            crate::progress::TtyFinishBehavior::Preserve
+        };
+        p.finish(!install_is_noop, tty_behavior);
     }
 
     if !virtual_store_only {

--- a/crates/aube/src/commands/install/resolve.rs
+++ b/crates/aube/src/commands/install/resolve.rs
@@ -189,7 +189,7 @@ pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::R
     if fresh {
         tracing::debug!("--lockfile-only: lockfile already up to date");
         if let Some(p) = prog_ref {
-            p.finish(true);
+            p.finish(true, crate::progress::TtyFinishBehavior::Preserve);
         }
         if !write_lockfile {
             super::control::output(
@@ -325,7 +325,7 @@ pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::R
     crate::commands::prepare_resolved_graph_for_lockfile_write(&mut graph);
     if !write_lockfile {
         if let Some(p) = prog_ref {
-            p.finish(true);
+            p.finish(true, crate::progress::TtyFinishBehavior::Preserve);
         }
         super::control::output(
             super::InstallOutputLevel::Info,
@@ -369,7 +369,7 @@ pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::R
     // primary output.
     maybe_cleanup_unused_catalogs(cwd, settings_ctx, workspace_catalogs, &graph.catalogs)?;
     if let Some(p) = prog_ref {
-        p.finish(true);
+        p.finish(true, crate::progress::TtyFinishBehavior::Preserve);
     }
     super::control::output(
         super::InstallOutputLevel::Info,

--- a/crates/aube/src/progress/mod.rs
+++ b/crates/aube/src/progress/mod.rs
@@ -146,6 +146,12 @@ pub struct InstallProgress {
     unpacked_sizes: Arc<Mutex<HashMap<String, u64>>>,
 }
 
+#[derive(Clone, Copy)]
+pub(crate) enum TtyFinishBehavior {
+    Preserve,
+    Clear,
+}
+
 #[derive(Clone)]
 enum Mode {
     Tty {
@@ -971,11 +977,11 @@ impl InstallProgress {
         }
     }
 
-    /// Finalize the progress display. TTY mode leaves the collapsed final
-    /// root row behind so the terminal does not visibly blink/clear right
-    /// before the install summary. CI mode blocks until the heartbeat thread has actually
-    /// stopped so no stray tick can appear after this returns, and
-    /// optionally writes the final framed `[ ✓ … ]` status line.
+    /// Finalize the progress display. TTY mode either preserves the collapsed
+    /// final root row or clears it according to `tty_behavior`. CI mode blocks
+    /// until the heartbeat thread has actually stopped so no stray tick can
+    /// appear after this returns, and optionally writes the final framed
+    /// `[ ✓ … ]` status line.
     /// Idempotent.
     ///
     /// `print_ci_summary`: set to `false` when a later call site will
@@ -983,7 +989,7 @@ impl InstallProgress {
     /// doesn't double up with [`print_install_summary`]). Set to `true`
     /// for early-return paths (`--lockfile-only`, drift check) that
     /// want the framed summary to remain the end of CI log output.
-    pub fn finish(&self, print_ci_summary: bool) {
+    pub fn finish(&self, print_ci_summary: bool, tty_behavior: TtyFinishBehavior) {
         match &self.mode {
             Mode::Tty {
                 root,
@@ -1014,7 +1020,10 @@ impl InstallProgress {
                 );
                 root.set_status(ProgressStatus::Done);
                 finished.store(true, Ordering::Relaxed);
-                clx::progress::stop();
+                match tty_behavior {
+                    TtyFinishBehavior::Preserve => clx::progress::stop(),
+                    TtyFinishBehavior::Clear => clx::progress::stop_clear(),
+                }
             }
             Mode::Ci(s) => s.stop(print_ci_summary),
             Mode::Events(s) => {
@@ -1475,7 +1484,7 @@ mod tests {
             progress.set_phase("future-phase");
             progress.inc_downloaded_bytes(512);
             drop(progress.start_fetch("dep", "1.0.0"));
-            progress.finish(false);
+            progress.finish(false, TtyFinishBehavior::Preserve);
         })
         .await;
 


### PR DESCRIPTION
## Summary

- clear the transient TTY progress row when an install performs no linking work
- leave `Already up to date` as the single durable no-op result
- preserve the completed progress row for real installs and lockfile-only completion paths
- make the TTY completion behavior explicit at each progress finalization call site

## Root cause

`InstallProgress::finish` always used `clx::progress::stop()`, which preserves the completed row. The no-op path then printed `Already up to date`, leaving two durable completion lines for one result.

Addresses https://github.com/jdx/aube/discussions/1115#discussioncomment-17789994

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo test -p aube progress:: --lib`
- `mise run test:bats test/install.bats` — relevant install/no-op tests pass; Node-dependent cases fail because the test environment's `node` mise shim does not resolve

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TTY-only install output behavior; CI summary logic is unchanged and call sites are explicit.
> 
> **Overview**
> **Install progress teardown** now takes an explicit `TtyFinishBehavior` on `InstallProgress::finish`, choosing `clx::progress::stop()` to keep the collapsed bar or `stop_clear()` to remove it.
> 
> On **no-op installs** (nothing linked at top level), finalize passes **`Clear`** so the transient progress row disappears before **`Already up to date`** prints—fixing duplicate completion lines on TTY. **Real installs** and **`--lockfile-only`** early exits still use **`Preserve`** so the finished bar (or CI framed summary) stays visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ca266989695d716bd67d56a8f18c875b9e06415. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved progress display handling for completed installations.
  * No-op installations now clear temporary progress output, while active installations preserve the final progress state.
  * Lockfile-only operations retain their completion output consistently.
  * Updated progress behavior across terminal and CI environments for more reliable completion reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->