### PR TITLE
perf: compare instruction counts on every pull request

### DIFF
--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -1,0 +1,144 @@
+name: perf-pr
+
+# Measures this pull request and compares it against the commit it branched
+# from, then says so in a comment and fails if an instruction count rose beyond
+# the gate.
+#
+# The gate is the point. A chart on a dashboard is something nobody opens; a
+# failing check on the pull request that caused the regression is read by the
+# person who can still do something about it.
+#
+# Nothing here writes to refs/notes/tak. A pull request's measurements are
+# recorded locally, used for the comparison, and discarded with the runner. Only
+# main contributes to the history — a branch's numbers are not the trunk's, and
+# a series that mixes them cannot be read.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+
+jobs:
+  compare:
+    name: Compare instruction counts
+    if: github.event_name == 'pull_request'
+    # Same runner class as perf.yml and perf-backfill.yml. Absolute counts shift
+    # between machine types by more than a real regression does, so a comparison
+    # across runner classes is not a comparison — tak refuses to make one, and
+    # the report would say "nothing was compared" instead of anything useful.
+    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
+    timeout-minutes: 40
+    permissions:
+      contents: read
+      pull-requests: write # the sticky comment
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Needed twice over: to find the merge base, and for the sparkline,
+          # which walks twenty commits of trunk history.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
+        with:
+          cache: rust
+
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          cache: false
+        env:
+          MISE_LOCKED: "1"
+
+      - name: Install valgrind
+        run: |
+          command -v valgrind || {
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends valgrind
+          }
+          valgrind --version
+
+      # `--record` writes a git note locally and nothing more. There is no
+      # `tak push` in this workflow and there should never be one.
+      - name: Measure this pull request
+        run: mise run perf:record
+
+      - name: Find the base commit
+        id: base
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch --quiet origin "$BASE_REF"
+          # The merge base, not the branch tip: comparing against a moving
+          # target attributes other people's commits to this pull request.
+          base=$(git merge-base "origin/$BASE_REF" HEAD)
+          echo "sha=$base" >> "$GITHUB_OUTPUT"
+          echo "comparing against $base on $BASE_REF"
+
+      # Deliberately not `continue-on-error`. That would hide a compare that
+      # died for an unrelated reason behind a green check. The exit code is
+      # captured, the comment is posted either way, and a later step re-raises
+      # it — so a regression always arrives with the table that explains it.
+      - name: Compare against the base
+        env:
+          BASE_SHA: ${{ steps.base.outputs.sha }}
+        run: |
+          set +e
+          tak compare "$BASE_SHA" > /tmp/tak-report.md
+          echo $? > /tmp/tak-gate-status
+          set -e
+          cat /tmp/tak-report.md
+          cat /tmp/tak-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      # Skipped for pull requests from forks, which get a read-only token. The
+      # comparison and the gate still run there; only the comment is missing.
+      - name: Comment on the pull request
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ steps.base.outputs.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          marker='<!-- aube-perf-pr -->'
+          # The backticks below are markdown, not command substitution, and
+          # single quotes are what keeps them literal.
+          # shellcheck disable=SC2016
+          {
+            printf '%s\n' "$marker"
+            printf '### Instruction counts\n\n'
+            cat /tmp/tak-report.md
+            printf '\n<sub>`%s` vs `%s` · measured on this runner, not pushed to the history.</sub>\n' \
+              "${HEAD_SHA:0:12}" "${BASE_SHA:0:12}"
+          } > /tmp/tak-comment.md
+
+          # One comment per pull request, edited in place. A new comment on
+          # every push buries the conversation under numbers.
+          existing="$(gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq ".[] | select(.body | contains(\"$marker\")) | .id" | tail -n1)"
+          if [ -n "$existing" ]; then
+            gh api --method PATCH "repos/$GH_REPO/issues/comments/$existing" \
+              --field body="$(cat /tmp/tak-comment.md)"
+          else
+            gh api --method POST "repos/$GH_REPO/issues/$PR_NUMBER/comments" \
+              --field body="$(cat /tmp/tak-comment.md)"
+          fi
+
+      - name: Fail on a regression
+        run: |
+          status=$(cat /tmp/tak-gate-status)
+          if [ "$status" -ne 0 ]; then
+            echo "::error::an instruction count rose beyond the gate — see the table in the comment or the job summary"
+            exit "$status"
+          fi

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -45,6 +45,12 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # The branch commit, not the merge commit actions/checkout defaults to
+          # for a pull_request event. That default is synthetic: it exists only
+          # for the run, changes whenever main advances, and measuring it would
+          # attribute a number to a commit nobody can check out. It would also
+          # make the footer below name a commit the measurement is not of.
+          ref: ${{ github.event.pull_request.head.sha }}
           # Needed twice over: to find the merge base, and for the sparkline,
           # which walks twenty commits of trunk history.
           fetch-depth: 0
@@ -135,8 +141,17 @@ jobs:
               --field body="$(cat /tmp/tak-comment.md)"
           fi
 
+      # `always()` because a step that fails stops the ones after it, and the
+      # gate is the reason this workflow exists. Without it, a `gh api` hiccup
+      # in the comment step would skip the gate entirely: the job would still go
+      # red, but for the wrong reason and with no regression error to read.
       - name: Fail on a regression
+        if: always()
         run: |
+          if [ ! -f /tmp/tak-gate-status ]; then
+            echo "::error::the comparison never ran — nothing was gated"
+            exit 1
+          fi
           status=$(cat /tmp/tak-gate-status)
           if [ "$status" -ne 0 ]; then
             echo "::error::an instruction count rose beyond the gate — see the table in the comment or the job summary"

--- a/mise.lock
+++ b/mise.lock
@@ -180,43 +180,43 @@ url = "https://github.com/foresterre/cargo-msrv/releases/download/v0.19.3/cargo-
 url_api = "https://api.github.com/repos/foresterre/cargo-msrv/releases/assets/380851496"
 
 [[tools."github:jdx/tak"]]
-version = "0.0.3"
+version = "0.0.4"
 backend = "github:jdx/tak"
 
 [tools."github:jdx/tak"."platforms.linux-arm64"]
-checksum = "sha256:d9468292fa103e5d2fe586dcfdce547061a4878d2af783624af5fa823edc6e83"
-url = "https://github.com/jdx/tak/releases/download/v0.0.3/tak-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/489889522"
+checksum = "sha256:76361a7d8820c9b955b7393d960e5e3744816d020904bd142ca9103cc70616d5"
+url = "https://github.com/jdx/tak/releases/download/v0.0.4/tak-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/490853625"
 provenance = "github-attestations"
 
 [tools."github:jdx/tak"."platforms.linux-arm64-musl"]
-checksum = "sha256:a1b881251acefcc5e0bc8044007c3b2044f1871b2e2f5a44d42bbe79f38d8fa7"
-url = "https://github.com/jdx/tak/releases/download/v0.0.3/tak-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/489889524"
+checksum = "sha256:8a171779ea86d82c327dc407f8330d98da593751982c718bed3d5aca2c2bb958"
+url = "https://github.com/jdx/tak/releases/download/v0.0.4/tak-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/490853627"
 provenance = "github-attestations"
 
 [tools."github:jdx/tak"."platforms.linux-x64"]
-checksum = "sha256:2368e272e6416589fcf86b40f94830ccfd2769dff90fe32a7046de29f44e598b"
-url = "https://github.com/jdx/tak/releases/download/v0.0.3/tak-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/489889528"
+checksum = "sha256:4d5a6c20c4c088f9771f5ba3f138b9e336a53a37b6d59b1dda1d4291294ed4db"
+url = "https://github.com/jdx/tak/releases/download/v0.0.4/tak-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/490853634"
 provenance = "github-attestations"
 
 [tools."github:jdx/tak"."platforms.linux-x64-musl"]
-checksum = "sha256:ec82aae7e45fed4d728eb69a20a10b72fc837339dfd18d7e683085ce33b7ffff"
-url = "https://github.com/jdx/tak/releases/download/v0.0.3/tak-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/489889531"
+checksum = "sha256:c2bc482ff5010b084e50ad9d6435ca988a743b8303519a38a3801cf1f82ae8b1"
+url = "https://github.com/jdx/tak/releases/download/v0.0.4/tak-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/490853633"
 provenance = "github-attestations"
 
 [tools."github:jdx/tak"."platforms.macos-arm64"]
-checksum = "sha256:e907b1206f0378ca219c8841922e828c927ad68d2f2c8d235f82e95c2de5cece"
-url = "https://github.com/jdx/tak/releases/download/v0.0.3/tak-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/489889526"
+checksum = "sha256:3bf2c09c461ed4db66f58e9d6ce31400e9d57cfe8132c104ca56313b881bd300"
+url = "https://github.com/jdx/tak/releases/download/v0.0.4/tak-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/490853626"
 provenance = "github-attestations"
 
 [tools."github:jdx/tak"."platforms.windows-x64"]
-checksum = "sha256:5eda4254af4eb1ded91b6e3748a71edf37a34bbccee6297c64ec06174f8a6303"
-url = "https://github.com/jdx/tak/releases/download/v0.0.3/tak-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/489889529"
+checksum = "sha256:e6669edcde51625a637a7d3f90b26f3737ca113f8188f6e0f6872b421f51e49e"
+url = "https://github.com/jdx/tak/releases/download/v0.0.4/tak-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/490853632"
 provenance = "github-attestations"
 
 [[tools.hk]]

--- a/mise.toml
+++ b/mise.toml
@@ -11,10 +11,10 @@ communique = "latest"
 # upgrade that changes how it samples would land in the series as a step
 # change in aube's numbers, indistinguishable from a real regression. Bump
 # deliberately, on a commit that does nothing else.
-# TODO: switch to plain `tak = "0.0.3"` once a mise release ships the registry
+# TODO: switch to plain `tak = "0.0.4"` once a mise release ships the registry
 # entry from jdx/mise#11307 — the shorthand exists on main but the registry is
 # compiled in, so it is not usable until then.
-"github:jdx/tak" = "0.0.3"
+"github:jdx/tak" = "0.0.4"
 hk = "latest"
 node = "24"
 pitchfork = "latest"


### PR DESCRIPTION
The gate. This PR should comment on itself — that is the test.

Measures the pull request, compares it against the commit it branched from, posts the table, and **fails the check** when an instruction count rose beyond `gate_pct` (1% by default).

The gate is the point. A chart on a dashboard is something nobody opens; a failing check on the pull request that caused the regression is read by the person who can still do something about it.

## What the comment looks like

Real output, from aube's own notes:

| benchmark | trend | instructions | Δ | wall (min) | Δ |
|---|---|---:|---:|---:|---:|
| release-graph (aube) | `███▁` | 15,981,921 → 15,477,394 | **-3.16%** | 4.26 → 3.70ms | -13.29% |

No instruction-count regression above 1%.

<sub>Only instruction counts gate. Wall clock is shown for context — on identical hardware it moves 4-20% run to run.</sub>

The trend is twenty commits of trunk history with this branch's own value appended, so drift and change read as one line. Unicode blocks rather than a rendered chart: they need nothing to render them — no mermaid version to depend on, no image host — and they read the same in a terminal, a diff, and a comment.

## Decisions

- **Nothing writes to `refs/notes/tak`.** A pull request's measurements are recorded locally, used for the comparison, and discarded with the runner. Only main contributes to the history; a series that mixes trunk and branch numbers cannot be read. There is no `tak push` in this workflow and there should never be one.
- **Merge base, not branch tip.** Comparing against a moving target attributes other people's commits to this pull request.
- **The comment posts before the gate decides.** A failing check whose explanation never arrived is the worst version of this feature. The exit code is captured and re-raised in a later step.
- **The compare step is not `continue-on-error`.** That would hide a compare which died for an unrelated reason behind a green check — a failure mode this repo has already seen twice in tak's release workflow.
- **Fork pull requests skip the comment**, matching `bench-pr.yml`. The comparison and the gate still run; only the write is missing.

## Notes

- Requires tak **0.0.4** for `tak compare`; the pin and lockfile move with it.
- The merge base needs measurements for there to be anything to compare. If `perf.yml` did not record there, tak says "nothing was compared, and so nothing was gated" and passes — honest, and visible, rather than a silent green.
- actionlint and zizmor at `--persona=pedantic` are clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes (new workflow and tool pin); no application runtime or security-sensitive code paths.
> 
> **Overview**
> Adds a **`perf-pr`** GitHub Actions workflow that runs on every pull request, records instruction counts locally via `mise run perf:record`, compares the PR head against the **merge base** with `tak compare`, and **fails the check** when counts rise beyond the configured gate.
> 
> The workflow posts or updates a single sticky PR comment with the comparison table (skipped for fork PRs), mirrors the report in the job summary, and uses a final `always()` step to re-raise the compare exit code so regressions fail with the explanation already visible. Measurements stay on the runner—no `tak push` or updates to `refs/notes/tak`.
> 
> **`tak`** is bumped from **0.0.3** to **0.0.4** in `mise.toml` and `mise.lock` for `tak compare` support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 614e254961ec063a99a55a72cbf77ca63cf16eed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->