### PR TITLE
fix(clean): preserve third-party caches

### DIFF
--- a/crates/aube/src/commands/check.rs
+++ b/crates/aube/src/commands/check.rs
@@ -197,18 +197,7 @@ fn is_link_or_junction(path: &Path) -> bool {
         // half-created or permission-restricted entry.
         return true;
     };
-    if md.file_type().is_symlink() {
-        return true;
-    }
-    #[cfg(windows)]
-    {
-        use std::os::windows::fs::MetadataExt;
-        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
-        if md.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
-            return true;
-        }
-    }
-    false
+    super::is_link_or_junction_metadata(&md)
 }
 
 /// Inspect one package's `package.json` and check that each declared

--- a/crates/aube/src/commands/clean.rs
+++ b/crates/aube/src/commands/clean.rs
@@ -6,7 +6,9 @@
 //!   invoked as `aube purge`) script, delegate to `aube run <name>` and
 //!   do nothing else. User scripts always win.
 //! - Otherwise, walk the workspace (root + every package matched by
-//!   `pnpm-workspace.yaml`) and delete each project's `node_modules/`.
+//!   `pnpm-workspace.yaml`) and delete installed packages plus aube-owned
+//!   hidden entries from each project's `node_modules/`. Third-party hidden
+//!   entries such as `.vite/` are preserved.
 //! - With `--lockfile` / `-l`, also remove the root lockfiles:
 //!   `aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`,
 //!   `npm-shrinkwrap.json`, `yarn.lock`, and `bun.lock`. Workspace
@@ -17,6 +19,7 @@
 //! tree" command.
 
 use clap::Args;
