### PR TITLE
feat(embed): add configurable workspace discovery

### DIFF
--- a/crates/aube-workspace/src/lib.rs
+++ b/crates/aube-workspace/src/lib.rs
@@ -8,10 +8,41 @@
 pub mod selector;
 pub mod topo;
 
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 pub use aube_manifest::workspace::WorkspaceConfig;
 pub use selector::{Selector, WorkspacePkg};
+
+/// Whether workspace globs may select packages outside the workspace root.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum WorkspaceBoundary {
+    /// Preserve pnpm-compatible behavior, including patterns such as `../**`.
+    #[default]
+    AllowOutsideRoot,
+    /// Reject absolute and parent-relative patterns.
+    ///
+    /// Embedding hosts that discover projects inside a preselected repository
+    /// should use this mode so workspace configuration cannot expand the scan
+    /// beyond that repository.
+    ConfinedToRoot,
+}
+
+/// Controls workspace package discovery.
+#[derive(Debug, Clone, Copy, Default)]
+#[non_exhaustive]
+pub struct WorkspaceDiscoveryOptions {
+    /// Boundary applied to positive and negative workspace patterns.
+    pub boundary: WorkspaceBoundary,
+}
+
+impl WorkspaceDiscoveryOptions {
+    /// Restrict discovery to packages beneath the workspace root.
+    pub fn confined_to_root() -> Self {
+        Self {
+            boundary: WorkspaceBoundary::ConfinedToRoot,
+        }
+    }
+}
 
 /// Whether `project_dir` is the root of a workspace project — i.e.
 /// the user has set up workspace mode via `aube-workspace.yaml` /
