### PR TITLE
feat(settings): let cacheDir relocate the global virtual store

### DIFF
--- a/crates/aube-codes/src/warnings.rs
+++ b/crates/aube-codes/src/warnings.rs
@@ -27,6 +27,7 @@ pub const WARN_AUBE_LTHASH_MISMATCH: &str = "WARN_AUBE_LTHASH_MISMATCH";
 pub const WARN_AUBE_DELTA_INVALIDATE_FAILED: &str = "WARN_AUBE_DELTA_INVALIDATE_FAILED";
 pub const WARN_AUBE_GVS_INCOMPATIBLE: &str = "WARN_AUBE_GVS_INCOMPATIBLE";
 pub const WARN_AUBE_GVS_MODE_CHANGED: &str = "WARN_AUBE_GVS_MODE_CHANGED";
+pub const WARN_AUBE_GVS_CROSS_VOLUME: &str = "WARN_AUBE_GVS_CROSS_VOLUME";
 
 // ── settings / config validation ────────────────────────────────────
 pub const WARN_AUBE_INVALID_CONCURRENCY: &str = "WARN_AUBE_INVALID_CONCURRENCY";
@@ -239,6 +240,12 @@ pub const ALL: &[CodeMeta] = &[
         name: WARN_AUBE_GVS_MODE_CHANGED,
         category: category::INSTALL_LIFECYCLE,
         description: "Switching between gvs-on and gvs-off; removing `node_modules` and reinstalling from scratch.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: WARN_AUBE_GVS_CROSS_VOLUME,
+        category: category::INSTALL_LIFECYCLE,
+        description: "`cacheDir` (global virtual store) and `storeDir` are on different volumes, so linking falls back to per-file copy.",
         exit_code: None,
     },
     // Settings / config validation

