### PR TITLE
fix(list): accept --lockfile-only

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -2238,13 +2238,7 @@ Shortcut for `--format json`.
 Emit a JSON array of package entries.
 """#
     }
-    flag --lockfile-only help="List packages from the lockfile only, without checking node_modules" {
-        long_help #"""
-List packages from the lockfile only, without checking node_modules.
-
-This is a pnpm compatibility flag: aube's list implementation already reads exclusively from the canonical lockfile.
-"""#
-    }
+    flag --lockfile-only help="List packages from the lockfile only, without checking node_modules"
     flag --long help="Show version and path for each entry" {
         long_help #"""
 Show version and path for each entry.
@@ -2419,13 +2413,7 @@ Shortcut for `--format json`.
 Emit a JSON array of package entries.
 """#
     }
-    flag --lockfile-only help="List packages from the lockfile only, without checking node_modules" {
-        long_help #"""
-List packages from the lockfile only, without checking node_modules.
-
-This is a pnpm compatibility flag: aube's list implementation already reads exclusively from the canonical lockfile.
-"""#
-    }
+    flag --lockfile-only help="List packages from the lockfile only, without checking node_modules"
     flag --long help="Show version and path for each entry" {
         long_help #"""
 Show version and path for each entry.
@@ -2466,13 +2454,7 @@ Shortcut for `--format json`.
 Emit a JSON array of package entries.
 """#
     }
-    flag --lockfile-only help="List packages from the lockfile only, without checking node_modules" {
-        long_help #"""
-List packages from the lockfile only, without checking node_modules.
-
-This is a pnpm compatibility flag: aube's list implementation already reads exclusively from the canonical lockfile.
-"""#
-    }
+    flag --lockfile-only help="List packages from the lockfile only, without checking node_modules"
     flag --long help="Show version and path for each entry" {
         long_help #"""
 Show version and path for each entry.

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -2350,7 +2350,7 @@ The registry lives at `$AUBE_HOME/global-links`. Default behavior for bare `aube
     }
     arg "[PACKAGE]" help="Package name, or path to a local directory" required=#false
 }
-cmd list help="Print the installed dependency tree" effect=read {
+cmd list help="Print the resolved dependency tree" effect=read {
     alias ls
     after_long_help #"""
 Examples:

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -2238,6 +2238,13 @@ Shortcut for `--format json`.
 Emit a JSON array of package entries.
 """#
     }
+    flag --lockfile-only help="List packages from the lockfile only, without checking node_modules" {
+        long_help #"""
+List packages from the lockfile only, without checking node_modules.
+
+This is a pnpm compatibility flag: aube's list implementation already reads exclusively from the canonical lockfile.
+"""#
+    }
     flag --long help="Show version and path for each entry" {
         long_help #"""
 Show version and path for each entry.
@@ -2412,6 +2419,13 @@ Shortcut for `--format json`.
 Emit a JSON array of package entries.
 """#
     }
+    flag --lockfile-only help="List packages from the lockfile only, without checking node_modules" {
+        long_help #"""
+List packages from the lockfile only, without checking node_modules.
+
+This is a pnpm compatibility flag: aube's list implementation already reads exclusively from the canonical lockfile.
+"""#
+    }
     flag --long help="Show version and path for each entry" {
         long_help #"""
 Show version and path for each entry.
@@ -2450,6 +2464,13 @@ How deep to render the transitive tree.
 Shortcut for `--format json`.
 
 Emit a JSON array of package entries.
+"""#
+    }
+    flag --lockfile-only help="List packages from the lockfile only, without checking node_modules" {
+        long_help #"""
+List packages from the lockfile only, without checking node_modules.
+
+This is a pnpm compatibility flag: aube's list implementation already reads exclusively from the canonical lockfile.
 """#
     }
     flag --long help="Show version and path for each entry" {

--- a/crates/aube/src/commands/list.rs
+++ b/crates/aube/src/commands/list.rs
@@ -93,19 +93,19 @@ pub struct ListArgs {
     #[arg(long, conflicts_with = "format")]
     pub json: bool,
 
-    /// Show version and path for each entry.
-    ///
-    /// Default output is already name + version; `--long` adds the
-    /// store path for debugging.
-    #[arg(long)]
-    pub long: bool,
-
     /// List packages from the lockfile only, without checking node_modules.
     ///
     /// This is a pnpm compatibility flag: aube's list implementation
     /// already reads exclusively from the canonical lockfile.
     #[arg(long)]
     pub lockfile_only: bool,
+
+    /// Show version and path for each entry.
+    ///
+    /// Default output is already name + version; `--long` adds the
+    /// store path for debugging.
+    #[arg(long)]
+    pub long: bool,
 
     /// Shortcut for `--format parseable`.
     ///

--- a/crates/aube/src/commands/list.rs
+++ b/crates/aube/src/commands/list.rs
@@ -100,6 +100,13 @@ pub struct ListArgs {
     #[arg(long)]
     pub long: bool,
 
+    /// List packages from the lockfile only, without checking node_modules.
+    ///
+    /// This is a pnpm compatibility flag: aube's list implementation
+    /// already reads exclusively from the canonical lockfile.
+    #[arg(long)]
+    pub lockfile_only: bool,
+
     /// Shortcut for `--format parseable`.
     ///
     /// Emit one tab-separated line per package.
@@ -162,6 +169,8 @@ pub async fn run(
     args: ListArgs,
     filter: aube_workspace::selector::EffectiveFilter,
 ) -> miette::Result<()> {
+    let _ = args.lockfile_only;
+
     if args.global {
         return run_global(&args);
     }
@@ -1005,6 +1014,7 @@ mod tests {
             format: ListFormat::Json,
             json: true,
             long: false,
+            lockfile_only: false,
             parseable: false,
         };
 

--- a/crates/aube/src/commands/list.rs
+++ b/crates/aube/src/commands/list.rs
@@ -1,4 +1,4 @@
-//! `aube list` / `ls` — print the installed dependency tree.
+//! `aube list` / `ls` — print the resolved dependency tree.
 //!
 //! Reads `package.json` and the lockfile, walks the resolved graph, and
 //! prints the root importer's direct deps (and optionally their transitive

--- a/crates/aube/src/commands/list.rs
+++ b/crates/aube/src/commands/list.rs
@@ -93,10 +93,8 @@ pub struct ListArgs {
     #[arg(long, conflicts_with = "format")]
     pub json: bool,
 
+    // Compatibility flag: aube already reads exclusively from the canonical lockfile.
     /// List packages from the lockfile only, without checking node_modules.
-    ///
-    /// This is a pnpm compatibility flag: aube's list implementation
-    /// already reads exclusively from the canonical lockfile.
     #[arg(long)]
     pub lockfile_only: bool,
 

--- a/crates/aube/src/lib.rs
+++ b/crates/aube/src/lib.rs
@@ -407,7 +407,7 @@ enum Commands {
     /// Link a local package globally, or into the current project
     #[command(visible_alias = "ln")]
     Link(commands::link::LinkArgs),
-    /// Print the installed dependency tree
+    /// Print the resolved dependency tree
     #[command(visible_alias = "ls", after_long_help = commands::list::AFTER_LONG_HELP)]
     List(commands::list::ListArgs),
     /// Alias for `list --long` (hidden; prefer `list --long`)

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -6519,7 +6519,6 @@
             "name": "lockfile-only",
             "usage": "--lockfile-only",
             "help": "List packages from the lockfile only, without checking node_modules",
-            "help_long": "List packages from the lockfile only, without checking node_modules.\n\nThis is a pnpm compatibility flag: aube's list implementation already reads exclusively from the canonical lockfile.",
             "help_first_line": "List packages from the lockfile only, without checking node_modules",
             "short": [],
             "long": [
@@ -6947,7 +6946,6 @@
             "name": "lockfile-only",
             "usage": "--lockfile-only",
             "help": "List packages from the lockfile only, without checking node_modules",
-            "help_long": "List packages from the lockfile only, without checking node_modules.\n\nThis is a pnpm compatibility flag: aube's list implementation already reads exclusively from the canonical lockfile.",
             "help_first_line": "List packages from the lockfile only, without checking node_modules",
             "short": [],
             "long": [
@@ -7125,7 +7123,6 @@
             "name": "lockfile-only",
             "usage": "--lockfile-only",
             "help": "List packages from the lockfile only, without checking node_modules",
-            "help_long": "List packages from the lockfile only, without checking node_modules.\n\nThis is a pnpm compatibility flag: aube's list implementation already reads exclusively from the canonical lockfile.",
             "help_first_line": "List packages from the lockfile only, without checking node_modules",
             "short": [],
             "long": [

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -6516,6 +6516,19 @@
             "global": false
           },
           {
+            "name": "lockfile-only",
+            "usage": "--lockfile-only",
+            "help": "List packages from the lockfile only, without checking node_modules",
+            "help_long": "List packages from the lockfile only, without checking node_modules.\n\nThis is a pnpm compatibility flag: aube's list implementation already reads exclusively from the canonical lockfile.",
+            "help_first_line": "List packages from the lockfile only, without checking node_modules",
+            "short": [],
+            "long": [
+              "lockfile-only"
+            ],
+            "hide": false,
+            "global": false
+          },
+          {
             "name": "long",
             "usage": "--long",
             "help": "Show version and path for each entry",
@@ -6931,6 +6944,19 @@
             "global": false
           },
           {
+            "name": "lockfile-only",
+            "usage": "--lockfile-only",
+            "help": "List packages from the lockfile only, without checking node_modules",
+            "help_long": "List packages from the lockfile only, without checking node_modules.\n\nThis is a pnpm compatibility flag: aube's list implementation already reads exclusively from the canonical lockfile.",
+            "help_first_line": "List packages from the lockfile only, without checking node_modules",
+            "short": [],
+            "long": [
+              "lockfile-only"
+            ],
+            "hide": false,
+            "global": false
+          },
+          {
             "name": "long",
             "usage": "--long",
             "help": "Show version and path for each entry",
@@ -7091,6 +7117,19 @@
             "short": [],
             "long": [
               "json"
+            ],
+            "hide": false,
+            "global": false
+          },
+          {
+            "name": "lockfile-only",
+            "usage": "--lockfile-only",
+            "help": "List packages from the lockfile only, without checking node_modules",
+            "help_long": "List packages from the lockfile only, without checking node_modules.\n\nThis is a pnpm compatibility flag: aube's list implementation already reads exclusively from the canonical lockfile.",
+            "help_first_line": "List packages from the lockfile only, without checking node_modules",
+            "short": [],
+            "long": [
+              "lockfile-only"
             ],
             "hide": false,
             "global": false

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -6984,7 +6984,7 @@
         "mounts": [],
         "effect": "read",
         "hide": false,
-        "help": "Print the installed dependency tree",
+        "help": "Print the resolved dependency tree",
         "name": "list",
         "aliases": [
           "ls"

--- a/docs/cli/list.md
+++ b/docs/cli/list.md
@@ -55,9 +55,7 @@ Emit a JSON array of package entries.
 
 ### `--lockfile-only`
 
-List packages from the lockfile only, without checking node_modules.
-
-This is a pnpm compatibility flag: aube's list implementation already reads exclusively from the canonical lockfile.
+List packages from the lockfile only, without checking node_modules
 
 ### `--long`
 

--- a/docs/cli/list.md
+++ b/docs/cli/list.md
@@ -5,7 +5,7 @@
 - **Aliases**: `ls`
 - **Effect**: read-only
 
-Print the installed dependency tree
+Print the resolved dependency tree
 
 ## Arguments
 

--- a/docs/cli/list.md
+++ b/docs/cli/list.md
@@ -53,6 +53,12 @@ Shortcut for `--format json`.
 
 Emit a JSON array of package entries.
 
+### `--lockfile-only`
+
+List packages from the lockfile only, without checking node_modules.
+
+This is a pnpm compatibility flag: aube's list implementation already reads exclusively from the canonical lockfile.
+
 ### `--long`
 
 Show version and path for each entry.

--- a/test/list.bats
+++ b/test/list.bats
@@ -168,6 +168,27 @@ JSON
 	assert_output --partial "ok"
 }
 
+@test "aube list --lockfile-only reads the lockfile without node_modules" {
+	cat >package.json <<'JSON'
+{
+  "name": "list-lockfile-only",
+  "version": "1.0.0",
+  "devDependencies": {
+    "is-odd": "3.0.1"
+  }
+}
+JSON
+
+	run aube install --lockfile-only
+	assert_success
+	[ ! -e node_modules ]
+
+	run aube list --json --lockfile-only is-odd
+	assert_success
+	assert_output --partial '"is-odd"'
+	assert_output --partial '"version": "3.0.1"'
+}
+
 @test "aube list --parseable emits tab-separated lines" {
 	_setup_mixed_fixture
 	run aube list --parseable

--- a/test/list.bats
+++ b/test/list.bats
@@ -185,6 +185,7 @@ JSON
 
 	run aube list --json --lockfile-only is-odd
 	assert_success
+	[ ! -e node_modules ]
 	assert_output --partial '"is-odd"'
 	assert_output --partial '"version": "3.0.1"'
 }


### PR DESCRIPTION
## Summary

- accept `--lockfile-only` on `aube list` / `ls`
- document that the flag is a compatibility no-op because aube already reads exclusively from the canonical lockfile
- cover listing a filtered dependency from a lockfile when `node_modules` does not exist

## Why

pnpm added `list --lockfile-only` in v10.23.0, and CI scripts use it to inspect the wanted dependency version without requiring an installation. Aube already has the required lockfile-backed behavior, but clap rejected the flag before the list command could run.

## Validation

- `cargo fmt --check`
- `cargo test -p aube commands::list::tests`
- `cargo clippy -p aube --all-targets -- -D warnings`
- `mise run test:bats test/list.bats --filter 'aube list --lockfile-only reads the lockfile without node_modules'`

The complete `test/list.bats` file ran the new regression successfully; one pre-existing JSON test could not invoke `node` because the local mise `node` shim is unavailable.

Fixes discussion #1160.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only CLI compatibility and documentation; no change to list resolution logic beyond accepting the new flag.
> 
> **Overview**
> Adds **`--lockfile-only`** to **`aube list`** (and hidden **`la`** / **`ll`** aliases) so scripts that pass the pnpm v10.23+ flag no longer fail at parse time. The flag is documented as a **compatibility no-op**: list already walks the canonical lockfile and does not require **`node_modules`**.
> 
> CLI help and docs now describe the command as printing the **resolved** dependency tree instead of the **installed** tree, matching lockfile-backed behavior.
> 
> A bats regression covers **`install --lockfile-only`** followed by **`list --json --lockfile-only`** with no **`node_modules`** on disk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e622be86439a7e3ecad59e1daf45d251c6b7da5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--lockfile-only` option to `list` (including `la`/`ll` aliases) to list the resolved dependency tree from the lockfile only.
  * `list` output help now describes the **resolved dependency tree** (not the installed one).

* **Tests**
  * Added coverage to ensure `--lockfile-only` does not create `node_modules` and that `--json` output includes expected entries.

* **Documentation**
  * Updated CLI usage/help and `list` docs to document `--lockfile-only` and the resolved-dependency wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->