### PR TITLE
fix(deps): keep yamlpath compatible with MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,9 @@ yaml_serde = "0.10.4"
 # yamlpatch uses yaml_serde for patch payloads; serde_yaml remains only
 # for the manual block injector that works around nested Add formatting.
 yamlpatch = "1.25"
-yamlpath = "1.25"
+# yamlpath 1.28 does not declare the Rust 1.97 requirement it inherits
+# from tree-sitter-iter 1.28, so resolver 3 cannot avoid it.
+yamlpath = ">=1.25, <1.28"
 serde_yaml = "0.9"
 sonic-rs = "0.5"
 toml = "1.1"


### PR DESCRIPTION
## Summary

- constrain `yamlpath` below 1.28
- document why resolver 3 cannot avoid the incompatible transitive dependency

## Root cause

`yamlpath` 1.28 does not declare the Rust 1.97 requirement it inherits from `tree-sitter-iter` 1.28. Resolver 3 therefore selects `yamlpath` as compatible, then falls back to the Rust-1.97-only transitive dependency because no compatible version satisfies `yamlpath`'s requirement.

This broke lock file maintenance on the workspace's declared Rust 1.91 floor.

## Validation

- generated a fresh lockfile with resolver 3; it selected `yamlpath` 1.27.0 and `tree-sitter-iter` 1.27.0
- `cargo check -p aube-manifest`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version constraint and documentation only; no runtime or application logic changes.
> 
> **Overview**
> Caps the workspace **`yamlpath`** dependency at **&lt;1.28** (was a loose **`1.25`**) so Cargo resolver 3 cannot pull **`yamlpath` 1.28**, which transitively needs Rust 1.97 via **`tree-sitter-iter`** without declaring that MSRV—breaking lockfile maintenance on the workspace’s **Rust 1.91** floor.
> 
> Adds a short comment in **`Cargo.toml`** documenting that resolver behavior so future bumps don’t drop the upper bound by mistake.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70f5863fc991a8a91e747ff76880f9ffb7700daf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->