### PR TITLE
fix(update): update catalog entries selected for upgrade

### DIFF
--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -538,6 +538,38 @@ updateConfig:
     }
 
     #[test]
+    fn edit_workspace_yaml_invalidates_loaded_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("aube-workspace.yaml");
+        std::fs::write(&path, "catalog:\n  is-odd: 0.1.2\n").unwrap();
+
+        let before = WorkspaceConfig::load(dir.path()).unwrap();
+        assert_eq!(
+            before.catalog.get("is-odd").map(String::as_str),
+            Some("0.1.2")
+        );
+
+        edit_workspace_yaml(&path, |map| {
+            let catalog = map
+                .get_mut(yaml_serde::Value::String("catalog".to_string()))
+                .and_then(yaml_serde::Value::as_mapping_mut)
+                .unwrap();
+            catalog.insert(
+                yaml_serde::Value::String("is-odd".to_string()),
+                yaml_serde::Value::String("3.0.1".to_string()),
+            );
+            Ok(())
+        })
+        .unwrap();
+
+        let after = WorkspaceConfig::load(dir.path()).unwrap();
+        assert_eq!(
+            after.catalog.get("is-odd").map(String::as_str),
+            Some("3.0.1")
+        );
+    }
+
+    #[test]
     fn edit_workspace_yaml_preserves_comments_around_unchanged_keys() {
         // The whole point of going through yamlpatch: a structural
         // change to one key must not strip comments attached to keys

--- a/crates/aube-manifest/src/workspace/config.rs
+++ b/crates/aube-manifest/src/workspace/config.rs
@@ -719,6 +719,19 @@ fn typed_cache_insert(project_dir: &Path, value: WorkspaceConfig) {
     }
 }
 
+pub(super) fn invalidate_cache(project_dir: &Path) {
+    if let Some(cache) = TYPED_CACHE.get()
+        && let Ok(mut cache) = cache.lock()
+    {
+        cache.remove(project_dir);
+    }
+    if let Some(cache) = RAW_CACHE.get()
+        && let Ok(mut cache) = cache.lock()
+    {
+        cache.remove(project_dir);
+    }
+}
+
 /// Load the workspace yaml as a raw top-level key/value map, without
 /// coercing into `WorkspaceConfig`'s typed fields. Intended for
 /// metadata-driven setting resolution (see `aube-settings`), where

--- a/crates/aube-manifest/src/workspace/edits.rs
+++ b/crates/aube-manifest/src/workspace/edits.rs
@@ -377,6 +377,9 @@ where
 
     let after = std::mem::take(map);
     write_workspace_yaml(path, original_source.as_deref(), &before, &after)?;
+    if let Some(project_dir) = path.parent() {
+        super::config::invalidate_cache(project_dir);
+    }
     Ok(path.to_path_buf())
 }
 

--- a/crates/aube/src/commands/catalog_discovery.rs
+++ b/crates/aube/src/commands/catalog_discovery.rs
@@ -1,5 +1,14 @@
 use miette::{Context, IntoDiagnostic};
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum CatalogSource {
+    WorkspaceYaml(std::path::PathBuf),
+    PackageJson {
+        path: std::path::PathBuf,
+        namespace: String,
+    },
+}
+
 /// Type alias for the catalog map the resolver consumes — outer key is
 /// the catalog name (`default` for the unnamed catalog), inner map goes
 /// from package name to version range.
