### PR TITLE
ci: use mise native cargo installer

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -39,38 +39,6 @@ checksum = "sha256:6e7241b51e6817ea6a047693d8e6fed13b31819c9a0dd6c5a726e1592d22f
 url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_windows_amd64.zip"
 provenance = "github-attestations"
 
-[[tools.cargo-binstall]]
-version = "1.18.1"
-backend = "aqua:cargo-bins/cargo-binstall"
-
-[tools.cargo-binstall."platforms.linux-arm64"]
-checksum = "sha256:c55962a0115f9716b709216de7f8bdd59d6ba8738779e60b051b4593f677717a"
-url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-aarch64-unknown-linux-musl.tgz"
-
-[tools.cargo-binstall."platforms.linux-arm64-musl"]
-checksum = "sha256:c55962a0115f9716b709216de7f8bdd59d6ba8738779e60b051b4593f677717a"
-url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-aarch64-unknown-linux-musl.tgz"
-
-[tools.cargo-binstall."platforms.linux-x64"]
-checksum = "sha256:cf2a4b54494ea8555d6349685e9a301efc1051d9fba6308c76914b2486f8700f"
-url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-x86_64-unknown-linux-musl.tgz"
-
-[tools.cargo-binstall."platforms.linux-x64-musl"]
-checksum = "sha256:cf2a4b54494ea8555d6349685e9a301efc1051d9fba6308c76914b2486f8700f"
-url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-x86_64-unknown-linux-musl.tgz"
-
-[tools.cargo-binstall."platforms.macos-arm64"]
-checksum = "sha256:955abf167994c90f3547e233edace4c0f794465dd4aa408249b38999aa5ca3cf"
-url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-aarch64-apple-darwin.zip"
-
-[tools.cargo-binstall."platforms.macos-x64"]
-checksum = "sha256:e06370bec7143668653bb7c09d0b8b689fc703dd4fa58ec5847c4b571d8a490d"
-url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-x86_64-apple-darwin.zip"
-
-[tools.cargo-binstall."platforms.windows-x64"]
-checksum = "sha256:89706aa5215c164d8d091597a470fee72308ac87e8553af395ea77db844a888c"
-url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.18.1/cargo-binstall-x86_64-pc-windows-msvc.zip"
-
 [[tools.communique]]
 version = "1.2.3"
 backend = "github:jdx/communique"

--- a/mise.toml
+++ b/mise.toml
@@ -1,9 +1,12 @@
 [env]
 _.path = ["./bin"]
 
+[settings]
+experimental = true
+cargo.binstall_native = true
+
 [tools]
 actionlint = "latest"
-cargo-binstall = "latest"
 communique = "latest"
 "github:bnjbvr/cargo-machete" = "latest"
 "github:foresterre/cargo-msrv" = "latest"


### PR DESCRIPTION
## Summary

- remove the standalone `cargo-binstall` tool and its lockfile artifacts
- enable mise’s experimental native Cargo binary installer
- retain source compilation as mise’s fallback when no native artifact is available

This avoids making every CI job depend on downloading `cargo-binstall` before setup can proceed. The repository’s current tools already use direct Aqua, GitHub, or core backends.

## Validation

- `mise settings --json` reports `experimental: true` and `cargo.binstall_native: true`
- isolated `mise install --locked --dry-run` succeeds without a global mise config
- `mise lock --dry-run --json` reports no pending lockfile changes
- `git diff --check`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Cargo-based tools are installed in CI/dev (experimental mise path); misconfiguration could break tool installs, but scope is limited to mise bootstrap, not app runtime.
> 
> **Overview**
> **CI/tooling** stops bootstrapping the standalone `cargo-binstall` tool and instead turns on mise’s experimental native Cargo binary installer via `experimental = true` and `cargo.binstall_native = true` in `mise.toml`.
> 
> The `cargo-binstall = "latest"` tool entry is removed, and the corresponding `[[tools.cargo-binstall]]` block (all platform checksums/URLs) is dropped from `mise.lock`. Other locked tools are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e766f6ed1e367eb78283bb8f065b4c5acb8c0da5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->