### PR TITLE
fix(deps): pin decmpfs to 0.1.0 to unbreak musl builds

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,12 @@
       "matchManagers": ["cargo"],
       "matchPackageNames": ["/^sigstore-/"],
       "groupName": "sigstore crates"
+    },
+    {
+      "description": "decmpfs 0.1.2 fails to compile for musl targets (FICLONE ioctl request typed c_ulong, which is c_int on musl). Hold at 0.1.0 until upstream fixes it.",
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["decmpfs"],
+      "allowedVersions": "<=0.1.0"
     }
   ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1336,9 +1336,9 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "decmpfs"
-version = "0.1.2"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a32fcc951ae53a24a3138b63f54bbb7a9b27e1da6d1578144e397732dd2c530c"
+checksum = "651715809b4119e14ba1ba88650756d8a7012686473a32ec14c0e602e90fc47f"
 dependencies = [
  "libc",
  "sha2 0.10.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,11 @@ reflink-copy = "0.1"
 # applied to native addons as they land in the CAS. The `addon` feature
 # unwraps a napi `--compress` hybrid back to the raw `.node` before the
 # kernel re-compresses it transparently.
-decmpfs = { version = "0.1", features = ["addon"] }
+# Pinned to 0.1.0: 0.1.2's FICLONE reflink path types the ioctl request as
+# `libc::c_ulong`, which is `libc::Ioctl` on glibc but `c_int` on musl, so it
+# fails to compile for *-unknown-linux-musl. Unpin once
+# https://github.com/SocketDev/decmpfs releases a fix.
+decmpfs = { version = "=0.1.0", features = ["addon"] }
 glob = "0.3"
 # BurntSushi's gitignore matcher (from ripgrep). Used by `aube pack` /
 # `aube publish` to honor `.npmignore` / `.gitignore` with full


### PR DESCRIPTION
## Why

`node-addon` and `ffi` have been failing on `main` since [b6223cf](https://github.com/jdx/aube/commit/b6223cf) (`chore(deps): lock file maintenance`, #1142) bumped the lockfile from decmpfs 0.1.0 → 0.1.2. Only the musl legs fail — [example](https://github.com/jdx/aube/actions/runs/30284128626/job/90037647425):

```
error[E0308]: mismatched types
 --> decmpfs-0.1.2/src/linux.rs:296:60
296 | let cloned = unsafe { libc::ioctl(dest_file.as_raw_fd(), FICLONE, src_file.as_raw_fd()) } == 0;
    |                                                          ^^^^^^^ expected `i32`, found `u64`
```

0.1.2 added a btrfs/XFS reflink path with `const FICLONE: libc::c_ulong`. `libc::ioctl`'s request parameter is `libc::Ioctl`, which is `c_ulong` on glibc and `c_int` on musl, so the constant type-checks on gnu and fails on every `*-unknown-linux-musl` target. 0.1.0 handled this by casting with `as _` at each call site (and says so in a comment right above `FS_IOC_GETFLAGS`); the new call site dropped the cast.

`release.yml` builds musl targets too, so this also blocks cutting a release.

## What

- Pin `decmpfs = "=0.1.0"` in the workspace `Cargo.toml`, with the reason inline, and downgrade `Cargo.lock`.
- Add a renovate `packageRule` holding decmpfs at `<=0.1.0` so lock file maintenance doesn't re-introduce 0.1.2.

Upstream fix is a one-liner (`FICLONE as _`) in https://github.com/SocketDev/decmpfs — unpin once that ships.

## Verification

- `mise run lint` (fmt + clippy + shellcheck) clean.
- `cargo check --locked --workspace --all-targets` clean on 0.1.0, so nothing in `aube-store` depended on 0.1.2.
- No local musl C toolchain here, so the musl leg itself is verified by CI on this PR; every musl build on `main` before the bump was green with 0.1.0.

*This PR was generated by Claude.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version rollback with no application logic changes; only affects the transitive filesystem compression crate used by store/CAS paths.
> 
> **Overview**
> **Pins `decmpfs` back to 0.1.0** after lockfile maintenance pulled in 0.1.2, which breaks compilation on `*-unknown-linux-musl` (and thus CI `node-addon`/`ffi` legs and release musl artifacts). The regression comes from 0.1.2’s new FICLONE reflink path typing the ioctl request as `c_ulong` where musl expects `i32`.
> 
> The workspace dependency is set to `=0.1.0` with an inline rationale in `Cargo.toml`, `Cargo.lock` is downgraded to match, and **Renovate** gets a `packageRule` capping `decmpfs` at `<=0.1.0` so lock maintenance cannot re-bump to 0.1.2 before upstream fixes it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e485ca56328ec59b1b5e851b2e4f48ad53273b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pinned a compression dependency to a compatible version to prevent compilation issues on musl-based systems.
  * Updated automated dependency management rules to avoid incompatible upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->