@@ -47,13 +78,26 @@ pub fn is_workspace_project_root(project_dir: &Path) -> bool {
 /// 2. `package.json#workspaces` (yarn/npm/bun shape — array form or the
 ///    `{ packages: [...] }` object form).
 pub fn find_workspace_packages(project_dir: &Path) -> Result<Vec<PathBuf>, Error> {
+    find_workspace_packages_with_options(project_dir, WorkspaceDiscoveryOptions::default())
+}
+
+/// Discover workspace package directories with host-selected policy.
+///
+/// This has the same source precedence and matching behavior as
+/// [`find_workspace_packages`]. The options only constrain behavior that an
+/// embedding host may need to make stricter than the package-manager CLI.
+pub fn find_workspace_packages_with_options(
+    project_dir: &Path,
+    options: WorkspaceDiscoveryOptions,
+) -> Result<Vec<PathBuf>, Error> {
     let config = WorkspaceConfig::load(project_dir).map_err(|e| match e {
         aube_manifest::Error::Io(p, e) => Error::Io(p, e),
         aube_manifest::Error::YamlParse(p, e) => Error::Parse(p, e),
         aube_manifest::Error::Parse(pe) => Error::ParseDiag(pe),
     })?;
 
-    let patterns: Vec<String> = if !config.packages.is_empty() {
+    let workspace_yaml = aube_manifest::workspace::workspace_yaml_existing(project_dir);
+    let patterns: Vec<String> = if workspace_yaml.is_some() {
         config.packages.clone()
     } else {
         package_json_workspace_patterns(project_dir)?
@@ -63,27 +107,33 @@ pub fn find_workspace_packages(project_dir: &Path) -> Result<Vec<PathBuf>, Error
         return Ok(vec![]);
     }
 
+    let definition_path = workspace_yaml.unwrap_or_else(|| project_dir.join("package.json"));
     let mut neg_matchers = Vec::new();
     let mut positives = Vec::new();
     for raw in &patterns {
-        if let Some(rest) = raw.strip_prefix('!') {
-            let mk = |p: &str| {
-                glob::Pattern::new(p).map_err(|e| {
-                    Error::Parse(project_dir.join("pnpm-workspace.yaml"), e.to_string())
-                })
-            };
-            // pnpm uses micromatch where `**` matches zero-or-more
-            // path components, so `!**/example/**` excludes the
-            // directory `example` itself. The `glob` crate requires
-            // `**` to consume at least one component, so emit a
-            // companion matcher with the trailing `/**` stripped to
-            // catch the directory itself in addition to its descendants.
-            neg_matchers.push(mk(rest)?);
-            if let Some(self_form) = rest.strip_suffix("/**") {
-                neg_matchers.push(mk(self_form)?);
+        let (negated, pattern) = raw
+            .strip_prefix('!')
+            .map_or((false, raw.as_str()), |pattern| (true, pattern));
+        validate_workspace_pattern(&definition_path, pattern, options.boundary)?;
+        for expanded in expand_braces(pattern) {
+            if negated {
+                let mk = |p: &str| {
+                    glob::Pattern::new(p)
+                        .map_err(|e| Error::Parse(definition_path.clone(), e.to_string()))
+                };
+                // pnpm uses micromatch where `**` matches zero-or-more
+                // path components, so `!**/example/**` excludes the
+                // directory `example` itself. The `glob` crate requires
+                // `**` to consume at least one component, so emit a
+                // companion matcher with the trailing `/**` stripped to
+                // catch the directory itself in addition to its descendants.
+                neg_matchers.push(mk(&expanded)?);
+                if let Some(self_form) = expanded.strip_suffix("/**") {
+                    neg_matchers.push(mk(self_form)?);
+                }
+            } else {
+                positives.push(expanded);
             }
-        } else {
-            positives.push(raw.as_str());
         }
     }
 
@@ -97,7 +147,7 @@ pub fn find_workspace_packages(project_dir: &Path) -> Result<Vec<PathBuf>, Error
     let mut seen = std::collections::HashSet::new();
     let mut packages = Vec::new();
     for pattern in &positives {
-        for pkg_dir in expand_workspace_pattern(project_dir, pattern)? {
+        for pkg_dir in expand_workspace_pattern(project_dir, &definition_path, pattern)? {
             // `pathdiff` produces the as-written-from-`project_dir`
             // form (`../sibling` for parent-tree matches), which is
             // what the negation matcher was compiled against. Falling
@@ -119,9 +169,83 @@ pub fn find_workspace_packages(project_dir: &Path) -> Result<Vec<PathBuf>, Error
     Ok(packages)
 }
 
-fn expand_workspace_pattern(project_dir: &Path, pattern: &str) -> Result<Vec<PathBuf>, Error> {
+fn validate_workspace_pattern(
+    definition_path: &Path,
+    pattern: &str,
+    boundary: WorkspaceBoundary,
+) -> Result<(), Error> {
+    if boundary == WorkspaceBoundary::ConfinedToRoot
+        && (Path::new(pattern).is_absolute()
+            || Path::new(pattern)
+                .components()
+                .any(|component| component == Component::ParentDir))
+    {
+        return Err(Error::Parse(
+            definition_path.to_path_buf(),
+            format!(
+                "workspace pattern {pattern:?} must be relative and cannot escape the workspace root"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn expand_braces(pattern: &str) -> Vec<String> {
+    let mut depth = 0;
+    let mut open = None;
+    let mut commas = Vec::new();
+    for (index, character) in pattern.char_indices() {
+        match character {
+            '{' => {
+                if depth == 0 {
+                    open = Some(index);
+                    commas.clear();
+                }
+                depth += 1;
+            }
+            ',' if depth == 1 => commas.push(index),
+            '}' if depth > 0 => {
+                depth -= 1;
+                if depth == 0 {
+                    let Some(open_index) = open else {
+                        continue;
+                    };
+                    if commas.is_empty() {
+                        open = None;
+                        continue;
+                    }
+                    let mut boundaries = Vec::with_capacity(commas.len() + 2);
+                    boundaries.push(open_index + 1);
+                    boundaries.extend(commas.iter().map(|comma| comma + 1));
+                    boundaries.push(index + 1);
+                    return boundaries
+                        .windows(2)
+                        .flat_map(|window| {
+                            let end = window[1] - 1;
+                            let expanded = format!(
+                                "{}{}{}",
+                                &pattern[..open_index],
+                                &pattern[window[0]..end],
+                                &pattern[index + 1..]
+                            );
+                            expand_braces(&expanded)
+                        })
+                        .collect();
+                }
+            }
+            _ => {}
+        }
+    }
+    vec![pattern.to_string()]
+}
+
+fn expand_workspace_pattern(
+    project_dir: &Path,
+    definition_path: &Path,
+    pattern: &str,
+) -> Result<Vec<PathBuf>, Error> {
     let matcher = glob::Pattern::new(pattern)
-        .map_err(|e| Error::Parse(project_dir.join("pnpm-workspace.yaml"), e.to_string()))?;
+        .map_err(|e| Error::Parse(definition_path.to_path_buf(), e.to_string()))?;
     if !pattern.contains("**") {
         return Ok(glob_workspace_pattern(project_dir, pattern));
     }
@@ -212,7 +336,6 @@ fn workspace_pattern_root(project_dir: &Path, pattern: &str) -> PathBuf {
     // same way they do for in-tree patterns.
     let mut anchor = PathBuf::from(project_dir);
     for component in Path::new(dir_prefix).components() {
-        use std::path::Component;
         match component {
             Component::ParentDir => {
                 anchor.pop();
@@ -335,6 +458,59 @@ mod tests {
             names(found),
             ["example"].iter().map(|s| s.to_string()).collect()
         );
+    }
+
+    #[test]
+    fn expands_brace_workspace_patterns() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("package.json"),
+            r#"{"workspaces":["{apps,packages}/{web,lib}","!{apps,packages}/excluded/**"]}"#,
+        );
+        write(&dir.path().join("apps/web/package.json"), "{}");
+        write(&dir.path().join("packages/lib/package.json"), "{}");
+        write(
+            &dir.path().join("packages/excluded/example/package.json"),
+            "{}",
+        );
+
+        let found = find_workspace_packages(dir.path()).unwrap();
+        assert_eq!(
+            names(found),
+            ["lib", "web"].iter().map(|s| s.to_string()).collect()
+        );
+    }
+
+    #[test]
+    fn confined_discovery_rejects_parent_relative_patterns() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - '../packages/**'\n",
+        );
+
+        let err = find_workspace_packages_with_options(
+            dir.path(),
+            WorkspaceDiscoveryOptions::confined_to_root(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, Error::Parse(_, _)));
+        assert!(err.to_string().contains("cannot escape the workspace root"));
+    }
+
+    #[test]
+    fn empty_workspace_yaml_remains_authoritative() {
+        let dir = tempfile::tempdir().unwrap();
+        write(&dir.path().join("pnpm-workspace.yaml"), "packages: []\n");
+        write(
+            &dir.path().join("package.json"),
+            r#"{"workspaces":["packages/*"]}"#,
+        );
+        write(&dir.path().join("packages/app/package.json"), "{}");
+
+        let found = find_workspace_packages(dir.path()).unwrap();
+        assert!(found.is_empty());
     }
 
     #[test]

--- a/crates/aube-workspace/src/lib.rs
+++ b/crates/aube-workspace/src/lib.rs
@@ -114,8 +114,8 @@ pub fn find_workspace_packages_with_options(
         let (negated, pattern) = raw
             .strip_prefix('!')
             .map_or((false, raw.as_str()), |pattern| (true, pattern));
-        validate_workspace_pattern(&definition_path, pattern, options.boundary)?;
         for expanded in expand_braces(pattern) {
+            validate_workspace_pattern(&definition_path, &expanded, options.boundary)?;
             if negated {
                 let mk = |p: &str| {
                     glob::Pattern::new(p)
@@ -496,6 +496,25 @@ mod tests {
         .unwrap_err();
 
         assert!(matches!(err, Error::Parse(_, _)));
+        assert!(err.to_string().contains("cannot escape the workspace root"));
+    }
+
+    #[test]
+    fn confined_discovery_validates_expanded_brace_alternatives() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir.path().join("package.json"),
+            r#"{"workspaces":["{../outside,packages}/*"]}"#,
+        );
+
+        let err = find_workspace_packages_with_options(
+            dir.path(),
+            WorkspaceDiscoveryOptions::confined_to_root(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, Error::Parse(_, _)));
+        assert!(err.to_string().contains("../outside/*"));
         assert!(err.to_string().contains("cannot escape the workspace root"));
     }
 

--- a/crates/aube-workspace/src/lib.rs
+++ b/crates/aube-workspace/src/lib.rs
@@ -86,6 +86,8 @@ pub fn find_workspace_packages(project_dir: &Path) -> Result<Vec<PathBuf>, Error
 /// This has the same source precedence and matching behavior as
 /// [`find_workspace_packages`]. The options only constrain behavior that an
 /// embedding host may need to make stricter than the package-manager CLI.
+/// [`WorkspaceBoundary::ConfinedToRoot`] returns canonical package paths so a
+/// validated symlink cannot be redirected before the host consumes the result.
 pub fn find_workspace_packages_with_options(
     project_dir: &Path,
     options: WorkspaceDiscoveryOptions,
@@ -166,7 +168,7 @@ pub fn find_workspace_packages_with_options(
             if neg_matchers.iter().any(|m| m.matches_path(rel)) {
                 continue;
             }
-            if let Some(confined_root) = &confined_root {
+            let package_path = if let Some(confined_root) = &confined_root {
                 let canonical_package = pkg_dir
                     .canonicalize()
                     .map_err(|error| Error::Io(pkg_dir.clone(), error))?;
@@ -179,9 +181,12 @@ pub fn find_workspace_packages_with_options(
                         ),
                     ));
                 }
-            }
-            if seen.insert(pkg_dir.clone()) {
-                packages.push(pkg_dir);
+                canonical_package
+            } else {
+                pkg_dir
+            };
+            if seen.insert(package_path.clone()) {
+                packages.push(package_path);
             }
         }
     }
@@ -561,6 +566,35 @@ mod tests {
 
         assert!(matches!(err, Error::Parse(_, _)));
         assert!(err.to_string().contains("resolves outside"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn confined_discovery_returns_the_validated_canonical_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = dir.path().join("workspace");
+        let package = workspace.join("packages/app");
+        let link = workspace.join("aliases/app");
+        let outside = dir.path().join("outside");
+        write(
+            &workspace.join("package.json"),
+            r#"{"workspaces":["aliases/*"]}"#,
+        );
+        write(&package.join("package.json"), "{}");
+        write(&outside.join("package.json"), "{}");
+        std::fs::create_dir_all(link.parent().unwrap()).unwrap();
+        std::os::unix::fs::symlink(&package, &link).unwrap();
+
+        let found = find_workspace_packages_with_options(
+            &workspace,
+            WorkspaceDiscoveryOptions::confined_to_root(),
+        )
+        .unwrap();
+        std::fs::remove_file(&link).unwrap();
+        std::os::unix::fs::symlink(&outside, &link).unwrap();
+
+        assert_eq!(found, vec![package.canonicalize().unwrap()]);
+        assert_ne!(found, vec![link.canonicalize().unwrap()]);
     }
 
     #[test]

--- a/crates/aube-workspace/src/lib.rs
+++ b/crates/aube-workspace/src/lib.rs
@@ -108,6 +108,13 @@ pub fn find_workspace_packages_with_options(
     }
 
     let definition_path = workspace_yaml.unwrap_or_else(|| project_dir.join("package.json"));
+    let confined_root = (options.boundary == WorkspaceBoundary::ConfinedToRoot)
+        .then(|| {
+            project_dir
+                .canonicalize()
+                .map_err(|error| Error::Io(project_dir.to_path_buf(), error))
+        })
+        .transpose()?;
     let mut neg_matchers = Vec::new();
     let mut positives = Vec::new();
     for raw in &patterns {
@@ -158,6 +165,20 @@ pub fn find_workspace_packages_with_options(
             let rel = rel_owned.as_deref().unwrap_or(&pkg_dir);
             if neg_matchers.iter().any(|m| m.matches_path(rel)) {
                 continue;
+            }
+            if let Some(confined_root) = &confined_root {
+                let canonical_package = pkg_dir
+                    .canonicalize()
+                    .map_err(|error| Error::Io(pkg_dir.clone(), error))?;
+                if !canonical_package.starts_with(confined_root) {
+                    return Err(Error::Parse(
+                        definition_path.clone(),
+                        format!(
+                            "workspace package {} resolves outside the workspace root",
+                            pkg_dir.display()
+                        ),
+                    ));
+                }
             }
             if seen.insert(pkg_dir.clone()) {
                 packages.push(pkg_dir);
@@ -516,6 +537,30 @@ mod tests {
         assert!(matches!(err, Error::Parse(_, _)));
         assert!(err.to_string().contains("../outside/*"));
         assert!(err.to_string().contains("cannot escape the workspace root"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn confined_discovery_rejects_symlinks_outside_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = dir.path().join("workspace");
+        let outside = dir.path().join("outside");
+        write(
+            &workspace.join("package.json"),
+            r#"{"workspaces":["packages/*"]}"#,
+        );
+        write(&outside.join("package.json"), "{}");
+        std::fs::create_dir_all(workspace.join("packages")).unwrap();
+        std::os::unix::fs::symlink(&outside, workspace.join("packages/linked")).unwrap();
+
+        let err = find_workspace_packages_with_options(
+            &workspace,
+            WorkspaceDiscoveryOptions::confined_to_root(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, Error::Parse(_, _)));
+        assert!(err.to_string().contains("resolves outside"));
     }
 
     #[test]

--- a/crates/aube/src/embed.rs
+++ b/crates/aube/src/embed.rs
@@ -15,6 +15,7 @@ pub use crate::commands::install::{
     InstallPromptHandler, InstallReporter,
 };
 pub use crate::runtime::{EmbedderRuntime, set_embedder_runtime};
+pub use aube_manifest::{Error as ManifestError, PackageJson, Workspaces};
 pub use aube_registry::NetworkMode;
 pub use aube_util::{AUBE, Embedder as Host};
 
@@ -251,4 +252,38 @@ pub async fn node(
 /// Extract a stable `ERR_AUBE_*` identifier from a failed operation.
 pub fn error_code(error: &miette::Report) -> Option<String> {
     error.code().map(|code| code.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_manifest_types_keep_tolerant_parsing() {
+        let manifest: PackageJson = serde_json::from_str(
+            r#"{
+                "name": "app",
+                "workspaces": "packages/*",
+                "dependencies": null,
+                "devDependencies": {"local": "workspace:*", "junk": false}
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(manifest.name.as_deref(), Some("app"));
+        assert_eq!(
+            manifest.workspaces.as_ref().map(|workspaces| workspaces
+                .patterns()
+                .iter()
+                .map(String::as_str)
+                .collect()),
+            Some(vec!["packages/*"])
+        );
+        assert!(manifest.dependencies.is_empty());
+        assert_eq!(
+            manifest.dev_dependencies.get("local").map(String::as_str),
+            Some("workspace:*")
+        );
+        assert!(!manifest.dev_dependencies.contains_key("junk"));
+    }
 }

--- a/crates/aube/src/embed.rs
+++ b/crates/aube/src/embed.rs
@@ -18,6 +18,7 @@ pub use crate::runtime::{EmbedderRuntime, set_embedder_runtime};
 pub use aube_manifest::{Error as ManifestError, PackageJson, Workspaces};
 pub use aube_registry::NetworkMode;
 pub use aube_util::{AUBE, Embedder as Host};
+pub use aube_workspace::{WorkspaceBoundary, WorkspaceDiscoveryOptions};
 
 /// Options for an in-process install.
 ///
@@ -105,6 +106,29 @@ pub fn initialize(host: &'static Host, setting_defaults: Vec<(String, String)>) 
 /// Return the process's active host profile.
 pub fn host() -> &'static Host {
     aube_util::embedder()
+}
+
+/// Whether `project_dir` declares a Node workspace.
+///
+/// This recognizes Aube and pnpm workspace YAML plus the npm/Yarn/Bun
+/// `package.json#workspaces` field. Invalid or unrelated package manifests are
+/// treated as non-workspaces, making this suitable for repository-wide
+/// provider probing.
+pub fn is_workspace_project_root(project_dir: &Path) -> bool {
+    aube_workspace::is_workspace_project_root(project_dir)
+}
+
+/// Discover packages declared by a Node workspace.
+///
+/// Use [`WorkspaceBoundary::ConfinedToRoot`] when `project_dir` is a security
+/// or repository boundary chosen by the host. The default preserves
+/// package-manager compatibility with parent-relative pnpm workspace globs.
+pub fn discover_workspace_packages(
+    project_dir: &Path,
+    options: WorkspaceDiscoveryOptions,
+) -> Result<Vec<PathBuf>> {
+    aube_workspace::find_workspace_packages_with_options(project_dir, options)
+        .map_err(miette::Report::new)
 }
 
 /// Install the dependencies declared by a project.

--- a/crates/aube/src/embed.rs
+++ b/crates/aube/src/embed.rs
@@ -123,6 +123,8 @@ pub fn is_workspace_project_root(project_dir: &Path) -> bool {
 /// Use [`WorkspaceBoundary::ConfinedToRoot`] when `project_dir` is a security
 /// or repository boundary chosen by the host. The default preserves
 /// package-manager compatibility with parent-relative pnpm workspace globs.
+/// Confined discovery returns canonical package paths; other modes preserve
+/// the package-manager-facing lexical paths.
 pub fn discover_workspace_packages(
     project_dir: &Path,
     options: WorkspaceDiscoveryOptions,

--- a/crates/aube/tests/embed.rs
+++ b/crates/aube/tests/embed.rs
@@ -160,3 +160,33 @@ fn error_code_reads_structured_diagnostic_code() {
         Some("ERR_AUBE_TEST")
     );
 }
+
+#[test]
+fn facade_discovers_confined_workspace_packages() {
+    let workspace = tempfile::tempdir().unwrap();
+    std::fs::write(
+        workspace.path().join("package.json"),
+        r#"{"workspaces":["{apps,packages}/*"]}"#,
+    )
+    .unwrap();
+    for package in ["apps/web", "packages/lib"] {
+        let directory = workspace.path().join(package);
+        std::fs::create_dir_all(&directory).unwrap();
+        std::fs::write(directory.join("package.json"), "{}").unwrap();
+    }
+
+    assert!(aube::embed::is_workspace_project_root(workspace.path()));
+    let packages = aube::embed::discover_workspace_packages(
+        workspace.path(),
+        aube::embed::WorkspaceDiscoveryOptions::confined_to_root(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        packages,
+        vec![
+            workspace.path().join("apps/web"),
+            workspace.path().join("packages/lib"),
+        ]
+    );
+}

--- a/crates/aube/tests/embed.rs
+++ b/crates/aube/tests/embed.rs
@@ -185,8 +185,12 @@ fn facade_discovers_confined_workspace_packages() {
     assert_eq!(
         packages,
         vec![
-            workspace.path().join("apps/web"),
-            workspace.path().join("packages/lib"),
+            workspace.path().join("apps/web").canonicalize().unwrap(),
+            workspace
+                .path()
+                .join("packages/lib")
+                .canonicalize()
+                .unwrap(),
         ]
     );
 }


### PR DESCRIPTION
## Summary
- expose workspace-root detection and package discovery through `aube::embed`
- add an opt-in `ConfinedToRoot` boundary for repository-scoped embedding hosts
- support brace expansion in positive and negative workspace globs
- keep workspace YAML authoritative even when its package list is empty

## Why
Embedding hosts such as mise need Aube’s workspace semantics without allowing a workspace pattern to scan outside a host-selected repository root. Previously they had to duplicate discovery or call lower-level crates with incompatible boundary behavior.

The default remains pnpm-compatible and continues to allow parent-relative patterns such as `../**`; only hosts that explicitly select the confined option get the stricter policy.

## Stack
- depends on #1168

## Validation
- `cargo test -p aube-workspace`
- `cargo test -p aube embed::tests`
- `cargo test -p aube --test embed`
- `cargo clippy -p aube-workspace -p aube --all-targets -- -D warnings`
- `cargo fmt --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Confined discovery changes security-sensitive path resolution for embed hosts; the empty-YAML precedence tweak can alter which packages are discovered for projects with both files.
> 
> **Overview**
> **Workspace discovery** gains `find_workspace_packages_with_options` with `WorkspaceBoundary::ConfinedToRoot`, which rejects parent-relative or absolute globs, canonicalizes matched packages, and errors on symlinks that resolve outside the workspace root; the default remains pnpm-compatible (`../**` still allowed).
> 
> Discovery now **expands brace alternates** in positive and negative patterns (e.g. `{apps,packages}/*`), and treats an **on-disk workspace YAML as authoritative** even when `packages:` is empty, so `package.json#workspaces` is not used as a fallback in that case.
> 
> The **`aube::embed` facade** exposes `is_workspace_project_root`, `discover_workspace_packages`, and re-exports `WorkspaceDiscoveryOptions`, `PackageJson`, and related manifest types for embedding hosts (e.g. repository-scoped tooling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ab2087aa723ae509ce26d7d2906c8a56423c56a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable workspace discovery with options to allow packages outside the project root or confine discovery to the root.
  * Added support for brace-expanded workspace patterns and canonical package paths.
  * Added embedding helpers to detect workspace roots and discover workspace packages.
  * Added public access to workspace and manifest types.

* **Bug Fixes**
  * Prevented confined workspace discovery from following symlinks outside the workspace.
  * Preserved empty workspace configuration files as authoritative settings.
  * Improved tolerance when parsing unexpected manifest fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->