### PR TITLE
feat(add): route embedded confirmations through host handlers

### DIFF
--- a/crates/aube/src/commands/add/filtered.rs
+++ b/crates/aube/src/commands/add/filtered.rs
@@ -39,7 +39,13 @@ pub(super) async fn run(
     // `args.packages` list. The Bun-style `securityScanner` is
     // NOT called here: it runs post-resolve from `install::run`
     // against the full resolved graph.
-    supply_chain::run_cli_name_gates(&root, &args.packages, args.allow_low_downloads, true).await?;
+    supply_chain::run_cli_name_gates(
+        &root,
+        &args.packages,
+        args.allow_low_downloads,
+        crate::commands::add_supply_chain::LowDownloadPrompt::Terminal,
+    )
+    .await?;
 
     let mut snapshots = Vec::new();
     let lockfile_path = no_save::lockfile_path_for_project(&root);

--- a/crates/aube/src/commands/add/mod.rs
+++ b/crates/aube/src/commands/add/mod.rs
@@ -92,7 +92,9 @@ pub async fn add_to_project(
                         lock.project_dir(),
                         packages,
                         false,
-                        false,
+                        crate::commands::add_supply_chain::LowDownloadPrompt::Host(
+                            options.control.clone(),
+                        ),
                     )
                     .await?;
                 }
