### PR TITLE
feat(manifest): preserve existing indentation in package.json

### DIFF
--- a/crates/aube-manifest/src/lib.rs
+++ b/crates/aube-manifest/src/lib.rs
@@ -1293,13 +1293,12 @@ pub fn serialize_json_with_indent<T: serde::Serialize>(
     value: &T,
     indent: &str,
 ) -> Result<String, serde_json::Error> {
-    let mut buf = Vec::new();
+    let mut buf = Vec::with_capacity(128);
     let formatter = serde_json::ser::PrettyFormatter::with_indent(indent.as_bytes());
     let mut serializer = serde_json::Serializer::with_formatter(&mut buf, formatter);
     value.serialize(&mut serializer)?;
-    String::from_utf8(buf).map_err(|e| {
-        serde_json::Error::io(std::io::Error::new(std::io::ErrorKind::InvalidData, e))
-    })
+    String::from_utf8(buf)
+        .map_err(|e| serde_json::Error::io(std::io::Error::new(std::io::ErrorKind::InvalidData, e)))
 }
 
 #[cfg(test)]

--- a/crates/aube-manifest/src/lib.rs
+++ b/crates/aube-manifest/src/lib.rs
@@ -1263,6 +1263,7 @@ fn line_col_to_byte_offset(content: &str, line: usize, column: usize) -> usize {
 /// could be detected.
 pub fn detect_json_indent(raw: &str) -> &str {
     let mut root_indent: Option<&str> = None;
+    let mut detected: Option<&str> = None;
 
     for line in raw.lines() {
         let trimmed = line.trim_start();
@@ -1279,13 +1280,16 @@ pub fn detect_json_indent(raw: &str) -> &str {
             }
             Some(root) => {
                 if current_indent.len() > root.len() && current_indent.starts_with(root) {
-                    return &current_indent[root.len()..];
+                    let candidate = &current_indent[root.len()..];
+                    if detected.is_none_or(|indent| candidate.len() < indent.len()) {
+                        detected = Some(candidate);
+                    }
                 }
             }
         }
     }
 
-    "  "
+    detected.unwrap_or("  ")
 }
 
 /// Serialize `value` as pretty JSON using `indent` for indentation.
@@ -1311,8 +1315,20 @@ mod tests {
         assert_eq!(detect_json_indent("{\n   \"name\": \"foo\"\n}"), "   ");
         assert_eq!(detect_json_indent("{\n    \"name\": \"foo\"\n}"), "    ");
         assert_eq!(detect_json_indent("{\n\t\"name\": \"foo\"\n}"), "\t");
+        assert_eq!(
+            detect_json_indent("\u{FEFF}{\n\t\"name\": \"foo\"\n}"),
+            "\t"
+        );
         assert_eq!(detect_json_indent("  {\n    \"name\": \"foo\"\n  }"), "  ");
         assert_eq!(detect_json_indent("{\"name\":\"foo\"}"), "  ");
+    }
+
+    #[test]
+    fn detect_json_indent_uses_shallowest_indented_line() {
+        assert_eq!(
+            detect_json_indent("{\"dependencies\": {\n    \"foo\": \"1.0.0\"\n  }\n}"),
+            "  "
+        );
     }
 
     #[test]

--- a/crates/aube-manifest/src/lib.rs
+++ b/crates/aube-manifest/src/lib.rs
@@ -1256,9 +1256,81 @@ fn line_col_to_byte_offset(content: &str, line: usize, column: usize) -> usize {
     content.len()
 }
 
