### PR TITLE
DO NOT MERGE: canary regression to prove the perf gate blocks a PR

### DIFF
--- a/crates/aube/src/main.rs
+++ b/crates/aube/src/main.rs
@@ -19,7 +19,28 @@
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+/// CANARY — DO NOT MERGE.
+///
+/// A deliberate instruction-count regression, to prove the perf gate actually
+/// blocks a pull request. Every failure the gate has produced so far has been
+/// a missing baseline or a broken build; it has never once stopped a real
+/// regression in CI, which is the only thing it exists to do.
+///
+/// ~600k retired instructions against a `startup` baseline of 7,605,183 — about
+/// 8%, comfortably over the 1% gate and far above the ~0.02% noise floor.
+/// `black_box` keeps the optimiser from deleting it.
+#[inline(never)]
+fn canary_burn() {
+    let mut sink = 0u64;
+    for i in 0..200_000u64 {
+        sink = sink.wrapping_add(i ^ sink);
+    }
+    std::hint::black_box(sink);
+}
+
 fn main() {
+    canary_burn();
+
     // The standalone `aube` binary runs with aube's own embedder profile.
     // Embedders call `aube::cli_main` with their own `&'static Embedder`
     // instead (and `cli_main_with_defaults` to also seed setting defaults).


### PR DESCRIPTION
**This will be closed unmerged.** It exists to make the perf gate fail on purpose.

## Why

The gate has produced red checks before — for a missing baseline, and for builds I broke. It has **never once stopped a real regression**, which is the only thing it exists to do.

That gap matters because the failure mode is silent. A misread `gate_pct`, a mis-keyed comparison, a swallowed exit code — every one of those would look exactly like the green checks we have now, with charts filling in and nothing being caught. "It should work" and "it did work" are different claims, and only one of them has been tested.

## What it does

`canary_burn()` at the top of `main`, ~600k retired instructions:

```rust
#[inline(never)]
fn canary_burn() {
    let mut sink = 0u64;
    for i in 0..200_000u64 {
        sink = sink.wrapping_add(i ^ sink);
    }
    std::hint::black_box(sink);
}
```

Against a `startup` baseline of **7,605,183** instructions that is about **8%** — comfortably over the 1% gate and three orders of magnitude above the ~0.02% noise floor. `black_box` stops the optimiser deleting it; confirmed locally, where startup wall clock goes 2.80ms → 3.20ms.

## What should happen

- `perf-pr` comments a table with `startup` up ~8%, flagged ⚠️
- The **Report and gate** job fails with `an instruction count rose beyond the gate`
- The other three benchmarks stay flat, since the burn is in the startup path they all share — so they should each move by roughly the same absolute amount, and proportionally most on the smallest

That last point is itself a check on the method: if `install` (102M) moved by 8% too, something is wrong with the comparison.

Once the check is red, I close this.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are isolated to a labeled canary in the binary entrypoint and are meant to be closed unmerged; no production behavior change is intended to ship.
> 
> **Overview**
> **Intentional, non-mergeable canary** to verify CI’s instruction-count perf gate actually fails on a real regression (not only missing baselines or broken builds).
> 
> Adds `canary_burn()` in `crates/aube/src/main.rs`: a 200k-iteration loop with `black_box`, marked `#[inline(never)]`, and invoked at the very start of `main()`. The goal is ~600k extra retired instructions on the shared startup path—about **8%** vs the `startup` baseline (~7.6M), well above the **1%** gate.
> 
> **Expected CI behavior:** `perf-pr` reports `startup` up ~8% (⚠️), the report/gate job fails with an instruction-count regression message, and other benchmarks should only move slightly in absolute terms (same startup burn), not by ~8% each.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5622683636a5322ecf32bff9e8cafc448704fa95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Added startup performance monitoring to help detect instruction-count regressions.
  * Existing command dispatch and usage behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->