### PR TITLE
feat(embed): expose package manifest types

### DIFF
--- a/crates/aube/src/embed.rs
+++ b/crates/aube/src/embed.rs
@@ -15,6 +15,7 @@ pub use crate::commands::install::{
     InstallPromptHandler, InstallReporter,
 };
 pub use crate::runtime::{EmbedderRuntime, set_embedder_runtime};
+pub use aube_manifest::{Error as ManifestError, PackageJson, Workspaces};
 pub use aube_registry::NetworkMode;
 pub use aube_util::{AUBE, Embedder as Host};
 
@@ -251,4 +252,38 @@ pub async fn node(
 /// Extract a stable `ERR_AUBE_*` identifier from a failed operation.
 pub fn error_code(error: &miette::Report) -> Option<String> {
     error.code().map(|code| code.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_manifest_types_keep_tolerant_parsing() {
+        let manifest: PackageJson = serde_json::from_str(
+            r#"{
+                "name": "app",
+                "workspaces": "packages/*",
+                "dependencies": null,
+                "devDependencies": {"local": "workspace:*", "junk": false}
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(manifest.name.as_deref(), Some("app"));
+        assert_eq!(
+            manifest.workspaces.as_ref().map(|workspaces| workspaces
+                .patterns()
+                .iter()
+                .map(String::as_str)
+                .collect()),
+            Some(vec!["packages/*"])
+        );
+        assert!(manifest.dependencies.is_empty());
+        assert_eq!(
+            manifest.dev_dependencies.get("local").map(String::as_str),
+            Some("workspace:*")
+        );
+        assert!(!manifest.dev_dependencies.contains_key("junk"));
+    }
 }


### PR DESCRIPTION
## Summary
- re-export `PackageJson`, `Workspaces`, and the manifest error type from the stable embedding facade
- verify embedded consumers retain Aube’s tolerant real-world manifest parsing

## Why
Embedding hosts currently have to depend on `aube-manifest` directly or duplicate package.json schemas. Keeping these types on `aube::embed` gives hosts a stable route to Aube’s workspace syntax and tolerant dependency parsing.

## Validation
- `cargo fmt --check`
- `cargo test -p aube embed::tests`
- `cargo clippy -p aube --lib -- -D warnings`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Public re-exports and a test only; no changes to install, lockfile, or resolution behavior.
> 
> **Overview**
> Embedding hosts can use **`PackageJson`**, **`Workspaces`**, and **`ManifestError`** from the stable **`aube::embed`** facade instead of taking a direct **`aube-manifest`** dependency or duplicating schemas.
> 
> A new unit test parses a messy **`package.json`** through the re-exported **`PackageJson`** type and asserts workspace patterns, null/empty dependency maps, and invalid dependency entries are handled the same way Aube does elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71219dc38208ca3a7a74d9ec0c6639bafaee7a1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when reading embedded package manifests with string-based workspace definitions.
  * Manifest parsing now safely handles missing dependencies and ignores invalid development dependency entries.

* **New Features**
  * Exposed additional manifest information for integrations that process embedded package metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->