### PR TITLE
fix(ci): enable mise cache outside release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,9 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         with:
           cache: rust
-      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1 # zizmor: ignore[cache-poisoning] PRs restore only; saves are restricted to main
         with:
-          cache: false
+          cache_save: ${{ github.ref == 'refs/heads/main' }}
       - run: mise run build
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -79,9 +79,9 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         with:
           cache: rust
-      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1 # zizmor: ignore[cache-poisoning] PRs restore only; saves are restricted to main
         with:
-          cache: false
+          cache_save: ${{ github.ref == 'refs/heads/main' }}
       - run: node benchmarks/validate-results.mts
       - run: mise run test
       - run: mise run lint
@@ -134,9 +134,9 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         with:
           cache: rust
-      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1 # zizmor: ignore[cache-poisoning] PRs restore only; saves are restricted to main
         with:
-          cache: false
+          cache_save: ${{ github.ref == 'refs/heads/main' }}
       - name: Fetch semver baseline
         run: git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
       - name: Determine breaking-change override
@@ -251,9 +251,9 @@ jobs:
       - name: Install GNU parallel (macos)
         if: startsWith(matrix.os, 'macos')
         run: brew install parallel
-      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1 # zizmor: ignore[cache-poisoning] PRs restore only; saves are restricted to main
         with:
-          cache: false
+          cache_save: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: aube-${{ matrix.os }}
@@ -296,9 +296,9 @@ jobs:
       - name: Install GNU parallel (macos)
         if: startsWith(matrix.os, 'macos')
         run: brew install parallel
-      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1 # zizmor: ignore[cache-poisoning] PRs restore only; saves are restricted to main
         with:
-          cache: false
+          cache_save: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: aube-${{ matrix.os }}

--- a/.github/workflows/perf-backfill.yml
+++ b/.github/workflows/perf-backfill.yml
@@ -52,8 +52,6 @@ jobs:
           persist-credentials: false
 
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
-        with:
-          cache: false
         env:
           MISE_LOCKED: "1"
 
@@ -145,8 +143,6 @@ jobs:
           persist-credentials: false
 
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
-        with:
-          cache: false
         env:
           MISE_LOCKED: "1"
 

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -62,7 +62,7 @@ jobs:
 
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
-          cache: false
+          cache_save: false
         env:
           MISE_LOCKED: "1"
 

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -48,8 +48,6 @@ jobs:
           cache: rust
 
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
-        with:
-          cache: false
         env:
           MISE_LOCKED: "1"
 


### PR DESCRIPTION
## Summary

- enable mise cache restores across CI and performance workflows
- restrict CI cache saves to pushes on `main`
- keep mise caching disabled in the release-capable FFI and Node-addon packaging workflows

## Root cause

The security-hardening change disabled mise caching across ordinary CI as well as release jobs. That made every matrix shard download the full toolset from GitHub Releases, exposing CI to transient download failures such as the recent cargo-binstall HTTP 500.

## Impact

Pull requests can restore the trusted default-branch cache without writing caches themselves. Main and trusted performance workflows can populate caches, reducing repeated downloads and setup flakes.

## Validation

- `actionlint .github/workflows/*.yml`
- `zizmor --offline .github/workflows`
- `git diff --check`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only caching policy with explicit main-only saves and documented zizmor suppressions; no application or auth logic changes.
> 
> **Overview**
> Re-enables **mise** tool caching in ordinary CI and performance workflows after a prior hardening pass turned it off everywhere, which forced full tool downloads on every matrix shard and increased flake risk (e.g. cargo-binstall HTTP failures).
> 
> In **`ci.yml`**, all five `jdx/mise-action` steps drop `cache: false` and set **`cache_save`** to main-only pushes so pull requests can **restore** the trusted cache but not **write** it; each step gets a **zizmor** `cache-poisoning` ignore documenting that policy.
> 
> **`perf-pr.yml`** keeps restore behavior but sets **`cache_save: false`** so PR perf runs never populate the shared cache. **`perf.yml`** and **`perf-backfill.yml`** remove explicit `cache: false` so main/dispatch runs can use default restore/save. Release-capable **`ffi`** / **`node-addon`** workflows are unchanged and still disable mise cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ca08e35fdd11fc8b1044f379afea4ad739aab17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build and test workflow caching, with cache saves restricted to the main branch.
  * Enabled cache restoration for performance backfill and Rust performance builds.
  * Updated performance pull request caching to prevent unnecessary cache writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->