--- a/crates/aube-manifest/src/workspace/config.rs
+++ b/crates/aube-manifest/src/workspace/config.rs
@@ -187,6 +187,14 @@ pub struct WorkspaceConfig {
     #[serde(default)]
     pub store_dir: Option<String>,
 
+    /// Path to the global virtual store — the shared tree of
+    /// materialized packages every project symlinks into. Defaults to
+    /// `<cacheDir>/virtual-store`; set it to keep the virtual store on
+    /// the same volume as `storeDir` without moving the rest of the
+    /// cache.
+    #[serde(default)]
+    pub global_virtual_store_dir: Option<String>,
+
     // -- Lockfile Settings --
     /// Whether to use a lockfile (default: true).
     #[serde(default)]

--- a/crates/aube-settings/build.rs
+++ b/crates/aube-settings/build.rs
@@ -422,7 +422,10 @@ fn default_expr(name: &str, def: &SettingDef, kind: Kind, rust_ty: &str) -> Opti
     // in aube or routed through a crate-specific helper so callers
     // still need to distinguish "not configured" from "configured to
     // this literal value".
-    if matches!(name, "preferFrozenLockfile" | "storeDir" | "nodeVersion") {
+    if matches!(
+        name,
+        "preferFrozenLockfile" | "storeDir" | "cacheDir" | "nodeVersion"
+    ) {
         return None;
     }
     let raw = def.default.trim();

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -2617,14 +2617,34 @@ sources.npmrc = ["stateDir"]
 examples = []
 
 [cacheDir]
-description = "Directory for package metadata and dlx cache."
+description = "Directory for the global virtual store and cached package metadata."
 type = "path"
-default = "~/.cache/aube"
-docs = "Overrides the cache directory. `XDG_CACHE_HOME` is honored by the platform default (`aube_store::dirs::cache_dir`) which appends `/aube`; this setting takes a complete path."
+default = "$XDG_CACHE_HOME/aube"
+docs = """
+Overrides the cache directory. `XDG_CACHE_HOME` is honored by the
+platform default (`aube_store::dirs::cache_dir`), which appends
+`/aube`; this setting takes a complete path, so
+`AUBE_CACHE_DIR=/mnt/fast/aube` puts the cache directly there.
+
+Everything regenerable lives under this directory: the global virtual
+store (`<cacheDir>/virtual-store/`) and cached packument metadata
+(`<cacheDir>/packuments-v1/`, `<cacheDir>/packuments-full-v1/`). The
+content-addressable store is *not* here — it is `storeDir`, which
+defaults under `$XDG_DATA_HOME` instead.
+
+Set this alongside `storeDir` when the store lives on a non-default
+volume. The global virtual store hardlinks out of the CAS, so if
+`cacheDir` and `storeDir` land on different filesystems every install
+degrades to a per-file copy and aube warns about it. Pointing both at
+the same volume (`AUBE_CACHE_DIR=/mnt/dev/cache/aube` plus
+`AUBE_STORE_DIR=/mnt/dev/stores/aube`) keeps the hardlink fast path.
+"""
 sources.cli = []
 sources.env = ["npm_config_cache_dir", "NPM_CONFIG_CACHE_DIR", "AUBE_CACHE_DIR"]
 sources.npmrc = ["cache-dir", "cacheDir"]
-examples = []
+examples = [
+    "AUBE_CACHE_DIR=/mnt/dev/cache/aube AUBE_STORE_DIR=/mnt/dev/stores/aube aube install",
+]
 
 [useStderr]
 description = "Write all output to stderr instead of stdout."

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -1121,6 +1121,41 @@ examples = [
   "aube dlx --enable-gvs create-vite",
 ]
 
+[globalVirtualStoreDir]
+description = "Location of the shared virtual store used by every project."
+type = "path"
+default = "undefined"
+docs = """
+Relocates the global virtual store — the shared tree of materialized
+package directories that `node_modules/.aube/<dep>` symlinks into when
+`enableGlobalVirtualStore` is on. Unset, it lives at
+`<cacheDir>/virtual-store/`.
+
+Set this when the global virtual store belongs somewhere other than
+the rest of the cache — typically to put it on the same volume as
+`storeDir` while leaving packument metadata on the system disk.
+Setting `cacheDir` moves the virtual store too, so reach for that one
+when you want the whole cache to travel together and this one when you
+want to split them.
+
+Entries in the global virtual store are hardlinked out of the content
+store, so keep this on the same volume as `storeDir`. When they land
+on different filesystems aube warns (`WARN_AUBE_GVS_CROSS_VOLUME`) and
+every install falls back to a per-file copy.
+
+Path interpretation matches `storeDir`: `~` expands to the user's home
+directory and relative paths resolve against the project root. The
+path is used verbatim — no schema suffix is appended — so point it at
+a directory aube can own.
+"""
+sources.cli = []
+sources.env = ["npm_config_global_virtual_store_dir", "NPM_CONFIG_GLOBAL_VIRTUAL_STORE_DIR", "AUBE_GLOBAL_VIRTUAL_STORE_DIR"]
+sources.npmrc = ["globalVirtualStoreDir", "global-virtual-store-dir"]
+sources.workspaceYaml = ["globalVirtualStoreDir"]
+examples = [
+    "AUBE_GLOBAL_VIRTUAL_STORE_DIR=/mnt/dev/aube-virtual-store aube install",
+]
+
 [disableGlobalVirtualStoreForPackages]
 description = "Package names whose presence in any importer forces per-project materialization."
 type = "list<string>"
@@ -2619,25 +2654,32 @@ examples = []
 [cacheDir]
 description = "Directory for the global virtual store and cached package metadata."
 type = "path"
-default = "$XDG_CACHE_HOME/aube"
+default = "platform cache dir (`$XDG_CACHE_HOME/aube`)"
 docs = """
-Overrides the cache directory. `XDG_CACHE_HOME` is honored by the
-platform default (`aube_store::dirs::cache_dir`), which appends
-`/aube`; this setting takes a complete path, so
+Overrides the cache directory. Unset, aube derives it per platform
+(`aube_store::dirs::cache_dir`): `$XDG_CACHE_HOME/aube` when
+`XDG_CACHE_HOME` is set, `%LOCALAPPDATA%\\aube` on Windows, else
+`~/.cache/aube`. Those are all *base* directories that aube appends
+its own name to; this setting takes a complete path instead, so
 `AUBE_CACHE_DIR=/mnt/fast/aube` puts the cache directly there.
 
-Everything regenerable lives under this directory: the global virtual
-store (`<cacheDir>/virtual-store/`) and cached packument metadata
-(`<cacheDir>/packuments-v1/`, `<cacheDir>/packuments-full-v1/`). The
+The global virtual store (`<cacheDir>/virtual-store/`) and cached
+packument metadata (`<cacheDir>/packuments-v1/`,
+`<cacheDir>/packuments-full-v1/`) live under this directory. The
 content-addressable store is *not* here — it is `storeDir`, which
-defaults under `$XDG_DATA_HOME` instead.
+defaults under `$XDG_DATA_HOME` instead. A few smaller caches (the OSV
+advisory mirror, the bootstrapped `node-gyp`, git clones) still follow
+the platform cache dir regardless of this setting.
 
 Set this alongside `storeDir` when the store lives on a non-default
-volume. The global virtual store hardlinks out of the CAS, so if
-`cacheDir` and `storeDir` land on different filesystems every install
-degrades to a per-file copy and aube warns about it. Pointing both at
-the same volume (`AUBE_CACHE_DIR=/mnt/dev/cache/aube` plus
+volume. Entries in the global virtual store are hardlinked out of the
+CAS, so on installs with the global virtual store enabled, a `cacheDir`
+and `storeDir` split across filesystems degrades every install to a
+per-file copy and aube warns about it. Pointing both at the same volume
+(`AUBE_CACHE_DIR=/mnt/dev/cache/aube` plus
 `AUBE_STORE_DIR=/mnt/dev/stores/aube`) keeps the hardlink fast path.
+Use `globalVirtualStoreDir` to move only the virtual store and leave
+the metadata caches where they are.
 """
 sources.cli = []
 sources.env = ["npm_config_cache_dir", "NPM_CONFIG_CACHE_DIR", "AUBE_CACHE_DIR"]

--- a/crates/aube-settings/src/values.rs
+++ b/crates/aube-settings/src/values.rs
@@ -1657,6 +1657,44 @@ mod tests {
     }
 
     #[test]
+    fn cache_dir_is_unset_until_configured() {
+        // `cacheDir` deliberately carries no baked-in default so the
+        // caller can tell "not configured" (fall back to the
+        // XDG_CACHE_HOME-aware platform path, which appends `/aube`)
+        // from "configured to a literal path". A default here would
+        // have every install read `~/.cache/aube` and ignore
+        // `XDG_CACHE_HOME`.
+        let npmrc: Vec<(String, String)> = Vec::new();
+        let ws: std::collections::BTreeMap<String, yaml_serde::Value> =
+            std::collections::BTreeMap::new();
+        let ctx = ResolveCtx::files_only(&npmrc, &ws);
+        assert_eq!(resolved::cache_dir(&ctx), None);
+    }
+
+    #[test]
+    fn cache_dir_reads_aube_env_alias() {
+        let npmrc: Vec<(String, String)> = Vec::new();
+        let ws: std::collections::BTreeMap<String, yaml_serde::Value> =
+            std::collections::BTreeMap::new();
+        let env = entries(&[("AUBE_CACHE_DIR", "/mnt/dev/cache/aube")]);
+        let ctx = ResolveCtx {
+            managed_aube_config: &[],
+            project_aube_config: &[],
+            project_npmrc: &npmrc,
+            user_aube_config: &[],
+            user_npmrc: &[],
+            workspace_yaml: &ws,
+            env: &env,
+            cli: &[],
+            embedder_defaults: &[],
+        };
+        assert_eq!(
+            resolved::cache_dir(&ctx),
+            Some("/mnt/dev/cache/aube".to_string())
+        );
+    }
+
+    #[test]
     fn generated_string_accessor_reads_workspace_yaml() {
         // `storeDir` is a string setting with a workspaceYaml source.
         // Before the generator learned about `string_from_workspace_yaml`,

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -69,13 +69,19 @@ pub const PACKUMENT_FULL_CACHE_SUBDIR: &str = "packuments-full-v1";
 ///   single backup/mount captures the whole store; matches pnpm's
 ///   `~/.pnpm-store/v11/{files,index.db}` grouping)
 ///
-/// `cache_dir` (the `cacheDir` setting, default `$XDG_CACHE_HOME/aube`)
-/// still holds genuinely regenerable caches: the global virtual store
-/// and packument metadata.
+/// `cache_dir` (the `cacheDir` setting, default: the platform cache
+/// dir) still holds genuinely regenerable caches: the global virtual
+/// store and packument metadata.
 #[derive(Clone)]
 pub struct Store {
     root: PathBuf,
     cache_dir: PathBuf,
+    /// Root of the global virtual store. Defaults to
+    /// `<cache_dir>/virtual-store` and is overridden wholesale by the
+    /// `globalVirtualStoreDir` setting, which users point at the
+    /// `storeDir` volume so materialized packages can be hardlinked
+    /// out of the CAS.
+    virtual_store_dir: PathBuf,
     /// When set, `create_cas_file` writes directly to the final
     /// content-addressed path on non-Linux platforms instead of the
     /// tempfile-then-rename dance. Caller must guarantee no concurrent
@@ -86,13 +92,6 @@ pub struct Store {
 }
 
 impl Store {
-    /// Open the store at the default location (see [`dirs::store_dir`]).
-    pub fn default_location() -> Result<Self, Error> {
-        let root = dirs::store_dir().ok_or(Error::NoHome)?;
-        let cache_dir = dirs::cache_dir().ok_or(Error::NoHome)?;
-        Ok(Self::with_dirs(root, cache_dir))
-    }
-
     /// Open the store with an explicit CAS root and cache dir. Used when
     /// a user overrides `storeDir` (the CAS) and/or `cacheDir` (the
     /// global virtual store + packument caches); the two are independent
@@ -101,10 +100,12 @@ impl Store {
     /// hardlink fast path.
     ///
     /// `root` is the CAS shard directory (`<storeDir>/v1/files`), not the
-    /// user-facing store dir.
+    /// user-facing store dir. The global virtual store lands under
+    /// `cache_dir` unless [`Store::with_virtual_store_dir`] moves it.
     pub fn with_dirs(root: PathBuf, cache_dir: PathBuf) -> Self {
         let store = Self {
             root,
+            virtual_store_dir: cache_dir.join(VIRTUAL_STORE_SUBDIR),
             cache_dir,
             fast_path: Arc::new(AtomicBool::new(false)),
         };
@@ -112,13 +113,23 @@ impl Store {
         store
     }
 
+    /// Point the global virtual store somewhere other than
+    /// `<cache_dir>/virtual-store` (the `globalVirtualStoreDir`
+    /// setting). The path is used verbatim.
+    #[must_use]
+    pub fn with_virtual_store_dir(mut self, dir: PathBuf) -> Self {
+        self.virtual_store_dir = dir;
+        self
+    }
+
     /// Open the store at a specific path (cache dir derived from store root).
     /// Used by tests that need a fully isolated layout; production code
-    /// should prefer `default_location` or `with_root`.
+    /// should prefer `with_dirs`.
     pub fn at(root: PathBuf) -> Self {
         let cache_dir = root.parent().unwrap_or(&root).join(CACHE_DIR_NAME);
         Self {
             root,
+            virtual_store_dir: cache_dir.join(VIRTUAL_STORE_SUBDIR),
             cache_dir,
             fast_path: Arc::new(AtomicBool::new(false)),
         }
@@ -256,9 +267,10 @@ impl Store {
     }
 
     /// Directory for the global virtual store (materialized packages).
-    /// `<cacheDir>/virtual-store/`, so it moves with `cacheDir`.
+    /// `<cacheDir>/virtual-store/` unless `globalVirtualStoreDir`
+    /// moved it, so it follows `cacheDir` by default.
     pub fn virtual_store_dir(&self) -> PathBuf {
-        self.cache_dir.join(VIRTUAL_STORE_SUBDIR)
+        self.virtual_store_dir.clone()
     }
 
     /// Directory for cached packument metadata (abbreviated/corgi format).
@@ -332,6 +344,7 @@ mod tests {
     fn store_for_migration_test(root: PathBuf, cache_dir: PathBuf) -> Store {
         Store {
             root,
+            virtual_store_dir: cache_dir.join(VIRTUAL_STORE_SUBDIR),
             cache_dir,
             fast_path: Arc::new(AtomicBool::new(false)),
         }

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -69,8 +69,9 @@ pub const PACKUMENT_FULL_CACHE_SUBDIR: &str = "packuments-full-v1";
 ///   single backup/mount captures the whole store; matches pnpm's
 ///   `~/.pnpm-store/v11/{files,index.db}` grouping)
 ///
-/// `cache_dir` ($XDG_CACHE_HOME/aube) still holds genuinely
-/// regenerable caches: the virtual store and packument metadata.
+/// `cache_dir` (the `cacheDir` setting, default `$XDG_CACHE_HOME/aube`)
+/// still holds genuinely regenerable caches: the global virtual store
+/// and packument metadata.
 #[derive(Clone)]
 pub struct Store {
     root: PathBuf,
@@ -89,29 +90,26 @@ impl Store {
     pub fn default_location() -> Result<Self, Error> {
         let root = dirs::store_dir().ok_or(Error::NoHome)?;
         let cache_dir = dirs::cache_dir().ok_or(Error::NoHome)?;
-        let store = Self {
-            root,
-            cache_dir,
-            fast_path: Arc::new(AtomicBool::new(false)),
-        };
-        store.migrate_legacy_index_dir();
-        Ok(store)
+        Ok(Self::with_dirs(root, cache_dir))
     }
 
-    /// Open the store with an explicit root, keeping the default
-    /// cache dir (`$XDG_CACHE_HOME/aube`). Used when a user overrides
-    /// `storeDir` via `.npmrc` / `pnpm-workspace.yaml` — only the CAS
-    /// moves; the packument and virtual-store caches stay where the
-    /// rest of aube expects them.
-    pub fn with_root(root: PathBuf) -> Result<Self, Error> {
-        let cache_dir = dirs::cache_dir().ok_or(Error::NoHome)?;
+    /// Open the store with an explicit CAS root and cache dir. Used when
+    /// a user overrides `storeDir` (the CAS) and/or `cacheDir` (the
+    /// global virtual store + packument caches); the two are independent
+    /// settings, but the global virtual store hardlinks out of the CAS,
+    /// so a caller pointing them at different volumes gives up the
+    /// hardlink fast path.
+    ///
+    /// `root` is the CAS shard directory (`<storeDir>/v1/files`), not the
+    /// user-facing store dir.
+    pub fn with_dirs(root: PathBuf, cache_dir: PathBuf) -> Self {
         let store = Self {
             root,
             cache_dir,
             fast_path: Arc::new(AtomicBool::new(false)),
         };
         store.migrate_legacy_index_dir();
-        Ok(store)
+        store
     }
 
     /// Open the store at a specific path (cache dir derived from store root).
@@ -258,6 +256,7 @@ impl Store {
     }
 
     /// Directory for the global virtual store (materialized packages).
+    /// `<cacheDir>/virtual-store/`, so it moves with `cacheDir`.
     pub fn virtual_store_dir(&self) -> PathBuf {
         self.cache_dir.join(VIRTUAL_STORE_SUBDIR)
     }

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -92,6 +92,27 @@ pub struct Store {
 }
 
 impl Store {
+    /// Open the store at the platform default location (see
+    /// [`dirs::store_dir`] and [`dirs::cache_dir`]).
+    ///
+    /// aube's own CLI resolves `storeDir` / `cacheDir` /
+    /// `globalVirtualStoreDir` first and goes through [`Store::with_dirs`];
+    /// this is the entry point for embedders that just want the same
+    /// directories a default install would use.
+    pub fn default_location() -> Result<Self, Error> {
+        let root = dirs::store_dir().ok_or(Error::NoHome)?;
+        let cache_dir = dirs::cache_dir().ok_or(Error::NoHome)?;
+        Ok(Self::with_dirs(root, cache_dir))
+    }
+
+    /// Open the store with an explicit CAS root, keeping the platform
+    /// cache dir for the global virtual store and packument caches.
+    /// Equivalent to `with_dirs(root, dirs::cache_dir())`.
+    pub fn with_root(root: PathBuf) -> Result<Self, Error> {
+        let cache_dir = dirs::cache_dir().ok_or(Error::NoHome)?;
+        Ok(Self::with_dirs(root, cache_dir))
+    }
+
     /// Open the store with an explicit CAS root and cache dir. Used when
     /// a user overrides `storeDir` (the CAS) and/or `cacheDir` (the
     /// global virtual store + packument caches); the two are independent

--- a/crates/aube/src/commands/doctor.rs
+++ b/crates/aube/src/commands/doctor.rs
@@ -183,7 +183,16 @@ fn runtime_section(warnings: &mut Vec<String>) -> Section {
 
 fn dirs_section(anchor: &Path) -> Section {
     let mut s = Section::new("dirs");
-    let store_root = aube_store::dirs::store_dir()
+    // Report the same paths the install will use, so `storeDir` /
+    // `cacheDir` overrides are visible here instead of only showing
+    // the platform defaults. Printed at `v1/` granularity to match
+    // `aube store path`; `dirs::store_dir` returns the `files/` shard
+    // dir one level below it.
+    let store_root = super::resolved_store_dir(anchor)
+        .map(|dir| dir.join("v1"))
+        .or_else(|| {
+            aube_store::dirs::store_dir().and_then(|files| files.parent().map(Path::to_path_buf))
+        })
         .map(display_path_owned)
         .unwrap_or_else(|| "(unresolved)".into());
     s.push("store", store_root);
@@ -194,6 +203,10 @@ fn dirs_section(anchor: &Path) -> Section {
     s.push(
         "packument-cache",
         display_path_owned(super::resolved_cache_dir(anchor).join("packuments-v1")),
+    );
+    s.push(
+        "global-virtual-store",
+        display_path_owned(super::global_virtual_store_dir(anchor)),
     );
     s.push(
         "virtual-store",

--- a/crates/aube/src/commands/install/gvs.rs
+++ b/crates/aube/src/commands/install/gvs.rs
@@ -500,11 +500,7 @@ pub(super) fn reset_on_mode_change(
     modules_dir_name: &str,
     planned_gvs: bool,
 ) -> miette::Result<()> {
-    let Some(global_virtual_store) =
-        aube_store::dirs::cache_dir().map(|dir| dir.join(aube_store::VIRTUAL_STORE_SUBDIR))
-    else {
-        return Ok(());
-    };
+    let global_virtual_store = crate::commands::global_virtual_store_dir(cwd);
     let Some(existing_gvs) = detect_existing_global_virtual_store(
         cwd,
         aube_dir,

--- a/crates/aube/src/commands/install/lifecycle.rs
+++ b/crates/aube/src/commands/install/lifecycle.rs
@@ -293,8 +293,8 @@ pub(super) fn resolve_link_strategy(
         // Two distinct cross-volume regimes, two different messages.
         // With GVS on, the probe targets the GVS dir (always same FS
         // as the store in a sane setup), so Copy here means the user
-        // pointed `storeDir` and `XDG_CACHE_HOME` at different volumes
-        // — a real misconfiguration that costs per-file copies. Warn.
+        // pointed `storeDir` and `cacheDir` at different volumes — a
+        // real misconfiguration that costs per-file copies. Warn.
         // With GVS off, the probe targets `cwd`; a cross-volume verdict
         // there is the documented "project lives on an external mount"
         // regime where aube still outperforms other PMs, so log at
@@ -305,11 +305,13 @@ pub(super) fn resolve_link_strategy(
         {
             if gvs_dir.is_some() {
                 tracing::warn!(
+                    code = aube_codes::warnings::WARN_AUBE_GVS_CROSS_VOLUME,
                     store = %sd.display(),
                     gvs_dir = %probe_dst.display(),
                     "global virtual store dir is on a different volume than `storeDir`; \
-                     install will fall back to per-file copy. Move `XDG_CACHE_HOME` \
-                     (or `storeDir`) so both live on the same volume."
+                     install will fall back to per-file copy. Point `cacheDir` \
+                     (`AUBE_CACHE_DIR`) or `storeDir` (`AUBE_STORE_DIR`) at a path \
+                     on the same volume as the other."
                 );
             } else {
                 tracing::debug!(

--- a/crates/aube/src/commands/install/lifecycle.rs
+++ b/crates/aube/src/commands/install/lifecycle.rs
@@ -309,9 +309,11 @@ pub(super) fn resolve_link_strategy(
                     store = %sd.display(),
                     gvs_dir = %probe_dst.display(),
                     "global virtual store dir is on a different volume than `storeDir`; \
-                     install will fall back to per-file copy. Point `cacheDir` \
-                     (`AUBE_CACHE_DIR`) or `storeDir` (`AUBE_STORE_DIR`) at a path \
-                     on the same volume as the other."
+                     install will fall back to per-file copy. Move the two onto one \
+                     volume with `globalVirtualStoreDir` \
+                     (`AUBE_GLOBAL_VIRTUAL_STORE_DIR`, virtual store only), \
+                     `cacheDir` (`AUBE_CACHE_DIR`, the whole cache), or `storeDir` \
+                     (`AUBE_STORE_DIR`)."
                 );
             } else {
                 tracing::debug!(

--- a/crates/aube/src/commands/install/startup.rs
+++ b/crates/aube/src/commands/install/startup.rs
@@ -110,11 +110,7 @@ fn compatibility_metadata_is_current(cwd: &Path) -> bool {
     let expected = match layout.linker {
         state::InstallLayoutMode::Hoisted => Some(aube_dir),
         state::InstallLayoutMode::Isolated => {
-            let Some(global_virtual_store) =
-                aube_store::dirs::cache_dir().map(|dir| dir.join(aube_store::VIRTUAL_STORE_SUBDIR))
-            else {
-                return false;
-            };
+            let global_virtual_store = super::super::global_virtual_store_dir(cwd);
             match super::gvs::detect_existing_global_virtual_store(
                 cwd,
                 &aube_dir,

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -133,14 +133,15 @@ pub(crate) use script_settings::{configure_script_settings, configure_script_set
 pub(crate) use settings_context::{
     FileSources, GlobalOutputFlags, build_resolver, chained_frozen_mode,
     ensure_registry_auth_for_package, expand_setting_path, global_frozen_override,
-    global_output_flags, global_virtual_store_flags, load_npm_config, make_client, open_store,
-    packument_cache_dir, packument_cache_dir_for_cwd, packument_full_cache_dir,
-    packument_full_cache_dir_for_cwd, project_modules_dir, resolve_fetch_policy,
-    resolve_modules_dir_name_for_cwd, resolve_virtual_store_dir, resolve_virtual_store_dir_for_cwd,
-    resolve_virtual_store_dir_max_length, resolve_virtual_store_dir_max_length_for_cwd,
-    resolved_cache_dir, run_pnpmfile_pre_resolution, set_fetch_cli_overrides,
-    set_global_frozen_override, set_global_output_flags, set_global_virtual_store_flags,
-    set_registry_override, set_skip_auto_install_on_package_manager_mismatch,
+    global_output_flags, global_virtual_store_dir, global_virtual_store_flags, load_npm_config,
+    make_client, open_store, packument_cache_dir, packument_cache_dir_for_cwd,
+    packument_full_cache_dir, packument_full_cache_dir_for_cwd, project_modules_dir,
+    resolve_fetch_policy, resolve_modules_dir_name_for_cwd, resolve_virtual_store_dir,
+    resolve_virtual_store_dir_for_cwd, resolve_virtual_store_dir_max_length,
+    resolve_virtual_store_dir_max_length_for_cwd, resolved_cache_dir, resolved_store_dir,
+    run_pnpmfile_pre_resolution, set_fetch_cli_overrides, set_global_frozen_override,
+    set_global_output_flags, set_global_virtual_store_flags, set_registry_override,
+    set_skip_auto_install_on_package_manager_mismatch,
     skip_auto_install_on_package_manager_mismatch, with_settings_ctx,
 };
 pub(crate) use workspace_helpers::{

--- a/crates/aube/src/commands/settings_context.rs
+++ b/crates/aube/src/commands/settings_context.rs
@@ -199,6 +199,10 @@ pub(crate) fn ensure_registry_auth_for_package(
 /// back to the aube-owned default under `$XDG_DATA_HOME/aube/store/`
 /// (see [`aube_store::dirs::store_dir`] for exact resolution).
 ///
+/// The store's cache dir — global virtual store, packument caches —
+/// comes from [`resolved_cache_dir`], so `cacheDir` and `storeDir` can
+/// be pointed at the same volume without touching `XDG_CACHE_HOME`.
+///
 /// Path interpretation matches pnpm: a leading `~` expands to the
 /// user's home directory; relative paths are resolved against `cwd`
 /// (so each project sees a consistent store regardless of where the
@@ -207,15 +211,14 @@ pub(crate) fn ensure_registry_auth_for_package(
 /// across versions of aube and never collides with a pnpm store rooted
 /// at the same path.
 pub(crate) fn open_store(cwd: &std::path::Path) -> miette::Result<aube_store::Store> {
-    if let Some(custom) = resolved_store_dir(cwd) {
-        aube_store::Store::with_root(custom.join("v1").join("files"))
+    let root = match resolved_store_dir(cwd) {
+        Some(custom) => custom.join("v1").join("files"),
+        None => aube_store::dirs::store_dir()
+            .ok_or(aube_store::Error::NoHome)
             .into_diagnostic()
-            .wrap_err("failed to open store")
-    } else {
-        aube_store::Store::default_location()
-            .into_diagnostic()
-            .wrap_err("failed to open store")
-    }
+            .wrap_err("failed to open store")?,
+    };
+    Ok(aube_store::Store::with_dirs(root, resolved_cache_dir(cwd)))
 }
 
 /// Resolve the configured `storeDir` for `cwd`, returning `None` if
@@ -419,32 +422,42 @@ pub(crate) fn resolve_fetch_policy(cwd: &std::path::Path) -> aube_registry::conf
     aube_registry::config::FetchPolicy::from_ctx(&ctx)
 }
 
-/// Resolve the `cacheDir` setting for `cwd`. If an explicit override
-/// is set in `.npmrc`, expands it and returns that path. Otherwise
-/// falls back to the XDG-aware platform default (`~/.cache/aube`).
+/// Resolve the `cacheDir` setting for `cwd`. When set (via
+/// `AUBE_CACHE_DIR` / `npm_config_cache_dir`, or `cache-dir` in
+/// `.npmrc` / `aube-config.toml`), expands it and returns that path.
+/// Otherwise falls back to the XDG-aware platform default
+/// (`$XDG_CACHE_HOME/aube`, else `~/.cache/aube`).
 ///
-/// Note: `XDG_CACHE_HOME` is intentionally *not* a source for this
-/// setting — it's a base directory, and `aube_store::dirs::cache_dir()`
-/// already appends `/aube`. Routing it through the settings accessor
-/// would lose the subdirectory.
+/// `cacheDir` has no default baked into the generated accessor (see the
+/// exclusion list in `aube-settings/build.rs`) precisely so this
+/// function can tell "not configured" from "configured to the literal
+/// default path": `XDG_CACHE_HOME` is a *base* directory that the
+/// platform default appends `/aube` to, so routing it through the
+/// settings accessor would lose the subdirectory.
+///
+/// Everything derived from the cache dir — the global virtual store,
+/// the packument caches, `dlx` — flows through here, so a user who
+/// moves the cache to another volume moves all of it at once.
 pub(crate) fn resolved_cache_dir(cwd: &std::path::Path) -> std::path::PathBuf {
     let platform_default =
         || aube_store::dirs::cache_dir().unwrap_or_else(|| std::env::temp_dir().join("aube"));
-    // Check whether .npmrc explicitly sets cacheDir, rather than comparing
-    // the resolved value against the default string — a user who writes
-    // `cacheDir=~/.cache/aube` explicitly should get that literal path,
-    // not the XDG_CACHE_HOME-aware platform default.
-    let npmrc = aube_registry::config::load_npmrc_entries(cwd);
-    let has_explicit = npmrc
-        .iter()
-        .any(|(k, _)| k == "cacheDir" || k == "cache-dir");
-    if !has_explicit {
-        return platform_default();
-    }
-    with_settings_ctx(cwd, |ctx| {
-        let raw = aube_settings::resolved::cache_dir(ctx);
-        expand_setting_path(&raw, cwd).unwrap_or_else(platform_default)
+    with_settings_ctx(cwd, |ctx| match aube_settings::resolved::cache_dir(ctx) {
+        Some(raw) => expand_setting_path(&raw, cwd).unwrap_or_else(platform_default),
+        None => platform_default(),
     })
+}
+
+/// Absolute path of the global virtual store — the shared tree of
+/// materialized packages that project `node_modules/.aube/<dep_path>`
+/// entries symlink into. Lives under the resolved [`resolved_cache_dir`]
+/// so `cacheDir` moves it along with the rest of the regenerable state.
+///
+/// Every read-side caller (layout detection, mode-change reset) must
+/// resolve it the same way the install write path does, otherwise a
+/// custom `cacheDir` makes them look at an empty directory and
+/// silently re-materialize.
+pub(crate) fn global_virtual_store_dir(cwd: &std::path::Path) -> std::path::PathBuf {
+    resolved_cache_dir(cwd).join(aube_store::VIRTUAL_STORE_SUBDIR)
 }
 
 /// Resolve the `virtualStoreDirMaxLength` setting, falling back to the

--- a/crates/aube/src/commands/settings_context.rs
+++ b/crates/aube/src/commands/settings_context.rs
@@ -199,9 +199,10 @@ pub(crate) fn ensure_registry_auth_for_package(
 /// back to the aube-owned default under `$XDG_DATA_HOME/aube/store/`
 /// (see [`aube_store::dirs::store_dir`] for exact resolution).
 ///
-/// The store's cache dir — global virtual store, packument caches —
-/// comes from [`resolved_cache_dir`], so `cacheDir` and `storeDir` can
-/// be pointed at the same volume without touching `XDG_CACHE_HOME`.
+/// The store's cache dir — packument caches, and the global virtual
+/// store unless `globalVirtualStoreDir` moves it — comes from
+/// [`resolved_cache_dir`], so `cacheDir` and `storeDir` can be pointed
+/// at the same volume without touching `XDG_CACHE_HOME`.
 ///
 /// Path interpretation matches pnpm: a leading `~` expands to the
 /// user's home directory; relative paths are resolved against `cwd`
@@ -218,7 +219,8 @@ pub(crate) fn open_store(cwd: &std::path::Path) -> miette::Result<aube_store::St
             .into_diagnostic()
             .wrap_err("failed to open store")?,
     };
-    Ok(aube_store::Store::with_dirs(root, resolved_cache_dir(cwd)))
+    Ok(aube_store::Store::with_dirs(root, resolved_cache_dir(cwd))
+        .with_virtual_store_dir(global_virtual_store_dir(cwd)))
 }
 
 /// Resolve the configured `storeDir` for `cwd`, returning `None` if
@@ -425,19 +427,20 @@ pub(crate) fn resolve_fetch_policy(cwd: &std::path::Path) -> aube_registry::conf
 /// Resolve the `cacheDir` setting for `cwd`. When set (via
 /// `AUBE_CACHE_DIR` / `npm_config_cache_dir`, or `cache-dir` in
 /// `.npmrc` / `aube-config.toml`), expands it and returns that path.
-/// Otherwise falls back to the XDG-aware platform default
-/// (`$XDG_CACHE_HOME/aube`, else `~/.cache/aube`).
+/// Otherwise falls back to the platform cache dir:
+/// `$XDG_CACHE_HOME/aube` when `XDG_CACHE_HOME` is set,
+/// `%LOCALAPPDATA%\aube` on Windows, else `~/.cache/aube`.
 ///
 /// `cacheDir` has no default baked into the generated accessor (see the
 /// exclusion list in `aube-settings/build.rs`) precisely so this
 /// function can tell "not configured" from "configured to the literal
-/// default path": `XDG_CACHE_HOME` is a *base* directory that the
-/// platform default appends `/aube` to, so routing it through the
+/// default path": every platform fallback above is a *base* directory
+/// that aube appends its own name to, so routing them through the
 /// settings accessor would lose the subdirectory.
 ///
-/// Everything derived from the cache dir — the global virtual store,
-/// the packument caches, `dlx` — flows through here, so a user who
-/// moves the cache to another volume moves all of it at once.
+/// The packument caches and — unless [`global_virtual_store_dir`]
+/// overrides it — the global virtual store hang off this path, so a
+/// user who moves the cache to another volume moves them together.
 pub(crate) fn resolved_cache_dir(cwd: &std::path::Path) -> std::path::PathBuf {
     let platform_default =
         || aube_store::dirs::cache_dir().unwrap_or_else(|| std::env::temp_dir().join("aube"));
@@ -449,15 +452,25 @@ pub(crate) fn resolved_cache_dir(cwd: &std::path::Path) -> std::path::PathBuf {
 
 /// Absolute path of the global virtual store — the shared tree of
 /// materialized packages that project `node_modules/.aube/<dep_path>`
-/// entries symlink into. Lives under the resolved [`resolved_cache_dir`]
-/// so `cacheDir` moves it along with the rest of the regenerable state.
+/// entries symlink into.
+///
+/// `globalVirtualStoreDir` wins when set and is used verbatim (no
+/// `virtual-store` suffix); otherwise the store lands under the
+/// resolved [`resolved_cache_dir`]. The dedicated setting exists
+/// because this tree — unlike the rest of the cache — has to sit on
+/// the same volume as `storeDir` to be hardlinkable, which is not
+/// necessarily where the packument caches belong.
 ///
 /// Every read-side caller (layout detection, mode-change reset) must
 /// resolve it the same way the install write path does, otherwise a
-/// custom `cacheDir` makes them look at an empty directory and
-/// silently re-materialize.
+/// relocated store makes them look at an empty directory and silently
+/// re-materialize.
 pub(crate) fn global_virtual_store_dir(cwd: &std::path::Path) -> std::path::PathBuf {
-    resolved_cache_dir(cwd).join(aube_store::VIRTUAL_STORE_SUBDIR)
+    let from_setting = with_settings_ctx(cwd, |ctx| {
+        let raw = aube_settings::resolved::global_virtual_store_dir(ctx)?;
+        expand_setting_path(&raw, cwd)
+    });
+    from_setting.unwrap_or_else(|| resolved_cache_dir(cwd).join(aube_store::VIRTUAL_STORE_SUBDIR))
 }
 
 /// Resolve the `virtualStoreDirMaxLength` setting, falling back to the

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -603,6 +603,12 @@
       "exit_code": null
     },
     {
+      "name": "WARN_AUBE_GVS_CROSS_VOLUME",
+      "category": "Install lifecycle",
+      "description": "`cacheDir` (global virtual store) and `storeDir` are on different volumes, so linking falls back to per-file copy.",
+      "exit_code": null
+    },
+    {
       "name": "WARN_AUBE_INVALID_CONCURRENCY",
       "category": "Settings / config validation",
       "description": "`network-concurrency` or `link-concurrency` was 0 (must be ≥ 1).",

--- a/docs/package-manager/global-virtual-store.md
+++ b/docs/package-manager/global-virtual-store.md
@@ -45,11 +45,11 @@ shared cache. Each project points directly at that shared tree:
 ```text
 project-a/
   node_modules/
-    react -> $XDG_CACHE_HOME/aube/virtual-store/react@18.2.0/<graph-hash>/node_modules/react
+    react -> <cacheDir>/virtual-store/react@18.2.0/<graph-hash>/node_modules/react
 
 project-b/
   node_modules/
-    react -> $XDG_CACHE_HOME/aube/virtual-store/react@18.2.0/<graph-hash>/node_modules/react
+    react -> <cacheDir>/virtual-store/react@18.2.0/<graph-hash>/node_modules/react
 ```
 
 The global virtual store still imports package files from the global content
@@ -83,9 +83,9 @@ The global virtual store is most useful on developer machines:
 - several projects using the same package versions
 - one-off `aubx` and script workflows that benefit from warm local state
 
-It is usually less useful in CI. CI jobs often start without a warm
-`$XDG_CACHE_HOME/aube/virtual-store/`, so aube disables the global virtual store
-under CI and materializes packages per project instead.
+It is usually less useful in CI. CI jobs often start without a warm global
+virtual store, so aube disables it under CI and materializes packages per
+project instead.
 
 ## Configuration
 
@@ -110,19 +110,29 @@ aube install --disable-global-virtual-store
 
 ### Moving it off the default volume
 
-The global virtual store lives under [`cacheDir`](/settings/#setting-cachedir),
-so point that at the volume you want — no need to move `XDG_CACHE_HOME`, which
-also relocates every other tool's cache:
+Two settings relocate the global virtual store, and neither requires moving
+`XDG_CACHE_HOME` (which would drag every other tool's cache along with it).
+
+[`globalVirtualStoreDir`](/settings/#setting-globalvirtualstoredir) moves the
+virtual store on its own and leaves packument metadata where it is:
+
+```sh
+export AUBE_GLOBAL_VIRTUAL_STORE_DIR=/Volumes/Mini/dev/aube-virtual-store
+export AUBE_STORE_DIR=/Volumes/Mini/dev/stores/aube
+```
+
+[`cacheDir`](/settings/#setting-cachedir) moves the whole cache — virtual store
+and metadata together:
 
 ```sh
 export AUBE_CACHE_DIR=/Volumes/Mini/dev/cache/aube
 export AUBE_STORE_DIR=/Volumes/Mini/dev/stores/aube
 ```
 
-Keep both on the *same* volume. Entries in the global virtual store are
-hardlinked out of the content store, so a `cacheDir` and `storeDir` split across
-filesystems makes every install fall back to a per-file copy. aube warns
-(`WARN_AUBE_GVS_CROSS_VOLUME`) when it detects that split:
+Either way, keep the virtual store on the *same* volume as `storeDir`. Its
+entries are hardlinked out of the content store, so a split across filesystems
+makes every global-virtual-store install fall back to a per-file copy. aube
+warns (`WARN_AUBE_GVS_CROSS_VOLUME`) when it detects that split:
 
 ```text
 global virtual store dir is on a different volume than `storeDir`; install will
@@ -136,7 +146,7 @@ settings took effect.
 
 Some tools canonicalize `node_modules/<pkg>` symlinks to their real path and
 then walk upward looking for project files, app roots, or hoisted dependencies.
-When the real path is in `$XDG_CACHE_HOME/aube/virtual-store/`, that walk has
+When the real path is in the global virtual store, that walk has
 escaped the project and the tool can fail.
 
 aube automatically falls back to per-project materialization when an importer

--- a/docs/package-manager/global-virtual-store.md
+++ b/docs/package-manager/global-virtual-store.md
@@ -8,7 +8,8 @@ This is separate from the global content store:
 - The **global content store** (`$XDG_DATA_HOME/aube/store/v1/`) stores
   package files by BLAKE3 hash. Every install uses it.
 - The **global virtual store**
-  (`$XDG_CACHE_HOME/aube/virtual-store/`, defaulting to
+  (`<cacheDir>/virtual-store/`, defaulting to
+  `$XDG_CACHE_HOME/aube/virtual-store/`, then
   `~/.cache/aube/virtual-store/`) stores package directory trees keyed by
   dependency graph. Project `node_modules` entries symlink into it.
 
@@ -106,6 +107,30 @@ Override a single command with:
 aube install --enable-global-virtual-store
 aube install --disable-global-virtual-store
 ```
+
+### Moving it off the default volume
+
+The global virtual store lives under [`cacheDir`](/settings/#setting-cachedir),
+so point that at the volume you want — no need to move `XDG_CACHE_HOME`, which
+also relocates every other tool's cache:
+
+```sh
+export AUBE_CACHE_DIR=/Volumes/Mini/dev/cache/aube
+export AUBE_STORE_DIR=/Volumes/Mini/dev/stores/aube
+```
+
+Keep both on the *same* volume. Entries in the global virtual store are
+hardlinked out of the content store, so a `cacheDir` and `storeDir` split across
+filesystems makes every install fall back to a per-file copy. aube warns
+(`WARN_AUBE_GVS_CROSS_VOLUME`) when it detects that split:
+
+```text
+global virtual store dir is on a different volume than `storeDir`; install will
+fall back to per-file copy.
+```
+
+`aube doctor` prints both resolved paths under `dirs` so you can confirm the
+settings took effect.
 
 ## Limitations
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -57,6 +57,7 @@ Aube generates this page from [`settings.toml`](https://github.com/jdx/aube/blob
 | [`modulesCacheMaxAge`](#setting-modulescachemaxage) | `int` | Minutes before orphan packages are removed from the virtual store. |
 | [`dlxCacheMaxAge`](#setting-dlxcachemaxage) | `int` | Minutes before the dlx cache is considered stale. |
 | [`enableGlobalVirtualStore`](#setting-enableglobalvirtualstore) | `bool` | Use a per-user virtual store for all projects. |
+| [`globalVirtualStoreDir`](#setting-globalvirtualstoredir) | `path` | Location of the shared virtual store used by every project. |
 | [`disableGlobalVirtualStoreForPackages`](#setting-disableglobalvirtualstoreforpackages) | `list<string>` | Package names whose presence in any importer forces per-project materialization. |
 | [`storeDir`](#setting-storedir) | `path` | Location where packages are saved on disk (content-addressable store). |
 | [`verifyStoreIntegrity`](#setting-verifystoreintegrity) | `bool` | Check store file integrity before linking. |
@@ -1178,6 +1179,42 @@ Examples:
 - `echo 'enableGlobalVirtualStore=false' >> .npmrc`
 - `aube --disable-global-virtual-store install`
 - `aube dlx --enable-gvs create-vite`
+
+### `globalVirtualStoreDir` {#setting-globalvirtualstoredir}
+
+Location of the shared virtual store used by every project.
+
+- Type: `path`
+- Default: `undefined`
+- Environment: `npm_config_global_virtual_store_dir`, `NPM_CONFIG_GLOBAL_VIRTUAL_STORE_DIR`, `AUBE_GLOBAL_VIRTUAL_STORE_DIR`
+- .npmrc keys: `globalVirtualStoreDir`, `global-virtual-store-dir`
+- Workspace YAML keys: `globalVirtualStoreDir`
+
+Relocates the global virtual store — the shared tree of materialized
+package directories that `node_modules/.aube/<dep>` symlinks into when
+`enableGlobalVirtualStore` is on. Unset, it lives at
+`<cacheDir>/virtual-store/`.
+
+Set this when the global virtual store belongs somewhere other than
+the rest of the cache — typically to put it on the same volume as
+`storeDir` while leaving packument metadata on the system disk.
+Setting `cacheDir` moves the virtual store too, so reach for that one
+when you want the whole cache to travel together and this one when you
+want to split them.
+
+Entries in the global virtual store are hardlinked out of the content
+store, so keep this on the same volume as `storeDir`. When they land
+on different filesystems aube warns (`WARN_AUBE_GVS_CROSS_VOLUME`) and
+every install falls back to a per-file copy.
+
+Path interpretation matches `storeDir`: `~` expands to the user's home
+directory and relative paths resolve against the project root. The
+path is used verbatim — no schema suffix is appended — so point it at
+a directory aube can own.
+
+Examples:
+
+- `AUBE_GLOBAL_VIRTUAL_STORE_DIR=/mnt/dev/aube-virtual-store aube install`
 
 ### `disableGlobalVirtualStoreForPackages` {#setting-disableglobalvirtualstoreforpackages}
 
@@ -2626,27 +2663,34 @@ Overrides the directory that holds the `.aube-state` install-state file. Default
 Directory for the global virtual store and cached package metadata.
 
 - Type: `path`
-- Default: `$XDG_CACHE_HOME/aube`
+- Default: `` platform cache dir (`$XDG_CACHE_HOME/aube`) ``
 - Environment: `npm_config_cache_dir`, `NPM_CONFIG_CACHE_DIR`, `AUBE_CACHE_DIR`
 - .npmrc keys: `cache-dir`, `cacheDir`
 
-Overrides the cache directory. `XDG_CACHE_HOME` is honored by the
-platform default (`aube_store::dirs::cache_dir`), which appends
-`/aube`; this setting takes a complete path, so
+Overrides the cache directory. Unset, aube derives it per platform
+(`aube_store::dirs::cache_dir`): `$XDG_CACHE_HOME/aube` when
+`XDG_CACHE_HOME` is set, `%LOCALAPPDATA%\aube` on Windows, else
+`~/.cache/aube`. Those are all *base* directories that aube appends
+its own name to; this setting takes a complete path instead, so
 `AUBE_CACHE_DIR=/mnt/fast/aube` puts the cache directly there.
 
-Everything regenerable lives under this directory: the global virtual
-store (`<cacheDir>/virtual-store/`) and cached packument metadata
-(`<cacheDir>/packuments-v1/`, `<cacheDir>/packuments-full-v1/`). The
+The global virtual store (`<cacheDir>/virtual-store/`) and cached
+packument metadata (`<cacheDir>/packuments-v1/`,
+`<cacheDir>/packuments-full-v1/`) live under this directory. The
 content-addressable store is *not* here — it is `storeDir`, which
-defaults under `$XDG_DATA_HOME` instead.
+defaults under `$XDG_DATA_HOME` instead. A few smaller caches (the OSV
+advisory mirror, the bootstrapped `node-gyp`, git clones) still follow
+the platform cache dir regardless of this setting.
 
 Set this alongside `storeDir` when the store lives on a non-default
-volume. The global virtual store hardlinks out of the CAS, so if
-`cacheDir` and `storeDir` land on different filesystems every install
-degrades to a per-file copy and aube warns about it. Pointing both at
-the same volume (`AUBE_CACHE_DIR=/mnt/dev/cache/aube` plus
+volume. Entries in the global virtual store are hardlinked out of the
+CAS, so on installs with the global virtual store enabled, a `cacheDir`
+and `storeDir` split across filesystems degrades every install to a
+per-file copy and aube warns about it. Pointing both at the same volume
+(`AUBE_CACHE_DIR=/mnt/dev/cache/aube` plus
 `AUBE_STORE_DIR=/mnt/dev/stores/aube`) keeps the hardlink fast path.
+Use `globalVirtualStoreDir` to move only the virtual store and leave
+the metadata caches where they are.
 
 Examples:
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -131,7 +131,7 @@ Aube generates this page from [`settings.toml`](https://github.com/jdx/aube/blob
 | [`globalBinDir`](#setting-globalbindir) | `path` | Directory where global binaries are symlinked. |
 | [`npmrcAuthFile`](#setting-npmrcauthfile) | `path` | Path to an additional .npmrc file consulted for registry authentication tokens. |
 | [`stateDir`](#setting-statedir) | `path` | Directory for aube install-state files. |
-| [`cacheDir`](#setting-cachedir) | `path` | Directory for package metadata and dlx cache. |
+| [`cacheDir`](#setting-cachedir) | `path` | Directory for the global virtual store and cached package metadata. |
 | [`useStderr`](#setting-usestderr) | `bool` | Write all output to stderr instead of stdout. |
 | [`updateNotifier`](#setting-updatenotifier) | `bool` | Show an update notification when a newer aube is available. |
 | [`updateRewritesSpecifier`](#setting-updaterewritesspecifier) | `bool` | Rewrite caret/tilde manifest specifiers on `aube update` without `--latest`. |
@@ -2623,14 +2623,34 @@ Overrides the directory that holds the `.aube-state` install-state file. Default
 
 ### `cacheDir` {#setting-cachedir}
 
-Directory for package metadata and dlx cache.
+Directory for the global virtual store and cached package metadata.
 
 - Type: `path`
-- Default: `~/.cache/aube`
+- Default: `$XDG_CACHE_HOME/aube`
 - Environment: `npm_config_cache_dir`, `NPM_CONFIG_CACHE_DIR`, `AUBE_CACHE_DIR`
 - .npmrc keys: `cache-dir`, `cacheDir`
 
-Overrides the cache directory. `XDG_CACHE_HOME` is honored by the platform default (`aube_store::dirs::cache_dir`) which appends `/aube`; this setting takes a complete path.
+Overrides the cache directory. `XDG_CACHE_HOME` is honored by the
+platform default (`aube_store::dirs::cache_dir`), which appends
+`/aube`; this setting takes a complete path, so
+`AUBE_CACHE_DIR=/mnt/fast/aube` puts the cache directly there.
+
+Everything regenerable lives under this directory: the global virtual
+store (`<cacheDir>/virtual-store/`) and cached packument metadata
+(`<cacheDir>/packuments-v1/`, `<cacheDir>/packuments-full-v1/`). The
+content-addressable store is *not* here — it is `storeDir`, which
+defaults under `$XDG_DATA_HOME` instead.
+
+Set this alongside `storeDir` when the store lives on a non-default
+volume. The global virtual store hardlinks out of the CAS, so if
+`cacheDir` and `storeDir` land on different filesystems every install
+degrades to a per-file copy and aube warns about it. Pointing both at
+the same volume (`AUBE_CACHE_DIR=/mnt/dev/cache/aube` plus
+`AUBE_STORE_DIR=/mnt/dev/stores/aube`) keeps the hardlink fast path.
+
+Examples:
+
+- `AUBE_CACHE_DIR=/mnt/dev/cache/aube AUBE_STORE_DIR=/mnt/dev/stores/aube aube install`
 
 ### `useStderr` {#setting-usestderr}
 

--- a/test/settings.bats
+++ b/test/settings.bats
@@ -193,6 +193,58 @@ _make_env_probe_project() {
 	# setting (tested in the config-get test above).
 }
 
+# --- cacheDir relocates the global virtual store ---
+#
+# The global virtual store is the biggest thing under `cacheDir`, and
+# it hardlinks out of the CAS, so users who move `storeDir` to another
+# volume need to move this with it. Before `cacheDir` was honored here,
+# the only lever was `XDG_CACHE_HOME`.
+
+@test "AUBE_CACHE_DIR relocates the global virtual store" {
+	_setup_basic_fixture
+	local custom_cache="$TEST_TEMP_DIR/custom-cache"
+
+	AUBE_CACHE_DIR="$custom_cache" run aube install
+	assert_success
+
+	assert_dir_exists "$custom_cache/virtual-store"
+	# `.aube/<dep_path>` is a symlink into the relocated global store,
+	# not into the XDG default.
+	[ -L node_modules/.aube/is-odd@3.0.1 ]
+	run readlink node_modules/.aube/is-odd@3.0.1
+	assert_success
+	[[ "$output" == "$custom_cache/virtual-store/"* ]]
+	[ ! -d "$HOME/.cache/aube/virtual-store" ]
+}
+
+@test "cacheDir in .npmrc relocates the global virtual store" {
+	_setup_basic_fixture
+	local custom_cache="$TEST_TEMP_DIR/npmrc-cache"
+	echo "cacheDir=$custom_cache" >>"$HOME/.npmrc"
+
+	run aube install
+	assert_success
+	assert_dir_exists "$custom_cache/virtual-store"
+	[ ! -d "$HOME/.cache/aube/virtual-store" ]
+}
+
+@test "reinstall under AUBE_CACHE_DIR keeps the layout, no gvs transition wipe" {
+	_setup_basic_fixture
+	local custom_cache="$TEST_TEMP_DIR/custom-cache"
+
+	AUBE_CACHE_DIR="$custom_cache" run aube install
+	assert_success
+
+	# The warm-path layout check must resolve the same relocated global
+	# store the install wrote to. If it looked at the XDG default it
+	# would see an empty dir, decide the layout flipped, and wipe
+	# `node_modules/` on every install.
+	AUBE_CACHE_DIR="$custom_cache" run aube install
+	assert_success
+	refute_output --partial "global virtual store"
+	[ -L node_modules/.aube/is-odd@3.0.1 ]
+}
+
 @test "linkConcurrency in .npmrc is read during install" {
 	_setup_basic_fixture
 	echo "linkConcurrency=0" >>"$HOME/.npmrc"

--- a/test/settings.bats
+++ b/test/settings.bats
@@ -193,12 +193,23 @@ _make_env_probe_project() {
 	# setting (tested in the config-get test above).
 }
 
-# --- cacheDir relocates the global virtual store ---
+# --- relocating the global virtual store ---
 #
 # The global virtual store is the biggest thing under `cacheDir`, and
 # it hardlinks out of the CAS, so users who move `storeDir` to another
-# volume need to move this with it. Before `cacheDir` was honored here,
-# the only lever was `XDG_CACHE_HOME`.
+# volume need to move this with it. Before these settings were honored
+# here, the only lever was `XDG_CACHE_HOME`. `cacheDir` moves the whole
+# cache; `globalVirtualStoreDir` moves only the virtual store.
+
+# Assert `.aube/<dep_path>` is an absolute symlink into `$1`, the
+# expected global virtual store root.
+_assert_links_into_gvs() {
+	local gvs="$1"
+	[ -L node_modules/.aube/is-odd@3.0.1 ]
+	local target
+	target=$(readlink node_modules/.aube/is-odd@3.0.1)
+	[[ "$target" == "$gvs/"* ]]
+}
 
 @test "AUBE_CACHE_DIR relocates the global virtual store" {
 	_setup_basic_fixture
@@ -210,10 +221,7 @@ _make_env_probe_project() {
 	assert_dir_exists "$custom_cache/virtual-store"
 	# `.aube/<dep_path>` is a symlink into the relocated global store,
 	# not into the XDG default.
-	[ -L node_modules/.aube/is-odd@3.0.1 ]
-	run readlink node_modules/.aube/is-odd@3.0.1
-	assert_success
-	[[ "$output" == "$custom_cache/virtual-store/"* ]]
+	_assert_links_into_gvs "$custom_cache/virtual-store"
 	[ ! -d "$HOME/.cache/aube/virtual-store" ]
 }
 
@@ -225,7 +233,51 @@ _make_env_probe_project() {
 	run aube install
 	assert_success
 	assert_dir_exists "$custom_cache/virtual-store"
+	_assert_links_into_gvs "$custom_cache/virtual-store"
 	[ ! -d "$HOME/.cache/aube/virtual-store" ]
+}
+
+@test "AUBE_GLOBAL_VIRTUAL_STORE_DIR relocates only the virtual store" {
+	_setup_basic_fixture
+	local gvs="$TEST_TEMP_DIR/custom-gvs"
+
+	AUBE_GLOBAL_VIRTUAL_STORE_DIR="$gvs" run aube install
+	assert_success
+
+	# The path is used verbatim — no `virtual-store` suffix appended.
+	_assert_links_into_gvs "$gvs"
+	[ ! -d "$HOME/.cache/aube/virtual-store" ]
+	# The rest of the cache stays put: metadata still lands under the
+	# platform cache dir.
+	assert_dir_exists "$HOME/.cache/aube"
+}
+
+@test "globalVirtualStoreDir in .npmrc wins over cacheDir" {
+	_setup_basic_fixture
+	local custom_cache="$TEST_TEMP_DIR/split-cache"
+	local gvs="$TEST_TEMP_DIR/split-gvs"
+	cat >>"$HOME/.npmrc" <<RC
+cacheDir=$custom_cache
+globalVirtualStoreDir=$gvs
+RC
+
+	run aube install
+	assert_success
+	_assert_links_into_gvs "$gvs"
+	[ ! -d "$custom_cache/virtual-store" ]
+}
+
+@test "reinstall under AUBE_GLOBAL_VIRTUAL_STORE_DIR keeps the layout" {
+	_setup_basic_fixture
+	local gvs="$TEST_TEMP_DIR/custom-gvs"
+
+	AUBE_GLOBAL_VIRTUAL_STORE_DIR="$gvs" run aube install
+	assert_success
+
+	AUBE_GLOBAL_VIRTUAL_STORE_DIR="$gvs" run aube install
+	assert_success
+	refute_output --partial "global virtual store"
+	_assert_links_into_gvs "$gvs"
 }
 
 @test "reinstall under AUBE_CACHE_DIR keeps the layout, no gvs transition wipe" {


### PR DESCRIPTION
Relocating the global virtual store used to require moving `XDG_CACHE_HOME`, which drags every other tool's cache along with it. This adds two ways to move it and fixes the two bugs that stopped the existing `cacheDir` setting from working.

```sh
# move the whole cache (virtual store + packument metadata)
export AUBE_CACHE_DIR=/Volumes/Mini/dev/cache/aube
export AUBE_STORE_DIR=/Volumes/Mini/dev/stores/aube

# or move only the virtual store, leaving metadata on the system disk
export AUBE_GLOBAL_VIRTUAL_STORE_DIR=/Volumes/Mini/dev/aube-virtual-store
export AUBE_STORE_DIR=/Volumes/Mini/dev/stores/aube
```

### `cacheDir` didn't work for this — two reasons

1. **`AUBE_CACHE_DIR` was ignored entirely.** `resolved_cache_dir` sniffed `.npmrc` for a literal `cacheDir` key and returned the platform default otherwise, so env sources never applied. The sniffing existed because `cacheDir` carried a baked-in accessor default (`~/.cache/aube`) that would have clobbered `XDG_CACHE_HOME`. Dropping `cacheDir` from the default-expr list in `aube-settings/build.rs` makes the accessor return `Option<String>`, so "unset" is distinguishable from "set to that literal path" and every source resolves normally.

2. **The global virtual store never followed `cacheDir`.** `Store::with_root` / `default_location` always derived the cache dir from `aube_store::dirs::cache_dir()`, so even an explicit `.npmrc cacheDir` only moved the packument caches — the store stayed at `~/.cache/aube/virtual-store`. Both are replaced by `Store::with_dirs(root, cache_dir)`, and `open_store` passes the resolved value.

### New setting: `globalVirtualStoreDir`

`cacheDir` is the blunt instrument — it moves metadata caches too. Only the virtual store actually *has* to be on the `storeDir` volume (its entries are hardlinked out of the CAS), so `globalVirtualStoreDir` moves just that tree. Used verbatim, no schema suffix appended; wins over `cacheDir` when both are set. Available via env, `.npmrc`, and `aube-workspace.yaml`.

### Notes

- The read-side sites that computed the virtual store path independently (`install/gvs.rs`, `install/startup.rs`) now share one `global_virtual_store_dir(cwd)`. Without that, the warm-path layout check looks at an empty dir under a relocated store, concludes the layout flipped, and wipes `node_modules/` on every install — covered by a test.
- The cross-volume warning now names all three knobs and carries a code: `WARN_AUBE_GVS_CROSS_VOLUME`.
- `aube doctor` gained a `global-virtual-store` line, and its `store` line now honors `storeDir` — it previously printed the platform default regardless, at `files/` granularity. It now matches `aube store path`.
- Unchanged: the OSV advisory mirror, the bootstrapped node-gyp, and git clones still read the platform cache dir directly. Pre-existing and separable; the `cacheDir` docs now say so explicitly.

### Stacked on #1147

The `linux-*-musl` legs were already red on main — `decmpfs` 0.1.2 (via #1142's lock maintenance) hands a `libc::c_ulong` FICLONE to `libc::ioctl`, whose `Ioctl` parameter is `c_int` on musl. #1147 pins it back to 0.1.0, so this PR is based on that branch and will retarget to `main` once it merges.

### Testing

- Six cases in `test/settings.bats` covering both settings: env and `.npmrc` relocation for each, `globalVirtualStoreDir` winning over `cacheDir`, and reinstalls not triggering a layout wipe. Verified the `cacheDir` ones fail against the pre-fix binary.
- Two unit tests in `aube-settings` for the accessor's unset/env behavior.
- `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` clean; settings / store / install / gvs / doctor / cache / prune bats suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches install layout detection and store open paths; mis-resolution could trigger spurious GVS mode wipes, though bats cover relocation and reinstall stability.
> 
> **Overview**
> Users can move the **global virtual store** without changing `XDG_CACHE_HOME`: **`cacheDir`** (`AUBE_CACHE_DIR`, `.npmrc`) now drives both packument caches and `<cacheDir>/virtual-store`, and **`globalVirtualStoreDir`** relocates only that tree (wins over `cacheDir` when both are set).
> 
> **`cacheDir` fixes:** the generated accessor no longer bakes in `~/.cache/aube`, so unset vs configured is distinguishable and env/npmrc resolution works; **`resolved_cache_dir`** stops sniffing `.npmrc` only. **`Store::with_dirs`** plus **`with_virtual_store_dir`** wire cache and GVS into **`open_store`**; install/GVS/startup paths share **`global_virtual_store_dir(cwd)`** so warm-path layout checks don’t wipe **`node_modules`** after a move.
> 
> Adds **`WARN_AUBE_GVS_CROSS_VOLUME`**, clearer cross-volume install guidance, **`aube doctor`** `global-virtual-store` and **`storeDir`**-aware store paths, workspace YAML field, docs, and bats/unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5abc14d54cf409daa9e089defd9eee46f6d7db99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `globalVirtualStoreDir` to relocate the global virtual store independently from the cache directory.
  * Updated cache directory handling with platform-specific defaults and clearer separation of virtual-store and metadata storage.
  * Added workspace configuration support for the global virtual store location.

* **Bug Fixes**
  * Improved cross-volume handling, with a clear warning when linking falls back to per-file copying.
  * `aube doctor` now reports resolved global virtual-store paths.

* **Documentation**
  * Expanded settings and global virtual-store guidance, including relocation and filesystem recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->