@@ -520,7 +522,13 @@ pub async fn run(
     // full resolved graph (matching Bun's contract), with
     // concrete versions + transitives the OSV/downloads probes
     // wouldn't see at this stage.
-    supply_chain::run_cli_name_gates(&cwd, packages, allow_low_downloads, true).await?;
+    supply_chain::run_cli_name_gates(
+        &cwd,
+        packages,
+        allow_low_downloads,
+        crate::commands::add_supply_chain::LowDownloadPrompt::Terminal,
+    )
+    .await?;
 
     update_manifest_for_add(
         &cwd,

--- a/crates/aube/src/commands/add/supply_chain.rs
+++ b/crates/aube/src/commands/add/supply_chain.rs
@@ -7,7 +7,7 @@ pub(super) async fn run_cli_name_gates(
     cwd: &Path,
     packages: &[String],
     allow_low_downloads: bool,
-    allow_prompt: bool,
+    prompt: crate::commands::add_supply_chain::LowDownloadPrompt,
 ) -> miette::Result<()> {
     let project_dir = supply_chain_project_dir(cwd);
     let manifest = crate::commands::load_manifest_or_default(&project_dir)?;
@@ -44,7 +44,7 @@ pub(super) async fn run_cli_name_gates(
         low_download_threshold,
         crate::commands::add_supply_chain::LowDownloadPolicy {
             allow: allow_low_downloads,
-            prompt: allow_prompt,
+            prompt,
         },
         &allowed_unpopular,
     )

--- a/crates/aube/src/commands/add_supply_chain.rs
+++ b/crates/aube/src/commands/add_supply_chain.rs
@@ -39,10 +39,16 @@ use aube_settings::resolved::{AdvisoryBloomCheck, AdvisoryCheck, AdvisoryCheckOn
 use miette::miette;
 use std::io::{BufRead, IsTerminal, Write};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub(crate) struct LowDownloadPolicy {
     pub(crate) allow: bool,
-    pub(crate) prompt: bool,
+    pub(crate) prompt: LowDownloadPrompt,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum LowDownloadPrompt {
+    Terminal,
+    Host(crate::commands::install::InstallControl),
 }
 
 /// Run both supply-chain gates against the registry-bound specs the
@@ -54,8 +60,7 @@ pub(crate) struct LowDownloadPolicy {
 ///
 /// `low_download_policy` controls the per-invocation
 /// `--allow-low-downloads` override and whether the caller permits a
-/// terminal prompt. Embedded callers disable prompting so an in-process
-/// install can never block on aube's stdin.
+/// terminal prompt or delegates confirmation to an embedding host.
 ///
 /// `allowed_unpopular_globs` are the `allowedUnpopularPackages`
 /// setting entries: full-name globs that exempt matching names from
@@ -125,7 +130,7 @@ pub(crate) async fn run_gates(
                 &client,
                 &gated,
                 low_download_threshold,
-                low_download_policy.prompt,
+                &low_download_policy.prompt,
             )
             .await?;
         }
@@ -703,9 +708,8 @@ async fn downloads_gate(
     client: &reqwest::Client,
     names: &[String],
     threshold: u64,
-    allow_prompt: bool,
+    prompt: &LowDownloadPrompt,
 ) -> miette::Result<()> {
-    let interactive = prompt_is_interactive(allow_prompt);
     let mut set: tokio::task::JoinSet<(String, Result<DownloadCount, _>)> =
         tokio::task::JoinSet::new();
     for name in names {
@@ -761,13 +765,7 @@ async fn downloads_gate(
             code = WARN_AUBE_LOW_DOWNLOAD_PACKAGE,
             "{name}: {weekly} weekly downloads (threshold: {threshold})"
         );
-        if !interactive {
-            return Err(miette!(
-                code = ERR_AUBE_LOW_DOWNLOAD_PACKAGE,
-                "refusing to add {name}: only {weekly} weekly downloads (threshold: {threshold}). Pass --allow-low-downloads to bypass, or set `lowDownloadThreshold = 0`."
-            ));
-        }
-        if !prompt_continue(name, weekly, threshold)? {
+        if !confirm_low_download(prompt, name, weekly, threshold).await? {
             return Err(miette!(
                 code = ERR_AUBE_LOW_DOWNLOAD_PACKAGE,
                 "user aborted `{} {name}`",
@@ -778,8 +776,36 @@ async fn downloads_gate(
     Ok(())
 }
 
-fn prompt_is_interactive(allow_prompt: bool) -> bool {
-    allow_prompt && std::io::stdin().is_terminal() && std::io::stderr().is_terminal()
+async fn confirm_low_download(
+    prompt: &LowDownloadPrompt,
+    name: &str,
+    weekly: u64,
+    threshold: u64,
+) -> miette::Result<bool> {
+    let refusal = || {
+        miette!(
+            code = ERR_AUBE_LOW_DOWNLOAD_PACKAGE,
+            "refusing to add {name}: only {weekly} weekly downloads (threshold: {threshold}). Pass --allow-low-downloads to bypass, or set `lowDownloadThreshold = 0`."
+        )
+    };
+    match prompt {
+        LowDownloadPrompt::Terminal
+            if std::io::stdin().is_terminal() && std::io::stderr().is_terminal() =>
+        {
+            prompt_continue(name, weekly, threshold)
+        }
+        LowDownloadPrompt::Terminal => Err(refusal()),
+        LowDownloadPrompt::Host(control) => control
+            .confirm(
+                crate::commands::install::InstallPrompt::LowDownloadPackage {
+                    package: name.to_string(),
+                    weekly_downloads: weekly,
+                    threshold,
+                },
+            )
+            .await
+            .unwrap_or_else(|| Err(refusal())),
+    }
 }
 
 fn prompt_continue(name: &str, weekly: u64, threshold: u64) -> miette::Result<bool> {
@@ -808,6 +834,22 @@ fn prompt_continue(name: &str, weekly: u64, threshold: u64) -> miette::Result<bo
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::install::{
+        InstallControl, InstallPrompt, InstallPromptFuture, InstallPromptHandler,
+    };
+    use std::sync::{Arc, Mutex};
+
+    struct RecordingPromptHandler {
+        answer: bool,
+        prompts: Mutex<Vec<InstallPrompt>>,
+    }
+
+    impl InstallPromptHandler for RecordingPromptHandler {
+        fn confirm(&self, prompt: InstallPrompt) -> InstallPromptFuture<'_> {
+            self.prompts.lock().unwrap().push(prompt);
+            Box::pin(async move { Ok(self.answer) })
+        }
+    }
 
     #[tokio::test]
     async fn osv_gate_off_skips_network() {
@@ -836,7 +878,7 @@ mod tests {
                 1000,
                 LowDownloadPolicy {
                     allow: false,
-                    prompt: true,
+                    prompt: LowDownloadPrompt::Terminal,
                 },
                 &[],
             )
@@ -845,9 +887,42 @@ mod tests {
         );
     }
 
-    #[test]
-    fn embedded_callers_cannot_enable_terminal_prompts() {
-        assert!(!prompt_is_interactive(false));
+    #[tokio::test]
+    async fn embedded_confirmation_is_routed_to_the_host() {
+        let handler = Arc::new(RecordingPromptHandler {
+            answer: true,
+            prompts: Mutex::new(Vec::new()),
+        });
+        let prompt =
+            LowDownloadPrompt::Host(InstallControl::silent().with_prompt_handler(handler.clone()));
+
+        assert!(
+            confirm_low_download(&prompt, "@scope/tiny", 12, 1000)
+                .await
+                .unwrap()
+        );
+        assert_eq!(
+            *handler.prompts.lock().unwrap(),
+            vec![InstallPrompt::LowDownloadPackage {
+                package: "@scope/tiny".to_string(),
+                weekly_downloads: 12,
+                threshold: 1000,
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn embedded_confirmation_without_a_handler_fails_closed() {
+        let prompt = LowDownloadPrompt::Host(InstallControl::silent());
+
+        let error = confirm_low_download(&prompt, "tiny", 12, 1000)
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error.code().map(|code| code.to_string()).as_deref(),
+            Some(ERR_AUBE_LOW_DOWNLOAD_PACKAGE)
+        );
     }
 
     #[test]

--- a/crates/aube/src/commands/install/control.rs
+++ b/crates/aube/src/commands/install/control.rs
@@ -1,4 +1,5 @@
 use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 
 use miette::miette;
@@ -60,10 +61,34 @@ pub trait InstallReporter: Send + Sync + 'static {
     fn report(&self, event: InstallEvent);
 }
 
+/// A confirmation requested by an embedded aube operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum InstallPrompt {
+    LowDownloadPackage {
+        package: String,
+        weekly_downloads: u64,
+        threshold: u64,
+    },
+}
+
+/// Future returned by an [`InstallPromptHandler`].
+pub type InstallPromptFuture<'a> = Pin<Box<dyn Future<Output = miette::Result<bool>> + Send + 'a>>;
+
+/// Host-provided destination for interactive confirmation requests.
+///
+/// Embedded aube operations never read process stdin themselves. When no
+/// handler is configured, an operation that needs confirmation fails with
+/// its normal structured error.
+pub trait InstallPromptHandler: Send + Sync + 'static {
+    fn confirm(&self, prompt: InstallPrompt) -> InstallPromptFuture<'_>;
+}
+
 #[derive(Clone)]
 pub struct InstallControl {
     output: InstallOutputMode,
     reporter: Option<Arc<dyn InstallReporter>>,
+    prompt_handler: Option<Arc<dyn InstallPromptHandler>>,
     cancellation: tokio_util::sync::CancellationToken,
 }
 
@@ -72,6 +97,7 @@ impl std::fmt::Debug for InstallControl {
         f.debug_struct("InstallControl")
             .field("output", &self.output)
             .field("has_reporter", &self.reporter.is_some())
+            .field("has_prompt_handler", &self.prompt_handler.is_some())
             .field("cancelled", &self.is_cancelled())
             .finish()
     }
@@ -82,6 +108,7 @@ impl Default for InstallControl {
         Self {
             output: InstallOutputMode::Human,
             reporter: None,
+            prompt_handler: None,
             cancellation: tokio_util::sync::CancellationToken::new(),
         }
     }
@@ -92,6 +119,7 @@ impl InstallControl {
         Self {
             output: InstallOutputMode::Events,
             reporter: Some(reporter),
+            prompt_handler: None,
             cancellation: tokio_util::sync::CancellationToken::new(),
         }
     }
@@ -105,6 +133,11 @@ impl InstallControl {
 
     pub fn output_mode(&self) -> InstallOutputMode {
         self.output
+    }
+
+    pub fn with_prompt_handler(mut self, handler: Arc<dyn InstallPromptHandler>) -> Self {
+        self.prompt_handler = Some(handler);
+        self
     }
 
     pub fn cancel(&self) {
@@ -121,6 +154,15 @@ impl InstallControl {
 
     pub(crate) fn reporter(&self) -> Option<Arc<dyn InstallReporter>> {
         self.reporter.clone()
+    }
+
+    pub(crate) async fn confirm(&self, prompt: InstallPrompt) -> Option<miette::Result<bool>> {
+        let handler = self.prompt_handler.clone()?;
+        Some(tokio::select! {
+            biased;
+            _ = self.cancelled() => self.check_cancelled().map(|()| false),
+            result = handler.confirm(prompt) => result,
+        })
     }
 
     pub(crate) fn check_cancelled(&self) -> miette::Result<()> {

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -37,7 +37,8 @@ pub use args::{InstallArgs, InstallOptions};
 pub(crate) use bin_linking::{PkgJsonCache, link_dep_bins, materialized_pkg_dir};
 pub use control::{
     InstallControl, InstallEvent, InstallOutputLevel, InstallOutputMode, InstallPhase,
-    InstallProgressSnapshot, InstallReporter,
+    InstallProgressSnapshot, InstallPrompt, InstallPromptFuture, InstallPromptHandler,
+    InstallReporter,
 };
 pub use dep_selection::DepSelection;
 pub(super) use fetch::fetch_packages;

--- a/crates/aube/src/embed.rs
+++ b/crates/aube/src/embed.rs
@@ -11,7 +11,8 @@ use std::path::{Path, PathBuf};
 pub use crate::commands::add::AddToProjectOptions;
 pub use crate::commands::install::{
     DepSelection, FrozenMode, InstallControl, InstallEvent, InstallOutputLevel, InstallOutputMode,
-    InstallPhase, InstallProgressSnapshot, InstallReporter,
+    InstallPhase, InstallProgressSnapshot, InstallPrompt, InstallPromptFuture,
+    InstallPromptHandler, InstallReporter,
 };
 pub use crate::runtime::{EmbedderRuntime, set_embedder_runtime};
 pub use aube_registry::NetworkMode;


### PR DESCRIPTION
## Summary
- expose a structured, async `InstallPromptHandler` on the embedded install control
- route embedded low-download confirmations to the host instead of reading process stdin
- preserve standalone aube terminal prompts and fail closed when an embedder provides no handler
- keep prompt waits cancellable through the existing install cancellation token

## Why
Embedding hosts such as mise need to own terminal detection, progress suspension, prompt serialization, and rendering. A pseudo-TTY can look interactive to a dependency even when the surrounding workflow is unattended, so an embedded aube operation should request confirmation from its host rather than access stdio directly.

This API lets mise display aube confirmations through mise's own UI while retaining aube's interactive behavior as a standalone CLI.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

## Follow-up
After this API is released, mise can attach its prompt handler to embedded aube installs and decide whether to display the confirmation or return the structured refusal in non-interactive contexts.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes supply-chain confirmation behavior for embedded adds and adds a new public embed API; standalone CLI behavior is preserved, with fail-closed defaults when no host handler is set.
> 
> **Overview**
> Replaces the low-download gate’s **`allow_prompt` boolean** with **`LowDownloadPrompt`** (`Terminal` vs **`Host(InstallControl)`**), so embedded **`add_to_project`** can confirm suspicious packages without reading process stdin.
> 
> **`InstallControl`** gains an optional **`InstallPromptHandler`**, **`InstallPrompt::LowDownloadPackage`**, and **`confirm()`** wired through install cancellation. The downloads gate calls **`confirm_low_download`**, which keeps the CLI tty prompt for **`Terminal`** and delegates to the host for **`Host`**; missing handler or non-interactive terminal still **fail closed** with **`ERR_AUBE_LOW_DOWNLOAD_PACKAGE`**. Prompt types are re-exported from **`embed`** for hosts like mise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 240c5dd7f0fcddf06413ed8d234517e9bcf94338. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive confirmation for packages with low weekly download counts.
  * Install operations can now route confirmation requests through an embedding host.
  * Added cancellation-aware handling for host-provided confirmation prompts.
  * Low-download prompts now fail safely when no handler is available or confirmation is declined.

* **Bug Fixes**
  * Improved consistency of low-download checks across terminal, filtered, and embedded install workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->