@@ -102,4 +111,77 @@ pub(crate) fn discover_catalogs(project_root: &std::path::Path) -> miette::Resul
 /// [`discover_catalogs`] so every command sees the same merged view.
 pub(crate) fn load_workspace_catalogs(cwd: &std::path::Path) -> miette::Result<CatalogMap> {
     discover_catalogs(cwd)
+}
+
+fn manifest_catalog_source(
+    path: &std::path::Path,
+    catalog: &str,
+    package: &str,
+) -> Option<CatalogSource> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&content).ok()?;
+    let root = json.as_object()?;
+    let mut source = None;
+    let id = aube_util::embedder();
+    let namespaces = std::iter::once("workspaces")
+        .chain(id.compatible_names.iter().copied())
+        .chain((!id.manifest_namespace.is_empty()).then_some(id.manifest_namespace));
+    for namespace in namespaces {
+        let Some(config) = root.get(namespace).and_then(serde_json::Value::as_object) else {
+            continue;
+        };
+        let entries = if catalog == "default" {
+            config.get("catalog").and_then(serde_json::Value::as_object)
+        } else {
+            config
+                .get("catalogs")
+                .and_then(serde_json::Value::as_object)
+                .and_then(|catalogs| catalogs.get(catalog))
+                .and_then(serde_json::Value::as_object)
+        };
+        if entries.is_some_and(|entries| entries.contains_key(package)) {
+            source = Some(CatalogSource::PackageJson {
+                path: path.to_path_buf(),
+                namespace: namespace.to_string(),
+            });
+        }
+    }
+    source
+}
+
+/// Locate the highest-precedence source that supplied one catalog entry.
+pub(crate) fn catalog_entry_source(
+    project_root: &std::path::Path,
+    catalog: &str,
+    package: &str,
+) -> Option<CatalogSource> {
+    let project_manifest = project_root.join("package.json");
+    let mut source = manifest_catalog_source(&project_manifest, catalog, package);
+    let workspace_root = crate::dirs::find_workspace_root(project_root);
+    if let Some(root) = &workspace_root
+        && root != project_root
+        && let Some(root_source) =
+            manifest_catalog_source(&root.join("package.json"), catalog, package)
+    {
+        source = Some(root_source);
+    }
+
+    let yaml_dir = crate::dirs::find_workspace_yaml_root(project_root);
+    if let Some(dir) = yaml_dir
+        && let Some(path) = aube_manifest::workspace::workspace_yaml_existing(&dir)
+        && let Ok(config) = aube_manifest::workspace::WorkspaceConfig::load(&dir)
+    {
+        let entries = if catalog == "default" {
+            config.catalog.get(package)
+        } else {
+            config
+                .catalogs
+                .get(catalog)
+                .and_then(|entries| entries.get(package))
+        };
+        if entries.is_some() {
+            source = Some(CatalogSource::WorkspaceYaml(path));
+        }
+    }
+    source
 }

--- a/crates/aube/src/commands/catalogs.rs
+++ b/crates/aube/src/commands/catalogs.rs
@@ -231,6 +231,119 @@ pub(crate) struct CatalogUpsert {
     pub range: String,
 }
 
+/// One existing catalog entry that `aube update --latest` should replace.
+#[derive(Debug, Clone)]
+pub(crate) struct CatalogUpdate {
+    pub catalog: String,
+    pub package: String,
+    pub range: String,
+}
+
+/// Replace existing catalog entries after update resolution succeeds.
+///
+/// Unlike [`upsert_catalog_entries`], this never creates a new entry: the
+/// manifest's `catalog:` reference was resolved from an existing catalog, so
+/// a missing write target means the source changed underneath the update and
+/// should fail instead of silently creating a shadowing entry.
+pub(crate) fn update_catalog_entries(
+    source: &super::CatalogSource,
+    entries: &[CatalogUpdate],
+) -> miette::Result<()> {
+    if entries.is_empty() {
+        return Ok(());
+    }
+    match source {
+        super::CatalogSource::WorkspaceYaml(workspace_path) => {
+            update_workspace_yaml_catalog_entries(workspace_path, entries)
+        }
+        super::CatalogSource::PackageJson { path, namespace } => {
+            update_manifest_catalog_entries(path, namespace, entries)
+        }
+    }
+}
+
+fn update_workspace_yaml_catalog_entries(
+    workspace_path: &Path,
+    entries: &[CatalogUpdate],
+) -> miette::Result<()> {
+    aube_manifest::workspace::edit_workspace_yaml(workspace_path, |root| {
+        for entry in entries {
+            let CatalogUpdate {
+                catalog,
+                package,
+                range,
+            } = entry;
+            let map = if catalog == "default" {
+                workspace_yaml_submap(root, "catalog", workspace_path)?
+            } else {
+                let catalogs = workspace_yaml_submap(root, "catalogs", workspace_path)?;
+                workspace_yaml_submap(catalogs, catalog.as_str(), workspace_path)?
+            };
+            let key = yaml_serde::Value::String(package.clone());
+            let Some(value) = map.get_mut(&key) else {
+                return Err(aube_manifest::Error::YamlParse(
+                    workspace_path.to_path_buf(),
+                    format!("catalog `{catalog}` has no entry for `{package}`"),
+                ));
+            };
+            *value = yaml_serde::Value::String(range.clone());
+        }
+        Ok(())
+    })
+    .map_err(miette::Report::new)
+    .wrap_err_with(|| format!("failed to write {} after update", workspace_path.display()))?;
+    Ok(())
+}
+
+fn update_manifest_catalog_entries(
+    manifest_path: &Path,
+    namespace: &str,
+    entries: &[CatalogUpdate],
+) -> miette::Result<()> {
+    super::update_manifest_json_object(manifest_path, |root| {
+        let config = root
+            .get_mut(namespace)
+            .and_then(serde_json::Value::as_object_mut)
+            .ok_or_else(|| {
+                miette::miette!(
+                    code = aube_codes::errors::ERR_AUBE_MANIFEST_PARSE,
+                    "`{namespace}` must be an object"
+                )
+            })?;
+        for entry in entries {
+            let entries = if entry.catalog == "default" {
+                config
+                    .get_mut("catalog")
+                    .and_then(serde_json::Value::as_object_mut)
+            } else {
+                config
+                    .get_mut("catalogs")
+                    .and_then(serde_json::Value::as_object_mut)
+                    .and_then(|catalogs| catalogs.get_mut(&entry.catalog))
+                    .and_then(serde_json::Value::as_object_mut)
+            }
+            .ok_or_else(|| {
+                miette::miette!(
+                    code = aube_codes::errors::ERR_AUBE_MANIFEST_PARSE,
+                    "catalog `{}` must be an object",
+                    entry.catalog
+                )
+            })?;
+            let value = entries.get_mut(&entry.package).ok_or_else(|| {
+                miette::miette!(
+                    code = aube_codes::errors::ERR_AUBE_UNKNOWN_CATALOG_ENTRY,
+                    "catalog `{}` has no entry for `{}`",
+                    entry.catalog,
+                    entry.package
+                )
+            })?;
+            *value = serde_json::Value::String(entry.range.clone());
+        }
+        Ok(())
+    })
+    .wrap_err_with(|| format!("failed to write {} after update", manifest_path.display()))
+}
+
 /// Upsert a batch of catalog entries into the workspace yaml. Existing
 /// entries are NEVER overwritten — pnpm's `--save-catalog` treats the
 /// catalog as the source of truth and lets the caller fall back to the

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -117,7 +117,9 @@ pub(crate) fn settings_hoisting_limits_to_linker(
         }
     }
 }
