### PR TITLE
feat(add): block new and lookalike package names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,15 +105,19 @@ jobs:
             exit 1
           fi
           out="crates/aube-resolver/data/primer-top${AUBE_PRIMER_TOP}-v${AUBE_PRIMER_VERSION_CAP}-s${schema}.rkyv.json"
+          popular_out="crates/aube-resolver/data/popular-top100000-v1.json"
           node scripts/generate-primer.mjs \
             --top "$AUBE_PRIMER_TOP" \
             --versions "$AUBE_PRIMER_VERSION_CAP" \
-            --out "$out"
+            --out "$out" \
+            --popular-names-out "$popular_out"
           echo "path=$out" >> "$GITHUB_OUTPUT"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: metadata-primer
-          path: ${{ steps.primer.outputs.path }}
+          path: |
+            ${{ steps.primer.outputs.path }}
+            crates/aube-resolver/data/popular-top100000-v1.json
 
   # Non-PGO Windows targets (untested PGO toolchain). Built via taiki-e
   # straight from the release profile. `aarch64-unknown-linux-musl` lives

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /.claude/
 /crates/aube-resolver/data/primer-top*.json
 /crates/aube-resolver/data/primer-top*.rkyv.zst
+/crates/aube-resolver/data/popular-top*.json

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -256,11 +256,11 @@ Conflicts with `--no-save`, which only snapshots `package.json` and the lockfile
 """#
         arg <PKG>
     }
-    flag --allow-low-downloads help="Bypass the new-name and [`lowDownloadThreshold`] confirm prompts / refusals for this invocation" {
+    flag --allow-low-downloads help="Bypass the similar-name, new-name, and [`lowDownloadThreshold`] confirm prompts / refusals for this invocation" {
         long_help #"""
-Bypass the new-name and [`lowDownloadThreshold`] confirm prompts / refusals for this invocation.
+Bypass the similar-name, new-name, and [`lowDownloadThreshold`] confirm prompts / refusals for this invocation.
 
-`aube add` looks up each candidate's weekly download count and prompts (interactive) or fails (CI) when the count is below [`lowDownloadThreshold`] or the package name is newer than [`minimumPackageAge`]. The flag is intended for cases where you've already verified the package out-of-band. It does not affect the OSV malicious-package check, which remains a hard block.
+`aube add` looks up each candidate's weekly download count and prompts (interactive) or fails (CI) when the count is below [`lowDownloadThreshold`], resembles a top-100,000 npm package, or is newer than [`minimumPackageAge`]. The flag is intended for cases where you've already verified the package out-of-band. It does not affect the OSV malicious-package check, which remains a hard block.
 """#
     }
     flag --dangerously-allow-all-builds help="Allow every dependency's lifecycle scripts to run" {

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -256,11 +256,11 @@ Conflicts with `--no-save`, which only snapshots `package.json` and the lockfile
 """#
         arg <PKG>
     }