+use miette::{Context, IntoDiagnostic};
 
 #[derive(Debug, Args)]
 pub struct CleanArgs {
@@ -42,6 +45,20 @@ fn lockfile_names() -> [&'static str; 6] {
         "yarn.lock",
         "bun.lock",
     ]
+}
+
+fn is_managed_modules_entry(name: &std::ffi::OsStr) -> bool {
+    let name = name.to_string_lossy();
+    let Some(hidden_name) = name.strip_prefix('.') else {
+        return true;
+    };
+
+    let embedder_name = aube_util::embedder().name;
+    hidden_name == "bin"
+        || hidden_name == "modules.yaml"
+        || hidden_name
+            .strip_prefix(embedder_name)
+            .is_some_and(|suffix| matches!(suffix, "" | "-state" | "-applied-patches.json"))
 }
 
 pub async fn run(args: CleanArgs) -> miette::Result<Option<i32>> {
@@ -116,13 +133,46 @@ async fn run_as(invoked_as: &str, args: CleanArgs) -> miette::Result<Option<i32>
     let modules_dir_name = super::resolve_modules_dir_name_for_cwd(&cwd);
     for proj in &projects {
         let nm = proj.join(&modules_dir_name);
-        // `symlink_metadata` so a `node_modules -> somewhere` symlink
-        // gets removed as a link (not followed into its target).
-        if nm.symlink_metadata().is_ok() {
+        let metadata = match nm.symlink_metadata() {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(error)
+                    .into_diagnostic()
+                    .wrap_err_with(|| format!("failed to inspect {}", nm.display()));
+            }
+        };
+
+        // A non-directory or directory link is wholly install-managed.
+        // Remove the entry itself without traversing a symlink/junction target.
+        if !metadata.is_dir() || metadata.file_type().is_symlink() {
             eprintln!("Removing {}", nm.display());
             super::remove_existing(&nm)?;
             removed_nm += 1;
+            continue;
         }
+
+        let mut managed_entries = Vec::new();
+        for entry in std::fs::read_dir(&nm)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to read {}", nm.display()))?
+        {
+            let entry = entry
+                .into_diagnostic()
+                .wrap_err_with(|| format!("failed to read an entry in {}", nm.display()))?;
+            if is_managed_modules_entry(&entry.file_name()) {
+                managed_entries.push(entry.path());
+            }
+        }
+        if managed_entries.is_empty() {
+            continue;
+        }
+
+        eprintln!("Removing {}", nm.display());
+        for entry in managed_entries {
+            super::remove_existing(&entry)?;
+        }
+        removed_nm += 1;
     }
 
     if args.lockfile {

--- a/crates/aube/src/commands/clean.rs
+++ b/crates/aube/src/commands/clean.rs
@@ -56,6 +56,8 @@ fn is_managed_modules_entry(name: &std::ffi::OsStr) -> bool {
     let embedder_name = aube_util::embedder().name;
     hidden_name == "bin"
         || hidden_name == "modules.yaml"
+        || hidden_name == "pnpm"
+        || hidden_name == "pnpm-workspace-state-v1.json"
         || hidden_name
             .strip_prefix(embedder_name)
             .is_some_and(|suffix| matches!(suffix, "" | "-state" | "-applied-patches.json"))
@@ -145,7 +147,7 @@ async fn run_as(invoked_as: &str, args: CleanArgs) -> miette::Result<Option<i32>
 
         // A non-directory or directory link is wholly install-managed.
         // Remove the entry itself without traversing a symlink/junction target.
-        if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        if !metadata.is_dir() || super::is_link_or_junction_metadata(&metadata) {
             eprintln!("Removing {}", nm.display());
             super::remove_existing(&nm)?;
             removed_nm += 1;

--- a/crates/aube/src/commands/fs_helpers.rs
+++ b/crates/aube/src/commands/fs_helpers.rs
@@ -25,16 +25,33 @@ pub(crate) fn format_virtual_store_display_prefix(
     format!("{}/", aube_dir.display())
 }
 
+/// Whether metadata describes a POSIX symlink, Windows symlink, or NTFS
+/// junction. Rust reports junctions as directories rather than symlinks, so
+/// Windows callers must also inspect the reparse-point attribute before
+/// traversing a path.
+pub(crate) fn is_link_or_junction_metadata(metadata: &std::fs::Metadata) -> bool {
+    if metadata.file_type().is_symlink() {
+        return true;
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+        if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            return true;
+        }
+    }
+    false
+}
+
 /// Remove an existing file/dir/symlink at the given path, if present.
 ///
-/// Windows quirk: directory junctions and directory symlinks report as
-/// symlinks via `symlink_metadata`, but `std::fs::remove_file` returns
-/// `Access is denied (os error 5)` for them — the Win32 `DeleteFile`
-/// syscall only works on file-shaped entries. The link entry has to be
-/// torn down with `RemoveDirectory` (= `std::fs::remove_dir`), which is
-/// non-recursive and so leaves the junction target untouched. Falling
-/// back on `remove_file` failure keeps every other platform on the
-/// usual single-syscall path.
+/// Windows quirk: directory symlinks report as symlinks, while NTFS junctions
+/// report as directories. `remove_dir_all` handles the latter without
+/// traversing the reparse point. For directory symlinks, `remove_file` may
+/// return `Access is denied (os error 5)` because Win32 requires
+/// `RemoveDirectory` for directory-shaped links, so fall back to
+/// `std::fs::remove_dir`.
 pub(crate) fn remove_existing(path: &std::path::Path) -> miette::Result<()> {
     let Ok(md) = path.symlink_metadata() else {
         return Ok(());
@@ -84,6 +101,9 @@ mod tests {
         #[cfg(windows)]
         aube_linker::create_dir_link(&target, &link).unwrap();
 
+        assert!(is_link_or_junction_metadata(
+            &link.symlink_metadata().unwrap()
+        ));
         remove_existing(&link).unwrap();
         assert!(!link.exists());
         assert!(

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -119,7 +119,9 @@ pub(crate) fn settings_hoisting_limits_to_linker(
 }
 pub(crate) use catalog_discovery::{CatalogMap, discover_catalogs, load_workspace_catalogs};
 pub(crate) use dep_filter::DepFilter;
-pub(crate) use fs_helpers::{format_virtual_store_display_prefix, remove_existing, symlink_dir};
+pub(crate) use fs_helpers::{
+    format_virtual_store_display_prefix, is_link_or_junction_metadata, remove_existing, symlink_dir,
+};
 pub(crate) use manifest_io::{
     load_manifest, load_manifest_or_default, update_manifest_json_object,
     write_manifest_dep_sections, write_manifest_json,

--- a/test/clean.bats
+++ b/test/clean.bats
@@ -45,10 +45,11 @@ EOF
 	cat >package.json <<'EOF'
 {"name":"demo","version":"1.0.0"}
 EOF
-	mkdir -p node_modules/foo node_modules/.aube node_modules/.bin \
+	mkdir -p node_modules/foo node_modules/.aube node_modules/.bin node_modules/.pnpm \
 		node_modules/.aube-state node_modules/.vite/deps node_modules/.vite-temp
 	: >node_modules/.modules.yaml
 	: >node_modules/.aube-applied-patches.json
+	: >node_modules/.pnpm-workspace-state-v1.json
 	: >node_modules/.vite/deps/cache
 	: >node_modules/.vite-temp/cache
 
@@ -61,6 +62,8 @@ EOF
 	assert [ ! -e node_modules/.aube-state ]
 	assert [ ! -e node_modules/.modules.yaml ]
 	assert [ ! -e node_modules/.aube-applied-patches.json ]
+	assert [ ! -e node_modules/.pnpm ]
+	assert [ ! -e node_modules/.pnpm-workspace-state-v1.json ]
 	assert [ -e node_modules/.vite/deps/cache ]
 	assert [ -e node_modules/.vite-temp/cache ]
 }

--- a/test/clean.bats
+++ b/test/clean.bats
@@ -37,7 +37,32 @@ EOF
 	run aube clean
 	assert_success
 	assert_output --partial "Removed 1 node_modules"
-	assert [ ! -e node_modules ]
+	assert [ -d node_modules ]
+	assert [ ! -e node_modules/foo ]
+}
+
+@test "aube clean preserves third-party caches and removes aube-owned hidden entries" {
+	cat >package.json <<'EOF'
+{"name":"demo","version":"1.0.0"}
+EOF
+	mkdir -p node_modules/foo node_modules/.aube node_modules/.bin \
+		node_modules/.aube-state node_modules/.vite/deps node_modules/.vite-temp
+	: >node_modules/.modules.yaml
+	: >node_modules/.aube-applied-patches.json
+	: >node_modules/.vite/deps/cache
+	: >node_modules/.vite-temp/cache
+
+	run aube clean
+	assert_success
+	assert [ -d node_modules ]
+	assert [ ! -e node_modules/foo ]
+	assert [ ! -e node_modules/.aube ]
+	assert [ ! -e node_modules/.bin ]
+	assert [ ! -e node_modules/.aube-state ]
+	assert [ ! -e node_modules/.modules.yaml ]
+	assert [ ! -e node_modules/.aube-applied-patches.json ]
+	assert [ -e node_modules/.vite/deps/cache ]
+	assert [ -e node_modules/.vite-temp/cache ]
 }
 
 @test "aube clean --lockfile also removes the root lockfile(s)" {
@@ -74,14 +99,17 @@ EOF
 	cat >packages/b/package.json <<'EOF'
 {"name":"b","version":"1.0.0"}
 EOF
-	mkdir -p node_modules packages/a/node_modules packages/b/node_modules
+	mkdir -p node_modules/foo packages/a/node_modules/foo packages/b/node_modules/foo
 
 	run aube clean
 	assert_success
 	assert_output --partial "Removed 3 node_modules"
-	assert [ ! -e node_modules ]
-	assert [ ! -e packages/a/node_modules ]
-	assert [ ! -e packages/b/node_modules ]
+	assert [ -d node_modules ]
+	assert [ -d packages/a/node_modules ]
+	assert [ -d packages/b/node_modules ]
+	assert [ ! -e node_modules/foo ]
+	assert [ ! -e packages/a/node_modules/foo ]
+	assert [ ! -e packages/b/node_modules/foo ]
 }
 
 @test "aube clean defers to a user-defined clean script" {
@@ -127,7 +155,7 @@ EOF
 	cat >package.json <<'EOF'
 {"name":"demo","version":"1.0.0"}
 EOF
-	mkdir -p node_modules
+	mkdir -p node_modules/foo
 
 	run aube clean --lockfile
 	assert_success
@@ -139,12 +167,13 @@ EOF
 	cat >package.json <<'EOF'
 {"name":"demo","version":"1.0.0"}
 EOF
-	mkdir -p node_modules
+	mkdir -p node_modules/foo
 
 	run aube purge
 	assert_success
 	assert_output --partial "Removed 1 node_modules"
-	assert [ ! -e node_modules ]
+	assert [ -d node_modules ]
+	assert [ ! -e node_modules/foo ]
 }
 
 @test "aube purge defers to a user-defined purge script" {


### PR DESCRIPTION
## Summary

- remove installed packages and Aube-owned metadata entry-by-entry during `clean`
- preserve third-party hidden entries such as Vite's `.vite` and `.vite-temp` caches
- keep symlink and junction cleanup safe by removing a linked modules directory itself
- add workspace and cache-preservation regression coverage

## Why

`aube clean` passed the entire modules directory to the generic removal helper. That deleted caches owned by other tools and diverged from pnpm, which preserves unrecognized hidden entries.

This fixes the behavior reported in [discussion #1162](https://github.com/jdx/aube/discussions/1162).

## Validation

- `mise run test:bats test/clean.bats`
- `cargo test -p aube`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default clean behavior for every workspace package and touches filesystem removal paths (including Windows junctions), though behavior is covered by updated bats and existing `remove_existing` tests.
> 
> **Overview**
> **`aube clean` / `purge` no longer deletes whole `node_modules/` trees** when the modules directory is a normal folder. It now removes only install-managed content: top-level packages/scopes plus Aube/pnpm-owned hidden entries (e.g. `.bin`, `.aube`, `.pnpm`, `.modules.yaml`), while leaving unrecognized dotdirs such as **`.vite/`** and **`.vite-temp/`** in place—matching pnpm-style semantics and fixing wiped tool caches.
> 
> When `node_modules` is a **symlink, junction, or non-directory**, clean still removes that entry wholesale without walking the link target. Inspect/read errors on missing dirs are skipped; other I/O failures surface with context.
> 
> Shared **`is_link_or_junction_metadata`** in `fs_helpers` centralizes Windows reparse-point detection; **`aube check`** uses it instead of duplicating logic. Bats tests were updated so the empty `node_modules` shell remains after clean, with new regression coverage for cache preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65bebc15325eebece1ef3039ba1e51e4551b2c66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->