### PR TITLE
fix(config): ignore unsupported allowBuilds npmrc values

### DIFF
--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -2392,7 +2392,7 @@ install adds unreviewed build packages to workspace `allowBuilds` as
 """
 sources.cli = []
 sources.env = []
-sources.npmrc = ["allowBuilds"]
+sources.npmrc = []
 sources.workspaceYaml = ["allowBuilds"]
 examples = ['pnpm.allowBuilds: { esbuild: true, "@some/pkg": false }']
 

--- a/crates/aube/src/commands/config/mod.rs
+++ b/crates/aube/src/commands/config/mod.rs
@@ -264,6 +264,25 @@ pub(super) fn setting_for_key(key: &str) -> Option<&'static settings_meta::Setti
     })
 }
 
+/// True when an entry read from `.npmrc` is a source install actually
+/// consumes for that setting. Unknown keys remain visible so free-form
+/// config still round-trips through `config get`; known settings are only
+/// surfaced when their metadata declares the matching `.npmrc` alias.
+///
+/// The canonical-name comparison also recognizes a kebab-case spelling for
+/// settings with no `.npmrc` aliases. This keeps stale entries such as both
+/// `allowBuilds` and `allow-builds` from being reported after the setting's
+/// `.npmrc` source is removed.
+fn npmrc_entry_is_supported(key: &str) -> bool {
+    let meta = setting_for_key(key).or_else(|| {
+        let normalized = key.replace('-', "").to_ascii_lowercase();
+        settings_meta::all()
+            .iter()
+            .find(|meta| meta.name.replace('-', "").to_ascii_lowercase() == normalized)
+    });
+    meta.is_none_or(|meta| meta.npmrc_keys.iter().any(|candidate| candidate == &key))
+}
+
 pub(super) fn setting_default_value(meta: &settings_meta::SettingMeta) -> Option<String> {
     if meta.default == "undefined" || meta.default == "null" {
         return None;
@@ -381,7 +400,11 @@ pub(super) fn read_single(path: &std::path::Path) -> miette::Result<Vec<(String,
         return Ok(Vec::new());
     }
     let edit = NpmrcEdit::load(path)?;
-    Ok(edit.entries())
+    Ok(edit
+        .entries()
+        .into_iter()
+        .filter(|(key, _)| npmrc_entry_is_supported(key))
+        .collect())
 }
 
 #[cfg(test)]
@@ -429,6 +452,15 @@ mod tests {
         let aliases = resolve_aliases("autoInstallPeers");
         assert!(aliases.iter().any(|a| a == "auto-install-peers"));
         assert!(aliases.iter().any(|a| a == "autoInstallPeers"));
+    }
+
+    #[test]
+    fn npmrc_entries_only_surface_declared_sources() {
+        assert!(!npmrc_entry_is_supported("allowBuilds"));
+        assert!(!npmrc_entry_is_supported("allow-builds"));
+        assert!(npmrc_entry_is_supported("autoInstallPeers"));
+        assert!(npmrc_entry_is_supported("auto-install-peers"));
+        assert!(npmrc_entry_is_supported("some-experimental-flag"));
     }
 
     #[test]

--- a/crates/aube/src/commands/config/mod.rs
+++ b/crates/aube/src/commands/config/mod.rs
@@ -268,19 +268,9 @@ pub(super) fn setting_for_key(key: &str) -> Option<&'static settings_meta::Setti
 /// consumes for that setting. Unknown keys remain visible so free-form
 /// config still round-trips through `config get`; known settings are only
 /// surfaced when their metadata declares the matching `.npmrc` alias.
-///
-/// The canonical-name comparison also recognizes a kebab-case spelling for
-/// settings with no `.npmrc` aliases. This keeps stale entries such as both
-/// `allowBuilds` and `allow-builds` from being reported after the setting's
-/// `.npmrc` source is removed.
 fn npmrc_entry_is_supported(key: &str) -> bool {
-    let meta = setting_for_key(key).or_else(|| {
-        let normalized = key.replace('-', "").to_ascii_lowercase();
-        settings_meta::all()
-            .iter()
-            .find(|meta| meta.name.replace('-', "").to_ascii_lowercase() == normalized)
-    });
-    meta.is_none_or(|meta| meta.npmrc_keys.iter().any(|candidate| candidate == &key))
+    setting_for_key(key)
+        .is_none_or(|meta| meta.npmrc_keys.iter().any(|candidate| candidate == &key))
 }
 
 pub(super) fn setting_default_value(meta: &settings_meta::SettingMeta) -> Option<String> {
@@ -457,10 +447,11 @@ mod tests {
     #[test]
     fn npmrc_entries_only_surface_declared_sources() {
         assert!(!npmrc_entry_is_supported("allowBuilds"));
-        assert!(!npmrc_entry_is_supported("allow-builds"));
+        assert!(npmrc_entry_is_supported("allow-builds"));
         assert!(npmrc_entry_is_supported("autoInstallPeers"));
         assert!(npmrc_entry_is_supported("auto-install-peers"));
         assert!(npmrc_entry_is_supported("some-experimental-flag"));
+        assert!(npmrc_entry_is_supported("hoistworkspacepackages"));
     }
 
     #[test]

--- a/crates/aube/src/commands/config/mod.rs
+++ b/crates/aube/src/commands/config/mod.rs
@@ -269,6 +269,13 @@ pub(super) fn setting_for_key(key: &str) -> Option<&'static settings_meta::Setti
 /// config still round-trips through `config get`; known settings are only
 /// surfaced when their metadata declares the matching `.npmrc` alias.
 fn npmrc_entry_is_supported(key: &str) -> bool {
+    // `allow-builds` was auto-generated from the old `allowBuilds` metadata,
+    // so keep that historical spelling hidden after removing the unsupported
+    // `.npmrc` source. Do not normalize arbitrary keys here: unknown
+    // free-form entries must continue to round-trip.
+    if key == "allow-builds" {
+        return false;
+    }
     setting_for_key(key)
         .is_none_or(|meta| meta.npmrc_keys.iter().any(|candidate| candidate == &key))
 }
@@ -447,7 +454,7 @@ mod tests {
     #[test]
     fn npmrc_entries_only_surface_declared_sources() {
         assert!(!npmrc_entry_is_supported("allowBuilds"));
-        assert!(npmrc_entry_is_supported("allow-builds"));
+        assert!(!npmrc_entry_is_supported("allow-builds"));
         assert!(npmrc_entry_is_supported("autoInstallPeers"));
         assert!(npmrc_entry_is_supported("auto-install-peers"));
         assert!(npmrc_entry_is_supported("some-experimental-flag"));

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -2393,7 +2393,6 @@ Explicitly allow or disallow script execution per package.
 
 - Type: `object`
 - Default: `undefined`
-- .npmrc keys: `allowBuilds`, `allow-builds`
 - Workspace YAML keys: `allowBuilds`
 
 Per-package review map for dependency lifecycle scripts. Read from

--- a/test/config.bats
+++ b/test/config.bats
@@ -36,15 +36,23 @@ teardown() {
 }
 
 @test "config inspection ignores allowBuilds from .npmrc" {
-	echo 'allowBuilds={"esbuild":true}' >"$HOME/.npmrc"
+	cat >"$HOME/.npmrc" <<-'NPMRC'
+		allowBuilds={"esbuild":true}
+		allow-builds={"sharp":true}
+	NPMRC
 
 	run aube config get allowBuilds
+	assert_success
+	assert_output "undefined"
+
+	run aube config get allow-builds
 	assert_success
 	assert_output "undefined"
 
 	run aube config list --location user
 	assert_success
 	refute_output --partial "allowBuilds"
+	refute_output --partial "allow-builds"
 
 	run aube config explain allowBuilds
 	assert_success

--- a/test/config.bats
+++ b/test/config.bats
@@ -52,6 +52,18 @@ teardown() {
 	assert_output --partial "Workspace YAML keys: allowBuilds"
 }
 
+@test "config inspection preserves unknown keys that resemble known settings" {
+	echo "hoistworkspacepackages=legacy" >"$HOME/.npmrc"
+
+	run aube config get hoistworkspacepackages
+	assert_success
+	assert_output "legacy"
+
+	run aube config list --location user
+	assert_success
+	assert_line "hoistworkspacepackages=legacy"
+}
+
 @test "config get and list prefer user config.toml over user .npmrc" {
 	# Aube's own user config wins over ~/.npmrc so values aube wrote
 	# via `aube config set` are authoritative — they are not silently

--- a/test/config.bats
+++ b/test/config.bats
@@ -35,6 +35,23 @@ teardown() {
 	assert_output "true"
 }
 
+@test "config inspection ignores allowBuilds from .npmrc" {
+	echo 'allowBuilds={"esbuild":true}' >"$HOME/.npmrc"
+
+	run aube config get allowBuilds
+	assert_success
+	assert_output "undefined"
+
+	run aube config list --location user
+	assert_success
+	refute_output --partial "allowBuilds"
+
+	run aube config explain allowBuilds
+	assert_success
+	refute_output --partial ".npmrc keys"
+	assert_output --partial "Workspace YAML keys: allowBuilds"
+}
+
 @test "config get and list prefer user config.toml over user .npmrc" {
 	# Aube's own user config wins over ~/.npmrc so values aube wrote
 	# via `aube config set` are authoritative — they are not silently


### PR DESCRIPTION
## Summary

- stop advertising `.npmrc` as a supported `allowBuilds` source
- filter known `.npmrc` settings from config inspection unless their metadata declares that source
- preserve free-form unknown-key round trips and supported camel/kebab aliases
- add Rust and Bats regression coverage for `config get`, `config list`, and `config explain`

## Root cause

`aube config get` and related inspection paths merged raw `.npmrc` entries without checking whether install consumed that source. `allowBuilds` was also incorrectly tagged with an `.npmrc` source even though the build policy intentionally reads it only from workspace YAML and the project manifest. This made a user-level allowlist appear effective while install safely ignored it.

Addresses [Discussion #1158](https://github.com/jdx/aube/discussions/1158).

## Validation

- `cargo fmt --check`
- `cargo test -p aube commands::config::tests::npmrc_entries_only_surface_declared_sources`
- `mise run test:bats test/config.bats` (69 passed)
- `cargo clippy --all-targets -- -D warnings`
- `mise run render`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to config metadata and read-path filtering for inspection commands; install build policy is unchanged.
> 
> **Overview**
> **`allowBuilds` is no longer treated as a `.npmrc` source**, so docs and `config explain` only list workspace YAML (and manifest) as supported. That matches install, which never applied user-level `.npmrc` allowlists.
> 
> **Config inspection now filters `.npmrc` rows** through `npmrc_entry_is_supported`: known settings appear only when their metadata declares that exact `.npmrc` key; legacy `allow-builds` / `allowBuilds` entries are dropped from `config get` and `config list` so they no longer look effective. **Unknown free-form keys still round-trip** (e.g. `hoistworkspacepackages`).
> 
> Regression coverage was added in Rust unit tests and Bats for `config get`, `config list`, and `config explain`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80397137c3630c6898c4515cc9193fc843712c3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->