### PR TITLE
fix(install): preserve platform optionals with supported architectures

### DIFF
--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -874,21 +874,18 @@ pub(crate) fn configure_resolver(
     // pnpm-lock.yaml, aube-lock.yaml, bun.lock, package-lock.json, and
     // npm-shrinkwrap.json are committed, cross-platform artifacts that
     // carry per-package os/cpu metadata.
-    // When the user hasn't declared `pnpm.supportedArchitectures`, record
-    // EVERY optional-dep variant a package declares (`accept_all`) so the
-    // committed lockfile installs cleanly on every contributor's platform
-    // — withholding variants leaves teammates with "Cannot find native
-    // binding". This matches what npm, pnpm, and bun write verbatim (all
-    // 26 `@esbuild/*` / `@rollup/rollup-*` natives, freebsd/ppc64/s390x
-    // and all), so a lockfile aube regenerates stays diff-clean against the
-    // native tool. Install-time filtering (`filter_graph`) and the
-    // streaming-fetch gate run against the unmodified host triple, so
-    // `node_modules` and tarball downloads stay trimmed to the host — the
-    // wider lockfile costs only bytes, never extra installs. Yarn lockfiles
-    // don't carry the same per-package os/cpu metadata, so widening there
-    // would only bloat them — keep the host-only default.
-    let manifest_set_supported_arch =
-        !(sup_os.is_empty() && sup_cpu.is_empty() && sup_libc.is_empty());
+    // Record EVERY optional-dep variant a package declares (`accept_all`) in
+    // portable lockfiles, even when the user configured
+    // `supportedArchitectures`. pnpm applies that setting when deciding what
+    // to install, not when deciding what its lockfile records; narrowing the
+    // resolver here silently removes the variants another platform needs.
+    // This also matches what npm and bun write verbatim (all 26 `@esbuild/*`
+    // / `@rollup/rollup-*` natives, freebsd/ppc64/s390x and all), so a
+    // lockfile aube regenerates stays diff-clean against the native tool.
+    // Install-time filtering (`filter_graph`) and the streaming-fetch gate
+    // still use the configured architectures, so the wider lockfile costs
+    // only bytes, never extra installs. Yarn lockfiles don't carry the same
+    // per-package os/cpu metadata, so widening there would only bloat them.
     let writes_cross_platform_lock = matches!(
         target_lockfile_kind,
         Some(
@@ -899,14 +896,7 @@ pub(crate) fn configure_resolver(
                 | aube_lockfile::LockfileKind::NpmShrinkwrap
         )
     );
-    let supported_architectures = if manifest_set_supported_arch {
-        aube_resolver::SupportedArchitectures {
-            os: sup_os,
-            cpu: sup_cpu,
-            libc: sup_libc,
-            ..Default::default()
-        }
-    } else if writes_cross_platform_lock {
+    let supported_architectures = if writes_cross_platform_lock {
         aube_resolver::SupportedArchitectures {
             accept_all: true,
             ..Default::default()

--- a/test/optional_platform.bats
+++ b/test/optional_platform.bats
@@ -199,6 +199,48 @@ assert_npm_lock_captures_cross_platform_optionals() {
 	assert_success
 }
 
+@test "filtered add preserves foreign optionals with supportedArchitectures" {
+	mkdir -p packages/app
+	cat >package.json <<-'JSON'
+		{
+		  "name": "supported-arch-filter-root",
+		  "version": "0.0.0",
+		  "private": true
+		}
+	JSON
+	cat >packages/app/package.json <<-'JSON'
+		{
+		  "name": "app",
+		  "version": "0.0.0",
+		  "private": true,
+		  "optionalDependencies": {
+		    "aube-test-optional-win32": "1.0.0"
+		  }
+		}
+	JSON
+	cat >pnpm-workspace.yaml <<-'YAML'
+		packages:
+		  - packages/*
+		supportedArchitectures:
+		  os: [current, linux]
+		  cpu: [current, x64]
+		  libc: [current, glibc]
+	YAML
+	: >pnpm-lock.yaml
+
+	run aube install --no-frozen-lockfile
+	assert_success
+	run grep -F 'aube-test-optional-win32@1.0.0:' pnpm-lock.yaml
+	assert_success
+	assert_not_exists node_modules/.aube/aube-test-optional-win32@1.0.0
+
+	run aube --filter app add is-positive@1.0.0
+	assert_success
+	run grep -F 'aube-test-optional-win32@1.0.0:' pnpm-lock.yaml
+	assert_success
+	assert_not_exists node_modules/.aube/aube-test-optional-win32@1.0.0
+}
+
 @test "aube-lock.yaml records optional natives for exotic arches (full pnpm parity)" {
 	# aube-lock.yaml records EVERY optional-dep variant a package declares,
 	# matching pnpm and bun — both write all natives (linux-ppc64, freebsd,


### PR DESCRIPTION
## Summary

- keep every platform-specific optional dependency in portable lockfiles even when `supportedArchitectures` is configured
- continue applying `supportedArchitectures` when fetching and linking, so foreign packages remain out of `node_modules`
- add a filtered workspace `add` regression covering a win32-only optional dependency on Linux

## Root cause

The shared resolver preferred the configured architecture set over the portable-lockfile `accept_all` mode. Any command that re-resolved the graph could therefore remove optional packages for other platforms from `pnpm-lock.yaml`, `aube-lock.yaml`, `bun.lock`, or npm lockfiles. A plain install often hid the problem by taking the fresh-lockfile fast path without rewriting the file.

Portable lockfiles now always resolve all platform variants. The existing post-write graph filter remains responsible for honoring the configured install architectures.

## Impact

Filtered and unfiltered lockfile rewrites no longer silently make a committed lockfile unusable on another platform. The supplied esbuild reproduction retains all 45 foreign-platform entries after `aube --filter app add`; the only lockfile additions are the newly requested package and its dependency.

## Tests

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `mise run test:bats test/optional_platform.bats`
- supplied Discussion #1155 reproduction compared against pnpm 11.17.0 baseline (45 foreign entries before and after)

Discussion: https://github.com/jdx/aube/discussions/1155

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared resolver configuration used by install, add, update, and other lockfile-rewriting commands; behavior change is intentional but could affect lockfile size and parity with prior aube-generated locks.
> 
> **Overview**
> **Portable lockfile resolution** no longer narrows optional platform packages when `supportedArchitectures` is set in `pnpm-workspace.yaml` or the manifest. For `pnpm-lock.yaml`, `aube-lock.yaml`, `bun.lock`, and npm lockfiles, the resolver now always uses `accept_all` so every declared optional native variant stays in the committed lockfile—matching pnpm/npm/bun and avoiding lockfile rewrites (e.g. filtered `add`) that dropped foreign-platform entries.
> 
> **Install behavior is unchanged:** `filter_graph` and fetch/link still honor the configured architecture set, so packages like a win32-only optional are recorded in the lockfile but not installed on Linux.
> 
> Adds a bats regression: workspace with `supportedArchitectures`, win32 optional on `app`, and `aube --filter app add` must keep the foreign optional in `pnpm-lock.yaml` and out of `node_modules`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 221c2af382de9d8e25ba586d46c9d18c3d47355a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved platform-specific optional dependencies in lockfiles during filtered package additions.
  * Improved cross-platform lockfile compatibility when architecture filtering is configured.
  * Prevented unsupported platform dependencies from being installed while retaining their lockfile metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->