-pub(crate) use catalog_discovery::{CatalogMap, discover_catalogs, load_workspace_catalogs};
+pub(crate) use catalog_discovery::{
+    CatalogMap, CatalogSource, catalog_entry_source, discover_catalogs, load_workspace_catalogs,
+};
 pub(crate) use dep_filter::DepFilter;
 pub(crate) use fs_helpers::{
     format_virtual_store_display_prefix, is_link_or_junction_metadata, remove_existing, symlink_dir,

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -4,6 +4,14 @@ use miette::{Context, IntoDiagnostic, miette};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::io::IsTerminal;
 
+#[derive(Debug)]
+struct CatalogUpdateTarget {
+    manifest_key: String,
+    catalog: String,
+    original_range: String,
+    source: super::CatalogSource,
+}
+
 #[derive(Debug, Clone, Args)]
 pub struct UpdateArgs {
     /// Package(s) to update (all if empty)
@@ -474,6 +482,36 @@ pub async fn run(
         .map(|k| resolve_real_name(k))
         .collect();
 
+    let mut workspace_catalogs = super::load_workspace_catalogs(&cwd)?;
+    let mut catalog_targets = Vec::new();
+    if effective_latest {
+        for key in &manifest_keys_to_update {
+            if !should_rewrite_key(key) || preserve_pin.contains(key) {
+                continue;
+            }
+            let original = all_specifiers.get(key).map(String::as_str).unwrap_or("");
+            let Some(catalog) = catalog_name_from_spec(original) else {
+                continue;
+            };
+            let Some(entries) = workspace_catalogs.get_mut(catalog) else {
+                continue;
+            };
+            let Some(original_range) = entries.get(key).cloned() else {
+                continue;
+            };
+            let Some(source) = super::catalog_entry_source(&cwd, catalog, key) else {
+                continue;
+            };
+            entries.insert(key.clone(), "latest".to_string());
+            catalog_targets.push(CatalogUpdateTarget {
+                manifest_key: key.clone(),
+                catalog: catalog.to_string(),
+                original_range,
+                source,
+            });
+        }
+    }
+
     if update_all {
         eprintln!("Updating all dependencies...");
     } else {
@@ -615,7 +653,6 @@ pub async fn run(
             Some((h, f)) => (Some(h), f),
             None => (None, Vec::new()),
         };
-    let workspace_catalogs = super::load_workspace_catalogs(&cwd)?;
     let workspace_package_versions = workspace_package_versions(&cwd)?;
     let mut resolver = super::build_resolver(&cwd, &manifest, workspace_catalogs);
     if let Some(host) = read_package_host {
@@ -637,6 +674,47 @@ pub async fn run(
     // records flush to stdout before afterAllResolved emits its own.
     crate::pnpmfile::ReadPackageHostChain::drain_forwarders(read_package_forwarders).await;
     crate::pnpmfile::run_after_all_resolved_chain(&pnpmfile_paths, &cwd, &mut graph).await?;
+
+    let mut catalog_updates: BTreeMap<super::CatalogSource, Vec<super::catalogs::CatalogUpdate>> =
+        BTreeMap::new();
+    for target in &catalog_targets {
+        let real_name = resolve_real_name(&target.manifest_key);
+        let Some(resolved) = lookup_pkg(&graph, &["."], &target.manifest_key, &real_name)
+            .map(|pkg| pkg.version.clone())
+        else {
+            continue;
+        };
+        let persisted_range = if no_save {
+            target.original_range.clone()
+        } else {
+            rewrite_specifier(&target.original_range, &real_name, &resolved, args.exact)
+        };
+        if let Some(entry) = graph
+            .catalogs
+            .get_mut(&target.catalog)
+            .and_then(|entries| entries.get_mut(&target.manifest_key))
+        {
+            entry.specifier = persisted_range.clone();
+        }
+        if !no_save && persisted_range != target.original_range {
+            catalog_updates
+                .entry(target.source.clone())
+                .or_default()
+                .push(super::catalogs::CatalogUpdate {
+                    catalog: target.catalog.clone(),
+                    package: target.manifest_key.clone(),
+                    range: persisted_range,
+                });
+        }
+    }
+    for (source, updates) in &catalog_updates {
+        super::catalogs::update_catalog_entries(source, updates)?;
+        let path = match source {
+            super::CatalogSource::WorkspaceYaml(path)
+            | super::CatalogSource::PackageJson { path, .. } => path,
+        };
+        eprintln!("Updated {}", path.display());
+    }
 
     // Report what changed. Aliased direct deps (`"alias": "npm:real@x"`)
     // land in the lockfile graph with `pkg.name == "alias"` and
@@ -1108,6 +1186,12 @@ fn real_name_from_spec(manifest_key: &str, specifier: Option<&String>) -> String
         return rest.to_string();
     }
     manifest_key.to_string()
+}
+
+fn catalog_name_from_spec(specifier: &str) -> Option<&str> {
+    specifier
+        .strip_prefix("catalog:")
+        .map(|name| if name.is_empty() { "default" } else { name })
 }
 
 /// Look up the LockedPackage for a direct dep of the current importer.

--- a/test/update.bats
+++ b/test/update.bats
@@ -142,6 +142,109 @@ EOF
 	assert_success
 }
 
+_setup_catalog_update_workspace() {
+	mkdir -p packages/a packages/b
+	cat >package.json <<'EOF'
+{"name":"catalog-update-root","private":true}
+EOF
+	cat >aube-workspace.yaml <<'EOF'
+packages:
+  - packages/*
+catalog:
+  # keep this comment
+  is-odd: 0.1.2
+EOF
+	for pkg in a b; do
+		cat >"packages/$pkg/package.json" <<EOF
+{"name":"$pkg","private":true,"dependencies":{"is-odd":"catalog:"}}
+EOF
+	done
+}
+
+@test "aube update -r --latest updates a shared catalog entry" {
+	_setup_catalog_update_workspace
+
+	run aube update -r --latest is-odd --lockfile-only
+	assert_success
+
+	run grep 'is-odd: 3.0.1' aube-workspace.yaml
+	assert_success
+	run grep '# keep this comment' aube-workspace.yaml
+	assert_success
+	run grep -A4 '^catalogs:' aube-lock.yaml
+	assert_output --partial 'specifier: 3.0.1'
+	assert_output --partial 'version: 3.0.1'
+	for pkg in a b; do
+		run grep '"is-odd":"catalog:"' "packages/$pkg/package.json"
+		assert_success
+	done
+}
+
+@test "aube update -r --latest --no-save leaves the catalog range unchanged" {
+	_setup_catalog_update_workspace
+
+	run aube update -r --latest is-odd --lockfile-only --no-save
+	assert_success
+
+	run grep 'is-odd: 0.1.2' aube-workspace.yaml
+	assert_success
+	run grep -A4 '^catalogs:' aube-lock.yaml
+	assert_output --partial 'specifier: 0.1.2'
+	assert_output --partial 'version: 3.0.1'
+}
+
+@test "aube update -r --latest updates a named catalog and preserves its prefix" {
+	mkdir -p packages/a
+	cat >package.json <<'EOF'
+{"name":"catalog-update-root","private":true}
+EOF
+	cat >aube-workspace.yaml <<'EOF'
+packages:
+  - packages/*
+catalogs:
+  legacy:
+    is-odd: ^0.1.2
+EOF
+	cat >packages/a/package.json <<'EOF'
+{"name":"a","private":true,"dependencies":{"is-odd":"catalog:legacy"}}
+EOF
+
+	run aube update -r --latest is-odd --lockfile-only
+	assert_success
+
+	run grep 'is-odd: \^3.0.1' aube-workspace.yaml
+	assert_success
+	run grep '"is-odd":"catalog:legacy"' packages/a/package.json
+	assert_success
+}
+
+@test "aube update -r --latest updates a package.json catalog source" {
+	mkdir -p packages/a
+	cat >package.json <<'EOF'
+{
+  "name": "catalog-update-root",
+  "private": true,
+  "workspaces": {
+    "packages": ["packages/*"],
+    "catalog": {
+      "is-odd": "0.1.2"
+    }
+  }
+}
+EOF
+	cat >packages/a/package.json <<'EOF'
+{"name":"a","private":true,"dependencies":{"is-odd":"catalog:"}}
+EOF
+
+	run aube update -r --latest is-odd --lockfile-only
+	assert_success
+
+	run grep '"is-odd": "3.0.1"' package.json
+	assert_success
+	run grep '"is-odd":"catalog:"' packages/a/package.json
+	assert_success
+}
+
 @test "aube update: updateConfig.ignoreDependencies skips all-deps updates" {
 	_setup_outdated_project
 	cat >package.json <<'EOF'


### PR DESCRIPTION
## Summary

- resolve selected `catalog:` dependencies through the registry `latest` tag during `update --latest`
- persist resolved versions back to default or named catalogs while preserving member manifest references, range prefixes, and YAML comments
- update the actual highest-precedence catalog source, including `aube-workspace.yaml`, `pnpm-workspace.yaml`, and package.json catalogs
- keep `--no-save` catalog ranges unchanged while refreshing lockfile resolutions
- invalidate workspace-config caches after YAML mutations so the chained install sees the new catalog

## Root cause

The interactive picker compared catalog dependencies with the registry and offered the upgrade, but both the resolver-manifest rewrite and persistence paths skipped `catalog:` specifiers. Resolution therefore reused the unchanged catalog range and reported the selected dependency as already latest.

Addresses discussion #1164.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `mise run test:bats test/update.bats` (24 tests)

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dependency update and catalog persistence paths across workspace YAML and package.json; behavior is well-tested but incorrect source precedence or cache staleness could affect monorepo installs.
> 
> **Overview**
> **`aube update -r --latest` now upgrades catalog-backed dependencies end-to-end.** Selected direct deps that use `catalog:` / `catalog:legacy` are no longer skipped for resolution: the in-memory catalog map is temporarily set to `latest` for those packages, then after a successful resolve the resolved range is written back to the **highest-precedence** source (`aube-workspace.yaml`, `pnpm-workspace.yaml`, or `workspaces`/`pnpm`/`aube` catalogs in `package.json`). Member `package.json` entries stay as `catalog:` references; range prefixes (e.g. `^`) are preserved via the same rewrite rules as normal updates. **`--no-save`** leaves on-disk catalog ranges unchanged while still refreshing lockfile resolutions.
> 
> New **`update_catalog_entries`** only **mutates existing** catalog keys (errors if the entry disappeared), unlike add-time upserts. **`catalog_entry_source`** / **`CatalogSource`** track where each entry came from for grouped writes.
> 
> **Workspace YAML edits** call **`invalidate_cache`** on typed and raw `WorkspaceConfig` caches so later loads see catalog changes immediately (covered by a unit test). Bats in `test/update.bats` cover shared default/named catalogs, `--no-save`, and package.json catalog sources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af45f4c32e03b4df0ead48c7018b93ad95e1565b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `aube update --latest` now updates existing catalog entries across workspace YAML and `package.json` sources.
  * Supports shared and named catalogs while preserving `catalog:` dependency references.
  * Catalog updates report the files that were changed.

* **Bug Fixes**
  * Workspace configuration changes are now reflected immediately instead of using stale cached values.
  * `--no-save` preserves catalog ranges while still resolving the latest versions.

* **Tests**
  * Added coverage for catalog updates, named catalogs, package-based catalogs, comments, and cache invalidation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->