### PR TITLE
fix(add): trust locked packages without embedded prompts

### DIFF
--- a/crates/aube/src/commands/add/filtered.rs
+++ b/crates/aube/src/commands/add/filtered.rs
@@ -39,7 +39,7 @@ pub(super) async fn run(
     // `args.packages` list. The Bun-style `securityScanner` is
     // NOT called here: it runs post-resolve from `install::run`
     // against the full resolved graph.
-    supply_chain::run_cli_name_gates(&root, &args.packages, args.allow_low_downloads).await?;
+    supply_chain::run_cli_name_gates(&root, &args.packages, args.allow_low_downloads, true).await?;
 
     let mut snapshots = Vec::new();
     let lockfile_path = no_save::lockfile_path_for_project(&root);

--- a/crates/aube/src/commands/add/mod.rs
+++ b/crates/aube/src/commands/add/mod.rs
@@ -88,7 +88,13 @@ pub async fn add_to_project(
             _ = mutation_control.cancelled() => mutation_control.check_cancelled(),
             result = async {
                 if !options.offline {
-                    supply_chain::run_cli_name_gates(project_dir, packages, false).await?;
+                    supply_chain::run_cli_name_gates(
+                        lock.project_dir(),
+                        packages,
+                        false,
+                        false,
+                    )
+                    .await?;
                 }
                 update_manifest_for_add(
                     project_dir,
@@ -514,7 +520,7 @@ pub async fn run(
     // full resolved graph (matching Bun's contract), with
     // concrete versions + transitives the OSV/downloads probes
     // wouldn't see at this stage.
-    supply_chain::run_cli_name_gates(&cwd, packages, allow_low_downloads).await?;
+    supply_chain::run_cli_name_gates(&cwd, packages, allow_low_downloads, true).await?;
 
     update_manifest_for_add(
         &cwd,

--- a/crates/aube/src/commands/add/supply_chain.rs
+++ b/crates/aube/src/commands/add/supply_chain.rs
@@ -1,14 +1,17 @@
 use super::manifest::collect_workspace_versions;
 use super::spec::parse_pkg_spec;
+use std::collections::BTreeSet;
 use std::path::Path;
 
 pub(super) async fn run_cli_name_gates(
     cwd: &Path,
     packages: &[String],
     allow_low_downloads: bool,
+    allow_prompt: bool,
 ) -> miette::Result<()> {
     let registry_inputs = registry_bound_inputs_for_supply_chain(cwd, packages);
-    let (advisory_check, low_download_threshold, allowed_unpopular) =
+    let locked_registry_names = locked_registry_names(cwd);
+    let (advisory_check, low_download_threshold, mut allowed_unpopular) =
         crate::commands::with_settings_ctx(cwd, |ctx| {
             let policy = if aube_settings::resolved::paranoid(ctx) {
                 aube_settings::resolved::AdvisoryCheck::Required
@@ -21,16 +24,43 @@ pub(super) async fn run_cli_name_gates(
                 aube_settings::resolved::allowed_unpopular_packages(ctx).unwrap_or_default(),
             )
         });
+    allowed_unpopular.extend(
+        locked_registry_names
+            .iter()
+            .map(|name| glob::Pattern::escape(name)),
+    );
     crate::commands::add_supply_chain::run_gates(
         &registry_inputs.name_only_advisory_names,
         &registry_inputs.exact_advisory_pairs,
         &registry_inputs.download_names,
         advisory_check,
         low_download_threshold,
-        allow_low_downloads,
+        crate::commands::add_supply_chain::LowDownloadPolicy {
+            allow: allow_low_downloads,
+            prompt: allow_prompt,
+        },
         &allowed_unpopular,
     )
     .await
+}
+
+fn locked_registry_names(cwd: &Path) -> BTreeSet<String> {
+    let Ok(manifest) = crate::commands::load_manifest_or_default(cwd) else {
+        return BTreeSet::new();
+    };
+    match aube_lockfile::parse_lockfile_with_kind(cwd, &manifest) {
+        Ok((graph, _)) => graph
+            .packages
+            .values()
+            .filter(|pkg| pkg.local_source.is_none())
+            .map(|pkg| pkg.registry_name().to_string())
+            .collect(),
+        Err(aube_lockfile::Error::NotFound(_)) => BTreeSet::new(),
+        Err(err) => {
+            tracing::debug!("could not read package names from active lockfile: {err}");
+            BTreeSet::new()
+        }
+    }
 }
 
 #[derive(Default)]
@@ -212,5 +242,50 @@ mod tests {
             vec![("nx".to_string(), "23.0.0".to_string())],
         );
         assert_eq!(inputs.download_names, vec!["nx".to_string()]);
+    }
+
+    #[test]
+    fn active_lockfile_packages_are_trusted_for_download_gate() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join("package.json"), "{}\n").expect("write package.json");
+        let mut graph = aube_lockfile::LockfileGraph::default();
+        graph.packages.insert(
+            "tiny-package@1.0.0".to_string(),
+            aube_lockfile::LockedPackage {
+                name: "tiny-package".to_string(),
+                version: "1.0.0".to_string(),
+                ..Default::default()
+            },
+        );
+        aube_lockfile::write_lockfile(tmp.path(), &graph, &aube_manifest::PackageJson::default())
+            .expect("write lockfile");
+
+        assert_eq!(
+            locked_registry_names(tmp.path()),
+            BTreeSet::from(["tiny-package".to_string()])
+        );
+    }
+
+    #[test]
+    fn lockfile_alias_trusts_the_registry_package_name() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join("package.json"), "{}\n").expect("write package.json");
+        let mut graph = aube_lockfile::LockfileGraph::default();
+        graph.packages.insert(
+            "tiny-alias@1.0.0".to_string(),
+            aube_lockfile::LockedPackage {
+                name: "tiny-alias".to_string(),
+                alias_of: Some("tiny-package".to_string()),
+                version: "1.0.0".to_string(),
+                ..Default::default()
+            },
+        );
+        aube_lockfile::write_lockfile(tmp.path(), &graph, &aube_manifest::PackageJson::default())
+            .expect("write lockfile");
+
+        assert_eq!(
+            locked_registry_names(tmp.path()),
+            BTreeSet::from(["tiny-package".to_string()])
+        );
     }
 }

--- a/crates/aube/src/commands/add/supply_chain.rs
+++ b/crates/aube/src/commands/add/supply_chain.rs
@@ -9,21 +9,28 @@ pub(super) async fn run_cli_name_gates(
     allow_low_downloads: bool,
     allow_prompt: bool,
 ) -> miette::Result<()> {
-    let registry_inputs = registry_bound_inputs_for_supply_chain(cwd, packages);
-    let locked_registry_names = locked_registry_names(cwd);
-    let (advisory_check, low_download_threshold, mut allowed_unpopular) =
-        crate::commands::with_settings_ctx(cwd, |ctx| {
+    let project_dir = supply_chain_project_dir(cwd);
+    let manifest = crate::commands::load_manifest_or_default(&project_dir)?;
+    let registry_inputs = registry_bound_inputs_for_supply_chain(&project_dir, packages);
+    let (advisory_check, low_download_threshold, mut allowed_unpopular, lockfile_dir) =
+        crate::commands::with_settings_ctx(&project_dir, |ctx| {
             let policy = if aube_settings::resolved::paranoid(ctx) {
                 aube_settings::resolved::AdvisoryCheck::Required
             } else {
                 aube_settings::resolved::advisory_check(ctx)
             };
-            (
+            Ok::<_, miette::Report>((
                 policy,
                 aube_settings::resolved::low_download_threshold(ctx),
                 aube_settings::resolved::allowed_unpopular_packages(ctx).unwrap_or_default(),
-            )
-        });
+                crate::commands::install::resolve_active_lockfile_dir(
+                    &project_dir,
+                    &manifest,
+                    ctx,
+                )?,
+            ))
+        })?;
+    let locked_registry_names = locked_registry_names(&lockfile_dir, &manifest);
     allowed_unpopular.extend(
         locked_registry_names
             .iter()
@@ -44,11 +51,15 @@ pub(super) async fn run_cli_name_gates(
     .await
 }
 
-fn locked_registry_names(cwd: &Path) -> BTreeSet<String> {
-    let Ok(manifest) = crate::commands::load_manifest_or_default(cwd) else {
-        return BTreeSet::new();
-    };
-    match aube_lockfile::parse_lockfile_with_kind(cwd, &manifest) {
+fn supply_chain_project_dir(cwd: &Path) -> std::path::PathBuf {
+    crate::dirs::find_workspace_root(cwd).unwrap_or_else(|| cwd.to_path_buf())
+}
+
+fn locked_registry_names(
+    lockfile_dir: &Path,
+    manifest: &aube_manifest::PackageJson,
+) -> BTreeSet<String> {
+    match aube_lockfile::parse_lockfile_with_kind(lockfile_dir, manifest) {
         Ok((graph, _)) => graph
             .packages
             .values()
@@ -261,7 +272,7 @@ mod tests {
             .expect("write lockfile");
 
         assert_eq!(
-            locked_registry_names(tmp.path()),
+            locked_registry_names(tmp.path(), &aube_manifest::PackageJson::default()),
             BTreeSet::from(["tiny-package".to_string()])
         );
     }
@@ -284,7 +295,69 @@ mod tests {
             .expect("write lockfile");
 
         assert_eq!(
-            locked_registry_names(tmp.path()),
+            locked_registry_names(tmp.path(), &aube_manifest::PackageJson::default()),
+            BTreeSet::from(["tiny-package".to_string()])
+        );
+    }
+
+    #[test]
+    fn workspace_member_uses_root_lockfile_packages() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let member = tmp.path().join("packages/app");
+        std::fs::create_dir_all(&member).expect("create member");
+        std::fs::write(
+            tmp.path().join("package.json"),
+            "{\"workspaces\":[\"packages/*\"]}\n",
+        )
+        .expect("write root package.json");
+        std::fs::write(member.join("package.json"), "{}\n").expect("write member package.json");
+        let mut graph = aube_lockfile::LockfileGraph::default();
+        graph.packages.insert(
+            "tiny-package@1.0.0".to_string(),
+            aube_lockfile::LockedPackage {
+                name: "tiny-package".to_string(),
+                version: "1.0.0".to_string(),
+                ..Default::default()
+            },
+        );
+        let manifest =
+            aube_manifest::PackageJson::from_path(&tmp.path().join("package.json")).unwrap();
+        aube_lockfile::write_lockfile(tmp.path(), &graph, &manifest).expect("write lockfile");
+
+        let project_dir = supply_chain_project_dir(&member);
+        assert_eq!(project_dir, tmp.path());
+        assert_eq!(
+            locked_registry_names(&project_dir, &manifest),
+            BTreeSet::from(["tiny-package".to_string()])
+        );
+    }
+
+    #[test]
+    fn configured_lockfile_dir_is_used_for_trusted_packages() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let lockfile_dir = tmp.path().join("locks");
+        std::fs::create_dir_all(&lockfile_dir).expect("create lockfile dir");
+        std::fs::write(tmp.path().join("package.json"), "{}\n").expect("write package.json");
+        std::fs::write(tmp.path().join(".npmrc"), "lockfile-dir=locks\n").expect("write .npmrc");
+        let manifest = aube_manifest::PackageJson::default();
+        let mut graph = aube_lockfile::LockfileGraph::default();
+        graph.packages.insert(
+            "tiny-package@1.0.0".to_string(),
+            aube_lockfile::LockedPackage {
+                name: "tiny-package".to_string(),
+                version: "1.0.0".to_string(),
+                ..Default::default()
+            },
+        );
+        aube_lockfile::write_lockfile(&lockfile_dir, &graph, &manifest).expect("write lockfile");
+
+        let active_dir = crate::commands::with_settings_ctx(tmp.path(), |ctx| {
+            crate::commands::install::resolve_active_lockfile_dir(tmp.path(), &manifest, ctx)
+        })
+        .expect("resolve active lockfile dir");
+        assert_eq!(active_dir, lockfile_dir.canonicalize().unwrap());
+        assert_eq!(
+            locked_registry_names(&active_dir, &manifest),
             BTreeSet::from(["tiny-package".to_string()])
         );
     }

--- a/crates/aube/src/commands/add_supply_chain.rs
+++ b/crates/aube/src/commands/add_supply_chain.rs
@@ -39,6 +39,12 @@ use aube_settings::resolved::{AdvisoryBloomCheck, AdvisoryCheck, AdvisoryCheckOn
 use miette::miette;
 use std::io::{BufRead, IsTerminal, Write};
 
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct LowDownloadPolicy {
+    pub(crate) allow: bool,
+    pub(crate) prompt: bool,
+}
+
 /// Run both supply-chain gates against the registry-bound specs the
 /// user passed to `aube add`. Inputs should already be filtered to
 /// packages that resolve via the public npm registry — workspace, git,
@@ -46,22 +52,23 @@ use std::io::{BufRead, IsTerminal, Write};
 /// version-aware query; ranges and dist-tags stay on the name-only
 /// query until the resolver picks a concrete version.
 ///
-/// `allow_low_downloads` is the per-invocation `--allow-low-downloads`
-/// override; when `true` the download gate is skipped entirely (the
-/// advisory check still runs).
+/// `low_download_policy` controls the per-invocation
+/// `--allow-low-downloads` override and whether the caller permits a
+/// terminal prompt. Embedded callers disable prompting so an in-process
+/// install can never block on aube's stdin.
 ///
 /// `allowed_unpopular_globs` are the `allowedUnpopularPackages`
 /// setting entries: full-name globs that exempt matching names from
 /// the downloads gate only. The advisory check still runs against
 /// every package regardless — exempting confirmed-malicious advisories
 /// is not what this list is for.
-pub async fn run_gates(
+pub(crate) async fn run_gates(
     name_only_advisory_names: &[String],
     exact_advisory_pairs: &[(String, String)],
     download_names: &[String],
     advisory_check: AdvisoryCheck,
     low_download_threshold: u64,
-    allow_low_downloads: bool,
+    low_download_policy: LowDownloadPolicy,
     allowed_unpopular_globs: &[String],
 ) -> miette::Result<()> {
     if name_only_advisory_names.is_empty()
@@ -111,15 +118,16 @@ pub async fn run_gates(
         "refusing to add malicious package(s):",
     )
     .await?;
-    if !allow_low_downloads && low_download_threshold > 0 {
-        let patterns = compile_allowed_unpopular(allowed_unpopular_globs);
-        let gated: Vec<String> = download_names
-            .iter()
-            .filter(|n| !patterns.iter().any(|p| p.matches(n)))
-            .cloned()
-            .collect();
+    if !low_download_policy.allow && low_download_threshold > 0 {
+        let gated = download_names_to_gate(download_names, allowed_unpopular_globs);
         if !gated.is_empty() {
-            downloads_gate(&client, &gated, low_download_threshold).await?;
+            downloads_gate(
+                &client,
+                &gated,
+                low_download_threshold,
+                low_download_policy.prompt,
+            )
+            .await?;
         }
     }
     Ok(())
@@ -574,6 +582,15 @@ fn compile_allowed_unpopular(raw: &[String]) -> Vec<glob::Pattern> {
         .collect()
 }
 
+fn download_names_to_gate(names: &[String], allowed_unpopular_globs: &[String]) -> Vec<String> {
+    let patterns = compile_allowed_unpopular(allowed_unpopular_globs);
+    names
+        .iter()
+        .filter(|name| !patterns.iter().any(|pattern| pattern.matches(name)))
+        .cloned()
+        .collect()
+}
+
 async fn osv_gate(
     client: &reqwest::Client,
     names: &[String],
@@ -686,8 +703,9 @@ async fn downloads_gate(
     client: &reqwest::Client,
     names: &[String],
     threshold: u64,
+    allow_prompt: bool,
 ) -> miette::Result<()> {
-    let interactive = std::io::stdin().is_terminal() && std::io::stderr().is_terminal();
+    let interactive = prompt_is_interactive(allow_prompt);
     let mut set: tokio::task::JoinSet<(String, Result<DownloadCount, _>)> =
         tokio::task::JoinSet::new();
     for name in names {
@@ -760,6 +778,10 @@ async fn downloads_gate(
     Ok(())
 }
 
+fn prompt_is_interactive(allow_prompt: bool) -> bool {
+    allow_prompt && std::io::stdin().is_terminal() && std::io::stderr().is_terminal()
+}
+
 fn prompt_continue(name: &str, weekly: u64, threshold: u64) -> miette::Result<bool> {
     let mut stderr = std::io::stderr().lock();
     writeln!(stderr, "  ⚠ {name} looks suspicious:").ok();
@@ -806,9 +828,36 @@ mod tests {
         // registry-name list. The function must be a no-op in that
         // case (no network, no error) so those code paths stay free.
         assert!(
-            run_gates(&[], &[], &[], AdvisoryCheck::Required, 1000, false, &[])
-                .await
-                .is_ok()
+            run_gates(
+                &[],
+                &[],
+                &[],
+                AdvisoryCheck::Required,
+                1000,
+                LowDownloadPolicy {
+                    allow: false,
+                    prompt: true,
+                },
+                &[],
+            )
+            .await
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn embedded_callers_cannot_enable_terminal_prompts() {
+        assert!(!prompt_is_interactive(false));
+    }
+
+    #[test]
+    fn exact_allowed_names_skip_only_the_download_gate() {
+        let names = vec!["locked[tiny]".to_string(), "new-tiny".to_string()];
+        let allowed = vec![glob::Pattern::escape("locked[tiny]")];
+
+        assert_eq!(
+            download_names_to_gate(&names, &allowed),
+            vec!["new-tiny".to_string()]
         );
     }
 

--- a/crates/aube/src/commands/install/layout.rs
+++ b/crates/aube/src/commands/install/layout.rs
@@ -58,7 +58,7 @@ pub(super) fn resolve_install_layout(
 
 /// Resolve `--lockfile-dir` / `lockfileDir` into the physical lockfile
 /// directory plus the importer key this project owns inside that lockfile.
-fn resolve_lockfile_location(
+pub(super) fn resolve_lockfile_location(
     cwd: &std::path::Path,
     manifest: &aube_manifest::PackageJson,
     settings_ctx: &aube_settings::ResolveCtx<'_>,

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -53,6 +53,14 @@ pub(crate) use lifecycle::{
 use lifecycle::{
     resolve_link_strategy, run_import_on_blocking, run_root_lifecycle, validate_required_scripts,
 };
+
+pub(crate) fn resolve_active_lockfile_dir(
+    cwd: &std::path::Path,
+    manifest: &aube_manifest::PackageJson,
+    settings_ctx: &aube_settings::ResolveCtx<'_>,
+) -> miette::Result<std::path::PathBuf> {
+    layout::resolve_lockfile_location(cwd, manifest, settings_ctx).map(|(dir, _)| dir)
+}
 use lockfile_dir::{
     parse_lockfile_dir_remapped_with_kind_and_options, write_lockfile_dir_remapped,
 };

--- a/docs/security.md
+++ b/docs/security.md
@@ -237,6 +237,9 @@ aube add supabase-javascript
 
 In non-interactive contexts the prompt becomes a hard refusal with
 `ERR_AUBE_LOW_DOWNLOAD_PACKAGE` unless `--allow-low-downloads` is passed.
+Packages already present in the active lockfile are trusted for this
+download-count check, regardless of which supported lockfile format the
+project uses. Lockfile membership does not bypass the OSV check.
 
 **Private packages skip both gates automatically.** Any package routed
 through a non-`registry.npmjs.org` registry — whether by a scoped


### PR DESCRIPTION
## Summary

- treat package membership in any active supported lockfile as approval for the low-download gate
- keep OSV malicious-package checks active for locked packages
- prevent embedded hosts from ever reading aube stdin for confirmation
- preserve the existing lockfile formats without adding approval metadata

## Root cause

The download gate inferred interactivity directly from process stdin/stderr. An embedding host such as mise could therefore enter aube’s confirmation prompt while the host owned the terminal progress display, which looked like a hang.

Lockfiles already represent a reviewed, reproducible dependency selection. Reusing their package names for only the popularity gate avoids a second approval mechanism while retaining the security checks.

This addresses https://github.com/jdx/mise/discussions/11375.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p aube --all-targets -- -D warnings`
- `mise run test`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes supply-chain behavior on `aube add` (lockfile-derived exemptions and prompt gating) in security-sensitive code paths, though scope is limited and covered by new unit tests.
> 
> **Overview**
> **Low-download gate** now treats every registry package name already in the **active lockfile** (workspace root, configured `lockfile-dir`, aliases resolved via `registry_name()`) as exempt—merged into the same glob list as `allowedUnpopularPackages`—so re-adding or bumping locked deps does not re-trigger the popularity prompt. **OSV malicious-package checks are unchanged** for those names.
> 
> **Embedded `add_to_project`** passes `allow_prompt: false` and uses the workspace **project lock dir** for gates; the CLI keeps prompts enabled. `LowDownloadPolicy` replaces the lone `--allow-low-downloads` flag at the gate layer so hosts like mise never block on aube reading stdin while the UI still owns the terminal.
> 
> Adds `install::resolve_active_lockfile_dir` for lockfile path resolution and documents lockfile trust in `docs/security.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57698a2adc7e50486c121632075d99c2836c4bb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->