-    flag --allow-low-downloads help="Bypass the [`lowDownloadThreshold`] confirm prompt / refusal for this invocation" {
+    flag --allow-low-downloads help="Bypass the new-name and [`lowDownloadThreshold`] confirm prompts / refusals for this invocation" {
         long_help #"""
-Bypass the [`lowDownloadThreshold`] confirm prompt / refusal for this invocation.
+Bypass the new-name and [`lowDownloadThreshold`] confirm prompts / refusals for this invocation.
 
-`aube add` looks up each candidate's weekly download count and prompts (interactive) or fails (CI) when the count is below [`lowDownloadThreshold`]. The flag is intended for the cases where you've already verified the package out-of-band — adding a brand-new niche tool, a fresh fork, an internal scratch package — and don't want the prompt to interrupt scripted workflows. Does not affect the OSV malicious-package check, which remains a hard block.
+`aube add` looks up each candidate's weekly download count and prompts (interactive) or fails (CI) when the count is below [`lowDownloadThreshold`] or the package name is newer than [`minimumReleaseAge`]. The flag is intended for cases where you've already verified the package out-of-band. It does not affect the OSV malicious-package check, which remains a hard block.
 """#
     }
     flag --dangerously-allow-all-builds help="Allow every dependency's lifecycle scripts to run" {

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -260,7 +260,7 @@ Conflicts with `--no-save`, which only snapshots `package.json` and the lockfile
         long_help #"""
 Bypass the new-name and [`lowDownloadThreshold`] confirm prompts / refusals for this invocation.
 
-`aube add` looks up each candidate's weekly download count and prompts (interactive) or fails (CI) when the count is below [`lowDownloadThreshold`] or the package name is newer than [`minimumReleaseAge`]. The flag is intended for cases where you've already verified the package out-of-band. It does not affect the OSV malicious-package check, which remains a hard block.
+`aube add` looks up each candidate's weekly download count and prompts (interactive) or fails (CI) when the count is below [`lowDownloadThreshold`] or the package name is newer than [`minimumPackageAge`]. The flag is intended for cases where you've already verified the package out-of-band. It does not affect the OSV malicious-package check, which remains a hard block.
 """#
     }
     flag --dangerously-allow-all-builds help="Allow every dependency's lifecycle scripts to run" {

--- a/crates/aube-codes/src/errors.rs
+++ b/crates/aube-codes/src/errors.rs
@@ -336,7 +336,7 @@ pub const ALL: &[CodeMeta] = &[
     CodeMeta {
         name: ERR_AUBE_NEW_PACKAGE_NAME,
         category: category::SUPPLY_CHAIN,
-        description: "`aube add` refused a package name first published within `minimumReleaseAge`. This protects against newly registered slopsquatting names.",
+        description: "`aube add` refused a package name first published within `minimumPackageAge`. This protects against newly registered slopsquatting names.",
         exit_code: None,
     },
     CodeMeta {

--- a/crates/aube-codes/src/errors.rs
+++ b/crates/aube-codes/src/errors.rs
@@ -43,6 +43,7 @@ pub const ERR_AUBE_INVALID_PACKAGE_NAME: &str = "ERR_AUBE_INVALID_PACKAGE_NAME";
 pub const ERR_AUBE_REGISTRY_WRITE_REJECTED: &str = "ERR_AUBE_REGISTRY_WRITE_REJECTED";
 pub const ERR_AUBE_MALICIOUS_PACKAGE: &str = "ERR_AUBE_MALICIOUS_PACKAGE";
 pub const ERR_AUBE_LOW_DOWNLOAD_PACKAGE: &str = "ERR_AUBE_LOW_DOWNLOAD_PACKAGE";
+pub const ERR_AUBE_NEW_PACKAGE_NAME: &str = "ERR_AUBE_NEW_PACKAGE_NAME";
 pub const ERR_AUBE_ADVISORY_CHECK_FAILED: &str = "ERR_AUBE_ADVISORY_CHECK_FAILED";
 pub const ERR_AUBE_SECURITY_SCANNER_FATAL: &str = "ERR_AUBE_SECURITY_SCANNER_FATAL";
 pub const ERR_AUBE_SECURITY_SCANNER_FAILED: &str = "ERR_AUBE_SECURITY_SCANNER_FAILED";
@@ -331,6 +332,12 @@ pub const ALL: &[CodeMeta] = &[
         category: category::REGISTRY_NETWORK,
         description: "`aube add` refused a package whose weekly downloads fall below `lowDownloadThreshold` in a non-interactive context (or when stdin is not a TTY). Pass `--allow-low-downloads` to bypass.",
         exit_code: Some(47),
+    },
+    CodeMeta {
+        name: ERR_AUBE_NEW_PACKAGE_NAME,
+        category: category::SUPPLY_CHAIN,
+        description: "`aube add` refused a package name first published within `minimumReleaseAge`. This protects against newly registered slopsquatting names.",
+        exit_code: None,
     },
     CodeMeta {
         name: ERR_AUBE_ADVISORY_CHECK_FAILED,

--- a/crates/aube-codes/src/errors.rs
+++ b/crates/aube-codes/src/errors.rs
@@ -44,6 +44,7 @@ pub const ERR_AUBE_REGISTRY_WRITE_REJECTED: &str = "ERR_AUBE_REGISTRY_WRITE_REJE
 pub const ERR_AUBE_MALICIOUS_PACKAGE: &str = "ERR_AUBE_MALICIOUS_PACKAGE";
 pub const ERR_AUBE_LOW_DOWNLOAD_PACKAGE: &str = "ERR_AUBE_LOW_DOWNLOAD_PACKAGE";
 pub const ERR_AUBE_NEW_PACKAGE_NAME: &str = "ERR_AUBE_NEW_PACKAGE_NAME";
+pub const ERR_AUBE_PACKAGE_AGE_CHECK_FAILED: &str = "ERR_AUBE_PACKAGE_AGE_CHECK_FAILED";
 pub const ERR_AUBE_ADVISORY_CHECK_FAILED: &str = "ERR_AUBE_ADVISORY_CHECK_FAILED";
 pub const ERR_AUBE_SECURITY_SCANNER_FATAL: &str = "ERR_AUBE_SECURITY_SCANNER_FATAL";
 pub const ERR_AUBE_SECURITY_SCANNER_FAILED: &str = "ERR_AUBE_SECURITY_SCANNER_FAILED";
@@ -337,6 +338,12 @@ pub const ALL: &[CodeMeta] = &[
         name: ERR_AUBE_NEW_PACKAGE_NAME,
         category: category::SUPPLY_CHAIN,
         description: "`aube add` refused a package name first published within `minimumPackageAge`. This protects against newly registered slopsquatting names.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: ERR_AUBE_PACKAGE_AGE_CHECK_FAILED,
+        category: category::SUPPLY_CHAIN,
+        description: "`aube add` couldn't verify a package name's registry creation time while `minimumPackageAge` was enabled, so the package-age gate failed closed.",
         exit_code: None,
     },
     CodeMeta {

--- a/crates/aube-codes/src/errors.rs
+++ b/crates/aube-codes/src/errors.rs
@@ -42,6 +42,7 @@ pub const ERR_AUBE_OFFLINE: &str = "ERR_AUBE_OFFLINE";
 pub const ERR_AUBE_INVALID_PACKAGE_NAME: &str = "ERR_AUBE_INVALID_PACKAGE_NAME";
 pub const ERR_AUBE_REGISTRY_WRITE_REJECTED: &str = "ERR_AUBE_REGISTRY_WRITE_REJECTED";
 pub const ERR_AUBE_MALICIOUS_PACKAGE: &str = "ERR_AUBE_MALICIOUS_PACKAGE";
+pub const ERR_AUBE_SIMILAR_PACKAGE_NAME: &str = "ERR_AUBE_SIMILAR_PACKAGE_NAME";
 pub const ERR_AUBE_LOW_DOWNLOAD_PACKAGE: &str = "ERR_AUBE_LOW_DOWNLOAD_PACKAGE";
 pub const ERR_AUBE_NEW_PACKAGE_NAME: &str = "ERR_AUBE_NEW_PACKAGE_NAME";
 pub const ERR_AUBE_PACKAGE_AGE_CHECK_FAILED: &str = "ERR_AUBE_PACKAGE_AGE_CHECK_FAILED";
@@ -327,6 +328,12 @@ pub const ALL: &[CodeMeta] = &[
         category: category::REGISTRY_NETWORK,
         description: "`aube add` refused a package because OSV reports it as malicious (`MAL-*` advisory). Hard block — confirmed-malicious advisories aren't a judgement call.",
         exit_code: Some(46),
+    },
+    CodeMeta {
+        name: ERR_AUBE_SIMILAR_PACKAGE_NAME,
+        category: category::SUPPLY_CHAIN,
+        description: "`aube add` refused a package whose name closely resembles a more popular npm package. This protects against typosquatting and slopsquatting.",
+        exit_code: None,
     },
     CodeMeta {
         name: ERR_AUBE_LOW_DOWNLOAD_PACKAGE,

--- a/crates/aube-codes/src/warnings.rs
+++ b/crates/aube-codes/src/warnings.rs
@@ -104,6 +104,7 @@ pub const WARN_AUBE_WORKSPACE_TOPO_CYCLE: &str = "WARN_AUBE_WORKSPACE_TOPO_CYCLE
 
 // ── supply chain (add-time) ─────────────────────────────────────────
 pub const WARN_AUBE_LOW_DOWNLOAD_PACKAGE: &str = "WARN_AUBE_LOW_DOWNLOAD_PACKAGE";
+pub const WARN_AUBE_NEW_PACKAGE_NAME: &str = "WARN_AUBE_NEW_PACKAGE_NAME";
 pub const WARN_AUBE_ADVISORY_CHECK_FAILED: &str = "WARN_AUBE_ADVISORY_CHECK_FAILED";
 pub const WARN_AUBE_OSV_MIRROR_REFRESH_FAILED: &str = "WARN_AUBE_OSV_MIRROR_REFRESH_FAILED";
 pub const WARN_AUBE_OSV_BLOOM_REFRESH_FAILED: &str = "WARN_AUBE_OSV_BLOOM_REFRESH_FAILED";
@@ -546,6 +547,12 @@ pub const ALL: &[CodeMeta] = &[
         name: WARN_AUBE_LOW_DOWNLOAD_PACKAGE,
         category: category::SUPPLY_CHAIN,
         description: "`aube add` flagged a package whose weekly downloads fall below `lowDownloadThreshold`. Interactive sessions prompt for confirmation; non-interactive contexts fail with `ERR_AUBE_LOW_DOWNLOAD_PACKAGE` unless `--allow-low-downloads` is passed.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: WARN_AUBE_NEW_PACKAGE_NAME,
+        category: category::SUPPLY_CHAIN,
+        description: "`aube add` flagged a package name first published within `minimumReleaseAge`. Interactive sessions prompt for confirmation; non-interactive contexts fail with `ERR_AUBE_NEW_PACKAGE_NAME` unless explicitly allowed.",
         exit_code: None,
     },
     CodeMeta {

--- a/crates/aube-codes/src/warnings.rs
+++ b/crates/aube-codes/src/warnings.rs
@@ -552,7 +552,7 @@ pub const ALL: &[CodeMeta] = &[
     CodeMeta {
         name: WARN_AUBE_NEW_PACKAGE_NAME,
         category: category::SUPPLY_CHAIN,
-        description: "`aube add` flagged a package name first published within `minimumReleaseAge`. Interactive sessions prompt for confirmation; non-interactive contexts fail with `ERR_AUBE_NEW_PACKAGE_NAME` unless explicitly allowed.",
+        description: "`aube add` flagged a package name first published within `minimumPackageAge`. Interactive sessions prompt for confirmation; non-interactive contexts fail with `ERR_AUBE_NEW_PACKAGE_NAME` unless explicitly allowed.",
         exit_code: None,
     },
     CodeMeta {

--- a/crates/aube-codes/src/warnings.rs
+++ b/crates/aube-codes/src/warnings.rs
@@ -104,6 +104,7 @@ pub const WARN_AUBE_WORKSPACE_TOPO_CYCLE: &str = "WARN_AUBE_WORKSPACE_TOPO_CYCLE
 
 // ── supply chain (add-time) ─────────────────────────────────────────
 pub const WARN_AUBE_LOW_DOWNLOAD_PACKAGE: &str = "WARN_AUBE_LOW_DOWNLOAD_PACKAGE";
+pub const WARN_AUBE_SIMILAR_PACKAGE_NAME: &str = "WARN_AUBE_SIMILAR_PACKAGE_NAME";
 pub const WARN_AUBE_NEW_PACKAGE_NAME: &str = "WARN_AUBE_NEW_PACKAGE_NAME";
 pub const WARN_AUBE_ADVISORY_CHECK_FAILED: &str = "WARN_AUBE_ADVISORY_CHECK_FAILED";
 pub const WARN_AUBE_OSV_MIRROR_REFRESH_FAILED: &str = "WARN_AUBE_OSV_MIRROR_REFRESH_FAILED";
@@ -543,6 +544,12 @@ pub const ALL: &[CodeMeta] = &[
         exit_code: None,
     },
     // Supply chain (add-time)
+    CodeMeta {
+        name: WARN_AUBE_SIMILAR_PACKAGE_NAME,
+        category: category::SUPPLY_CHAIN,
+        description: "`aube add` flagged a package whose name closely resembles a top-100,000 npm package. Interactive sessions prompt for confirmation; non-interactive contexts fail with `ERR_AUBE_SIMILAR_PACKAGE_NAME` unless explicitly allowed.",
+        exit_code: None,
+    },
     CodeMeta {
         name: WARN_AUBE_LOW_DOWNLOAD_PACKAGE,
         category: category::SUPPLY_CHAIN,

--- a/crates/aube-manifest/src/workspace/config.rs
+++ b/crates/aube-manifest/src/workspace/config.rs
@@ -534,6 +534,12 @@ pub struct WorkspaceConfig {
     #[serde(default)]
     pub minimum_release_age: Option<u64>,
 
+    /// Minimum age in minutes that a public npm package name must
+    /// have before `aube add` accepts it without confirmation.
+    /// Default: 43200 (30 days).
+    #[serde(default)]
+    pub minimum_package_age: Option<u64>,
+
     /// Package names exempt from `minimum_release_age`.
     #[serde(default)]
     pub minimum_release_age_exclude: Option<Vec<String>>,

--- a/crates/aube-registry/src/supply_chain.rs
+++ b/crates/aube-registry/src/supply_chain.rs
@@ -11,6 +11,10 @@
 //!   have near-zero downloads on day one regardless of how cleverly
 //!   they're named, so a download floor catches the long tail of
 //!   reported-after-the-fact malicious names.
+//! - [`fetch_package_created_with`] reads the registry's immutable
+//!   `time.created` timestamp. A newly registered name is the signal
+//!   specific to slopsquatting: an attacker claimed a hallucinated
+//!   package shortly before the victim tried to install it.
 //!
 //! Both probes target public hosts and use their own reqwest client
 //! rather than [`crate::client::RegistryClient`] — they don't need
@@ -46,6 +50,14 @@ const OSV_BATCH_LIMIT: usize = 500;
 /// friendly compared to the `range` endpoint.
 const NPM_DOWNLOADS_BASE: &str = "https://api.npmjs.org/downloads/point/last-week";
 
+/// Public npm registry packument endpoint. These probes only run for
+/// names that upstream routing already confirmed use npmjs.
+const NPM_REGISTRY_BASE: &str = "https://registry.npmjs.org";
+
+/// Match the default `packumentMaxBytes` boundary for this unauthenticated
+/// public-registry probe.
+const PACKAGE_TIME_BODY_CAP: u64 = 200 * 1024 * 1024;
+
 /// One malicious-package advisory hit. We surface the OSV id and the
 /// candidate package name; the caller composes a link of the form
 /// `https://osv.dev/vulnerability/{id}`.
@@ -74,6 +86,8 @@ pub enum SupplyChainError {
     Decode(#[from] serde_json::Error),
     #[error("supply-chain probe returned non-success status: {0}")]
     Status(reqwest::StatusCode),
+    #[error("supply-chain probe response exceeds {cap} bytes")]
+    BodyTooLarge { cap: u64 },
     /// OSV's batch endpoint contract guarantees one `results[i]` per
     /// `queries[i]`. A short response means a trailing subset of
     /// candidate names was never actually checked — silently
@@ -157,6 +171,18 @@ struct NpmDownloadsResponse {
     /// scoped packages, which the downloads API doesn't support.
     #[serde(default)]
     error: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct NpmPackageTimeResponse {
+    #[serde(default)]
+    time: NpmPackageTime,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct NpmPackageTime {
+    #[serde(default)]
+    created: Option<String>,
 }
 
 /// Build the shared probe `reqwest::Client`. Centralized so the OSV
@@ -427,6 +453,16 @@ pub enum DownloadCount {
     Unknown,
 }
 
+/// First-seen timestamp for an npm package name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PackageCreated {
+    /// Registry-provided ISO-8601 `time.created` timestamp.
+    Known(String),
+    /// The registry omitted `time.created`; callers should treat this
+    /// as no signal rather than guessing an age.
+    Unknown,
+}
+
 /// Look up `name`'s weekly download count using a caller-supplied
 /// shared client. The caller is expected to reuse one
 /// [`build_probe_client`] across every probe in an invocation so
@@ -452,6 +488,50 @@ pub async fn fetch_weekly_downloads_with(
     let bytes = resp.bytes().await?;
     let parsed: NpmDownloadsResponse = serde_json::from_slice(&bytes)?;
     Ok(parse_downloads(&parsed))
+}
+
+/// Fetch the immutable creation time for a public npm package name.
+///
+/// The full packument is required because the abbreviated install-v1
+/// representation omits the top-level `time` map. Deserialize only the
+/// two fields this gate needs so popular packages do not allocate their
+/// complete version histories a second time.
+pub async fn fetch_package_created_with(
+    client: &reqwest::Client,
+    name: &str,
+) -> Result<PackageCreated, SupplyChainError> {
+    let encoded = name.replace('/', "%2F");
+    let url = format!("{NPM_REGISTRY_BASE}/{encoded}");
+    let mut resp = client
+        .get(&url)
+        .header(reqwest::header::ACCEPT, "application/json")
+        .send()
+        .await?;
+    let status = resp.status();
+    if status == reqwest::StatusCode::NOT_FOUND {
+        return Ok(PackageCreated::Unknown);
+    }
+    if !status.is_success() {
+        return Err(SupplyChainError::Status(status));
+    }
+    let initial = resp
+        .content_length()
+        .map(|len| len.min(PACKAGE_TIME_BODY_CAP) as usize)
+        .unwrap_or(64 * 1024);
+    let mut bytes = bytes::BytesMut::with_capacity(initial);
+    while let Some(chunk) = resp.chunk().await? {
+        if (bytes.len() as u64).saturating_add(chunk.len() as u64) > PACKAGE_TIME_BODY_CAP {
+            return Err(SupplyChainError::BodyTooLarge {
+                cap: PACKAGE_TIME_BODY_CAP,
+            });
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    let parsed: NpmPackageTimeResponse = serde_json::from_slice(&bytes)?;
+    Ok(match parsed.time.created {
+        Some(created) => PackageCreated::Known(created),
+        None => PackageCreated::Unknown,
+    })
 }
 
 fn parse_downloads(resp: &NpmDownloadsResponse) -> DownloadCount {
@@ -631,6 +711,23 @@ mod tests {
             error: None,
         };
         assert_eq!(parse_downloads(&resp), DownloadCount::Known(42_000_000));
+    }
+
+    #[test]
+    fn package_time_response_reads_created_timestamp() {
+        let parsed: NpmPackageTimeResponse = serde_json::from_value(serde_json::json!({
+            "name": "plausible-ai-package",
+            "time": {
+                "created": "2026-07-28T10:00:00.000Z",
+                "modified": "2026-07-28T10:01:00.000Z",
+                "1.0.0": "2026-07-28T10:00:00.000Z"
+            }
+        }))
+        .expect("package time response");
+        assert_eq!(
+            parsed.time.created.as_deref(),
+            Some("2026-07-28T10:00:00.000Z")
+        );
     }
 
     #[test]

--- a/crates/aube-registry/src/supply_chain.rs
+++ b/crates/aube-registry/src/supply_chain.rs
@@ -11,10 +11,6 @@
 //!   have near-zero downloads on day one regardless of how cleverly
 //!   they're named, so a download floor catches the long tail of
 //!   reported-after-the-fact malicious names.
-//! - [`fetch_package_created_with`] reads the registry's immutable
-//!   `time.created` timestamp. A newly registered name is the signal
-//!   specific to slopsquatting: an attacker claimed a hallucinated
-//!   package shortly before the victim tried to install it.
 //!
 //! Both probes target public hosts and use their own reqwest client
 //! rather than [`crate::client::RegistryClient`] — they don't need
@@ -50,14 +46,6 @@ const OSV_BATCH_LIMIT: usize = 500;
 /// friendly compared to the `range` endpoint.
 const NPM_DOWNLOADS_BASE: &str = "https://api.npmjs.org/downloads/point/last-week";
 
-/// Public npm registry packument endpoint. These probes only run for
-/// names that upstream routing already confirmed use npmjs.
-const NPM_REGISTRY_BASE: &str = "https://registry.npmjs.org";
-
-/// Match the default `packumentMaxBytes` boundary for this unauthenticated
-/// public-registry probe.
-const PACKAGE_TIME_BODY_CAP: u64 = 200 * 1024 * 1024;
-
 /// One malicious-package advisory hit. We surface the OSV id and the
 /// candidate package name; the caller composes a link of the form
 /// `https://osv.dev/vulnerability/{id}`.
@@ -86,8 +74,6 @@ pub enum SupplyChainError {
     Decode(#[from] serde_json::Error),
     #[error("supply-chain probe returned non-success status: {0}")]
     Status(reqwest::StatusCode),
-    #[error("supply-chain probe response exceeds {cap} bytes")]
-    BodyTooLarge { cap: u64 },
     /// OSV's batch endpoint contract guarantees one `results[i]` per
     /// `queries[i]`. A short response means a trailing subset of
     /// candidate names was never actually checked — silently
@@ -171,18 +157,6 @@ struct NpmDownloadsResponse {
     /// scoped packages, which the downloads API doesn't support.
     #[serde(default)]
     error: Option<String>,
-}
-
-#[derive(Debug, Deserialize, Default)]
-struct NpmPackageTimeResponse {
-    #[serde(default)]
-    time: NpmPackageTime,
-}
-
-#[derive(Debug, Deserialize, Default)]
-struct NpmPackageTime {
-    #[serde(default)]
-    created: Option<String>,
 }
 
 /// Build the shared probe `reqwest::Client`. Centralized so the OSV
@@ -453,16 +427,6 @@ pub enum DownloadCount {
     Unknown,
 }
 
-/// First-seen timestamp for an npm package name.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum PackageCreated {
-    /// Registry-provided ISO-8601 `time.created` timestamp.
-    Known(String),
-    /// The registry omitted `time.created`; callers should treat this
-    /// as no signal rather than guessing an age.
-    Unknown,
-}
-
 /// Look up `name`'s weekly download count using a caller-supplied
 /// shared client. The caller is expected to reuse one
 /// [`build_probe_client`] across every probe in an invocation so
@@ -488,50 +452,6 @@ pub async fn fetch_weekly_downloads_with(
     let bytes = resp.bytes().await?;
     let parsed: NpmDownloadsResponse = serde_json::from_slice(&bytes)?;
     Ok(parse_downloads(&parsed))
-}
-
-/// Fetch the immutable creation time for a public npm package name.
-///
-/// The full packument is required because the abbreviated install-v1
-/// representation omits the top-level `time` map. Deserialize only the
-/// two fields this gate needs so popular packages do not allocate their
-/// complete version histories a second time.
-pub async fn fetch_package_created_with(
-    client: &reqwest::Client,
-    name: &str,
-) -> Result<PackageCreated, SupplyChainError> {
-    let encoded = name.replace('/', "%2F");
-    let url = format!("{NPM_REGISTRY_BASE}/{encoded}");
-    let mut resp = client
-        .get(&url)
-        .header(reqwest::header::ACCEPT, "application/json")
-        .send()
-        .await?;
-    let status = resp.status();
-    if status == reqwest::StatusCode::NOT_FOUND {
-        return Ok(PackageCreated::Unknown);
-    }
-    if !status.is_success() {
-        return Err(SupplyChainError::Status(status));
-    }
-    let initial = resp
-        .content_length()
-        .map(|len| len.min(PACKAGE_TIME_BODY_CAP) as usize)
-        .unwrap_or(64 * 1024);
-    let mut bytes = bytes::BytesMut::with_capacity(initial);
-    while let Some(chunk) = resp.chunk().await? {
-        if (bytes.len() as u64).saturating_add(chunk.len() as u64) > PACKAGE_TIME_BODY_CAP {
-            return Err(SupplyChainError::BodyTooLarge {
-                cap: PACKAGE_TIME_BODY_CAP,
-            });
-        }
-        bytes.extend_from_slice(&chunk);
-    }
-    let parsed: NpmPackageTimeResponse = serde_json::from_slice(&bytes)?;
-    Ok(match parsed.time.created {
-        Some(created) => PackageCreated::Known(created),
-        None => PackageCreated::Unknown,
-    })
 }
 
 fn parse_downloads(resp: &NpmDownloadsResponse) -> DownloadCount {
@@ -711,23 +631,6 @@ mod tests {
             error: None,
         };
         assert_eq!(parse_downloads(&resp), DownloadCount::Known(42_000_000));
-    }
-
-    #[test]
-    fn package_time_response_reads_created_timestamp() {
-        let parsed: NpmPackageTimeResponse = serde_json::from_value(serde_json::json!({
-            "name": "plausible-ai-package",
-            "time": {
-                "created": "2026-07-28T10:00:00.000Z",
-                "modified": "2026-07-28T10:01:00.000Z",
-                "1.0.0": "2026-07-28T10:00:00.000Z"
-            }
-        }))
-        .expect("package time response");
-        assert_eq!(
-            parsed.time.created.as_deref(),
-            Some("2026-07-28T10:00:00.000Z")
-        );
     }
 
     #[test]

--- a/crates/aube-resolver/build.rs
+++ b/crates/aube-resolver/build.rs
@@ -23,6 +23,8 @@ const RELEASE_TOP: usize = 2000;
 const DEFAULT_VERSION_CAP: usize = 100;
 const FAST_COMPRESSION_LEVEL: i32 = 10;
 const RELEASE_CI_COMPRESSION_LEVEL: i32 = 19;
+const POPULAR_NAMES_TOP: usize = 100_000;
+const POPULAR_NAMES_FORMAT: u32 = 1;
 // Bump when the on-disk rkyv schema (`src/primer_schema.rs`) changes
 // in a layout-breaking way. The on-disk `primer-topN-vM-sK.rkyv.zst`
 // artifact is gitignored, so older `sK` files orphan harmlessly and
@@ -41,12 +43,21 @@ fn main() {
                 "primer-top{top}-v{version_cap}-s{PRIMER_DATA_SCHEMA}.rkyv.zst"
             ))
         });
+    let popular_names_source = std::env::var_os("AUBE_POPULAR_NAMES_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            manifest_dir.join("data").join(format!(
+                "popular-top{POPULAR_NAMES_TOP}-v{POPULAR_NAMES_FORMAT}.json"
+            ))
+        });
 
     println!("cargo:rerun-if-env-changed=AUBE_PRIMER_PATH");
+    println!("cargo:rerun-if-env-changed=AUBE_POPULAR_NAMES_PATH");
     println!("cargo:rerun-if-env-changed=AUBE_PRIMER_TOP");
     println!("cargo:rerun-if-env-changed=AUBE_PRIMER_VERSION_CAP");
     println!("cargo:rerun-if-env-changed=AUBE_REQUIRE_PRIMER");
     println!("cargo:rerun-if-changed={}", source.display());
+    println!("cargo:rerun-if-changed={}", popular_names_source.display());
     let json = source.with_extension("json");
     println!("cargo:rerun-if-changed={}", json.display());
 
@@ -84,7 +95,8 @@ fn main() {
             //      tarball, but no `node`).
             // Ship an empty primer; runtime falls back to network packument
             // fetches.
-            write_package_blob(&out_dir, &[]);
+            let fallback_names = write_package_blob(&out_dir, &[]);
+            write_popular_names_blob(&out_dir, &popular_names_source, &fallback_names);
             return;
         }
     }
@@ -103,7 +115,8 @@ fn main() {
 
     let bytes = std::fs::read(&source)
         .unwrap_or_else(|e| panic!("failed to read primer {}: {e}", source.display()));
-    write_package_blob(&out_dir, &bytes);
+    let fallback_names = write_package_blob(&out_dir, &bytes);
+    write_popular_names_blob(&out_dir, &popular_names_source, &fallback_names);
 }
 
 fn primer_top() -> usize {
@@ -193,7 +206,7 @@ fn compress_json_primer(json: &Path, source: &Path) {
     std::fs::write(source, compressed).unwrap();
 }
 
-fn write_package_blob(out_dir: &Path, compressed: &[u8]) {
+fn write_package_blob(out_dir: &Path, compressed: &[u8]) -> Vec<String> {
     let mut blob = Vec::new();
     let mut index = Vec::new();
     if !compressed.is_empty() {
@@ -219,11 +232,60 @@ fn write_package_blob(out_dir: &Path, compressed: &[u8]) {
     let mut generated =
         "static PRIMER_BLOB: &[u8] = include_bytes!(concat!(env!(\"OUT_DIR\"), \"/primer-packages.bin\"));\nstatic PRIMER_INDEX: &[(&str, usize, usize)] = &[\n"
             .to_string();
+    let fallback_names = index.iter().map(|(name, _, _)| name.clone()).collect();
     for (name, offset, len) in index {
         generated.push_str(&format!("    ({name:?}, {offset}, {len}),\n"));
     }
-    generated.push_str("];\n");
+    generated.push_str(
+        "];\nstatic POPULAR_NAMES_BLOB: &[u8] = include_bytes!(concat!(env!(\"OUT_DIR\"), \"/popular-names.bin\"));\n",
+    );
     std::fs::write(out_dir.join("primer_index.rs"), generated).unwrap();
+    fallback_names
+}
+
+fn write_popular_names_blob(out_dir: &Path, source: &Path, fallback_names: &[String]) {
+    let names = if source.is_file() {
+        let input = std::fs::read(source).unwrap_or_else(|e| {
+            panic!(
+                "failed to read popular package names {}: {e}",
+                source.display()
+            )
+        });
+        serde_json::from_slice::<Vec<String>>(&input).unwrap_or_else(|e| {
+            panic!(
+                "failed to parse popular package names {}: {e}",
+                source.display()
+            )
+        })
+    } else {
+        if std::env::var_os("AUBE_POPULAR_NAMES_PATH").is_some() || primer_required() {
+            panic!(
+                "popular package names are required, but {} was missing",
+                source.display()
+            );
+        }
+        fallback_names.to_vec()
+    };
+    if primer_required() && names.len() != POPULAR_NAMES_TOP {
+        panic!(
+            "popular package names must contain exactly {POPULAR_NAMES_TOP} entries, found {}",
+            names.len()
+        );
+    }
+    let mut seen = std::collections::BTreeSet::new();
+    for name in &names {
+        if name.is_empty()
+            || name.bytes().any(|byte| byte.is_ascii_whitespace())
+            || !seen.insert(name)
+        {
+            panic!("popular package names contain an invalid or duplicate entry: {name:?}");
+        }
+    }
+    let joined = names.join("\n");
+    let compressed =
+        zstd::stream::encode_all(Cursor::new(joined.as_bytes()), primer_compression_level())
+            .unwrap();
+    std::fs::write(out_dir.join("popular-names.bin"), compressed).unwrap();
 }
 
 fn primer_required() -> bool {

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -29,7 +29,9 @@ pub use peer_context::{
     hoist_auto_installed_peers,
 };
 pub use platform::{SupportedArchitectures, is_supported};
-pub use primer::{PruneStats as PrimerPruneStats, prune_cache as prune_primer_cache};
+pub use primer::{
+    PruneStats as PrimerPruneStats, popular_package_names, prune_cache as prune_primer_cache,
+};
 pub use semver_util::{PickResult, pick_version_for_add};
 pub use trust::{
     MissingTimeDetails as MissingTrustTimeDetails, PriorTrustEvidence, TrustCheckError,

--- a/crates/aube-resolver/src/primer.rs
+++ b/crates/aube-resolver/src/primer.rs
@@ -148,6 +148,7 @@ fn deterministic_tarball_url(name: &str, version: &str) -> String {
 
 static GENERATED_AT: OnceLock<Option<String>> = OnceLock::new();
 static AUTO_PRUNED: OnceLock<()> = OnceLock::new();
+static POPULAR_NAMES: OnceLock<Option<String>> = OnceLock::new();
 
 pub(crate) fn get(name: &str) -> Option<Seed> {
     let (_, offset, len) = PRIMER_INDEX
@@ -163,6 +164,21 @@ pub(crate) fn get(name: &str) -> Option<Seed> {
 
 pub(crate) fn covers_cutoff(cutoff: &str) -> bool {
     generated_at().is_some_and(|generated_at| generated_at.as_str() >= cutoff)
+}
+
+/// Ranked public npm package names used as typo/squatting reference data.
+///
+/// Release builds embed the top 100,000 names. Development and downstream
+/// builds without the generated artifact fall back to the metadata-primer
+/// names, so callers always get a valid newline-delimited corpus.
+pub fn popular_package_names() -> &'static str {
+    POPULAR_NAMES
+        .get_or_init(|| {
+            let decoded = zstd::stream::decode_all(Cursor::new(POPULAR_NAMES_BLOB)).ok()?;
+            String::from_utf8(decoded).ok()
+        })
+        .as_deref()
+        .unwrap_or_default()
 }
 
 fn generated_at() -> Option<&'static String> {
@@ -298,6 +314,15 @@ mod tests {
             return;
         };
         assert!(super::get(name).is_some());
+    }
+
+    #[test]
+    fn bundled_popular_names_load() {
+        let names = popular_package_names();
+        if !PRIMER_INDEX.is_empty() {
+            assert!(!names.is_empty());
+        }
+        assert!(names.lines().all(|name| !name.is_empty()));
     }
 
     #[test]

--- a/crates/aube-resolver/src/trust.rs
+++ b/crates/aube-resolver/src/trust.rs
@@ -471,11 +471,15 @@ impl TrustExcludeRules {
         false
     }
 
-    /// Used when the picked version string fails semver parse — only a
-    /// no-version rule can match in that case (pnpm behavior:
-    /// `evaluateVersionPolicy` returns `true` for name-only rules
-    /// before the version array branch is taken).
-    pub(crate) fn matches_name_only(&self, name: &str) -> bool {
+    /// Return whether a rule exempts the package name without needing
+    /// a resolved version.
+    ///
+    /// Used both when a picked version fails semver parsing and by
+    /// pre-resolution package-name gates. Only a no-version rule can
+    /// match in either case (pnpm behavior: `evaluateVersionPolicy`
+    /// returns `true` for name-only rules before the version array
+    /// branch is taken).
+    pub fn matches_name_only(&self, name: &str) -> bool {
         self.rules
             .iter()
             .any(|r| r.version_ranges.is_none() && r.name_matcher.matches(name))

--- a/crates/aube-resolver/src/trust.rs
+++ b/crates/aube-resolver/src/trust.rs
@@ -471,15 +471,11 @@ impl TrustExcludeRules {
         false
     }
 
-    /// Return whether a rule exempts the package name without needing
-    /// a resolved version.
-    ///
-    /// Used both when a picked version fails semver parsing and by
-    /// pre-resolution package-name gates. Only a no-version rule can
-    /// match in either case (pnpm behavior: `evaluateVersionPolicy`
-    /// returns `true` for name-only rules before the version array
-    /// branch is taken).
-    pub fn matches_name_only(&self, name: &str) -> bool {
+    /// Used when the picked version string fails semver parse — only a
+    /// no-version rule can match in that case (pnpm behavior:
+    /// `evaluateVersionPolicy` returns `true` for name-only rules
+    /// before the version array branch is taken).
+    pub(crate) fn matches_name_only(&self, name: &str) -> bool {
         self.rules
             .iter()
             .any(|r| r.version_ranges.is_none() && r.name_matcher.matches(name))

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -311,6 +311,8 @@ longer than the 24-hour `minimumReleaseAge` quarantine for ordinary new
 versions. Existing lockfile entries and `allowedUnpopularPackages` are
 trusted. Set to `0` to disable, or pass `--allow-low-downloads` after
 verifying one new name out of band.
+If npm's creation-time metadata is missing or unavailable, the check fails
+closed with `ERR_AUBE_PACKAGE_AGE_CHECK_FAILED`.
 """
 sources.cli = []
 sources.env = ["npm_config_minimum_package_age", "NPM_CONFIG_MINIMUM_PACKAGE_AGE", "AUBE_MINIMUM_PACKAGE_AGE"]

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -283,10 +283,8 @@ type = "int"
 default = "1440"
 docs = """
 Supply-chain attack mitigation: versions published within the last N
-minutes are skipped by the resolver. `aube add` also challenges package
-names first registered inside this window, preventing a newly registered
-slopsquat from bypassing the version fallback. By default the resolver falls
-back to the next-oldest version that satisfies the range; set
+minutes are skipped by the resolver. By default the resolver falls back
+to the next-oldest version that satisfies the range; set
 `minimumReleaseAgeStrict=true` to fail the install instead. Defaults to
 24 hours, matching pnpm v11. Set to `0` to disable.
 """
@@ -296,6 +294,28 @@ sources.npmrc = ["minimumReleaseAge"]
 sources.workspaceYaml = ["minimumReleaseAge"]
 # pnpm v11 documents this as a workspace-level setting, so
 # pnpm-workspace.yaml wins over a stale .npmrc entry.
+precedence = ["workspaceYaml", "npmrc"]
+managedPolicy = "max"
+examples = []
+
+[minimumPackageAge]
+description = "Challenge newly registered package names during `aube add` (minutes)."
+type = "int"
+default = "43200"
+docs = """
+Slopsquatting mitigation: `aube add` challenges public npm package names
+first registered within the last N minutes. Interactive sessions prompt
+for confirmation; non-interactive sessions fail with
+`ERR_AUBE_NEW_PACKAGE_NAME`. Defaults to 30 days, deliberately much
+longer than the 24-hour `minimumReleaseAge` quarantine for ordinary new
+versions. Existing lockfile entries and `allowedUnpopularPackages` are
+trusted. Set to `0` to disable, or pass `--allow-low-downloads` after
+verifying one new name out of band.
+"""
+sources.cli = []
+sources.env = ["npm_config_minimum_package_age", "NPM_CONFIG_MINIMUM_PACKAGE_AGE", "AUBE_MINIMUM_PACKAGE_AGE"]
+sources.npmrc = ["minimumPackageAge"]
+sources.workspaceYaml = ["minimumPackageAge"]
 precedence = ["workspaceYaml", "npmrc"]
 managedPolicy = "max"
 examples = []

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -282,9 +282,11 @@ description = "Delay installation of newly published versions (minutes)."
 type = "int"
 default = "1440"
 docs = """
-Supply-chain attack mitigation: packages published within the last N
-minutes are skipped by the resolver. By default the resolver falls back
-to the next-oldest version that satisfies the range; set
+Supply-chain attack mitigation: versions published within the last N
+minutes are skipped by the resolver. `aube add` also challenges package
+names first registered inside this window, preventing a newly registered
+slopsquat from bypassing the version fallback. By default the resolver falls
+back to the next-oldest version that satisfies the range; set
 `minimumReleaseAgeStrict=true` to fail the install instead. Defaults to
 24 hours, matching pnpm v11. Set to `0` to disable.
 """
@@ -544,7 +546,7 @@ Packages that route through a non-`registry.npmjs.org` registry are
 skipped automatically: a scoped override like
 `@myorg:registry=https://npm.internal.example/` or a swapped-out
 default registry both mean npmjs has no signal on the package, so
-neither the downloads gate nor the OSV `MAL-*` check fires.
+neither the reputation gates nor the OSV `MAL-*` check fires.
 Workspace deps and git/local specs are also skipped. To exempt
 specific names that *do* resolve through npmjs (e.g. you publish a
 low-download but trusted package internally), see
@@ -561,14 +563,14 @@ managedPolicy = "max"
 examples = []
 
 [allowedUnpopularPackages]
-description = "Glob patterns exempted from the `lowDownloadThreshold` gate."
+description = "Glob patterns exempted from add-time package reputation gates."
 type = "list<string>"
 default = "undefined"
 docs = """
 Each pattern is matched against the registry name (`@scope/foo` or
-`bar`) of every candidate the `lowDownloadThreshold` gate would
-otherwise probe. Matches skip the weekly-downloads lookup entirely,
-so internal/low-traffic packages don't trip the prompt in CI or the
+`bar`) of every candidate the package-age and `lowDownloadThreshold`
+gates would otherwise probe. Matches skip both lookups, so
+internal/low-traffic packages don't trip the prompt in CI or the
 `y/N` prompt locally.
 
 Patterns are full-name globs (the [`glob`](https://docs.rs/glob)

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -590,10 +590,10 @@ type = "list<string>"
 default = "undefined"
 docs = """
 Each pattern is matched against the registry name (`@scope/foo` or
-`bar`) of every candidate the package-age and `lowDownloadThreshold`
-gates would otherwise probe. Matches skip both lookups, so
-internal/low-traffic packages don't trip the prompt in CI or the
-`y/N` prompt locally.
+`bar`) of every candidate the similar-name, package-age, and
+`lowDownloadThreshold` gates would otherwise probe. Matches skip all
+three checks, so internal/low-traffic packages don't trip the prompt
+in CI or the `y/N` prompt locally.
 
 Patterns are full-name globs (the [`glob`](https://docs.rs/glob)
 crate's syntax — `*`, `?`, `[…]`). Match-everything (`*`) is allowed

--- a/crates/aube-settings/src/values.rs
+++ b/crates/aube-settings/src/values.rs
@@ -1249,6 +1249,37 @@ mod tests {
     }
 
     #[test]
+    fn minimum_package_age_defaults_to_thirty_days_and_honors_workspace() {
+        let ws = raw_yaml("minimumPackageAge: 86400\n");
+        let ctx = ResolveCtx {
+            managed_aube_config: &[],
+            project_aube_config: &[],
+            project_npmrc: &[],
+            user_aube_config: &[],
+            user_npmrc: &[],
+            workspace_yaml: &ws,
+            env: &[],
+            cli: &[],
+            embedder_defaults: &[],
+        };
+        assert_eq!(resolved::minimum_package_age(&ctx), 86_400);
+
+        let empty = BTreeMap::new();
+        let ctx = ResolveCtx {
+            managed_aube_config: &[],
+            project_aube_config: &[],
+            project_npmrc: &[],
+            user_aube_config: &[],
+            user_npmrc: &[],
+            workspace_yaml: &empty,
+            env: &[],
+            cli: &[],
+            embedder_defaults: &[],
+        };
+        assert_eq!(resolved::minimum_package_age(&ctx), 43_200);
+    }
+
+    #[test]
     fn managed_max_policy_enforces_larger_integer() {
         let local = entries(&[("minimumReleaseAge", "0")]);
         let managed = entries(&[("minimumReleaseAge", "1440")]);

--- a/crates/aube/src/commands/add/mod.rs
+++ b/crates/aube/src/commands/add/mod.rs
@@ -207,16 +207,16 @@ pub struct AddArgs {
         value_parser = parse_allow_build_value,
     )]
     pub allow_build: Vec<String>,
-    /// Bypass the new-name and [`lowDownloadThreshold`] confirm prompts
-    /// / refusals for this invocation.
+    /// Bypass the similar-name, new-name, and [`lowDownloadThreshold`]
+    /// confirm prompts / refusals for this invocation.
     ///
     /// `aube add` looks up each candidate's weekly download count and
     /// prompts (interactive) or fails (CI) when the count is below
-    /// [`lowDownloadThreshold`] or the package name is newer than
-    /// [`minimumPackageAge`]. The flag is intended for cases where
-    /// you've already verified the package out-of-band. It does not
-    /// affect the OSV malicious-package check, which remains a hard
-    /// block.
+    /// [`lowDownloadThreshold`], resembles a top-100,000 npm package,
+    /// or is newer than [`minimumPackageAge`]. The flag is intended
+    /// for cases where you've already verified the package out-of-band.
+    /// It does not affect the OSV malicious-package check, which remains
+    /// a hard block.
     #[arg(long)]
     pub allow_low_downloads: bool,
     /// Allow every dependency's lifecycle scripts to run.

--- a/crates/aube/src/commands/add/mod.rs
+++ b/crates/aube/src/commands/add/mod.rs
@@ -213,7 +213,7 @@ pub struct AddArgs {
     /// `aube add` looks up each candidate's weekly download count and
     /// prompts (interactive) or fails (CI) when the count is below
     /// [`lowDownloadThreshold`] or the package name is newer than
-    /// [`minimumReleaseAge`]. The flag is intended for cases where
+    /// [`minimumPackageAge`]. The flag is intended for cases where
     /// you've already verified the package out-of-band. It does not
     /// affect the OSV malicious-package check, which remains a hard
     /// block.

--- a/crates/aube/src/commands/add/mod.rs
+++ b/crates/aube/src/commands/add/mod.rs
@@ -207,17 +207,16 @@ pub struct AddArgs {
         value_parser = parse_allow_build_value,
     )]
     pub allow_build: Vec<String>,
-    /// Bypass the [`lowDownloadThreshold`] confirm prompt / refusal for
-    /// this invocation.
+    /// Bypass the new-name and [`lowDownloadThreshold`] confirm prompts
+    /// / refusals for this invocation.
     ///
     /// `aube add` looks up each candidate's weekly download count and
     /// prompts (interactive) or fails (CI) when the count is below
-    /// [`lowDownloadThreshold`]. The flag is intended for the cases
-    /// where you've already verified the package out-of-band — adding
-    /// a brand-new niche tool, a fresh fork, an internal scratch
-    /// package — and don't want the prompt to interrupt scripted
-    /// workflows. Does not affect the OSV malicious-package check,
-    /// which remains a hard block.
+    /// [`lowDownloadThreshold`] or the package name is newer than
+    /// [`minimumReleaseAge`]. The flag is intended for cases where
+    /// you've already verified the package out-of-band. It does not
+    /// affect the OSV malicious-package check, which remains a hard
+    /// block.
     #[arg(long)]
     pub allow_low_downloads: bool,
     /// Allow every dependency's lifecycle scripts to run.

--- a/crates/aube/src/commands/add/supply_chain.rs
+++ b/crates/aube/src/commands/add/supply_chain.rs
@@ -38,6 +38,8 @@ pub(super) async fn run_cli_name_gates(
             .iter()
             .map(|name| glob::Pattern::escape(name)),
     );
+    let registry_client = crate::commands::make_client(&project_dir);
+    let full_packument_cache = crate::commands::packument_full_cache_dir_for_cwd(&project_dir);
     crate::commands::add_supply_chain::run_gates(
         &registry_inputs.name_only_advisory_names,
         &registry_inputs.exact_advisory_pairs,
@@ -48,6 +50,8 @@ pub(super) async fn run_cli_name_gates(
             allow: allow_low_downloads,
             prompt,
             minimum_package_age_minutes,
+            registry_client: &registry_client,
+            full_packument_cache: &full_packument_cache,
         },
         &allowed_unpopular,
     )

--- a/crates/aube/src/commands/add/supply_chain.rs
+++ b/crates/aube/src/commands/add/supply_chain.rs
@@ -12,24 +12,27 @@ pub(super) async fn run_cli_name_gates(
     let project_dir = supply_chain_project_dir(cwd);
     let manifest = crate::commands::load_manifest_or_default(&project_dir)?;
     let registry_inputs = registry_bound_inputs_for_supply_chain(&project_dir, packages);
-    let (advisory_check, low_download_threshold, mut allowed_unpopular, lockfile_dir) =
-        crate::commands::with_settings_ctx(&project_dir, |ctx| {
-            let policy = if aube_settings::resolved::paranoid(ctx) {
-                aube_settings::resolved::AdvisoryCheck::Required
-            } else {
-                aube_settings::resolved::advisory_check(ctx)
-            };
-            Ok::<_, miette::Report>((
-                policy,
-                aube_settings::resolved::low_download_threshold(ctx),
-                aube_settings::resolved::allowed_unpopular_packages(ctx).unwrap_or_default(),
-                crate::commands::install::resolve_active_lockfile_dir(
-                    &project_dir,
-                    &manifest,
-                    ctx,
-                )?,
-            ))
-        })?;
+    let (
+        advisory_check,
+        low_download_threshold,
+        minimum_release_age,
+        mut allowed_unpopular,
+        lockfile_dir,
+    ) = crate::commands::with_settings_ctx(&project_dir, |ctx| {
+        let policy = if aube_settings::resolved::paranoid(ctx) {
+            aube_settings::resolved::AdvisoryCheck::Required
+        } else {
+            aube_settings::resolved::advisory_check(ctx)
+        };
+        let minimum_release_age = crate::commands::install::resolve_minimum_release_age(ctx, None);
+        Ok::<_, miette::Report>((
+            policy,
+            aube_settings::resolved::low_download_threshold(ctx),
+            minimum_release_age,
+            aube_settings::resolved::allowed_unpopular_packages(ctx).unwrap_or_default(),
+            crate::commands::install::resolve_active_lockfile_dir(&project_dir, &manifest, ctx)?,
+        ))
+    })?;
     let locked_registry_names = locked_registry_names(&lockfile_dir, &manifest);
     allowed_unpopular.extend(
         locked_registry_names
@@ -42,9 +45,10 @@ pub(super) async fn run_cli_name_gates(
         &registry_inputs.download_names,
         advisory_check,
         low_download_threshold,
-        crate::commands::add_supply_chain::LowDownloadPolicy {
+        crate::commands::add_supply_chain::ReputationPolicy {
             allow: allow_low_downloads,
             prompt,
+            minimum_release_age,
         },
         &allowed_unpopular,
     )

--- a/crates/aube/src/commands/add/supply_chain.rs
+++ b/crates/aube/src/commands/add/supply_chain.rs
@@ -15,7 +15,7 @@ pub(super) async fn run_cli_name_gates(
     let (
         advisory_check,
         low_download_threshold,
-        minimum_release_age,
+        minimum_package_age_minutes,
         mut allowed_unpopular,
         lockfile_dir,
     ) = crate::commands::with_settings_ctx(&project_dir, |ctx| {
@@ -24,11 +24,10 @@ pub(super) async fn run_cli_name_gates(
         } else {
             aube_settings::resolved::advisory_check(ctx)
         };
-        let minimum_release_age = crate::commands::install::resolve_minimum_release_age(ctx, None);
         Ok::<_, miette::Report>((
             policy,
             aube_settings::resolved::low_download_threshold(ctx),
-            minimum_release_age,
+            aube_settings::resolved::minimum_package_age(ctx),
             aube_settings::resolved::allowed_unpopular_packages(ctx).unwrap_or_default(),
             crate::commands::install::resolve_active_lockfile_dir(&project_dir, &manifest, ctx)?,
         ))
@@ -48,7 +47,7 @@ pub(super) async fn run_cli_name_gates(
         crate::commands::add_supply_chain::ReputationPolicy {
             allow: allow_low_downloads,
             prompt,
-            minimum_release_age,
+            minimum_package_age_minutes,
         },
         &allowed_unpopular,
     )

--- a/crates/aube/src/commands/add_supply_chain.rs
+++ b/crates/aube/src/commands/add_supply_chain.rs
@@ -1,6 +1,6 @@
 //! Supply-chain gates that run at the top of `aube add`.
 //!
-//! Two checks, layered by signal strength:
+//! Three checks, layered by signal strength:
 //!
 //! 1. **OSV `MAL-*` advisory check** — hard block via
 //!    `ERR_AUBE_MALICIOUS_PACKAGE`. Confirmed malicious advisories
@@ -15,8 +15,13 @@
 //!    `allowedUnpopularPackages` setting (glob patterns) bypasses
 //!    this gate for opted-in names, leaving the OSV check intact.
 //!
+//! 3. **Package-name age** — applies `minimumReleaseAge` to the
+//!    registry's `time.created` timestamp. This closes the
+//!    slopsquatting window where an attacker registers a plausible
+//!    AI-hallucinated name immediately before a victim installs it.
+//!
 //! The gate fires only on the names the user typed for *registry*
-//! packages — git/local/workspace/jsr/aliased specs all skip both
+//! packages — git/local/workspace/jsr/aliased specs all skip these
 //! checks because the public-registry signal doesn't apply. Names
 //! whose resolved registry isn't `registry.npmjs.org` (per
 //! `NpmConfig::is_public_npmjs`) are filtered out upstream in
@@ -24,25 +29,27 @@
 
 use aube_codes::errors::{
     ERR_AUBE_ADVISORY_CHECK_FAILED, ERR_AUBE_LOW_DOWNLOAD_PACKAGE, ERR_AUBE_MALICIOUS_PACKAGE,
+    ERR_AUBE_NEW_PACKAGE_NAME,
 };
 use aube_codes::warnings::{
-    WARN_AUBE_ADVISORY_CHECK_FAILED, WARN_AUBE_LOW_DOWNLOAD_PACKAGE,
+    WARN_AUBE_ADVISORY_CHECK_FAILED, WARN_AUBE_LOW_DOWNLOAD_PACKAGE, WARN_AUBE_NEW_PACKAGE_NAME,
     WARN_AUBE_OSV_BLOOM_REFRESH_FAILED, WARN_AUBE_OSV_MIRROR_REFRESH_FAILED,
 };
 use aube_registry::osv_bloom_client::OsvBloomClient;
 use aube_registry::osv_mirror::OsvMirror;
 use aube_registry::supply_chain::{
-    DownloadCount, MaliciousAdvisory, advisory_url, fetch_malicious_advisories,
-    fetch_malicious_advisories_versioned, fetch_weekly_downloads_with,
+    DownloadCount, MaliciousAdvisory, PackageCreated, advisory_url, fetch_malicious_advisories,
+    fetch_malicious_advisories_versioned, fetch_package_created_with, fetch_weekly_downloads_with,
 };
 use aube_settings::resolved::{AdvisoryBloomCheck, AdvisoryCheck, AdvisoryCheckOnInstall};
 use miette::miette;
 use std::io::{BufRead, IsTerminal, Write};
 
 #[derive(Debug, Clone)]
-pub(crate) struct LowDownloadPolicy {
+pub(crate) struct ReputationPolicy {
     pub(crate) allow: bool,
     pub(crate) prompt: LowDownloadPrompt,
+    pub(crate) minimum_release_age: Option<aube_resolver::MinimumReleaseAge>,
 }
 
 #[derive(Debug, Clone)]
@@ -51,20 +58,20 @@ pub(crate) enum LowDownloadPrompt {
     Host(crate::commands::install::InstallControl),
 }
 
-/// Run both supply-chain gates against the registry-bound specs the
+/// Run the supply-chain gates against the registry-bound specs the
 /// user passed to `aube add`. Inputs should already be filtered to
 /// packages that resolve via the public npm registry — workspace, git,
 /// and local specs are not in scope. Exact pins can use OSV's
 /// version-aware query; ranges and dist-tags stay on the name-only
 /// query until the resolver picks a concrete version.
 ///
-/// `low_download_policy` controls the per-invocation
+/// `reputation_policy` controls the per-invocation
 /// `--allow-low-downloads` override and whether the caller permits a
 /// terminal prompt or delegates confirmation to an embedding host.
 ///
 /// `allowed_unpopular_globs` are the `allowedUnpopularPackages`
 /// setting entries: full-name globs that exempt matching names from
-/// the downloads gate only. The advisory check still runs against
+/// the package-age and downloads gates. The advisory check still runs against
 /// every package regardless — exempting confirmed-malicious advisories
 /// is not what this list is for.
 pub(crate) async fn run_gates(
@@ -73,7 +80,7 @@ pub(crate) async fn run_gates(
     download_names: &[String],
     advisory_check: AdvisoryCheck,
     low_download_threshold: u64,
-    low_download_policy: LowDownloadPolicy,
+    reputation_policy: ReputationPolicy,
     allowed_unpopular_globs: &[String],
 ) -> miette::Result<()> {
     if name_only_advisory_names.is_empty()
@@ -82,7 +89,7 @@ pub(crate) async fn run_gates(
     {
         return Ok(());
     }
-    // One client shared across both gates and every per-package
+    // One client shared across all gates and every per-package
     // probe so the OSV POST and the (potentially parallel) downloads
     // GETs all reuse the same connection pool + TLS session.
     //
@@ -90,7 +97,7 @@ pub(crate) async fn run_gates(
     // the same `advisoryCheck` policy `osv_gate` applies to HTTP
     // failures: under `Required` it's a hard fail with
     // `ERR_AUBE_ADVISORY_CHECK_FAILED`, otherwise it warns and skips
-    // both gates. `Off` short-circuits before even surfacing the
+    // all gates. `Off` short-circuits before even surfacing the
     // warning — the user opted out of OSV entirely, so a probe-
     // client init failure is no longer their concern.
     let client = match aube_registry::supply_chain::build_probe_client() {
@@ -123,19 +130,110 @@ pub(crate) async fn run_gates(
         "refusing to add malicious package(s):",
     )
     .await?;
-    if !low_download_policy.allow && low_download_threshold > 0 {
+    if !reputation_policy.allow
+        && (low_download_threshold > 0 || reputation_policy.minimum_release_age.is_some())
+    {
         let gated = download_names_to_gate(download_names, allowed_unpopular_globs);
         if !gated.is_empty() {
-            downloads_gate(
-                &client,
-                &gated,
-                low_download_threshold,
-                &low_download_policy.prompt,
-            )
-            .await?;
+            if let Some(minimum_release_age) = reputation_policy.minimum_release_age.as_ref() {
+                let package_age_names =
+                    package_age_names_to_gate(&gated, &minimum_release_age.exclude);
+                package_age_gate(
+                    &client,
+                    &package_age_names,
+                    minimum_release_age.minutes,
+                    minimum_release_age.cutoff().as_deref(),
+                    &reputation_policy.prompt,
+                )
+                .await?;
+            }
+            if low_download_threshold > 0 {
+                downloads_gate(
+                    &client,
+                    &gated,
+                    low_download_threshold,
+                    &reputation_policy.prompt,
+                )
+                .await?;
+            }
         }
     }
     Ok(())
+}
+
+async fn package_age_gate(
+    client: &reqwest::Client,
+    names: &[String],
+    minimum_age_minutes: u64,
+    cutoff: Option<&str>,
+    prompt: &LowDownloadPrompt,
+) -> miette::Result<()> {
+    let Some(cutoff) = cutoff else {
+        return Ok(());
+    };
+    let mut set: tokio::task::JoinSet<(String, Result<PackageCreated, _>)> =
+        tokio::task::JoinSet::new();
+    for name in names {
+        let client = client.clone();
+        let name = name.clone();
+        set.spawn(async move {
+            let result = fetch_package_created_with(&client, &name).await;
+            (name, result)
+        });
+    }
+    let mut by_name: std::collections::HashMap<String, _> =
+        std::collections::HashMap::with_capacity(names.len());
+    while let Some(joined) = set.join_next().await {
+        match joined {
+            Ok((name, result)) => {
+                by_name.insert(name, result);
+            }
+            Err(e) => tracing::debug!("package-age probe task join failed: {e}"),
+        }
+    }
+    for name in names {
+        let Some(result) = by_name.remove(name) else {
+            continue;
+        };
+        let created = match result {
+            Ok(PackageCreated::Known(created)) => created,
+            Ok(PackageCreated::Unknown) => continue,
+            Err(e) => {
+                tracing::debug!("package-age probe failed for {name}: {e}");
+                continue;
+            }
+        };
+        if !is_new_package_name(&created, cutoff) {
+            continue;
+        }
+        tracing::warn!(
+            code = WARN_AUBE_NEW_PACKAGE_NAME,
+            "{name}: package name was first published at {created}"
+        );
+        if !confirm_new_package(prompt, name, &created, minimum_age_minutes).await? {
+            return Err(miette!(
+                code = ERR_AUBE_NEW_PACKAGE_NAME,
+                "user aborted `{} {name}`",
+                aube_util::cmd("add")
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn is_new_package_name(created: &str, cutoff: &str) -> bool {
+    created > cutoff
+}
+
+fn package_age_names_to_gate(
+    names: &[String],
+    exclude: &aube_resolver::PackageVersionPolicy,
+) -> Vec<String> {
+    names
+        .iter()
+        .filter(|name| !exclude.matches_name_only(name))
+        .cloned()
+        .collect()
 }
 
 /// Single entry point for the post-resolve OSV `MAL-*` routing
@@ -831,6 +929,56 @@ fn prompt_continue(name: &str, weekly: u64, threshold: u64) -> miette::Result<bo
     Ok(answer == "y" || answer == "yes")
 }
 
+async fn confirm_new_package(
+    prompt: &LowDownloadPrompt,
+    name: &str,
+    created: &str,
+    minimum_age_minutes: u64,
+) -> miette::Result<bool> {
+    let refusal = || {
+        miette!(
+            code = ERR_AUBE_NEW_PACKAGE_NAME,
+            "refusing to add {name}: the package name was first published at {created}, within the configured minimum release age of {minimum_age_minutes} minutes. Pass --allow-low-downloads to approve this new name explicitly."
+        )
+    };
+    match prompt {
+        LowDownloadPrompt::Terminal
+            if std::io::stdin().is_terminal() && std::io::stderr().is_terminal() =>
+        {
+            prompt_new_package(name, created, minimum_age_minutes)
+        }
+        LowDownloadPrompt::Terminal => Err(refusal()),
+        LowDownloadPrompt::Host(control) => control
+            .confirm(crate::commands::install::InstallPrompt::NewPackageName {
+                package: name.to_string(),
+                created_at: created.to_string(),
+                minimum_age_minutes,
+            })
+            .await
+            .unwrap_or_else(|| Err(refusal())),
+    }
+}
+
+fn prompt_new_package(name: &str, created: &str, minimum_age_minutes: u64) -> miette::Result<bool> {
+    let mut stderr = std::io::stderr().lock();
+    writeln!(stderr, "  ⚠ {name} is a newly registered package name:").ok();
+    writeln!(stderr, "    • first published {created}").ok();
+    writeln!(stderr, "    • minimum age: {minimum_age_minutes} minutes").ok();
+    write!(stderr, "  Continue adding {name}? [y/N] ").ok();
+    stderr.flush().ok();
+    drop(stderr);
+
+    let mut line = String::new();
+    std::io::stdin().lock().read_line(&mut line).map_err(|e| {
+        miette!(
+            code = ERR_AUBE_NEW_PACKAGE_NAME,
+            "failed to read confirmation: {e}"
+        )
+    })?;
+    let answer = line.trim().to_ascii_lowercase();
+    Ok(answer == "y" || answer == "yes")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -876,9 +1024,13 @@ mod tests {
                 &[],
                 AdvisoryCheck::Required,
                 1000,
-                LowDownloadPolicy {
+                ReputationPolicy {
                     allow: false,
                     prompt: LowDownloadPrompt::Terminal,
+                    minimum_release_age: Some(aube_resolver::MinimumReleaseAge {
+                        minutes: 1440,
+                        ..Default::default()
+                    }),
                 },
                 &[],
             )
@@ -925,14 +1077,65 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn embedded_new_package_confirmation_is_routed_to_the_host() {
+        let handler = Arc::new(RecordingPromptHandler {
+            answer: true,
+            prompts: Mutex::new(Vec::new()),
+        });
+        let prompt =
+            LowDownloadPrompt::Host(InstallControl::silent().with_prompt_handler(handler.clone()));
+
+        assert!(
+            confirm_new_package(
+                &prompt,
+                "plausible-ai-package",
+                "2026-07-28T10:00:00.000Z",
+                1440,
+            )
+            .await
+            .unwrap()
+        );
+        assert_eq!(
+            *handler.prompts.lock().unwrap(),
+            vec![InstallPrompt::NewPackageName {
+                package: "plausible-ai-package".to_string(),
+                created_at: "2026-07-28T10:00:00.000Z".to_string(),
+                minimum_age_minutes: 1440,
+            }]
+        );
+    }
+
     #[test]
-    fn exact_allowed_names_skip_only_the_download_gate() {
+    fn exact_allowed_names_skip_reputation_gates() {
         let names = vec!["locked[tiny]".to_string(), "new-tiny".to_string()];
         let allowed = vec![glob::Pattern::escape("locked[tiny]")];
 
         assert_eq!(
             download_names_to_gate(&names, &allowed),
             vec!["new-tiny".to_string()]
+        );
+    }
+
+    #[test]
+    fn package_name_age_is_strictly_newer_than_cutoff() {
+        let cutoff = "2026-07-27T00:00:00.000Z";
+        assert!(is_new_package_name("2026-07-27T00:00:00.001Z", cutoff));
+        assert!(!is_new_package_name(cutoff, cutoff));
+        assert!(!is_new_package_name("2026-07-26T23:59:59.999Z", cutoff));
+    }
+
+    #[test]
+    fn bare_minimum_release_age_exclude_trusts_package_name() {
+        let names = vec![
+            "trusted-new-package".to_string(),
+            "unknown-new-package".to_string(),
+        ];
+        let exclude = aube_resolver::PackageVersionPolicy::parse(["trusted-new-package"])
+            .expect("valid exclude");
+        assert_eq!(
+            package_age_names_to_gate(&names, &exclude),
+            vec!["unknown-new-package".to_string()]
         );
     }
 

--- a/crates/aube/src/commands/add_supply_chain.rs
+++ b/crates/aube/src/commands/add_supply_chain.rs
@@ -79,10 +79,9 @@ pub(crate) enum LowDownloadPrompt {
 ///
 /// `allowed_unpopular_globs` are the `allowedUnpopularPackages`
 /// setting entries: full-name globs that exempt matching names from
-/// the package-age and downloads gates. The advisory check still runs against
-/// every package regardless — exempting confirmed-malicious advisories
-/// is not what this list is for.
-#[allow(clippy::too_many_arguments)]
+/// the similar-name, package-age, and downloads gates. The advisory
+/// check still runs against every package regardless — exempting
+/// confirmed-malicious advisories is not what this list is for.
 pub(crate) async fn run_gates(
     name_only_advisory_names: &[String],
     exact_advisory_pairs: &[(String, String)],
@@ -1137,7 +1136,7 @@ async fn confirm_new_package(
     let refusal = || {
         miette!(
             code = ERR_AUBE_NEW_PACKAGE_NAME,
-            "refusing to add {name}: the package name was first published at {created}, within the configured minimum release age of {minimum_age_minutes} minutes. Pass --allow-low-downloads to approve this new name explicitly."
+            "refusing to add {name}: the package name was first published at {created}, within the configured `minimumPackageAge` of {minimum_age_minutes} minutes. Pass --allow-low-downloads to approve this new name explicitly."
         )
     };
     match prompt {
@@ -1301,6 +1300,25 @@ mod tests {
                 created_at: "2026-07-28T10:00:00.000Z".to_string(),
                 minimum_age_minutes: 1440,
             }]
+        );
+    }
+
+    #[tokio::test]
+    async fn new_package_refusal_names_the_governing_setting() {
+        let prompt = LowDownloadPrompt::Host(InstallControl::silent());
+        let error = confirm_new_package(
+            &prompt,
+            "plausible-ai-package",
+            "2026-07-28T10:00:00.000Z",
+            43_200,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("`minimumPackageAge`"));
+        assert_eq!(
+            error.code().map(|code| code.to_string()).as_deref(),
+            Some(ERR_AUBE_NEW_PACKAGE_NAME)
         );
     }
 

--- a/crates/aube/src/commands/add_supply_chain.rs
+++ b/crates/aube/src/commands/add_supply_chain.rs
@@ -29,7 +29,7 @@
 
 use aube_codes::errors::{
     ERR_AUBE_ADVISORY_CHECK_FAILED, ERR_AUBE_LOW_DOWNLOAD_PACKAGE, ERR_AUBE_MALICIOUS_PACKAGE,
-    ERR_AUBE_NEW_PACKAGE_NAME,
+    ERR_AUBE_NEW_PACKAGE_NAME, ERR_AUBE_PACKAGE_AGE_CHECK_FAILED,
 };
 use aube_codes::warnings::{
     WARN_AUBE_ADVISORY_CHECK_FAILED, WARN_AUBE_LOW_DOWNLOAD_PACKAGE, WARN_AUBE_NEW_PACKAGE_NAME,
@@ -38,8 +38,9 @@ use aube_codes::warnings::{
 use aube_registry::osv_bloom_client::OsvBloomClient;
 use aube_registry::osv_mirror::OsvMirror;
 use aube_registry::supply_chain::{
-    DownloadCount, MaliciousAdvisory, PackageCreated, advisory_url, fetch_malicious_advisories,
-    fetch_malicious_advisories_versioned, fetch_package_created_with, fetch_weekly_downloads_with,
+    DownloadCount, MaliciousAdvisory, PackageCreated, SupplyChainError, advisory_url,
+    fetch_malicious_advisories, fetch_malicious_advisories_versioned, fetch_package_created_with,
+    fetch_weekly_downloads_with,
 };
 use aube_settings::resolved::{AdvisoryBloomCheck, AdvisoryCheck, AdvisoryCheckOnInstall};
 use miette::miette;
@@ -89,9 +90,17 @@ pub(crate) async fn run_gates(
     {
         return Ok(());
     }
+    let gated_reputation_names = if !reputation_policy.allow
+        && (low_download_threshold > 0 || reputation_policy.minimum_package_age_minutes > 0)
+    {
+        download_names_to_gate(download_names, allowed_unpopular_globs)
+    } else {
+        Vec::new()
+    };
     // One client shared across all gates and every per-package
-    // probe so the OSV POST and the (potentially parallel) downloads
-    // GETs all reuse the same connection pool + TLS session.
+    // probe so the OSV POST, sequential package-age GETs, and
+    // parallel downloads GETs all reuse the same connection pool +
+    // TLS session.
     //
     // Builder failure (TLS init, no root certs, etc.) routes through
     // the same `advisoryCheck` policy `osv_gate` applies to HTTP
@@ -103,6 +112,14 @@ pub(crate) async fn run_gates(
     let client = match aube_registry::supply_chain::build_probe_client() {
         Ok(c) => c,
         Err(e) => {
+            if reputation_policy.minimum_package_age_minutes > 0
+                && !gated_reputation_names.is_empty()
+            {
+                return Err(miette!(
+                    code = ERR_AUBE_PACKAGE_AGE_CHECK_FAILED,
+                    "could not initialise the package-name age check; refusing to bypass `minimumPackageAge`: {e}"
+                ));
+            }
             if matches!(advisory_check, AdvisoryCheck::Off) {
                 tracing::debug!(
                     "supply-chain probe client init failed; OSV is off, skipping all gates: {e}"
@@ -130,35 +147,30 @@ pub(crate) async fn run_gates(
         "refusing to add malicious package(s):",
     )
     .await?;
-    if !reputation_policy.allow
-        && (low_download_threshold > 0 || reputation_policy.minimum_package_age_minutes > 0)
-    {
-        let gated = download_names_to_gate(download_names, allowed_unpopular_globs);
-        if !gated.is_empty() {
-            if reputation_policy.minimum_package_age_minutes > 0 {
-                let cutoff = aube_resolver::MinimumReleaseAge {
-                    minutes: reputation_policy.minimum_package_age_minutes,
-                    ..Default::default()
-                }
-                .cutoff();
-                package_age_gate(
-                    &client,
-                    &gated,
-                    reputation_policy.minimum_package_age_minutes,
-                    cutoff.as_deref(),
-                    &reputation_policy.prompt,
-                )
-                .await?;
+    if !gated_reputation_names.is_empty() {
+        if reputation_policy.minimum_package_age_minutes > 0 {
+            let cutoff = aube_resolver::MinimumReleaseAge {
+                minutes: reputation_policy.minimum_package_age_minutes,
+                ..Default::default()
             }
-            if low_download_threshold > 0 {
-                downloads_gate(
-                    &client,
-                    &gated,
-                    low_download_threshold,
-                    &reputation_policy.prompt,
-                )
-                .await?;
-            }
+            .cutoff();
+            package_age_gate(
+                &client,
+                &gated_reputation_names,
+                reputation_policy.minimum_package_age_minutes,
+                cutoff.as_deref(),
+                &reputation_policy.prompt,
+            )
+            .await?;
+        }
+        if low_download_threshold > 0 {
+            downloads_gate(
+                &client,
+                &gated_reputation_names,
+                low_download_threshold,
+                &reputation_policy.prompt,
+            )
+            .await?;
         }
     }
     Ok(())
@@ -174,38 +186,11 @@ async fn package_age_gate(
     let Some(cutoff) = cutoff else {
         return Ok(());
     };
-    let mut set: tokio::task::JoinSet<(String, Result<PackageCreated, _>)> =
-        tokio::task::JoinSet::new();
     for name in names {
-        let client = client.clone();
-        let name = name.clone();
-        set.spawn(async move {
-            let result = fetch_package_created_with(&client, &name).await;
-            (name, result)
-        });
-    }
-    let mut by_name: std::collections::HashMap<String, _> =
-        std::collections::HashMap::with_capacity(names.len());
-    while let Some(joined) = set.join_next().await {
-        match joined {
-            Ok((name, result)) => {
-                by_name.insert(name, result);
-            }
-            Err(e) => tracing::debug!("package-age probe task join failed: {e}"),
-        }
-    }
-    for name in names {
-        let Some(result) = by_name.remove(name) else {
-            continue;
-        };
-        let created = match result {
-            Ok(PackageCreated::Known(created)) => created,
-            Ok(PackageCreated::Unknown) => continue,
-            Err(e) => {
-                tracing::debug!("package-age probe failed for {name}: {e}");
-                continue;
-            }
-        };
+        // Full npm packuments can be large. Probe sequentially so a multi-package
+        // add never retains several response bodies at once.
+        let created =
+            verified_package_created(name, fetch_package_created_with(client, name).await)?;
         if !is_new_package_name(&created, cutoff) {
             continue;
         }
@@ -222,6 +207,23 @@ async fn package_age_gate(
         }
     }
     Ok(())
+}
+
+fn verified_package_created(
+    name: &str,
+    result: Result<PackageCreated, SupplyChainError>,
+) -> miette::Result<String> {
+    match result {
+        Ok(PackageCreated::Known(created)) => Ok(created),
+        Ok(PackageCreated::Unknown) => Err(miette!(
+            code = ERR_AUBE_PACKAGE_AGE_CHECK_FAILED,
+            "npm did not return a creation timestamp for {name}; refusing to bypass `minimumPackageAge`"
+        )),
+        Err(error) => Err(miette!(
+            code = ERR_AUBE_PACKAGE_AGE_CHECK_FAILED,
+            "could not verify the package-name age for {name}; refusing to bypass `minimumPackageAge`: {error}"
+        )),
+    }
 }
 
 fn is_new_package_name(created: &str, cutoff: &str) -> bool {
@@ -1112,6 +1114,33 @@ mod tests {
         assert!(is_new_package_name("2026-07-27T00:00:00.001Z", cutoff));
         assert!(!is_new_package_name(cutoff, cutoff));
         assert!(!is_new_package_name("2026-07-26T23:59:59.999Z", cutoff));
+    }
+
+    #[test]
+    fn package_age_probe_requires_a_creation_timestamp() {
+        let error =
+            verified_package_created("missing-time", Ok(PackageCreated::Unknown)).unwrap_err();
+
+        assert_eq!(
+            error.code().map(|code| code.to_string()).as_deref(),
+            Some(ERR_AUBE_PACKAGE_AGE_CHECK_FAILED)
+        );
+    }
+
+    #[test]
+    fn package_age_probe_fails_closed_on_registry_errors() {
+        let error = verified_package_created(
+            "unreachable",
+            Err(SupplyChainError::Status(
+                reqwest::StatusCode::SERVICE_UNAVAILABLE,
+            )),
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error.code().map(|code| code.to_string()).as_deref(),
+            Some(ERR_AUBE_PACKAGE_AGE_CHECK_FAILED)
+        );
     }
 
     #[test]

--- a/crates/aube/src/commands/add_supply_chain.rs
+++ b/crates/aube/src/commands/add_supply_chain.rs
@@ -15,7 +15,7 @@
 //!    `allowedUnpopularPackages` setting (glob patterns) bypasses
 //!    this gate for opted-in names, leaving the OSV check intact.
 //!
-//! 3. **Package-name age** — applies `minimumReleaseAge` to the
+//! 3. **Package-name age** — applies `minimumPackageAge` to the
 //!    registry's `time.created` timestamp. This closes the
 //!    slopsquatting window where an attacker registers a plausible
 //!    AI-hallucinated name immediately before a victim installs it.
@@ -49,7 +49,7 @@ use std::io::{BufRead, IsTerminal, Write};
 pub(crate) struct ReputationPolicy {
     pub(crate) allow: bool,
     pub(crate) prompt: LowDownloadPrompt,
-    pub(crate) minimum_release_age: Option<aube_resolver::MinimumReleaseAge>,
+    pub(crate) minimum_package_age_minutes: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -131,18 +131,21 @@ pub(crate) async fn run_gates(
     )
     .await?;
     if !reputation_policy.allow
-        && (low_download_threshold > 0 || reputation_policy.minimum_release_age.is_some())
+        && (low_download_threshold > 0 || reputation_policy.minimum_package_age_minutes > 0)
     {
         let gated = download_names_to_gate(download_names, allowed_unpopular_globs);
         if !gated.is_empty() {
-            if let Some(minimum_release_age) = reputation_policy.minimum_release_age.as_ref() {
-                let package_age_names =
-                    package_age_names_to_gate(&gated, &minimum_release_age.exclude);
+            if reputation_policy.minimum_package_age_minutes > 0 {
+                let cutoff = aube_resolver::MinimumReleaseAge {
+                    minutes: reputation_policy.minimum_package_age_minutes,
+                    ..Default::default()
+                }
+                .cutoff();
                 package_age_gate(
                     &client,
-                    &package_age_names,
-                    minimum_release_age.minutes,
-                    minimum_release_age.cutoff().as_deref(),
+                    &gated,
+                    reputation_policy.minimum_package_age_minutes,
+                    cutoff.as_deref(),
                     &reputation_policy.prompt,
                 )
                 .await?;
@@ -223,17 +226,6 @@ async fn package_age_gate(
 
 fn is_new_package_name(created: &str, cutoff: &str) -> bool {
     created > cutoff
-}
-
-fn package_age_names_to_gate(
-    names: &[String],
-    exclude: &aube_resolver::PackageVersionPolicy,
-) -> Vec<String> {
-    names
-        .iter()
-        .filter(|name| !exclude.matches_name_only(name))
-        .cloned()
-        .collect()
 }
 
 /// Single entry point for the post-resolve OSV `MAL-*` routing
@@ -1027,10 +1019,7 @@ mod tests {
                 ReputationPolicy {
                     allow: false,
                     prompt: LowDownloadPrompt::Terminal,
-                    minimum_release_age: Some(aube_resolver::MinimumReleaseAge {
-                        minutes: 1440,
-                        ..Default::default()
-                    }),
+                    minimum_package_age_minutes: 43_200,
                 },
                 &[],
             )
@@ -1123,20 +1112,6 @@ mod tests {
         assert!(is_new_package_name("2026-07-27T00:00:00.001Z", cutoff));
         assert!(!is_new_package_name(cutoff, cutoff));
         assert!(!is_new_package_name("2026-07-26T23:59:59.999Z", cutoff));
-    }
-
-    #[test]
-    fn bare_minimum_release_age_exclude_trusts_package_name() {
-        let names = vec![
-            "trusted-new-package".to_string(),
-            "unknown-new-package".to_string(),
-        ];
-        let exclude = aube_resolver::PackageVersionPolicy::parse(["trusted-new-package"])
-            .expect("valid exclude");
-        assert_eq!(
-            package_age_names_to_gate(&names, &exclude),
-            vec!["unknown-new-package".to_string()]
-        );
     }
 
     #[test]

--- a/crates/aube/src/commands/add_supply_chain.rs
+++ b/crates/aube/src/commands/add_supply_chain.rs
@@ -1,6 +1,6 @@
 //! Supply-chain gates that run at the top of `aube add`.
 //!
-//! Three checks, layered by signal strength:
+//! Four checks, layered by signal strength:
 //!
 //! 1. **OSV `MAL-*` advisory check** — hard block via
 //!    `ERR_AUBE_MALICIOUS_PACKAGE`. Confirmed malicious advisories
@@ -8,14 +8,18 @@
 //!    (so offline workflows still install); `advisoryCheck=required`
 //!    flips that to fail closed for hardened CI.
 //!
-//! 2. **Weekly-downloads floor** — interactive confirm prompt below
+//! 2. **Popular-name similarity** — namespace-aware edit-distance
+//!    comparison against the top 100,000 npm packages catches names
+//!    designed to look like an established dependency.
+//!
+//! 3. **Weekly-downloads floor** — interactive confirm prompt below
 //!    the threshold, hard refusal in non-interactive contexts unless
 //!    `--allow-low-downloads` is passed. Catches typosquats and
 //!    impersonations that haven't been reported to OSV yet. The
 //!    `allowedUnpopularPackages` setting (glob patterns) bypasses
 //!    this gate for opted-in names, leaving the OSV check intact.
 //!
-//! 3. **Package-name age** — applies `minimumPackageAge` to the
+//! 4. **Package-name age** — applies `minimumPackageAge` to the
 //!    registry's `time.created` timestamp. This closes the
 //!    slopsquatting window where an attacker registers a plausible
 //!    AI-hallucinated name immediately before a victim installs it.
@@ -29,11 +33,12 @@
 
 use aube_codes::errors::{
     ERR_AUBE_ADVISORY_CHECK_FAILED, ERR_AUBE_LOW_DOWNLOAD_PACKAGE, ERR_AUBE_MALICIOUS_PACKAGE,
-    ERR_AUBE_NEW_PACKAGE_NAME, ERR_AUBE_PACKAGE_AGE_CHECK_FAILED,
+    ERR_AUBE_NEW_PACKAGE_NAME, ERR_AUBE_PACKAGE_AGE_CHECK_FAILED, ERR_AUBE_SIMILAR_PACKAGE_NAME,
 };
 use aube_codes::warnings::{
     WARN_AUBE_ADVISORY_CHECK_FAILED, WARN_AUBE_LOW_DOWNLOAD_PACKAGE, WARN_AUBE_NEW_PACKAGE_NAME,
     WARN_AUBE_OSV_BLOOM_REFRESH_FAILED, WARN_AUBE_OSV_MIRROR_REFRESH_FAILED,
+    WARN_AUBE_SIMILAR_PACKAGE_NAME,
 };
 use aube_registry::osv_bloom_client::OsvBloomClient;
 use aube_registry::osv_mirror::OsvMirror;
@@ -77,6 +82,7 @@ pub(crate) enum LowDownloadPrompt {
 /// the package-age and downloads gates. The advisory check still runs against
 /// every package regardless — exempting confirmed-malicious advisories
 /// is not what this list is for.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_gates(
     name_only_advisory_names: &[String],
     exact_advisory_pairs: &[(String, String)],
@@ -92,9 +98,7 @@ pub(crate) async fn run_gates(
     {
         return Ok(());
     }
-    let gated_reputation_names = if !reputation_policy.allow
-        && (low_download_threshold > 0 || reputation_policy.minimum_package_age_minutes > 0)
-    {
+    let gated_reputation_names = if !reputation_policy.allow {
         download_names_to_gate(download_names, allowed_unpopular_globs)
     } else {
         Vec::new()
@@ -142,6 +146,13 @@ pub(crate) async fn run_gates(
         .await?;
     }
     if !gated_reputation_names.is_empty() {
+        let approved_similar_names =
+            similar_name_gate(&gated_reputation_names, &reputation_policy.prompt).await?;
+        let remaining_reputation_names = gated_reputation_names
+            .iter()
+            .filter(|name| !approved_similar_names.contains(name.as_str()))
+            .cloned()
+            .collect::<Vec<_>>();
         if reputation_policy.minimum_package_age_minutes > 0 {
             let cutoff = aube_resolver::MinimumReleaseAge {
                 minutes: reputation_policy.minimum_package_age_minutes,
@@ -151,7 +162,7 @@ pub(crate) async fn run_gates(
             package_age_gate(
                 reputation_policy.registry_client,
                 reputation_policy.full_packument_cache,
-                &gated_reputation_names,
+                &remaining_reputation_names,
                 reputation_policy.minimum_package_age_minutes,
                 cutoff.as_deref(),
                 &reputation_policy.prompt,
@@ -163,7 +174,7 @@ pub(crate) async fn run_gates(
         {
             downloads_gate(
                 client,
-                &gated_reputation_names,
+                &remaining_reputation_names,
                 low_download_threshold,
                 &reputation_policy.prompt,
             )
@@ -801,6 +812,195 @@ fn format_malicious_message(header: &str, hits: &[MaliciousAdvisory], footer: &s
     lines.join("\n")
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PackageNameSuggestion {
+    name: String,
+    rank: usize,
+    distance: u8,
+}
+
+async fn similar_name_gate(
+    names: &[String],
+    prompt: &LowDownloadPrompt,
+) -> miette::Result<std::collections::HashSet<String>> {
+    let corpus = aube_resolver::popular_package_names();
+    let mut approved = std::collections::HashSet::new();
+    for name in names {
+        let Some(suggestion) = find_similar_package_name(name, corpus) else {
+            continue;
+        };
+        tracing::warn!(
+            code = WARN_AUBE_SIMILAR_PACKAGE_NAME,
+            "{name} resembles {} (popularity rank #{}, edit distance {})",
+            suggestion.name,
+            suggestion.rank,
+            suggestion.distance
+        );
+        if !confirm_similar_package(prompt, name, &suggestion).await? {
+            return Err(miette!(
+                code = ERR_AUBE_SIMILAR_PACKAGE_NAME,
+                "user aborted `{} {name}`",
+                aube_util::cmd("add")
+            ));
+        }
+        approved.insert(name.clone());
+    }
+    Ok(approved)
+}
+
+fn find_similar_package_name(name: &str, corpus: &str) -> Option<PackageNameSuggestion> {
+    let mut best: Option<PackageNameSuggestion> = None;
+    for (index, candidate) in corpus.lines().enumerate() {
+        if name == candidate {
+            continue;
+        }
+        let Some((requested_part, candidate_part)) = comparable_name_parts(name, candidate) else {
+            continue;
+        };
+        let threshold = if requested_part.len().max(candidate_part.len()) >= 5 {
+            2
+        } else {
+            1
+        };
+        let Some(distance) = bounded_damerau_levenshtein(requested_part, candidate_part, threshold)
+        else {
+            continue;
+        };
+        let suggestion = PackageNameSuggestion {
+            name: candidate.to_string(),
+            rank: index + 1,
+            distance,
+        };
+        if best
+            .as_ref()
+            .is_none_or(|current| (distance, index) < (current.distance, current.rank - 1))
+        {
+            best = Some(suggestion);
+        }
+    }
+    best
+}
+
+fn comparable_name_parts<'a>(requested: &'a str, candidate: &'a str) -> Option<(&'a str, &'a str)> {
+    let requested_scoped = requested
+        .strip_prefix('@')
+        .and_then(|name| name.split_once('/'));
+    let candidate_scoped = candidate
+        .strip_prefix('@')
+        .and_then(|name| name.split_once('/'));
+    match (requested_scoped, candidate_scoped) {
+        (None, None) => Some((requested, candidate)),
+        (Some((requested_scope, requested_name)), Some((candidate_scope, candidate_name)))
+            if requested_scope == candidate_scope =>
+        {
+            Some((requested_name, candidate_name))
+        }
+        (Some(_), Some(_)) => Some((requested, candidate)),
+        _ => None,
+    }
+}
+
+/// Optimal-string-alignment distance with an upper bound. npm package
+/// names are ASCII and capped at 214 characters, so fixed rows avoid
+/// allocating while scanning the embedded popularity corpus.
+fn bounded_damerau_levenshtein(left: &str, right: &str, limit: u8) -> Option<u8> {
+    const MAX_NAME_LEN: usize = 214;
+    if !left.is_ascii()
+        || !right.is_ascii()
+        || left.len() > MAX_NAME_LEN
+        || right.len() > MAX_NAME_LEN
+        || left.len().abs_diff(right.len()) > usize::from(limit)
+    {
+        return None;
+    }
+    let left = left.as_bytes();
+    let right = right.as_bytes();
+    let mut previous_previous = [0_u16; MAX_NAME_LEN + 1];
+    let mut previous = [0_u16; MAX_NAME_LEN + 1];
+    let mut current = [0_u16; MAX_NAME_LEN + 1];
+    for (j, cell) in previous.iter_mut().take(right.len() + 1).enumerate() {
+        *cell = j as u16;
+    }
+    for i in 1..=left.len() {
+        current[0] = i as u16;
+        let mut row_min = current[0];
+        for j in 1..=right.len() {
+            let substitution = previous[j - 1] + u16::from(left[i - 1] != right[j - 1]);
+            current[j] = (previous[j] + 1).min(current[j - 1] + 1).min(substitution);
+            if i > 1 && j > 1 && left[i - 1] == right[j - 2] && left[i - 2] == right[j - 1] {
+                current[j] = current[j].min(previous_previous[j - 2] + 1);
+            }
+            row_min = row_min.min(current[j]);
+        }
+        if row_min > u16::from(limit) {
+            return None;
+        }
+        previous_previous = previous;
+        previous = current;
+    }
+    let distance = previous[right.len()];
+    (distance <= u16::from(limit)).then_some(distance as u8)
+}
+
+async fn confirm_similar_package(
+    prompt: &LowDownloadPrompt,
+    name: &str,
+    suggestion: &PackageNameSuggestion,
+) -> miette::Result<bool> {
+    let refusal = || {
+        miette!(
+            code = ERR_AUBE_SIMILAR_PACKAGE_NAME,
+            "refusing to add {name}: did you mean {} (top-100,000 rank #{}, edit distance {})? Pass --allow-low-downloads after verifying the package name.",
+            suggestion.name,
+            suggestion.rank,
+            suggestion.distance
+        )
+    };
+    match prompt {
+        LowDownloadPrompt::Terminal
+            if std::io::stdin().is_terminal() && std::io::stderr().is_terminal() =>
+        {
+            prompt_similar_package(name, suggestion)
+        }
+        LowDownloadPrompt::Terminal => Err(refusal()),
+        LowDownloadPrompt::Host(control) => control
+            .confirm(
+                crate::commands::install::InstallPrompt::SimilarPackageName {
+                    package: name.to_string(),
+                    suggested_package: suggestion.name.clone(),
+                    popularity_rank: suggestion.rank,
+                    edit_distance: suggestion.distance,
+                },
+            )
+            .await
+            .unwrap_or_else(|| Err(refusal())),
+    }
+}
+
+fn prompt_similar_package(name: &str, suggestion: &PackageNameSuggestion) -> miette::Result<bool> {
+    let mut stderr = std::io::stderr().lock();
+    writeln!(stderr, "  ⚠ {name} resembles a popular package:").ok();
+    writeln!(
+        stderr,
+        "    • did you mean {}? (top-100,000 rank #{}, edit distance {})",
+        suggestion.name, suggestion.rank, suggestion.distance
+    )
+    .ok();
+    write!(stderr, "  Continue adding {name}? [y/N] ").ok();
+    stderr.flush().ok();
+    drop(stderr);
+
+    let mut line = String::new();
+    std::io::stdin().lock().read_line(&mut line).map_err(|e| {
+        miette!(
+            code = ERR_AUBE_SIMILAR_PACKAGE_NAME,
+            "failed to read confirmation: {e}"
+        )
+    })?;
+    let answer = line.trim().to_ascii_lowercase();
+    Ok(answer == "y" || answer == "yes")
+}
+
 async fn downloads_gate(
     client: &reqwest::Client,
     names: &[String],
@@ -1101,6 +1301,106 @@ mod tests {
                 created_at: "2026-07-28T10:00:00.000Z".to_string(),
                 minimum_age_minutes: 1440,
             }]
+        );
+    }
+
+    #[tokio::test]
+    async fn embedded_similar_name_confirmation_is_routed_to_the_host() {
+        let handler = Arc::new(RecordingPromptHandler {
+            answer: true,
+            prompts: Mutex::new(Vec::new()),
+        });
+        let prompt =
+            LowDownloadPrompt::Host(InstallControl::silent().with_prompt_handler(handler.clone()));
+        let suggestion = PackageNameSuggestion {
+            name: "lodash".to_string(),
+            rank: 12,
+            distance: 1,
+        };
+
+        assert!(
+            confirm_similar_package(&prompt, "lodahs", &suggestion)
+                .await
+                .unwrap()
+        );
+        assert_eq!(
+            *handler.prompts.lock().unwrap(),
+            vec![InstallPrompt::SimilarPackageName {
+                package: "lodahs".to_string(),
+                suggested_package: "lodash".to_string(),
+                popularity_rank: 12,
+                edit_distance: 1,
+            }]
+        );
+    }
+
+    #[test]
+    fn similar_name_detects_adjacent_transposition() {
+        assert_eq!(
+            find_similar_package_name("lodahs", "react\nlodash\nexpress\n"),
+            Some(PackageNameSuggestion {
+                name: "lodash".to_string(),
+                rank: 2,
+                distance: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn bundled_corpus_detects_common_package_typo() {
+        let suggestion =
+            find_similar_package_name("lodahs", aube_resolver::popular_package_names())
+                .expect("lodash should be present in the popularity corpus");
+        assert_eq!(suggestion.name, "lodash");
+        assert_eq!(suggestion.distance, 1);
+    }
+
+    #[test]
+    fn similar_name_compares_basename_within_same_scope() {
+        assert_eq!(
+            find_similar_package_name("@babel/parserr", "@types/node\n@babel/parser\n"),
+            Some(PackageNameSuggestion {
+                name: "@babel/parser".to_string(),
+                rank: 2,
+                distance: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn similar_name_compares_full_name_across_scopes() {
+        assert_eq!(
+            find_similar_package_name("@type/node", "@types/node\n"),
+            Some(PackageNameSuggestion {
+                name: "@types/node".to_string(),
+                rank: 1,
+                distance: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn similar_name_does_not_compare_scoped_with_unscoped() {
+        assert_eq!(find_similar_package_name("@example/react", "react\n"), None);
+    }
+
+    #[test]
+    fn similar_name_skips_exact_and_distant_names() {
+        assert_eq!(
+            find_similar_package_name("lodash", "lodash\nexpress\n"),
+            None
+        );
+    }
+
+    #[test]
+    fn similar_name_prefers_distance_then_popularity_rank() {
+        assert_eq!(
+            find_similar_package_name("foobarz", "foobars\nfoobaz\n"),
+            Some(PackageNameSuggestion {
+                name: "foobars".to_string(),
+                rank: 1,
+                distance: 1,
+            })
         );
     }
 

--- a/crates/aube/src/commands/add_supply_chain.rs
+++ b/crates/aube/src/commands/add_supply_chain.rs
@@ -145,13 +145,7 @@ pub(crate) async fn run_gates(
         .await?;
     }
     if !gated_reputation_names.is_empty() {
-        let approved_similar_names =
-            similar_name_gate(&gated_reputation_names, &reputation_policy.prompt).await?;
-        let remaining_reputation_names = gated_reputation_names
-            .iter()
-            .filter(|name| !approved_similar_names.contains(name.as_str()))
-            .cloned()
-            .collect::<Vec<_>>();
+        similar_name_gate(&gated_reputation_names, &reputation_policy.prompt).await?;
         if reputation_policy.minimum_package_age_minutes > 0 {
             let cutoff = aube_resolver::MinimumReleaseAge {
                 minutes: reputation_policy.minimum_package_age_minutes,
@@ -161,7 +155,7 @@ pub(crate) async fn run_gates(
             package_age_gate(
                 reputation_policy.registry_client,
                 reputation_policy.full_packument_cache,
-                &remaining_reputation_names,
+                &gated_reputation_names,
                 reputation_policy.minimum_package_age_minutes,
                 cutoff.as_deref(),
                 &reputation_policy.prompt,
@@ -173,7 +167,7 @@ pub(crate) async fn run_gates(
         {
             downloads_gate(
                 client,
-                &remaining_reputation_names,
+                &gated_reputation_names,
                 low_download_threshold,
                 &reputation_policy.prompt,
             )
@@ -818,12 +812,8 @@ struct PackageNameSuggestion {
     distance: u8,
 }
 
-async fn similar_name_gate(
-    names: &[String],
-    prompt: &LowDownloadPrompt,
-) -> miette::Result<std::collections::HashSet<String>> {
+async fn similar_name_gate(names: &[String], prompt: &LowDownloadPrompt) -> miette::Result<()> {
     let corpus = aube_resolver::popular_package_names();
-    let mut approved = std::collections::HashSet::new();
     for name in names {
         let Some(suggestion) = find_similar_package_name(name, corpus) else {
             continue;
@@ -842,9 +832,8 @@ async fn similar_name_gate(
                 aube_util::cmd("add")
             ));
         }
-        approved.insert(name.clone());
     }
-    Ok(approved)
+    Ok(())
 }
 
 fn find_similar_package_name(name: &str, corpus: &str) -> Option<PackageNameSuggestion> {

--- a/crates/aube/src/commands/add_supply_chain.rs
+++ b/crates/aube/src/commands/add_supply_chain.rs
@@ -38,19 +38,21 @@ use aube_codes::warnings::{
 use aube_registry::osv_bloom_client::OsvBloomClient;
 use aube_registry::osv_mirror::OsvMirror;
 use aube_registry::supply_chain::{
-    DownloadCount, MaliciousAdvisory, PackageCreated, SupplyChainError, advisory_url,
-    fetch_malicious_advisories, fetch_malicious_advisories_versioned, fetch_package_created_with,
-    fetch_weekly_downloads_with,
+    DownloadCount, MaliciousAdvisory, advisory_url, fetch_malicious_advisories,
+    fetch_malicious_advisories_versioned, fetch_weekly_downloads_with,
 };
 use aube_settings::resolved::{AdvisoryBloomCheck, AdvisoryCheck, AdvisoryCheckOnInstall};
 use miette::miette;
 use std::io::{BufRead, IsTerminal, Write};
+use std::path::Path;
 
-#[derive(Debug, Clone)]
-pub(crate) struct ReputationPolicy {
+#[derive(Clone)]
+pub(crate) struct ReputationPolicy<'a> {
     pub(crate) allow: bool,
     pub(crate) prompt: LowDownloadPrompt,
     pub(crate) minimum_package_age_minutes: u64,
+    pub(crate) registry_client: &'a aube_registry::client::RegistryClient,
+    pub(crate) full_packument_cache: &'a Path,
 }
 
 #[derive(Debug, Clone)]
@@ -81,7 +83,7 @@ pub(crate) async fn run_gates(
     download_names: &[String],
     advisory_check: AdvisoryCheck,
     low_download_threshold: u64,
-    reputation_policy: ReputationPolicy,
+    reputation_policy: ReputationPolicy<'_>,
     allowed_unpopular_globs: &[String],
 ) -> miette::Result<()> {
     if name_only_advisory_names.is_empty()
@@ -97,56 +99,48 @@ pub(crate) async fn run_gates(
     } else {
         Vec::new()
     };
-    // One client shared across all gates and every per-package
-    // probe so the OSV POST, sequential package-age GETs, and
-    // parallel downloads GETs all reuse the same connection pool +
-    // TLS session.
+    // One lightweight client shared across OSV and downloads probes.
+    // Package age uses the standard RegistryClient supplied by the
+    // caller so it shares full-packument caching and retry policy with
+    // the resolver.
     //
     // Builder failure (TLS init, no root certs, etc.) routes through
     // the same `advisoryCheck` policy `osv_gate` applies to HTTP
     // failures: under `Required` it's a hard fail with
-    // `ERR_AUBE_ADVISORY_CHECK_FAILED`, otherwise it warns and skips
-    // all gates. `Off` short-circuits before even surfacing the
-    // warning — the user opted out of OSV entirely, so a probe-
-    // client init failure is no longer their concern.
-    let client = match aube_registry::supply_chain::build_probe_client() {
-        Ok(c) => c,
+    // `ERR_AUBE_ADVISORY_CHECK_FAILED`; otherwise OSV/download probes
+    // are skipped while the independent package-age gate still runs.
+    let probe_client = match aube_registry::supply_chain::build_probe_client() {
+        Ok(client) => Some(client),
         Err(e) => {
-            if reputation_policy.minimum_package_age_minutes > 0
-                && !gated_reputation_names.is_empty()
-            {
-                return Err(miette!(
-                    code = ERR_AUBE_PACKAGE_AGE_CHECK_FAILED,
-                    "could not initialise the package-name age check; refusing to bypass `minimumPackageAge`: {e}"
-                ));
-            }
             if matches!(advisory_check, AdvisoryCheck::Off) {
                 tracing::debug!(
-                    "supply-chain probe client init failed; OSV is off, skipping all gates: {e}"
+                    "supply-chain probe client init failed; OSV is off, skipping downloads probe: {e}"
                 );
-                return Ok(());
+            } else {
+                tracing::warn!(
+                    code = WARN_AUBE_ADVISORY_CHECK_FAILED,
+                    "supply-chain probe client init failed: {e}"
+                );
+                if matches!(advisory_check, AdvisoryCheck::Required) {
+                    return Err(miette!(
+                        code = ERR_AUBE_ADVISORY_CHECK_FAILED,
+                        "supply-chain probe client could not be initialised and `advisoryCheck = required` is set: {e}"
+                    ));
+                }
             }
-            tracing::warn!(
-                code = WARN_AUBE_ADVISORY_CHECK_FAILED,
-                "supply-chain probe client init failed: {e}"
-            );
-            if matches!(advisory_check, AdvisoryCheck::Required) {
-                return Err(miette!(
-                    code = ERR_AUBE_ADVISORY_CHECK_FAILED,
-                    "supply-chain probe client could not be initialised and `advisoryCheck = required` is set: {e}"
-                ));
-            }
-            return Ok(());
+            None
         }
     };
-    osv_gate(&client, name_only_advisory_names, advisory_check).await?;
-    osv_gate_versioned(
-        &client,
-        exact_advisory_pairs,
-        advisory_check,
-        "refusing to add malicious package(s):",
-    )
-    .await?;
+    if let Some(client) = &probe_client {
+        osv_gate(client, name_only_advisory_names, advisory_check).await?;
+        osv_gate_versioned(
+            client,
+            exact_advisory_pairs,
+            advisory_check,
+            "refusing to add malicious package(s):",
+        )
+        .await?;
+    }
     if !gated_reputation_names.is_empty() {
         if reputation_policy.minimum_package_age_minutes > 0 {
             let cutoff = aube_resolver::MinimumReleaseAge {
@@ -155,7 +149,8 @@ pub(crate) async fn run_gates(
             }
             .cutoff();
             package_age_gate(
-                &client,
+                reputation_policy.registry_client,
+                reputation_policy.full_packument_cache,
                 &gated_reputation_names,
                 reputation_policy.minimum_package_age_minutes,
                 cutoff.as_deref(),
@@ -163,9 +158,11 @@ pub(crate) async fn run_gates(
             )
             .await?;
         }
-        if low_download_threshold > 0 {
+        if low_download_threshold > 0
+            && let Some(client) = &probe_client
+        {
             downloads_gate(
-                &client,
+                client,
                 &gated_reputation_names,
                 low_download_threshold,
                 &reputation_policy.prompt,
@@ -177,7 +174,8 @@ pub(crate) async fn run_gates(
 }
 
 async fn package_age_gate(
-    client: &reqwest::Client,
+    client: &aube_registry::client::RegistryClient,
+    full_packument_cache: &Path,
     names: &[String],
     minimum_age_minutes: u64,
     cutoff: Option<&str>,
@@ -187,10 +185,16 @@ async fn package_age_gate(
         return Ok(());
     };
     for name in names {
-        // Full npm packuments can be large. Probe sequentially so a multi-package
-        // add never retains several response bodies at once.
-        let created =
-            verified_package_created(name, fetch_package_created_with(client, name).await)?;
+        // Full npm packuments can be large. Fetch sequentially so a multi-package
+        // add never retains several response bodies at once. Use the registry
+        // client's existing full-packument path so URL encoding, retries, body
+        // limits, ETag revalidation, and the on-disk cache stay centralized.
+        let created = verified_package_created(
+            name,
+            client
+                .fetch_packument_with_time_cached(name, full_packument_cache)
+                .await,
+        )?;
         if !is_new_package_name(&created, cutoff) {
             continue;
         }
@@ -211,14 +215,15 @@ async fn package_age_gate(
 
 fn verified_package_created(
     name: &str,
-    result: Result<PackageCreated, SupplyChainError>,
+    result: Result<aube_registry::Packument, aube_registry::Error>,
 ) -> miette::Result<String> {
     match result {
-        Ok(PackageCreated::Known(created)) => Ok(created),
-        Ok(PackageCreated::Unknown) => Err(miette!(
-            code = ERR_AUBE_PACKAGE_AGE_CHECK_FAILED,
-            "npm did not return a creation timestamp for {name}; refusing to bypass `minimumPackageAge`"
-        )),
+        Ok(packument) => packument.time.get("created").cloned().ok_or_else(|| {
+            miette!(
+                code = ERR_AUBE_PACKAGE_AGE_CHECK_FAILED,
+                "npm did not return a creation timestamp for {name}; refusing to bypass `minimumPackageAge`"
+            )
+        }),
         Err(error) => Err(miette!(
             code = ERR_AUBE_PACKAGE_AGE_CHECK_FAILED,
             "could not verify the package-name age for {name}; refusing to bypass `minimumPackageAge`: {error}"
@@ -1022,6 +1027,8 @@ mod tests {
                     allow: false,
                     prompt: LowDownloadPrompt::Terminal,
                     minimum_package_age_minutes: 43_200,
+                    registry_client: &crate::commands::make_client(std::path::Path::new(".")),
+                    full_packument_cache: std::path::Path::new("."),
                 },
                 &[],
             )
@@ -1118,8 +1125,17 @@ mod tests {
 
     #[test]
     fn package_age_probe_requires_a_creation_timestamp() {
-        let error =
-            verified_package_created("missing-time", Ok(PackageCreated::Unknown)).unwrap_err();
+        let error = verified_package_created(
+            "missing-time",
+            Ok(aube_registry::Packument {
+                name: "missing-time".to_string(),
+                modified: None,
+                versions: Default::default(),
+                dist_tags: Default::default(),
+                time: Default::default(),
+            }),
+        )
+        .unwrap_err();
 
         assert_eq!(
             error.code().map(|code| code.to_string()).as_deref(),
@@ -1128,12 +1144,30 @@ mod tests {
     }
 
     #[test]
+    fn package_age_probe_reads_created_from_standard_packument() {
+        let created = "2026-07-28T10:00:00.000Z";
+        let value = verified_package_created(
+            "plausible-ai-package",
+            Ok(aube_registry::Packument {
+                name: "plausible-ai-package".to_string(),
+                modified: None,
+                versions: Default::default(),
+                dist_tags: Default::default(),
+                time: [("created".to_string(), created.to_string())]
+                    .into_iter()
+                    .collect(),
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(value, created);
+    }
+
+    #[test]
     fn package_age_probe_fails_closed_on_registry_errors() {
         let error = verified_package_created(
             "unreachable",
-            Err(SupplyChainError::Status(
-                reqwest::StatusCode::SERVICE_UNAVAILABLE,
-            )),
+            Err(aube_registry::Error::NotFound("unreachable".to_string())),
         )
         .unwrap_err();
 

--- a/crates/aube/src/commands/install/control.rs
+++ b/crates/aube/src/commands/install/control.rs
@@ -70,6 +70,11 @@ pub enum InstallPrompt {
         weekly_downloads: u64,
         threshold: u64,
     },
+    NewPackageName {
+        package: String,
+        created_at: String,
+        minimum_age_minutes: u64,
+    },
 }
 
 /// Future returned by an [`InstallPromptHandler`].

--- a/crates/aube/src/commands/install/control.rs
+++ b/crates/aube/src/commands/install/control.rs
@@ -65,6 +65,12 @@ pub trait InstallReporter: Send + Sync + 'static {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum InstallPrompt {
+    SimilarPackageName {
+        package: String,
+        suggested_package: String,
+        popularity_rank: usize,
+        edit_distance: u8,
+    },
     LowDownloadPackage {
         package: String,
         weekly_downloads: u64,

--- a/docs/cli/add.md
+++ b/docs/cli/add.md
@@ -45,7 +45,7 @@ Conflicts with `--no-save`, which only snapshots `package.json` and the lockfile
 
 Bypass the new-name and [`lowDownloadThreshold`] confirm prompts / refusals for this invocation.
 
-`aube add` looks up each candidate's weekly download count and prompts (interactive) or fails (CI) when the count is below [`lowDownloadThreshold`] or the package name is newer than [`minimumReleaseAge`]. The flag is intended for cases where you've already verified the package out-of-band. It does not affect the OSV malicious-package check, which remains a hard block.
+`aube add` looks up each candidate's weekly download count and prompts (interactive) or fails (CI) when the count is below [`lowDownloadThreshold`] or the package name is newer than [`minimumPackageAge`]. The flag is intended for cases where you've already verified the package out-of-band. It does not affect the OSV malicious-package check, which remains a hard block.
 
 ### `--dangerously-allow-all-builds`
 

--- a/docs/cli/add.md
+++ b/docs/cli/add.md
@@ -43,9 +43,9 @@ Conflicts with `--no-save`, which only snapshots `package.json` and the lockfile
 
 ### `--allow-low-downloads`
 
-Bypass the [`lowDownloadThreshold`] confirm prompt / refusal for this invocation.
+Bypass the new-name and [`lowDownloadThreshold`] confirm prompts / refusals for this invocation.
 
-`aube add` looks up each candidate's weekly download count and prompts (interactive) or fails (CI) when the count is below [`lowDownloadThreshold`]. The flag is intended for the cases where you've already verified the package out-of-band — adding a brand-new niche tool, a fresh fork, an internal scratch package — and don't want the prompt to interrupt scripted workflows. Does not affect the OSV malicious-package check, which remains a hard block.
+`aube add` looks up each candidate's weekly download count and prompts (interactive) or fails (CI) when the count is below [`lowDownloadThreshold`] or the package name is newer than [`minimumReleaseAge`]. The flag is intended for cases where you've already verified the package out-of-band. It does not affect the OSV malicious-package check, which remains a hard block.
 
 ### `--dangerously-allow-all-builds`
 

--- a/docs/cli/add.md
+++ b/docs/cli/add.md
@@ -43,9 +43,9 @@ Conflicts with `--no-save`, which only snapshots `package.json` and the lockfile
 
 ### `--allow-low-downloads`
 
-Bypass the new-name and [`lowDownloadThreshold`] confirm prompts / refusals for this invocation.
+Bypass the similar-name, new-name, and [`lowDownloadThreshold`] confirm prompts / refusals for this invocation.
 
-`aube add` looks up each candidate's weekly download count and prompts (interactive) or fails (CI) when the count is below [`lowDownloadThreshold`] or the package name is newer than [`minimumPackageAge`]. The flag is intended for cases where you've already verified the package out-of-band. It does not affect the OSV malicious-package check, which remains a hard block.
+`aube add` looks up each candidate's weekly download count and prompts (interactive) or fails (CI) when the count is below [`lowDownloadThreshold`], resembles a top-100,000 npm package, or is newer than [`minimumPackageAge`]. The flag is intended for cases where you've already verified the package out-of-band. It does not affect the OSV malicious-package check, which remains a hard block.
 
 ### `--dangerously-allow-all-builds`
 

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -620,9 +620,9 @@
           {
             "name": "allow-low-downloads",
             "usage": "--allow-low-downloads",
-            "help": "Bypass the [`lowDownloadThreshold`] confirm prompt / refusal for this invocation",
-            "help_long": "Bypass the [`lowDownloadThreshold`] confirm prompt / refusal for this invocation.\n\n`aube add` looks up each candidate's weekly download count and prompts (interactive) or fails (CI) when the count is below [`lowDownloadThreshold`]. The flag is intended for the cases where you've already verified the package out-of-band — adding a brand-new niche tool, a fresh fork, an internal scratch package — and don't want the prompt to interrupt scripted workflows. Does not affect the OSV malicious-package check, which remains a hard block.",
-            "help_first_line": "Bypass the [`lowDownloadThreshold`] confirm prompt / refusal for this invocation",
+            "help": "Bypass the new-name and [`lowDownloadThreshold`] confirm prompts / refusals for this invocation",
+            "help_long": "Bypass the new-name and [`lowDownloadThreshold`] confirm prompts / refusals for this invocation.\n\n`aube add` looks up each candidate's weekly download count and prompts (interactive) or fails (CI) when the count is below [`lowDownloadThreshold`] or the package name is newer than [`minimumReleaseAge`]. The flag is intended for cases where you've already verified the package out-of-band. It does not affect the OSV malicious-package check, which remains a hard block.",
+            "help_first_line": "Bypass the new-name and [`lowDownloadThreshold`] confirm prompts / refusals for this invocation",
             "short": [],
             "long": [
               "allow-low-downloads"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -620,9 +620,9 @@
           {
             "name": "allow-low-downloads",
             "usage": "--allow-low-downloads",
-            "help": "Bypass the new-name and [`lowDownloadThreshold`] confirm prompts / refusals for this invocation",
-            "help_long": "Bypass the new-name and [`lowDownloadThreshold`] confirm prompts / refusals for this invocation.\n\n`aube add` looks up each candidate's weekly download count and prompts (interactive) or fails (CI) when the count is below [`lowDownloadThreshold`] or the package name is newer than [`minimumPackageAge`]. The flag is intended for cases where you've already verified the package out-of-band. It does not affect the OSV malicious-package check, which remains a hard block.",
-            "help_first_line": "Bypass the new-name and [`lowDownloadThreshold`] confirm prompts / refusals for this invocation",
+            "help": "Bypass the similar-name, new-name, and [`lowDownloadThreshold`] confirm prompts / refusals for this invocation",
+            "help_long": "Bypass the similar-name, new-name, and [`lowDownloadThreshold`] confirm prompts / refusals for this invocation.\n\n`aube add` looks up each candidate's weekly download count and prompts (interactive) or fails (CI) when the count is below [`lowDownloadThreshold`], resembles a top-100,000 npm package, or is newer than [`minimumPackageAge`]. The flag is intended for cases where you've already verified the package out-of-band. It does not affect the OSV malicious-package check, which remains a hard block.",
+            "help_first_line": "Bypass the similar-name, new-name, and [`lowDownloadThreshold`] confirm prompts / refusals for this invocation",
             "short": [],
             "long": [
               "allow-low-downloads"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -621,7 +621,7 @@
             "name": "allow-low-downloads",
             "usage": "--allow-low-downloads",
             "help": "Bypass the new-name and [`lowDownloadThreshold`] confirm prompts / refusals for this invocation",
-            "help_long": "Bypass the new-name and [`lowDownloadThreshold`] confirm prompts / refusals for this invocation.\n\n`aube add` looks up each candidate's weekly download count and prompts (interactive) or fails (CI) when the count is below [`lowDownloadThreshold`] or the package name is newer than [`minimumReleaseAge`]. The flag is intended for cases where you've already verified the package out-of-band. It does not affect the OSV malicious-package check, which remains a hard block.",
+            "help_long": "Bypass the new-name and [`lowDownloadThreshold`] confirm prompts / refusals for this invocation.\n\n`aube add` looks up each candidate's weekly download count and prompts (interactive) or fails (CI) when the count is below [`lowDownloadThreshold`] or the package name is newer than [`minimumPackageAge`]. The flag is intended for cases where you've already verified the package out-of-band. It does not affect the OSV malicious-package check, which remains a hard block.",
             "help_first_line": "Bypass the new-name and [`lowDownloadThreshold`] confirm prompts / refusals for this invocation",
             "short": [],
             "long": [

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -193,6 +193,12 @@
       "exit_code": null
     },
     {
+      "name": "ERR_AUBE_PACKAGE_AGE_CHECK_FAILED",
+      "category": "Supply chain (add-time)",
+      "description": "`aube add` couldn't verify a package name's registry creation time while `minimumPackageAge` was enabled, so the package-age gate failed closed.",
+      "exit_code": null
+    },
+    {
       "name": "ERR_AUBE_ADVISORY_CHECK_FAILED",
       "category": "Registry / network",
       "description": "`aube add` couldn't reach the OSV advisory API and `advisoryCheck = required` is set. Distinct from `ERR_AUBE_MALICIOUS_PACKAGE` so CI tooling can tell a network outage from a confirmed malicious advisory.",

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -187,6 +187,12 @@
       "exit_code": 47
     },
     {
+      "name": "ERR_AUBE_NEW_PACKAGE_NAME",
+      "category": "Supply chain (add-time)",
+      "description": "`aube add` refused a package name first published within `minimumReleaseAge`. This protects against newly registered slopsquatting names.",
+      "exit_code": null
+    },
+    {
       "name": "ERR_AUBE_ADVISORY_CHECK_FAILED",
       "category": "Registry / network",
       "description": "`aube add` couldn't reach the OSV advisory API and `advisoryCheck = required` is set. Distinct from `ERR_AUBE_MALICIOUS_PACKAGE` so CI tooling can tell a network outage from a confirmed malicious advisory.",
@@ -894,6 +900,12 @@
       "name": "WARN_AUBE_LOW_DOWNLOAD_PACKAGE",
       "category": "Supply chain (add-time)",
       "description": "`aube add` flagged a package whose weekly downloads fall below `lowDownloadThreshold`. Interactive sessions prompt for confirmation; non-interactive contexts fail with `ERR_AUBE_LOW_DOWNLOAD_PACKAGE` unless `--allow-low-downloads` is passed.",
+      "exit_code": null
+    },
+    {
+      "name": "WARN_AUBE_NEW_PACKAGE_NAME",
+      "category": "Supply chain (add-time)",
+      "description": "`aube add` flagged a package name first published within `minimumReleaseAge`. Interactive sessions prompt for confirmation; non-interactive contexts fail with `ERR_AUBE_NEW_PACKAGE_NAME` unless explicitly allowed.",
       "exit_code": null
     },
     {

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -181,6 +181,12 @@
       "exit_code": 46
     },
     {
+      "name": "ERR_AUBE_SIMILAR_PACKAGE_NAME",
+      "category": "Supply chain (add-time)",
+      "description": "`aube add` refused a package whose name closely resembles a more popular npm package. This protects against typosquatting and slopsquatting.",
+      "exit_code": null
+    },
+    {
       "name": "ERR_AUBE_LOW_DOWNLOAD_PACKAGE",
       "category": "Registry / network",
       "description": "`aube add` refused a package whose weekly downloads fall below `lowDownloadThreshold` in a non-interactive context (or when stdin is not a TTY). Pass `--allow-low-downloads` to bypass.",
@@ -900,6 +906,12 @@
       "name": "WARN_AUBE_WORKSPACE_TOPO_CYCLE",
       "category": "Workspace recursion",
       "description": "Topological sort of `aube run -r` / `aube exec -r` selected packages found a dependency cycle. Cycle members run in workspace-listing order after the rest of the topo-sorted set.",
+      "exit_code": null
+    },
+    {
+      "name": "WARN_AUBE_SIMILAR_PACKAGE_NAME",
+      "category": "Supply chain (add-time)",
+      "description": "`aube add` flagged a package whose name closely resembles a top-100,000 npm package. Interactive sessions prompt for confirmation; non-interactive contexts fail with `ERR_AUBE_SIMILAR_PACKAGE_NAME` unless explicitly allowed.",
       "exit_code": null
     },
     {

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -189,7 +189,7 @@
     {
       "name": "ERR_AUBE_NEW_PACKAGE_NAME",
       "category": "Supply chain (add-time)",
-      "description": "`aube add` refused a package name first published within `minimumReleaseAge`. This protects against newly registered slopsquatting names.",
+      "description": "`aube add` refused a package name first published within `minimumPackageAge`. This protects against newly registered slopsquatting names.",
       "exit_code": null
     },
     {
@@ -905,7 +905,7 @@
     {
       "name": "WARN_AUBE_NEW_PACKAGE_NAME",
       "category": "Supply chain (add-time)",
-      "description": "`aube add` flagged a package name first published within `minimumReleaseAge`. Interactive sessions prompt for confirmation; non-interactive contexts fail with `ERR_AUBE_NEW_PACKAGE_NAME` unless explicitly allowed.",
+      "description": "`aube add` flagged a package name first published within `minimumPackageAge`. Interactive sessions prompt for confirmation; non-interactive contexts fail with `ERR_AUBE_NEW_PACKAGE_NAME` unless explicitly allowed.",
       "exit_code": null
     },
     {

--- a/docs/security.md
+++ b/docs/security.md
@@ -248,6 +248,8 @@ project uses. Lockfile membership does not bypass the OSV check.
 confirmation; non-interactive sessions fail with
 `ERR_AUBE_NEW_PACKAGE_NAME`. Packages already present in the active lockfile
 and names matched by `allowedUnpopularPackages` are trusted.
+Missing or unavailable creation-time metadata fails closed with
+`ERR_AUBE_PACKAGE_AGE_CHECK_FAILED`.
 `--allow-low-downloads` bypasses both reputation challenges after the package
 has been verified out of band.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -185,11 +185,9 @@ Settings: [`trustPolicy`](/settings/#setting-trustpolicy),
 
 ## Minimum release age
 
-Wait a configurable period before installing newly published versions. On
-`aube add`, the same window also applies to the registry's package-name
-creation time. This catches slopsquatting names registered shortly before an
-AI assistant recommends them, even when the resolver's version fallback would
-otherwise admit the package's first release.
+Wait a configurable period before installing newly published versions. This
+24-hour release quarantine is intentionally separate from the longer
+package-name quarantine used for slopsquatting protection.
 
 ```yaml
 minimumReleaseAge: 4320  # 3 days
@@ -246,12 +244,16 @@ project uses. Lockfile membership does not bypass the OSV check.
 
 **New package name.** Before adding a direct dependency, aube reads npm's
 `time.created` timestamp and challenges names registered within
-`minimumReleaseAge`. Interactive sessions require confirmation;
-non-interactive sessions fail with `ERR_AUBE_NEW_PACKAGE_NAME`. Packages
-already present in the active lockfile and names matched by
-`allowedUnpopularPackages` or a bare-name `minimumReleaseAgeExclude` entry are
-trusted. `--allow-low-downloads` bypasses both reputation challenges after the
-package has been verified out of band.
+`minimumPackageAge` (30 days by default). Interactive sessions require
+confirmation; non-interactive sessions fail with
+`ERR_AUBE_NEW_PACKAGE_NAME`. Packages already present in the active lockfile
+and names matched by `allowedUnpopularPackages` are trusted.
+`--allow-low-downloads` bypasses both reputation challenges after the package
+has been verified out of band.
+
+```yaml
+minimumPackageAge: 43200 # 30 days
+```
 
 **Private packages skip all three gates automatically.** Any package routed
 through a non-`registry.npmjs.org` registry — whether by a scoped

--- a/docs/security.md
+++ b/docs/security.md
@@ -185,8 +185,11 @@ Settings: [`trustPolicy`](/settings/#setting-trustpolicy),
 
 ## Minimum release age
 
-Wait a configurable period before installing newly published versions. Catches
-typo-squat and dependency-confusion attacks that get unpublished within hours.
+Wait a configurable period before installing newly published versions. On
+`aube add`, the same window also applies to the registry's package-name
+creation time. This catches slopsquatting names registered shortly before an
+AI assistant recommends them, even when the resolver's version fallback would
+otherwise admit the package's first release.
 
 ```yaml
 minimumReleaseAge: 4320  # 3 days
@@ -212,7 +215,7 @@ already pin. Plain reinstalls (where the lockfile was authoritative) skip
 the live API for latency; two opt-in local backends cover that path — see
 [Install-time OSV check](#install-time-osv-check) below.
 
-Two signals, with different response levels:
+Three signals, with different response levels:
 
 **Known-malicious advisories.** aube batch-queries [OSV](https://osv.dev) for
 `MAL-*` advisories on every name about to be added. A hit fails the install
@@ -241,16 +244,25 @@ Packages already present in the active lockfile are trusted for this
 download-count check, regardless of which supported lockfile format the
 project uses. Lockfile membership does not bypass the OSV check.
 
-**Private packages skip both gates automatically.** Any package routed
+**New package name.** Before adding a direct dependency, aube reads npm's
+`time.created` timestamp and challenges names registered within
+`minimumReleaseAge`. Interactive sessions require confirmation;
+non-interactive sessions fail with `ERR_AUBE_NEW_PACKAGE_NAME`. Packages
+already present in the active lockfile and names matched by
+`allowedUnpopularPackages` or a bare-name `minimumReleaseAgeExclude` entry are
+trusted. `--allow-low-downloads` bypasses both reputation challenges after the
+package has been verified out of band.
+
+**Private packages skip all three gates automatically.** Any package routed
 through a non-`registry.npmjs.org` registry — whether by a scoped
 override (`@myorg:registry=https://npm.internal.example/`) or by
 replacing the default `registry=` URL outright — is exempted from
-the OSV check and the downloads gate, because npmjs has no signal on
+the OSV check and the reputation gates, because npmjs has no signal on
 it. Workspace deps and git/local specs are also skipped.
 
 For names that *do* route through public npmjs but are known-internal
 (e.g. you publish a low-traffic helper under your own brand), list
-them in `allowedUnpopularPackages` to skip the downloads gate alone:
+them in `allowedUnpopularPackages` to skip both reputation gates:
 
 ```yaml
 advisoryCheck: on            # default; fail open on network error

--- a/docs/security.md
+++ b/docs/security.md
@@ -213,7 +213,7 @@ already pin. Plain reinstalls (where the lockfile was authoritative) skip
 the live API for latency; two opt-in local backends cover that path — see
 [Install-time OSV check](#install-time-osv-check) below.
 
-Three signals, with different response levels:
+Four signals, with different response levels:
 
 **Known-malicious advisories.** aube batch-queries [OSV](https://osv.dev) for
 `MAL-*` advisories on every name about to be added. A hit fails the install
@@ -222,6 +222,21 @@ the OSV API can't be reached, the default (`advisoryCheck: on`) warns and
 continues; `advisoryCheck: required` upgrades that to a fail-closed
 `ERR_AUBE_ADVISORY_CHECK_FAILED` so CI can tell a network outage from a
 confirmed-malicious advisory.
+
+**Similar package name.** aube compares requested names with a monthly
+snapshot of the 100,000 most-downloaded npm packages before contacting the
+registry. The comparison is namespace-aware: unscoped packages are compared
+only with unscoped packages, names within the same scope are compared by
+basename, and names in different scopes are compared in full. This catches
+lookalikes such as `lodahs` → `lodash`, `@babel/parserr` → `@babel/parser`,
+and `@type/node` → `@types/node` without treating an intentional scoped fork
+as an unscoped-package impersonation.
+
+Interactive sessions show a “did you mean?” prompt. Non-interactive sessions
+fail with `ERR_AUBE_SIMILAR_PACKAGE_NAME`. The popularity corpus contains
+names only, is compressed into release binaries, and is generated from the
+continuously updated ecosyste.ms npm registry index rather than an
+infrequently published npm data package.
 
 **Low download count.** A typosquat or impersonation has approximately zero
 installs on day one regardless of how cleverly it's named, so a
@@ -250,14 +265,14 @@ confirmation; non-interactive sessions fail with
 and names matched by `allowedUnpopularPackages` are trusted.
 Missing or unavailable creation-time metadata fails closed with
 `ERR_AUBE_PACKAGE_AGE_CHECK_FAILED`.
-`--allow-low-downloads` bypasses both reputation challenges after the package
-has been verified out of band.
+`--allow-low-downloads` bypasses all three reputation challenges after the
+package has been verified out of band.
 
 ```yaml
 minimumPackageAge: 43200 # 30 days
 ```
 
-**Private packages skip all three gates automatically.** Any package routed
+**Private packages skip all four gates automatically.** Any package routed
 through a non-`registry.npmjs.org` registry — whether by a scoped
 override (`@myorg:registry=https://npm.internal.example/`) or by
 replacing the default `registry=` URL outright — is exempted from
@@ -266,7 +281,7 @@ it. Workspace deps and git/local specs are also skipped.
 
 For names that *do* route through public npmjs but are known-internal
 (e.g. you publish a low-traffic helper under your own brand), list
-them in `allowedUnpopularPackages` to skip both reputation gates:
+them in `allowedUnpopularPackages` to skip all three reputation gates:
 
 ```yaml
 advisoryCheck: on            # default; fail open on network error

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -666,10 +666,10 @@ Glob patterns exempted from add-time package reputation gates.
 - Managed policy: `managedWins`
 
 Each pattern is matched against the registry name (`@scope/foo` or
-`bar`) of every candidate the package-age and `lowDownloadThreshold`
-gates would otherwise probe. Matches skip both lookups, so
-internal/low-traffic packages don't trip the prompt in CI or the
-`y/N` prompt locally.
+`bar`) of every candidate the similar-name, package-age, and
+`lowDownloadThreshold` gates would otherwise probe. Matches skip all
+three checks, so internal/low-traffic packages don't trip the prompt
+in CI or the `y/N` prompt locally.
 
 Patterns are full-name globs (the [`glob`](https://docs.rs/glob)
 crate's syntax — `*`, `?`, `[…]`). Match-everything (`*`) is allowed

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -33,7 +33,7 @@ Aube generates this page from [`settings.toml`](https://github.com/jdx/aube/blob
 | [`advisoryBloomCheck`](#setting-advisorybloomcheck) | `"on" \| "required" \| "off"` | Bloom-filter prefilter for OSV `MAL-*` advisories on lockfile-driven installs. |
 | [`advisoryCheckEveryInstall`](#setting-advisorycheckeveryinstall) | `bool` | Force the live-API OSV `MAL-*` check on every install (including frozen reinstalls). |
 | [`lowDownloadThreshold`](#setting-lowdownloadthreshold) | `int` | Weekly-download floor for `aube add` (typosquat prompt). |
-| [`allowedUnpopularPackages`](#setting-allowedunpopularpackages) | `list<string>` | Glob patterns exempted from the `lowDownloadThreshold` gate. |
+| [`allowedUnpopularPackages`](#setting-allowedunpopularpackages) | `list<string>` | Glob patterns exempted from add-time package reputation gates. |
 | [`paranoid`](#setting-paranoid) | `bool` | Turn on the strict-security setting bundle in one switch. |
 | [`trustPolicy`](#setting-trustpolicy) | `"no-downgrade" \| "off"` | Fail install when a package's trust evidence weakens between releases. |
 | [`trustPolicyExclude`](#setting-trustpolicyexclude) | `list<string>` | Packages exempt from `trustPolicy` checks. |
@@ -379,9 +379,11 @@ Delay installation of newly published versions (minutes).
 - Workspace YAML keys: `minimumReleaseAge`
 - Managed policy: `max`
 
-Supply-chain attack mitigation: packages published within the last N
-minutes are skipped by the resolver. By default the resolver falls back
-to the next-oldest version that satisfies the range; set
+Supply-chain attack mitigation: versions published within the last N
+minutes are skipped by the resolver. `aube add` also challenges package
+names first registered inside this window, preventing a newly registered
+slopsquat from bypassing the version fallback. By default the resolver falls
+back to the next-oldest version that satisfies the range; set
 `minimumReleaseAgeStrict=true` to fail the install instead. Defaults to
 24 hours, matching pnpm v11. Set to `0` to disable.
 
@@ -623,7 +625,7 @@ Packages that route through a non-`registry.npmjs.org` registry are
 skipped automatically: a scoped override like
 `@myorg:registry=https://npm.internal.example/` or a swapped-out
 default registry both mean npmjs has no signal on the package, so
-neither the downloads gate nor the OSV `MAL-*` check fires.
+neither the reputation gates nor the OSV `MAL-*` check fires.
 Workspace deps and git/local specs are also skipped. To exempt
 specific names that *do* resolve through npmjs (e.g. you publish a
 low-download but trusted package internally), see
@@ -633,7 +635,7 @@ Set to `0` to disable.
 
 ### `allowedUnpopularPackages` {#setting-allowedunpopularpackages}
 
-Glob patterns exempted from the `lowDownloadThreshold` gate.
+Glob patterns exempted from add-time package reputation gates.
 
 - Type: `list<string>`
 - Default: `undefined`
@@ -643,9 +645,9 @@ Glob patterns exempted from the `lowDownloadThreshold` gate.
 - Managed policy: `managedWins`
 
 Each pattern is matched against the registry name (`@scope/foo` or
-`bar`) of every candidate the `lowDownloadThreshold` gate would
-otherwise probe. Matches skip the weekly-downloads lookup entirely,
-so internal/low-traffic packages don't trip the prompt in CI or the
+`bar`) of every candidate the package-age and `lowDownloadThreshold`
+gates would otherwise probe. Matches skip both lookups, so
+internal/low-traffic packages don't trip the prompt in CI or the
 `y/N` prompt locally.
 
 Patterns are full-name globs (the [`glob`](https://docs.rs/glob)

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -25,6 +25,7 @@ Aube generates this page from [`settings.toml`](https://github.com/jdx/aube/blob
 | [`pnpmfilePath`](#setting-pnpmfilepath) | `string` | Location of the pnpmfile hook file. |
 | [`globalPnpmfile`](#setting-globalpnpmfile) | `string` | Path to a second pnpmfile that runs before the project's pnpmfile. |
 | [`minimumReleaseAge`](#setting-minimumreleaseage) | `int` | Delay installation of newly published versions (minutes). |
+| [`minimumPackageAge`](#setting-minimumpackageage) | `int` | Challenge newly registered package names during `aube add` (minutes). |
 | [`minimumReleaseAgeExclude`](#setting-minimumreleaseageexclude) | `list<string>` | Packages exempt from the minimumReleaseAge requirement. |
 | [`minimumReleaseAgeStrict`](#setting-minimumreleaseagestrict) | `bool` | Fail the install when no version satisfies the minimumReleaseAge cutoff. |
 | [`securityScanner`](#setting-securityscanner) | `string` | Bun-compatible security scanner module. |
@@ -380,12 +381,30 @@ Delay installation of newly published versions (minutes).
 - Managed policy: `max`
 
 Supply-chain attack mitigation: versions published within the last N
-minutes are skipped by the resolver. `aube add` also challenges package
-names first registered inside this window, preventing a newly registered
-slopsquat from bypassing the version fallback. By default the resolver falls
-back to the next-oldest version that satisfies the range; set
+minutes are skipped by the resolver. By default the resolver falls back
+to the next-oldest version that satisfies the range; set
 `minimumReleaseAgeStrict=true` to fail the install instead. Defaults to
 24 hours, matching pnpm v11. Set to `0` to disable.
+
+### `minimumPackageAge` {#setting-minimumpackageage}
+
+Challenge newly registered package names during `aube add` (minutes).
+
+- Type: `int`
+- Default: `43200`
+- Environment: `npm_config_minimum_package_age`, `NPM_CONFIG_MINIMUM_PACKAGE_AGE`, `AUBE_MINIMUM_PACKAGE_AGE`
+- .npmrc keys: `minimumPackageAge`, `minimum-package-age`
+- Workspace YAML keys: `minimumPackageAge`
+- Managed policy: `max`
+
+Slopsquatting mitigation: `aube add` challenges public npm package names
+first registered within the last N minutes. Interactive sessions prompt
+for confirmation; non-interactive sessions fail with
+`ERR_AUBE_NEW_PACKAGE_NAME`. Defaults to 30 days, deliberately much
+longer than the 24-hour `minimumReleaseAge` quarantine for ordinary new
+versions. Existing lockfile entries and `allowedUnpopularPackages` are
+trusted. Set to `0` to disable, or pass `--allow-low-downloads` after
+verifying one new name out of band.
 
 ### `minimumReleaseAgeExclude` {#setting-minimumreleaseageexclude}
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -405,6 +405,8 @@ longer than the 24-hour `minimumReleaseAge` quarantine for ordinary new
 versions. Existing lockfile entries and `allowedUnpopularPackages` are
 trusted. Set to `0` to disable, or pass `--allow-low-downloads` after
 verifying one new name out of band.
+If npm's creation-time metadata is missing or unavailable, the check fails
+closed with `ERR_AUBE_PACKAGE_AGE_CHECK_FAILED`.
 
 ### `minimumReleaseAgeExclude` {#setting-minimumreleaseageexclude}
 

--- a/scripts/generate-primer.mjs
+++ b/scripts/generate-primer.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process'
-import { mkdir, readFile } from 'node:fs/promises'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 
 const args = new Map()
@@ -21,6 +21,10 @@ const versions = versionsArg === 'all' ? Infinity : Number(versionsArg)
 const out = resolve(args.get('out') ?? `crates/aube-resolver/data/primer-top${top}.json`)
 const namesFile = args.get('names')
 const namesUrl = args.get('names-url') ?? 'https://raw.githubusercontent.com/jdx/aube-primer-packages/main/data/packages.json'
+const popularNamesOut = args.get('popular-names-out')
+const popularNamesUrl =
+  args.get('popular-names-url') ??
+  'https://raw.githubusercontent.com/jdx/aube-primer-packages/main/data/popular.json'
 
 if (!Number.isInteger(top) || top < 1) throw new Error('--top must be a positive integer')
 if (versions !== Infinity && (!Number.isInteger(versions) || versions < 1)) {
@@ -31,6 +35,14 @@ const names = namesFile
   ? parseNames(await readFile(namesFile, 'utf8'), namesFile)
   : await fetchPopularNames(namesUrl)
 if (!Array.isArray(names)) throw new Error('package-name source must be a JSON array')
+if (popularNamesOut) {
+  const popularNames = await fetchPopularNames(popularNamesUrl)
+  if (popularNames.length !== 100000) {
+    throw new Error(`popular-name source must contain exactly 100000 names, found ${popularNames.length}`)
+  }
+  await mkdir(dirname(resolve(popularNamesOut)), { recursive: true })
+  await writeFile(resolve(popularNamesOut), `${JSON.stringify(popularNames)}\n`)
+}
 
 const primer = {}
 for (const [index, name] of names.slice(0, top).entries()) {
@@ -42,7 +54,7 @@ for (const [index, name] of names.slice(0, top).entries()) {
 await mkdir(dirname(out), { recursive: true })
 const raw = Buffer.from(`${JSON.stringify(primer)}\n`)
 if (out.endsWith('.json')) {
-  await import('node:fs/promises').then(({ writeFile }) => writeFile(out, raw))
+  await writeFile(out, raw)
 } else {
   const zstd = spawnSync('zstd', ['-q', '-19', '-f', '-o', out], { input: raw, stdio: ['pipe', 'inherit', 'inherit'] })
   if (zstd.status !== 0) throw new Error('zstd compression failed')

--- a/test/test_helper/common_setup.bash
+++ b/test/test_helper/common_setup.bash
@@ -70,12 +70,13 @@ _common_setup() {
 	# `aube add` runs supply-chain gates against public APIs
 	# (api.osv.dev for MAL-* advisories, api.npmjs.org for weekly
 	# downloads, and npmjs packuments for package-name age). Bats
-	# tests target the local Verdaccio mirror and
-	# can't depend on outbound network reachability, so disable
-	# public reputation gates wholesale. Tests that specifically exercise the
-	# gates can re-enable them in-test.
+	# tests target the local Verdaccio mirror and can't depend on
+	# outbound network reachability, so disable public reputation
+	# gates wholesale. Tests that specifically exercise the gates
+	# can re-enable them in-test.
 	export AUBE_ADVISORY_CHECK=off
 	export AUBE_LOW_DOWNLOAD_THRESHOLD=0
+	export AUBE_MINIMUM_PACKAGE_AGE=0
 }
 
 _common_teardown() {

--- a/test/test_helper/common_setup.bash
+++ b/test/test_helper/common_setup.bash
@@ -67,11 +67,12 @@ _common_setup() {
 		echo "registry=${AUBE_TEST_REGISTRY}" >"$TEST_TEMP_DIR/.npmrc"
 	fi
 
-	# `aube add` runs two supply-chain gates against public APIs
+	# `aube add` runs supply-chain gates against public APIs
 	# (api.osv.dev for MAL-* advisories, api.npmjs.org for weekly
-	# downloads). Bats tests target the local Verdaccio mirror and
+	# downloads, and npmjs packuments for package-name age). Bats
+	# tests target the local Verdaccio mirror and
 	# can't depend on outbound network reachability, so disable
-	# both gates wholesale. Tests that specifically exercise the
+	# public reputation gates wholesale. Tests that specifically exercise the
 	# gates can re-enable them in-test.
 	export AUBE_ADVISORY_CHECK=off
 	export AUBE_LOW_DOWNLOAD_THRESHOLD=0


### PR DESCRIPTION
## Summary

- quarantine newly registered public npm package names for 30 days with `minimumPackageAge`
- compare requested names against a ranked top-100,000 npm corpus using bounded Damerau-Levenshtein distance
- handle scopes deliberately: compare basenames within one scope, full names across scopes, and do not compare scoped names with unscoped names
- present “did you mean?” confirmations interactively and fail closed in non-interactive environments with stable diagnostics
- reuse cached full packuments for package creation timestamps and preserve explicit trust paths for locked packages, `allowedUnpopularPackages`, and `--allow-low-downloads`
- embed the compressed popularity corpus in release binaries and regenerate CLI, settings, security, and error-code references

## Corpus

The companion primer change is [jdx/aube-primer-packages#10](https://github.com/jdx/aube-primer-packages/pull/10). It publishes 100,000 names ranked by last-month npm downloads from the continuously updated ecosyste.ms registry index, including 52,724 scoped packages. The release workflow refreshes and embeds that names-only corpus; it does not depend on the stale `download-counts` package.

## Why

The 30-day name-age quarantine raises the cost of registering a plausible AI-hallucinated name immediately before use. The popularity comparison adds the vlt-style second signal: a new or obscure name that closely resembles an established package is challenged with a concrete suggestion before installation.

## Review feedback

- package-age verification fails closed and reuses the cached registry client path
- age probes run sequentially to bound packument memory
- the remaining refusal message now names the governing `minimumPackageAge` setting and has regression coverage

## Validation

- `cargo test`
- `cargo test -p aube add_supply_chain`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `mise run render`
- release-required corpus build with exactly 100,000 names

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes add-time supply-chain behavior and registry packument fetches on every gated `aube add`; mis-tuned similarity or age defaults could block legitimate packages, though lockfile trust and bypass flags limit blast radius.
> 
> **Overview**
> **`aube add` gains two supply-chain reputation gates** on public npmjs names (alongside OSV and low-download checks): **similar-name detection** against an embedded top-100,000 corpus, and **package-name age** via npm `time.created` against new `minimumPackageAge` (default 30 days).
> 
> The popularity list is generated in release CI (`popular-top100000-v1.json`), compressed into binaries at build time (`popular_package_names()`), with primer names as a dev fallback. Similarity uses bounded Damerau–Levenshtein with scope-aware rules (basename within a scope, full name across scopes). Interactive flows get “did you mean?” / new-name prompts; CI and non-TTY fail with `ERR_AUBE_SIMILAR_PACKAGE_NAME` / `ERR_AUBE_NEW_PACKAGE_NAME`. Missing creation metadata fails closed (`ERR_AUBE_PACKAGE_AGE_CHECK_FAILED`). **`--allow-low-downloads`** now bypasses all three reputation gates; **`allowedUnpopularPackages`** exempts similar-name, age, and download checks. Embedded hosts get new `InstallPrompt` variants. Docs, error codes, and bats setup (`AUBE_MINIMUM_PACKAGE_AGE=0`) are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9022906c9fe2fdb009c23ae57b4501cd84333548. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->