### PR TITLE
fix(resolver): never prefer a deprecated version inside a range

### DIFF
--- a/crates/aube-resolver/src/resolve/vulnerable.rs
+++ b/crates/aube-resolver/src/resolve/vulnerable.rs
@@ -65,14 +65,7 @@ pub(super) fn prefer_non_vulnerable_pick<'a>(
         {
             continue;
         }
-        let replace = best.as_ref().is_none_or(|(cur, _)| {
-            if pick_lowest {
-                version < *cur
-            } else {
-                version > *cur
-            }
-        });
-        if replace {
+        if crate::semver_util::outranks(&version, meta, best.as_ref(), pick_lowest) {
             best = Some((version, meta));
         }
     }

--- a/crates/aube-resolver/src/semver_util.rs
+++ b/crates/aube-resolver/src/semver_util.rs
@@ -109,6 +109,9 @@ pub fn pick_version_for_add<'a>(
 /// still clear `exempt_cutoff` (the time-based resolution cutoff). Pass
 /// `None` to fully bypass the cutoff for exempt versions (no time-based
 /// wall in effect).
+///
+/// Deprecated versions stay eligible but never win over a
+/// non-deprecated one in the same range — see [`outranks`].
 #[inline]
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn pick_version<'a>(
@@ -237,16 +240,13 @@ pub(crate) fn pick_version<'a>(
         // `exempt_cutoff` are eligible (a no-op `None` when time-based
         // mode is off).
         if passes_effective_cutoff(ver_str, exempt_cutoff)
-            && fallback_lowest.as_ref().is_none_or(|(cur, _)| v < *cur)
+            && outranks(&v, meta, fallback_lowest.as_ref(), true)
         {
             fallback_lowest = Some((v.clone(), meta));
         }
 
         if passes_cutoff(ver_str, Some(&v)) {
-            let replace = best
-                .as_ref()
-                .is_none_or(|(cur, _)| if pick_lowest { v < *cur } else { v > *cur });
-            if replace {
+            if outranks(&v, meta, best.as_ref(), pick_lowest) {
                 best = Some((v, meta));
             }
         } else {
@@ -271,7 +271,8 @@ pub(crate) fn pick_version<'a>(
 
     // Lenient fallback: pnpm's `pickPackageFromMetaUsingTime` bypasses
     // the minimumReleaseAge gate and picks the *lowest* satisfying
-    // version — the candidate already cleared the time-based wall above.
+    // version (lowest non-deprecated, per `outranks`) — the candidate
+    // already cleared the time-based wall above.
     if let Some((_, meta)) = fallback_lowest {
         return PickResult::Found(meta);
     }
@@ -284,6 +285,41 @@ pub(crate) fn pick_version<'a>(
     } else {
         PickResult::NoMatch
     }
+}
+
+/// Does the candidate `(v, meta)` beat the incumbent pick?
+///
+/// A non-deprecated version outranks a deprecated one whatever their
+/// order; between two versions of equal deprecation status `lowest`
+/// decides the direction. This is pnpm's `pickVersionByVersionRange`
+/// rule — when the highest match carries a `deprecated` message it
+/// re-runs the range match over the non-deprecated versions and only
+/// keeps the deprecated pick when the range admits nothing else —
+/// expressed as a comparison so every scan in this crate gets it from
+/// one place. Real case: `codemirror@6.65.7` is an accidentally
+/// mis-tagged republish of `5.65.7`, so it sorts above every genuine
+/// 6.x and a plain highest-satisfying scan hands it to anyone whose
+/// range reaches past `dist-tags.latest`.
+///
+/// pnpm applies the rule on its highest-version path only; aube applies
+/// it in both directions on purpose. A deprecated floor is no safer
+/// than a non-deprecated one, so `resolution-mode=time-based` has
+/// nothing to gain from pinning a version the publisher withdrew.
+#[inline]
+pub(crate) fn outranks(
+    v: &node_semver::Version,
+    meta: &aube_registry::VersionMetadata,
+    incumbent: Option<&(node_semver::Version, &aube_registry::VersionMetadata)>,
+    lowest: bool,
+) -> bool {
+    let Some((cur_v, cur_meta)) = incumbent else {
+        return true;
+    };
+    let live = meta.deprecated.is_none();
+    if live != cur_meta.deprecated.is_none() {
+        return live;
+    }
+    if lowest { v < cur_v } else { v > cur_v }
 }
 
 /// Walk the packument's versions and return the highest non

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -739,6 +739,80 @@ fn test_pick_version_falls_through_when_latest_outside_range() {
     assert_eq!(result.version, "1.1.0");
 }
 