+/// Detect the indentation style used in a JSON string.
+///
+/// Returns a slice of `raw` representing one level of indentation
+/// (e.g. `"  "`, `"   "`, `"    "`, `"\t"`), or `"  "` if no indentation
+/// could be detected.
+pub fn detect_json_indent(raw: &str) -> &str {
+    let mut root_indent: Option<&str> = None;
+
+    for line in raw.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.is_empty() || trimmed.starts_with("//") || trimmed.starts_with("/*") {
+            continue;
+        }
+
+        let indent_len = line.len() - trimmed.len();
+        let current_indent = &line[..indent_len];
+
+        match root_indent {
+            None => {
+                root_indent = Some(current_indent);
+            }
+            Some(root) => {
+                if current_indent.len() > root.len() && current_indent.starts_with(root) {
+                    return &current_indent[root.len()..];
+                }
+            }
+        }
+    }
+
+    "  "
+}
+
+/// Serialize `value` as pretty JSON using `indent` for indentation.
+pub fn serialize_json_with_indent<T: serde::Serialize>(
+    value: &T,
+    indent: &str,
+) -> Result<String, serde_json::Error> {
+    let mut buf = Vec::new();
+    let formatter = serde_json::ser::PrettyFormatter::with_indent(indent.as_bytes());
+    let mut serializer = serde_json::Serializer::with_formatter(&mut buf, formatter);
+    value.serialize(&mut serializer)?;
+    String::from_utf8(buf).map_err(|e| {
+        serde_json::Error::io(std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_detect_json_indent() {
+        assert_eq!(detect_json_indent("{\n  \"name\": \"foo\"\n}"), "  ");
+        assert_eq!(detect_json_indent("{\n   \"name\": \"foo\"\n}"), "   ");
+        assert_eq!(detect_json_indent("{\n    \"name\": \"foo\"\n}"), "    ");
+        assert_eq!(detect_json_indent("{\n\t\"name\": \"foo\"\n}"), "\t");
+        assert_eq!(detect_json_indent("  {\n    \"name\": \"foo\"\n  }"), "  ");
+        assert_eq!(detect_json_indent("{\"name\":\"foo\"}"), "  ");
+    }
+
+    #[test]
+    fn test_serialize_json_with_indent() {
+        let val = serde_json::json!({
+            "name": "foo",
+            "version": "1.0.0"
+        });
+        assert_eq!(
+            serialize_json_with_indent(&val, "   ").unwrap(),
+            "{\n   \"name\": \"foo\",\n   \"version\": \"1.0.0\"\n}"
+        );
+        assert_eq!(
+            serialize_json_with_indent(&val, "\t").unwrap(),
+            "{\n\t\"name\": \"foo\",\n\t\"version\": \"1.0.0\"\n}"
+        );
+    }
 
     fn parse(json: &str) -> PackageJson {
         serde_json::from_str(json).unwrap()

--- a/crates/aube-manifest/src/workspace/edits.rs
+++ b/crates/aube-manifest/src/workspace/edits.rs
@@ -39,6 +39,7 @@ pub fn remove_setting_entry(cwd: &Path, key: &str, entry_key: &str) -> Result<bo
         return Ok(false);
     }
     let raw = std::fs::read_to_string(&path).map_err(|e| crate::Error::Io(path.clone(), e))?;
+    let indent = crate::detect_json_indent(&raw).to_string();
     let mut value = crate::parse_json::<serde_json::Value>(&path, raw)?;
     let obj = value.as_object_mut().ok_or_else(|| {
         crate::Error::YamlParse(path.clone(), "package.json is not an object".to_string())
@@ -68,7 +69,7 @@ pub fn remove_setting_entry(cwd: &Path, key: &str, entry_key: &str) -> Result<bo
         return Ok(existed);
     }
 
-    let mut out = serde_json::to_string_pretty(&value)
+    let mut out = crate::serialize_json_with_indent(&value, &indent)
         .map_err(|e| crate::Error::YamlParse(path.clone(), format!("failed to serialize: {e}")))?;
     out.push('\n');
     std::fs::write(&path, out).map_err(|e| crate::Error::Io(path, e))?;
@@ -101,6 +102,7 @@ where
 {
     let path = cwd.join("package.json");
     let raw = std::fs::read_to_string(&path).map_err(|e| crate::Error::Io(path.clone(), e))?;
+    let indent = crate::detect_json_indent(&raw).to_string();
     let mut value = crate::parse_json::<serde_json::Value>(&path, raw)?;
 
     let obj = value.as_object_mut().ok_or_else(|| {
@@ -225,7 +227,7 @@ where
         return Ok(());
     }
 
-    let mut out = serde_json::to_string_pretty(&value)
+    let mut out = crate::serialize_json_with_indent(&value, &indent)
         .map_err(|e| crate::Error::YamlParse(path.clone(), format!("failed to serialize: {e}")))?;
     out.push('\n');
     std::fs::write(&path, out).map_err(|e| crate::Error::Io(path, e))?;

--- a/crates/aube/src/commands/deploy/rewrite.rs
+++ b/crates/aube/src/commands/deploy/rewrite.rs
@@ -283,7 +283,8 @@ pub(super) fn rewrite_local_refs(
         }
     }
 
-    let rewritten = serde_json::to_string_pretty(&doc)
+    let indent = aube_manifest::detect_json_indent(&raw);
+    let rewritten = aube_manifest::serialize_json_with_indent(&doc, indent)
         .into_diagnostic()
         .wrap_err("failed to serialize rewritten package.json")?;
     aube_util::fs_atomic::atomic_write(manifest_path, rewritten.as_bytes())

--- a/crates/aube/src/commands/manifest_io.rs
+++ b/crates/aube/src/commands/manifest_io.rs
@@ -30,14 +30,21 @@ pub(crate) fn write_manifest_json<T: serde::Serialize>(
     path: &Path,
     value: &T,
 ) -> miette::Result<()> {
-    let indent = if let Ok(content) = std::fs::read_to_string(path) {
-        aube_manifest::detect_json_indent(&content).to_string()
-    } else {
-        "  ".to_string()
+    let existing = match std::fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) => {
+            return Err(error)
+                .into_diagnostic()
+                .wrap_err("failed to read package.json");
+        }
     };
-    let json = aube_manifest::serialize_json_with_indent(value, &indent)
-        .into_diagnostic()
-        .wrap_err("failed to serialize package.json")?;
+    let json = aube_manifest::serialize_json_with_indent(
+        value,
+        aube_manifest::detect_json_indent(&existing),
+    )
+    .into_diagnostic()
+    .wrap_err("failed to serialize package.json")?;
     write_manifest_atomic(path, format!("{json}\n").as_bytes())
         .wrap_err("failed to write package.json")
 }
@@ -180,35 +187,42 @@ mod tests {
     }
 
     #[test]
+    fn write_manifest_json_rejects_invalid_utf8_without_overwriting() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("package.json");
+        let invalid_utf8 = [0xff];
+        std::fs::write(&path, invalid_utf8).unwrap();
+
+        let result = write_manifest_json(&path, &serde_json::json!({ "name": "example" }));
+
+        assert!(result.is_err());
+        assert_eq!(std::fs::read(&path).unwrap(), invalid_utf8);
+    }
+
+    #[test]
     fn write_manifest_dep_sections_preserves_indentation() {
         let dir = tempfile::tempdir().unwrap();
+        for (name, indent) in [
+            ("tabs", "\t"),
+            ("four-spaces", "    "),
+            ("three-spaces", "   "),
+        ] {
+            let path = dir.path().join(format!("package-{name}.json"));
+            std::fs::write(&path, format!("{{\n{indent}\"name\": \"{name}\"\n}}\n")).unwrap();
+            let mut manifest = aube_manifest::PackageJson::from_path(&path).unwrap();
+            manifest
+                .dependencies
+                .insert("foo".to_string(), "1.0.0".to_string());
 
-        // 1. Tabs
-        let path_tabs = dir.path().join("package_tabs.json");
-        std::fs::write(&path_tabs, "{\n\t\"name\": \"tabs-pkg\"\n}\n").unwrap();
-        let mut manifest_tabs = aube_manifest::PackageJson::from_path(&path_tabs).unwrap();
-        manifest_tabs.dependencies.insert("foo".to_string(), "1.0.0".to_string());
-        write_manifest_dep_sections(&path_tabs, &manifest_tabs).unwrap();
-        let written_tabs = std::fs::read_to_string(&path_tabs).unwrap();
-        assert!(written_tabs.contains("{\n\t\"name\": \"tabs-pkg\",\n\t\"dependencies\": {\n\t\t\"foo\": \"1.0.0\"\n\t}\n}"));
+            write_manifest_dep_sections(&path, &manifest).unwrap();
 
-        // 2. 4 spaces
-        let path_4sp = dir.path().join("package_4sp.json");
-        std::fs::write(&path_4sp, "{\n    \"name\": \"4sp-pkg\"\n}\n").unwrap();
-        let mut manifest_4sp = aube_manifest::PackageJson::from_path(&path_4sp).unwrap();
-        manifest_4sp.dependencies.insert("foo".to_string(), "1.0.0".to_string());
-        write_manifest_dep_sections(&path_4sp, &manifest_4sp).unwrap();
-        let written_4sp = std::fs::read_to_string(&path_4sp).unwrap();
-        assert!(written_4sp.contains("{\n    \"name\": \"4sp-pkg\",\n    \"dependencies\": {\n        \"foo\": \"1.0.0\"\n    }\n}"));
-
-        // 3. 3 spaces
-        let path_3sp = dir.path().join("package_3sp.json");
-        std::fs::write(&path_3sp, "{\n   \"name\": \"3sp-pkg\"\n}\n").unwrap();
-        let mut manifest_3sp = aube_manifest::PackageJson::from_path(&path_3sp).unwrap();
-        manifest_3sp.dependencies.insert("foo".to_string(), "1.0.0".to_string());
-        write_manifest_dep_sections(&path_3sp, &manifest_3sp).unwrap();
-        let written_3sp = std::fs::read_to_string(&path_3sp).unwrap();
-        assert!(written_3sp.contains("{\n   \"name\": \"3sp-pkg\",\n   \"dependencies\": {\n      \"foo\": \"1.0.0\"\n   }\n}"));
+            assert_eq!(
+                std::fs::read_to_string(&path).unwrap(),
+                format!(
+                    "{{\n{indent}\"name\": \"{name}\",\n{indent}\"dependencies\": {{\n{indent}{indent}\"foo\": \"1.0.0\"\n{indent}}}\n}}\n"
+                )
+            );
+        }
     }
 
     fn root_key_order(raw: &str) -> Vec<String> {

--- a/crates/aube/src/commands/manifest_io.rs
+++ b/crates/aube/src/commands/manifest_io.rs
@@ -30,7 +30,12 @@ pub(crate) fn write_manifest_json<T: serde::Serialize>(
     path: &Path,
     value: &T,
 ) -> miette::Result<()> {
-    let json = serde_json::to_string_pretty(value)
+    let indent = if let Ok(content) = std::fs::read_to_string(path) {
+        aube_manifest::detect_json_indent(&content).to_string()
+    } else {
+        "  ".to_string()
+    };
+    let json = aube_manifest::serialize_json_with_indent(value, &indent)
         .into_diagnostic()
         .wrap_err("failed to serialize package.json")?;
     write_manifest_atomic(path, format!("{json}\n").as_bytes())
@@ -44,6 +49,7 @@ where
     let content = std::fs::read_to_string(path)
         .into_diagnostic()
         .wrap_err("failed to read package.json")?;
+    let indent = aube_manifest::detect_json_indent(&content).to_string();
     let mut json: serde_json::Value = serde_json::from_str(&content)
         .into_diagnostic()
         .wrap_err("failed to parse package.json")?;
@@ -53,7 +59,7 @@ where
 
     update(obj)?;
 
-    let json = serde_json::to_string_pretty(&json)
+    let json = aube_manifest::serialize_json_with_indent(&json, &indent)
         .into_diagnostic()
         .wrap_err("failed to serialize package.json")?;
     write_manifest_atomic(path, format!("{json}\n").as_bytes())
@@ -171,6 +177,38 @@ mod tests {
         let written = std::fs::read_to_string(&path).unwrap();
         assert_eq!(root_key_order(&written), ["name", "license"]);
         assert!(!written.contains("devDependencies"));
+    }
+
+    #[test]
+    fn write_manifest_dep_sections_preserves_indentation() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // 1. Tabs
+        let path_tabs = dir.path().join("package_tabs.json");
+        std::fs::write(&path_tabs, "{\n\t\"name\": \"tabs-pkg\"\n}\n").unwrap();
+        let mut manifest_tabs = aube_manifest::PackageJson::from_path(&path_tabs).unwrap();
+        manifest_tabs.dependencies.insert("foo".to_string(), "1.0.0".to_string());
+        write_manifest_dep_sections(&path_tabs, &manifest_tabs).unwrap();
+        let written_tabs = std::fs::read_to_string(&path_tabs).unwrap();
+        assert!(written_tabs.contains("{\n\t\"name\": \"tabs-pkg\",\n\t\"dependencies\": {\n\t\t\"foo\": \"1.0.0\"\n\t}\n}"));
+
+        // 2. 4 spaces
+        let path_4sp = dir.path().join("package_4sp.json");
+        std::fs::write(&path_4sp, "{\n    \"name\": \"4sp-pkg\"\n}\n").unwrap();
+        let mut manifest_4sp = aube_manifest::PackageJson::from_path(&path_4sp).unwrap();
+        manifest_4sp.dependencies.insert("foo".to_string(), "1.0.0".to_string());
+        write_manifest_dep_sections(&path_4sp, &manifest_4sp).unwrap();
+        let written_4sp = std::fs::read_to_string(&path_4sp).unwrap();
+        assert!(written_4sp.contains("{\n    \"name\": \"4sp-pkg\",\n    \"dependencies\": {\n        \"foo\": \"1.0.0\"\n    }\n}"));
+
+        // 3. 3 spaces
+        let path_3sp = dir.path().join("package_3sp.json");
+        std::fs::write(&path_3sp, "{\n   \"name\": \"3sp-pkg\"\n}\n").unwrap();
+        let mut manifest_3sp = aube_manifest::PackageJson::from_path(&path_3sp).unwrap();
+        manifest_3sp.dependencies.insert("foo".to_string(), "1.0.0".to_string());
+        write_manifest_dep_sections(&path_3sp, &manifest_3sp).unwrap();
+        let written_3sp = std::fs::read_to_string(&path_3sp).unwrap();
+        assert!(written_3sp.contains("{\n   \"name\": \"3sp-pkg\",\n   \"dependencies\": {\n      \"foo\": \"1.0.0\"\n   }\n}"));
     }
 
     fn root_key_order(raw: &str) -> Vec<String> {

--- a/crates/aube/src/patches.rs
+++ b/crates/aube/src/patches.rs
@@ -280,6 +280,7 @@ fn remove_bun_patched_dependency(cwd: &Path, key: &str) -> Result<bool> {
     let raw = std::fs::read_to_string(&path)
         .into_diagnostic()
         .map_err(|e| miette!("failed to read {}: {e}", path.display()))?;
+    let indent = aube_manifest::detect_json_indent(&raw).to_string();
     let mut value =
         aube_manifest::parse_json::<serde_json::Value>(&path, raw).map_err(miette::Report::new)?;
     let obj = value
@@ -307,7 +308,7 @@ fn remove_bun_patched_dependency(cwd: &Path, key: &str) -> Result<bool> {
         return Ok(removed);
     }
 
-    let mut out = serde_json::to_string_pretty(&value)
+    let mut out = aube_manifest::serialize_json_with_indent(&value, &indent)
         .into_diagnostic()
         .map_err(|e| miette!("failed to serialize {}: {e}", path.display()))?;
     out.push('\n');


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing list discussions?
  Reference them here.
-->

## References

None.

## Summary

Preserves the indentation already used in `package.json` when aube rewrites manifests. Tabs and nonstandard space widths now survive workspace edits, deploy rewrites, patch removal, and shared manifest writes.

Read failures other than a missing file now stop the write. This prevents an invalid UTF-8 `package.json` from being replaced while aube tries to detect its indentation.

## Test plan

- [x] `cargo test -p aube-manifest`
- [x] `cargo test -p aube commands::manifest_io::tests`
- [x] `cargo test -p aube patches::tests`
- [x] `cargo test -p aube commands::deploy::rewrite::tests`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `mise run test:bats test/patch.bats`

*AI-assisted — Tool: Codex; model: openai/gpt-5.6-sol; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - JSON manifest writing and rewriting now preserves the existing indentation style (spaces, tabs, and custom spacing) when updating dependencies, settings, local references, and patched dependencies.
  - Added shared JSON formatting helpers to pretty-print output consistently with the detected indent.
  - Invalid UTF-8 is detected safely and will not overwrite the existing manifest.

- **Tests**
  - Added unit tests for indentation detection and formatted JSON output across multiple indentation styles.
  - Added coverage for invalid UTF-8 handling and indentation preservation during dependency updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->