+/// Mark `version` deprecated in an already-built test packument.
+fn deprecate(packument: &mut Packument, version: &str, reason: &str) {
+    packument
+        .versions
+        .get_mut(version)
+        .expect("version present in test packument")
+        .deprecated = Some(reason.to_string());
+}
+
+#[test]
+fn test_pick_version_skips_deprecated_when_range_admits_another() {
+    // Real case: `codemirror@6.65.7` is an accidentally mis-tagged
+    // republish of `5.65.7`, so it sorts above every genuine 6.x.
+    // A plain highest-satisfying scan hands it to anyone whose range
+    // reaches past `dist-tags.latest`; pnpm re-picks among the
+    // non-deprecated versions instead.
+    let mut packument = make_packument("foo", &["1.0.0", "1.1.0", "1.99.0", "2.0.0"], "2.0.0");
+    deprecate(&mut packument, "1.99.0", "mis-tagged instance of 0.99.0");
+    let result = pick_version(
+        &packument,
+        "^1.0.0",
+        None,
+        false,
+        None,
+        None,
+        false,
+        |_, _| false,
+    )
+    .unwrap();
+    assert_eq!(result.version, "1.1.0");
+}
+
+#[test]
+fn test_pick_version_keeps_deprecated_when_nothing_else_matches() {
+    // The deprecation preference is a tiebreak, not a filter: a range
+    // that only reaches deprecated versions still resolves.
+    let mut packument = make_packument("foo", &["1.0.0", "1.1.0", "2.0.0"], "2.0.0");
+    deprecate(&mut packument, "1.0.0", "unsupported");
+    deprecate(&mut packument, "1.1.0", "unsupported");
+    let result = pick_version(
+        &packument,
+        "^1.0.0",
+        None,
+        false,
+        None,
+        None,
+        false,
+        |_, _| false,
+    )
+    .unwrap();
+    assert_eq!(result.version, "1.1.0");
+}
+
+#[test]
+fn test_pick_version_lowest_skips_deprecated_floor() {
+    // TimeBased mode picks the floor of the range, but a deprecated
+    // floor is no safer than a live one — take the lowest version the
+    // publisher hasn't withdrawn.
+    let mut packument = make_packument("foo", &["1.0.0", "1.1.0", "1.2.0"], "1.2.0");
+    deprecate(&mut packument, "1.0.0", "critical bug, upgrade");
+    let result = pick_version(
+        &packument,
+        "^1.0.0",
+        None,
+        true,
+        None,
+        None,
+        false,
+        |_, _| false,
+    )
+    .unwrap();
+    assert_eq!(result.version, "1.1.0");
+}
+
 #[test]
 fn test_pick_version_lowest_ignores_dist_tag_preference() {
     // TimeBased mode (`pick_lowest=true`) wants the floor of the

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -124,7 +124,7 @@ pub(crate) use manifest_io::{
     write_manifest_dep_sections, write_manifest_json,
 };
 pub(crate) use package_spec::{
-    encode_package_name, max_satisfying_version, resolve_version, split_name_spec,
+    encode_package_name, resolve_version, split_name_spec, wanted_version,
 };
 pub(crate) use project_lock::take_install_project_lock;
 pub(crate) use project_lock::take_project_lock;

--- a/crates/aube/src/commands/outdated.rs
+++ b/crates/aube/src/commands/outdated.rs
@@ -480,7 +480,7 @@ async fn collect_rows(
         let wanted = dep
             .specifier
             .as_deref()
-            .and_then(|spec| super::max_satisfying_version(&packument, spec))
+            .and_then(|spec| super::wanted_version(&packument, spec))
             .unwrap_or_else(|| current.clone());
 
         let latest_known = latest.is_some();

--- a/crates/aube/src/commands/package_spec.rs
+++ b/crates/aube/src/commands/package_spec.rs
@@ -1,4 +1,24 @@
-/// Pick the highest version in `packument` that satisfies `range_str`.
+/// Pick the version of `packument` that an install would land on for
+/// `range_str` — the `Wanted` column of `aube outdated` and the upgrade
+/// target `aube update` offers.
+///
+/// Mirrors pnpm's `pickVersionByVersionRange`, which is also what the
+/// resolver's own `pick_version` implements, so the report can't promise
+/// a version the install won't produce:
+///
+/// 1. `dist-tags.latest` wins whenever it falls inside the range — the
+///    publisher used the tag to anchor the canonical install, and a
+///    higher version outside it is usually a hotfix on an old line or an
+///    unwithdrawn experiment.
+/// 2. Otherwise the highest satisfying version that isn't deprecated.
+/// 3. Otherwise the highest satisfying version, deprecated and all —
+///    the deprecation rule is a tiebreak, not a filter, so a range that
+///    only reaches deprecated versions still resolves.
+///
+/// Step 2 is what keeps `codemirror@6.65.7` — an accidentally mis-tagged
+/// republish of `5.65.7` that sorts above every genuine 6.x — from being
+/// offered as an upgrade to everyone on `^6`.
+///
 /// Returns the *original packument key* (not a round-tripped `Version`
 /// display string) so string comparisons against the lockfile's
 /// `current` — which also comes from a packument key — stay stable
@@ -7,24 +27,37 @@
 /// that `Version` drops). Returns `None` for unparseable ranges
 /// (workspace:/file: specs, git URLs, etc.) so callers can fall
 /// back to the locked version.
-pub(crate) fn max_satisfying_version(
+pub(crate) fn wanted_version(
     packument: &aube_registry::Packument,
     range_str: &str,
 ) -> Option<String> {
     let range = node_semver::Range::parse(range_str).ok()?;
-    let mut best: Option<(&str, node_semver::Version)> = None;
-    for ver_str in packument.versions.keys() {
+    if let Some(latest) = packument.dist_tags.get("latest")
+        && packument.versions.contains_key(latest)
+        && let Ok(v) = node_semver::Version::parse(latest)
+        && v.satisfies(&range)
+    {
+        return Some(latest.clone());
+    }
+    let mut best: Option<(&str, node_semver::Version, bool)> = None;
+    for (ver_str, meta) in &packument.versions {
         let Ok(v) = node_semver::Version::parse(ver_str) else {
             continue;
         };
         if !v.satisfies(&range) {
             continue;
         }
-        if best.as_ref().is_none_or(|(_, b)| v > *b) {
-            best = Some((ver_str.as_str(), v));
+        let live = meta.deprecated.is_none();
+        let outranks = match &best {
+            None => true,
+            Some((_, _, best_live)) if live != *best_live => live,
+            Some((_, best_v, _)) => v > *best_v,
+        };
+        if outranks {
+            best = Some((ver_str.as_str(), v, live));
         }
     }
-    best.map(|(key, _)| key.to_string())
+    best.map(|(key, _, _)| key.to_string())
 }
 
 /// Resolve a version spec against a full packument. Returns the concrete
@@ -103,6 +136,115 @@ pub(crate) fn encode_package_name(name: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn packument(json: serde_json::Value) -> aube_registry::Packument {
+        serde_json::from_value(json).expect("test packument parses")
+    }
+
+    /// Shape of the real `codemirror` packument: `6.65.7` is an
+    /// accidentally mis-tagged republish of `5.65.7`, deprecated by the
+    /// maintainer, and sorts above every genuine 6.x release.
+    fn codemirror() -> aube_registry::Packument {
+        packument(serde_json::json!({
+            "name": "codemirror",
+            "dist-tags": { "latest": "6.0.2", "version5": "5.65.21" },
+            "versions": {
+                "6.0.1": { "name": "codemirror", "version": "6.0.1" },
+                "6.0.2": { "name": "codemirror", "version": "6.0.2" },
+                "6.65.7": {
+                    "name": "codemirror",
+                    "version": "6.65.7",
+                    "deprecated": "This is an accidentally mis-tagged instance of 5.65.7"
+                }
+            }
+        }))
+    }
+
+    /// Shape of the real `graceful-fs` packument: `4.2.7` is deprecated
+    /// in favor of `4.2.8+`, and `dist-tags.latest` (4.2.11) sits above
+    /// any range pinned to the 4.2.0–4.2.7 window.
+    fn graceful_fs() -> aube_registry::Packument {
+        packument(serde_json::json!({
+            "name": "graceful-fs",
+            "dist-tags": { "latest": "4.2.11" },
+            "versions": {
+                "4.2.6": { "name": "graceful-fs", "version": "4.2.6" },
+                "4.2.7": {
+                    "name": "graceful-fs",
+                    "version": "4.2.7",
+                    "deprecated": "Please upgrade to v4.2.8 or higher"
+                },
+                "4.2.11": { "name": "graceful-fs", "version": "4.2.11" }
+            }
+        }))
+    }
+
+    #[test]
+    fn wanted_skips_deprecated_when_the_range_admits_another() {
+        // Regression: `aube outdated` reported `codemirror` as
+        // 6.0.2 → 6.65.7 (wanted) even though the registry marks
+        // 6.65.7 deprecated and `dist-tags.latest` is 6.0.2.
+        assert_eq!(
+            wanted_version(&codemirror(), "^6.0.2").as_deref(),
+            Some("6.0.2")
+        );
+        // Same rule with the dist-tag out of the picture: 4.2.11 is
+        // outside the range, so the scan runs and must step over the
+        // deprecated 4.2.7 down to 4.2.6.
+        assert_eq!(
+            wanted_version(&graceful_fs(), ">=4.2.0 <4.2.8").as_deref(),
+            Some("4.2.6")
+        );
+    }
+
+    #[test]
+    fn wanted_keeps_deprecated_when_nothing_else_matches() {
+        // pnpm parity: the deprecation preference is a tiebreak, not a
+        // filter — a range that only reaches deprecated versions still
+        // resolves rather than reporting nothing.
+        assert_eq!(
+            wanted_version(&codemirror(), "^6.65.0").as_deref(),
+            Some("6.65.7")
+        );
+        assert_eq!(
+            wanted_version(&graceful_fs(), "4.2.7").as_deref(),
+            Some("4.2.7")
+        );
+    }
+
+    #[test]
+    fn wanted_keeps_a_deprecated_latest_dist_tag() {
+        // `is-odd@3.0.1` is both deprecated *and* the `latest` tag. The
+        // resolver installs it (pnpm returns the tag before it ever
+        // looks at deprecation), so the report has to agree — otherwise
+        // `outdated` proposes 3.0.1 → 3.0.0, a downgrade to a version
+        // no install would ever pick.
+        let is_odd = packument(serde_json::json!({
+            "name": "is-odd",
+            "dist-tags": { "latest": "3.0.1" },
+            "versions": {
+                "3.0.0": { "name": "is-odd", "version": "3.0.0" },
+                "3.0.1": {
+                    "name": "is-odd",
+                    "version": "3.0.1",
+                    "deprecated": "please use is-even"
+                }
+            }
+        }));
+        assert_eq!(wanted_version(&is_odd, "^3.0.0").as_deref(), Some("3.0.1"));
+    }
+
+    #[test]
+    fn wanted_prefers_the_latest_dist_tag_over_a_higher_in_range_version() {
+        // pnpm parity: the publisher's tag anchors the canonical
+        // install, so a higher in-range version that isn't tagged
+        // `latest` must not be reported as wanted.
+        assert_eq!(
+            wanted_version(&graceful_fs(), "*").as_deref(),
+            Some("4.2.11")
+        );
+        assert_eq!(wanted_version(&codemirror(), "*").as_deref(), Some("6.0.2"));
+    }
 
     #[test]
     fn scoped_name_encodes_slash() {

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -1043,8 +1043,7 @@ async fn pick_update_interactively(
             .and_then(|g| lookup_pkg(g, existing_importers, key, &real_name))
             .map(|p| p.version.as_str());
         let registry_latest = packument.dist_tags.get("latest").map(String::as_str);
-        let wanted =
-            super::max_satisfying_version(packument, spec).or_else(|| current.map(str::to_owned));
+        let wanted = super::wanted_version(packument, spec).or_else(|| current.map(str::to_owned));
         // `--latest` rewrites past the manifest range, so the picker
         // shows the dist-tag latest as the target. Without `--latest`
         // we only refresh inside the range, so target = wanted.

--- a/test/outdated.bats
+++ b/test/outdated.bats
@@ -93,6 +93,33 @@ EOF
 	refute_output --partial "is-odd  "
 }
 
+@test "aube outdated does not propose a downgrade off a deprecated latest" {
+	# is-odd@3.0.1 is both the `latest` dist-tag and deprecated
+	# ("please use is-even") in the fixture registry. pnpm returns the
+	# tagged version before it ever looks at deprecation, so install
+	# lands on 3.0.1 and `Wanted` must say 3.0.1 too — reporting the
+	# non-deprecated 3.0.0 would offer a downgrade no install produces.
+	cat >package.json <<-'EOF'
+		{
+		  "name": "outdated-deprecated-latest",
+		  "version": "1.0.0",
+		  "dependencies": { "is-odd": "^3.0.0" }
+		}
+	EOF
+	run aube install
+	assert_success
+
+	# `--long --json` keeps the up-to-date row in the report (the table
+	# would drop it) without echoing the `^3.0.0` specifier, so a stray
+	# 3.0.0 anywhere in the output means `wanted` proposed the
+	# downgrade.
+	run aube outdated --long --json
+	assert_success
+	assert_output --partial '"current": "3.0.1"'
+	assert_output --partial '"wanted": "3.0.1"'
+	refute_output --partial "3.0.0"
+}
+
 @test "aube outdated skips registry for package.json workspace deps" {
 	cat >package.json <<'EOF'
 {"workspaces":["sub"],"dependencies":{"happy-sunny-hippo":"workspace:"}}


### PR DESCRIPTION
## Problem

```
$ aube outdated
Package     Current  Wanted   Latest
codemirror  6.0.2    6.65.7   6.0.2
```

`codemirror@6.65.7` exists on npm but is an accidentally mis-tagged republish of `5.65.7` — the maintainer deprecated it with *"This is an accidentally mis-tagged instance of 5.65.7"*. It sorts above every genuine 6.x release, so the highest-satisfying scan behind the `Wanted` column picked it and `aube outdated` offered a downgrade-in-disguise as an upgrade (exit 1 in CI).

## Fix

Mirror pnpm's `pickVersionByVersionRange` everywhere a version is chosen from a range:

1. `dist-tags.latest` wins when it falls inside the range.
2. Otherwise the highest satisfying version that isn't deprecated.
3. Otherwise the highest satisfying version, deprecated and all.

Step 3 matters: the deprecation rule is a **tiebreak, not a filter**, so a range that only reaches deprecated versions still resolves.

Landed as a single `outranks` comparison in `aube-resolver`, shared by `pick_version` (install/add/update) and the vulnerable-version re-pick, plus the same ordering in `outdated`/`update`'s wanted-version helper.

### Two things worth a second look

- **The resolver was in scope too.** `codemirror` happened to be saved by the `dist-tags.latest` preference, but `codemirror@^6.5.0` would have *installed* the deprecated 6.65.7. `outdated`'s `Wanted` is only meaningful if it agrees with what an install produces, so both sides moved together.
- **`outdated` needed the dist-tag preference the resolver already had.** Without it, the new deprecation rule regresses packages whose `latest` is itself deprecated: `is-odd@3.0.1` is tagged `latest` *and* deprecated, so install lands on 3.0.1 while `Wanted` would have said 3.0.0 — a downgrade to a version no install ever produces. `max_satisfying_version` is renamed `wanted_version` to match what it now computes.
- **One deliberate divergence:** pnpm applies the rule only on its highest-version path. aube applies it in both directions — a deprecated *floor* is no safer than a live one, so `resolution-mode=time-based` has nothing to gain from pinning a version the publisher withdrew. Documented at the call site.

## Verification

Against the real registry, before and after:

```
# before
codemirror  6.0.2  6.65.7  6.0.2     exit 1
# after
codemirror  6.0.2  6.0.2   6.0.2     exit 0
```

A range that only reaches the deprecated version (`^6.65.0`) still resolves to 6.65.7, and `aube update` now reports `codemirror: 6.0.2 (already latest)`.

- 7 new unit tests (resolver pick + wanted-version, covering skip / fallback / deprecated-`latest`)
- 1 new bats test guarding the `is-odd` downgrade case
- Full suite green: `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `mise run test:bats` (1398 passing, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes version selection for installs, updates, and outdated across the resolver and CLI; behavior intentionally diverges from pnpm on lowest/time-based picks for deprecated floors, with broad test coverage mitigating regressions.
> 
> **Overview**
> **Fixes misleading `Wanted` / install picks when a higher in-range version is deprecated** (e.g. `codemirror@6.65.7`), by mirroring pnpm’s range selection rules across resolver and CLI.
> 
> Adds shared **`outranks`** in `aube-resolver`: non-deprecated versions beat deprecated ones; deprecation is a **tiebreak**, not a hard filter. **`pick_version`** (including lenient lowest fallback and time-based lowest) and **vulnerable re-pick** use it instead of raw semver comparisons.
> 
> Renames **`max_satisfying_version` → `wanted_version`** for **`aube outdated`** and **`aube update`**. **`wanted_version`** now matches install semantics: **`dist-tags.latest`** wins when in range, then highest non-deprecated satisfying version, then deprecated-only if nothing else matches (avoids proposing downgrades when deprecated `latest` is what install would pick, e.g. `is-odd`).
> 
> New unit and bats tests cover skip/fallback, deprecated `latest`, and dist-tag preference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca85ea1b35888106fc9725245f9545d126e28161. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->