### PR TITLE
feat(publish): support publishConfig.name

### DIFF
--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -372,15 +372,17 @@ async fn publish_one(
     fanout: bool,
     registry_override: Option<&str>,
 ) -> miette::Result<PublishOutcome> {
-    // Read the manifest *first* so the name/version needed for the
-    // existence check are available without touching the filesystem
-    // for file collection or the CPU for gzip/SHA hashing. This is the
-    // whole reason re-running `aube publish -r` on a mostly-published
-    // workspace is cheap — the happy-path skip must not pay the cost
-    // of a packed tarball.
+    // Lifecycle hooks may rewrite the published name, version, registry,
+    // or tag. Run them before resolving the registry target so the
+    // already-published check and eventual upload use the same identity.
+    // We still defer file collection and gzip/SHA hashing until after the
+    // preflight, keeping recursive no-op publishes cheaper than packing.
     let manifest = PackageJson::from_path(&pkg_dir.join("package.json"))
         .map_err(miette::Report::new)
         .wrap_err_with(|| format!("failed to read {}/package.json", pkg_dir.display()))?;
+    run_publish_lifecycle_pre(pkg_dir, &manifest, args.ignore_scripts).await?;
+    let manifest = super::pack::read_root_manifest(pkg_dir)?;
+
     let name = published_name(&manifest)
         .wrap_err_with(|| format!("publish: invalid {}/package.json", pkg_dir.display()))?;
     let version = normalize_publish_version(manifest.version.as_deref().ok_or_else(|| {
@@ -424,11 +426,9 @@ async fn publish_one(
         .to_string();
 
     if args.dry_run {
-        // Dry-run still runs the pre-publish chain so users can smoke-test
-        // their `prepublishOnly` / `prepack` / `prepare` scripts without
-        // hitting the registry, matching pnpm. `publish` / `postpublish`
-        // are skipped — nothing was actually uploaded.
-        run_publish_lifecycle_pre(pkg_dir, &manifest, args.ignore_scripts).await?;
+        // Dry-run has already run the pre-publish chain so users can
+        // smoke-test it without hitting the registry, matching pnpm.
+        // `publish` / `postpublish` are skipped — nothing was uploaded.
         let archive = build_archive_for_publish(pkg_dir)?;
         super::pack::run_pack_lifecycle_post(pkg_dir, args.ignore_scripts).await?;
         // `--dry-run --provenance` is a common "does my CI actually have
@@ -476,11 +476,9 @@ async fn publish_one(
         ));
     }
 
-    // Lifecycle hooks + tarball build only happen now that we know
-    // we're actually going to PUT. For a re-run of `-r publish` where
-    // every package is already on the registry, the loop never reaches
-    // this point and the whole fanout is script-free and gzip-free.
-    run_publish_lifecycle_pre(pkg_dir, &manifest, args.ignore_scripts).await?;
+    // The tarball build only happens now that we know we're actually
+    // going to PUT. A recursive no-op publish still avoids file
+    // collection, gzip, and body hashing.
     let archive = build_archive_for_publish(pkg_dir)?;
     super::pack::run_pack_lifecycle_post(pkg_dir, args.ignore_scripts).await?;
 

--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -380,18 +380,15 @@ async fn publish_one(
     fanout: bool,
     registry_override: Option<&str>,
 ) -> miette::Result<PublishOutcome> {
-    // Resolve the initial target before lifecycle hooks so the common
-    // already-published package with no pre-publish hooks keeps its
-    // script-free, archive-free fast path.
+    // Resolve the initial target before lifecycle hooks so an
+    // already-published package keeps its script-free, archive-free
+    // fast path. Hooks only run after this identity needs publishing;
+    // if they change it, the post-hook target gets a second preflight.
     let manifest = PackageJson::from_path(&pkg_dir.join("package.json"))
         .map_err(miette::Report::new)
         .wrap_err_with(|| format!("failed to read {}/package.json", pkg_dir.display()))?;
     let initial_target =
         resolve_publish_target(&manifest, pkg_dir, config, args, registry_override)?;
-    let has_pre_publish_hooks = !args.ignore_scripts
-        && ["prepublishOnly", "prepublish", "prepack", "prepare"]
-            .iter()
-            .any(|hook| manifest.scripts.contains_key(*hook));
     let initial_already_published = !args.dry_run
         && !args.force
         && version_on_registry(
@@ -401,7 +398,7 @@ async fn publish_one(
             &initial_target.version,
         )
         .await;
-    if initial_already_published && !has_pre_publish_hooks {
+    if initial_already_published {
         if fanout {
             return Ok(PublishOutcome {
                 name: initial_target.name,
@@ -934,10 +931,9 @@ fn read_publish_otp(name: &str, version: &str) -> miette::Result<String> {
 }
 
 /// Pre-pack chain for publish: `prepublishOnly` → `prepublish` →
-/// `prepack` → `prepare`. Packages without these hooks retain the
-/// script-free "already on registry" fast path. When hooks exist they
-/// run before the final preflight because they may rewrite the publish
-/// identity. `prepublish` is
+/// `prepack` → `prepare`. The initial "already on registry" fast path
+/// returns before this chain. When hooks run they are followed by a
+/// second preflight if they rewrote the publish identity. `prepublish` is
 /// deprecated by npm but pnpm still runs it on publish, so we match
 /// pnpm for the common case the discussion in #253 flagged. The
 /// manifest is threaded through so the whole chain shares a single

--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -353,6 +353,14 @@ struct PublishOutcome {
     status: PublishStatus,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct PublishTarget {
+    name: String,
+    version: String,
+    registry_url: String,
+    tag: String,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PublishStatus {
     Published,
@@ -372,58 +380,45 @@ async fn publish_one(
     fanout: bool,
     registry_override: Option<&str>,
 ) -> miette::Result<PublishOutcome> {
-    // Lifecycle hooks may rewrite the published name, version, registry,
-    // or tag. Run them before resolving the registry target so the
-    // already-published check and eventual upload use the same identity.
-    // We still defer file collection and gzip/SHA hashing until after the
-    // preflight, keeping recursive no-op publishes cheaper than packing.
+    // Resolve the initial target before lifecycle hooks so the common
+    // already-published package with no pre-publish hooks keeps its
+    // script-free, archive-free fast path.
     let manifest = PackageJson::from_path(&pkg_dir.join("package.json"))
         .map_err(miette::Report::new)
         .wrap_err_with(|| format!("failed to read {}/package.json", pkg_dir.display()))?;
+    let initial_target =
+        resolve_publish_target(&manifest, pkg_dir, config, args, registry_override)?;
+    let has_pre_publish_hooks = !args.ignore_scripts
+        && ["prepublishOnly", "prepublish", "prepack", "prepare"]
+            .iter()
+            .any(|hook| manifest.scripts.contains_key(*hook));
+    let initial_already_published = !args.dry_run
+        && !args.force
+        && version_on_registry(
+            client,
+            &initial_target.registry_url,
+            &initial_target.name,
+            &initial_target.version,
+        )
+        .await;
+    if initial_already_published && !has_pre_publish_hooks {
+        if fanout {
+            return Ok(PublishOutcome {
+                name: initial_target.name,
+                version: initial_target.version,
+                registry_url: initial_target.registry_url,
+                archive: None,
+                status: PublishStatus::AlreadyPublished,
+            });
+        }
+        return Err(already_published_error(&initial_target));
+    }
+
+    // Hooks may rewrite name, version, registry, or tag. Re-resolve the
+    // complete target afterward and recheck the registry if it changed.
     run_publish_lifecycle_pre(pkg_dir, &manifest, args.ignore_scripts).await?;
     let manifest = super::pack::read_root_manifest(pkg_dir)?;
-
-    let name = published_name(&manifest)
-        .wrap_err_with(|| format!("publish: invalid {}/package.json", pkg_dir.display()))?;
-    let version = normalize_publish_version(manifest.version.as_deref().ok_or_else(|| {
-        miette!(
-            "publish: {}/package.json has no `version`",
-            pkg_dir.display()
-        )
-    })?);
-
-    // publishConfig in package.json overrides the published name and,
-    // when the user has not passed CLI flags, the registry and tag.
-    // The manifest's own name remains the workspace identity; only
-    // registry-facing operations use `publishConfig.name`. pnpm and npm
-    // both honor this field, so without it migrating users would silently
-    // publish to the wrong place. Most common case: scoped private
-    // registries like `{"publishConfig": {"registry": "https://npm.pkg.github.com"}}`
-    // and `{"publishConfig": {"access": "public"}}` for first-time
-    // scoped-public publishes. CLI override still wins over the
-    // manifest setting, matching pnpm precedence.
-    let publish_config = manifest
-        .extra
-        .get("publishConfig")
-        .and_then(|v| v.as_object());
-    let pc_registry = publish_config
-        .and_then(|p| p.get("registry"))
-        .and_then(|v| v.as_str());
-    let pc_tag = publish_config
-        .and_then(|p| p.get("tag"))
-        .and_then(|v| v.as_str());
-
-    let registry_url = registry_override
-        .map(normalize_registry_url_pub)
-        .or_else(|| pc_registry.map(normalize_registry_url_pub))
-        .unwrap_or_else(|| config.registry_for(&name).to_string());
-
-    let tag = args
-        .tag
-        .as_deref()
-        .or(pc_tag)
-        .unwrap_or("latest")
-        .to_string();
+    let target = resolve_publish_target(&manifest, pkg_dir, config, args, registry_override)?;
 
     if args.dry_run {
         // Dry-run has already run the pre-publish chain so users can
@@ -445,7 +440,7 @@ async fn publish_one(
         return Ok(PublishOutcome {
             name: archive.name.clone(),
             version: archive.version.clone(),
-            registry_url,
+            registry_url: target.registry_url,
             archive: Some(archive),
             status: PublishStatus::DryRun,
         });
@@ -458,22 +453,24 @@ async fn publish_one(
     // opts out of both: it turns the skip into a PUT and suppresses
     // the single-package error, leaving the registry to decide whether
     // a republish is allowed (npm refuses, Verdaccio usually accepts).
-    if !args.force && version_on_registry(client, &registry_url, &name, &version).await {
+    let already_published = if args.force {
+        false
+    } else if target == initial_target {
+        initial_already_published
+    } else {
+        version_on_registry(client, &target.registry_url, &target.name, &target.version).await
+    };
+    if already_published {
         if fanout {
             return Ok(PublishOutcome {
-                name,
-                version,
-                registry_url,
+                name: target.name,
+                version: target.version,
+                registry_url: target.registry_url,
                 archive: None,
                 status: PublishStatus::AlreadyPublished,
             });
         }
-        return Err(miette!(
-            "{}: {name}@{version} is already on {}\n\
-             help: pass --force to republish (the registry must allow it; npm's public registry does not)",
-            aube_util::cmd("publish"),
-            aube_util::url::redact_url(&registry_url),
-        ));
+        return Err(already_published_error(&target));
     }
 
     // The tarball build only happens now that we know we're actually
@@ -529,22 +526,23 @@ async fn publish_one(
     let body = build_publish_body(
         &archive,
         &manifest,
-        &registry_url,
-        &tag,
+        &target.registry_url,
+        &target.tag,
         effective_access,
         provenance_bundle.as_deref(),
     )?;
 
-    let url = put_url(&registry_url, &archive.name);
-    let trusted_publish_token = trusted_publish_token(client, &registry_url, &archive.name).await?;
+    let url = put_url(&target.registry_url, &archive.name);
+    let trusted_publish_token =
+        trusted_publish_token(client, &target.registry_url, &archive.name).await?;
     if trusted_publish_token.is_none() {
-        ensure_registry_auth_for_package(client, &registry_url, &archive.name)?;
+        ensure_registry_auth_for_package(client, &target.registry_url, &archive.name)?;
     }
     let body_bytes = serde_json::to_vec(&body).into_diagnostic()?;
     match send_publish_put(
         client,
         &url,
-        &registry_url,
+        &target.registry_url,
         &archive.name,
         body_bytes.clone(),
         trusted_publish_token.as_deref(),
@@ -558,7 +556,7 @@ async fn publish_one(
             if let Err(second) = send_publish_put(
                 client,
                 &url,
-                &registry_url,
+                &target.registry_url,
                 &archive.name,
                 body_bytes,
                 trusted_publish_token.as_deref(),
@@ -577,7 +575,7 @@ async fn publish_one(
     Ok(PublishOutcome {
         name: archive.name.clone(),
         version: archive.version.clone(),
-        registry_url,
+        registry_url: target.registry_url,
         archive: Some(archive),
         status: PublishStatus::Published,
     })
@@ -602,6 +600,69 @@ fn published_name(manifest: &PackageJson) -> miette::Result<String> {
         .and_then(|value| value.as_str())
         .unwrap_or(manifest_name)
         .to_string())
+}
+
+fn resolve_publish_target(
+    manifest: &PackageJson,
+    pkg_dir: &Path,
+    config: &NpmConfig,
+    args: &PublishArgs,
+    registry_override: Option<&str>,
+) -> miette::Result<PublishTarget> {
+    let name = published_name(manifest)
+        .wrap_err_with(|| format!("publish: invalid {}/package.json", pkg_dir.display()))?;
+    let version = normalize_publish_version(manifest.version.as_deref().ok_or_else(|| {
+        miette!(
+            "publish: {}/package.json has no `version`",
+            pkg_dir.display()
+        )
+    })?);
+
+    // publishConfig overrides the published name and, when the user has
+    // not passed CLI flags, the registry and tag. The manifest name stays
+    // the workspace identity; only registry-facing operations use the
+    // published target.
+    let publish_config = manifest
+        .extra
+        .get("publishConfig")
+        .and_then(|value| value.as_object());
+    let registry_url = registry_override
+        .map(normalize_registry_url_pub)
+        .or_else(|| {
+            publish_config
+                .and_then(|config| config.get("registry"))
+                .and_then(|value| value.as_str())
+                .map(normalize_registry_url_pub)
+        })
+        .unwrap_or_else(|| config.registry_for(&name).to_string());
+    let tag = args
+        .tag
+        .as_deref()
+        .or_else(|| {
+            publish_config
+                .and_then(|config| config.get("tag"))
+                .and_then(|value| value.as_str())
+        })
+        .unwrap_or("latest")
+        .to_string();
+
+    Ok(PublishTarget {
+        name,
+        version,
+        registry_url,
+        tag,
+    })
+}
+
+fn already_published_error(target: &PublishTarget) -> miette::Report {
+    miette!(
+        "{}: {}@{} is already on {}\n\
+         help: pass --force to republish (the registry must allow it; npm's public registry does not)",
+        aube_util::cmd("publish"),
+        target.name,
+        target.version,
+        aube_util::url::redact_url(&target.registry_url),
+    )
 }
 
 fn build_archive_for_publish(pkg_dir: &Path) -> miette::Result<BuiltArchive> {
@@ -873,9 +934,10 @@ fn read_publish_otp(name: &str, version: &str) -> miette::Result<String> {
 }
 
 /// Pre-pack chain for publish: `prepublishOnly` → `prepublish` →
-/// `prepack` → `prepare`. Runs only for packages that are actually
-/// being uploaded — the "already on registry" skip path avoids all of
-/// this so `aube -r publish` remains idempotent. `prepublish` is
+/// `prepack` → `prepare`. Packages without these hooks retain the
+/// script-free "already on registry" fast path. When hooks exist they
+/// run before the final preflight because they may rewrite the publish
+/// identity. `prepublish` is
 /// deprecated by npm but pnpm still runs it on publish, so we match
 /// pnpm for the common case the discussion in #253 flagged. The
 /// manifest is threaded through so the whole chain shares a single

--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -527,11 +527,11 @@ async fn publish_one(
         provenance_bundle.as_deref(),
     )?;
 
-    let url = put_url(&target.registry_url, &archive.name);
+    let url = put_url(&target.registry_url, &target.name);
     let trusted_publish_token =
-        trusted_publish_token(client, &target.registry_url, &archive.name).await?;
+        trusted_publish_token(client, &target.registry_url, &target.name).await?;
     if trusted_publish_token.is_none() {
-        ensure_registry_auth_for_package(client, &target.registry_url, &archive.name)?;
+        ensure_registry_auth_for_package(client, &target.registry_url, &target.name)?;
     }
     let body_bytes = serde_json::to_vec(&body).into_diagnostic()?;
     match send_publish_put(
@@ -1699,6 +1699,8 @@ mod tests {
         assert_eq!(archive.name, "@scope/published-name");
         assert_eq!(archive.filename, "scope-published-name-1.2.3.tgz");
         assert_eq!(package_json["name"], "@scope/published-name");
+        let on_disk = PackageJson::from_path(&tmp.path().join("package.json")).unwrap();
+        assert_eq!(on_disk.name.as_deref(), Some("workspace-name"));
     }
 
     #[test]

--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -381,9 +381,10 @@ async fn publish_one(
     registry_override: Option<&str>,
 ) -> miette::Result<PublishOutcome> {
     // Resolve the initial target before lifecycle hooks so an
-    // already-published package keeps its script-free, archive-free
-    // fast path. Hooks only run after this identity needs publishing;
-    // if they change it, the post-hook target gets a second preflight.
+    // already-published package in a recursive fanout keeps its
+    // script-free, archive-free fast path, matching pnpm. A direct
+    // publish must still run hooks before deciding which final target
+    // is already published because a hook can rewrite that identity.
     let manifest = PackageJson::from_path(&pkg_dir.join("package.json"))
         .map_err(miette::Report::new)
         .wrap_err_with(|| format!("failed to read {}/package.json", pkg_dir.display()))?;
@@ -398,17 +399,14 @@ async fn publish_one(
             &initial_target.version,
         )
         .await;
-    if initial_already_published {
-        if fanout {
-            return Ok(PublishOutcome {
-                name: initial_target.name,
-                version: initial_target.version,
-                registry_url: initial_target.registry_url,
-                archive: None,
-                status: PublishStatus::AlreadyPublished,
-            });
-        }
-        return Err(already_published_error(&initial_target));
+    if initial_already_published && fanout {
+        return Ok(PublishOutcome {
+            name: initial_target.name,
+            version: initial_target.version,
+            registry_url: initial_target.registry_url,
+            archive: None,
+            status: PublishStatus::AlreadyPublished,
+        });
     }
 
     // Hooks may rewrite name, version, registry, or tag. Re-resolve the

--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -28,9 +28,7 @@
 //! "already published" error, leaving the registry itself to decide
 //! whether a republish is allowed.
 
-use crate::commands::pack::{
-    BuiltArchive, build_archive, build_archive_with_package_json, tarball_filename,
-};
+use crate::commands::pack::{BuiltArchive, build_archive_with_package_json, tarball_filename};
 use crate::commands::{encode_package_name, ensure_registry_auth_for_package};
 use aube_manifest::PackageJson;
 use aube_registry::client::RegistryClient;
@@ -383,11 +381,8 @@ async fn publish_one(
     let manifest = PackageJson::from_path(&pkg_dir.join("package.json"))
         .map_err(miette::Report::new)
         .wrap_err_with(|| format!("failed to read {}/package.json", pkg_dir.display()))?;
-    let name = manifest
-        .name
-        .as_deref()
-        .ok_or_else(|| miette!("publish: {}/package.json has no `name`", pkg_dir.display()))?
-        .to_string();
+    let name = published_name(&manifest)
+        .wrap_err_with(|| format!("publish: invalid {}/package.json", pkg_dir.display()))?;
     let version = normalize_publish_version(manifest.version.as_deref().ok_or_else(|| {
         miette!(
             "publish: {}/package.json has no `version`",
@@ -395,9 +390,11 @@ async fn publish_one(
         )
     })?);
 
-    // publishConfig in package.json overrides both registry and tag
-    // if the user has not passed CLI flags. pnpm and npm both honor
-    // this field, so without it migrating users would silently
+    // publishConfig in package.json overrides the published name and,
+    // when the user has not passed CLI flags, the registry and tag.
+    // The manifest's own name remains the workspace identity; only
+    // registry-facing operations use `publishConfig.name`. pnpm and npm
+    // both honor this field, so without it migrating users would silently
     // publish to the wrong place. Most common case: scoped private
     // registries like `{"publishConfig": {"registry": "https://npm.pkg.github.com"}}`
     // and `{"publishConfig": {"access": "public"}}` for first-time
@@ -590,10 +587,23 @@ async fn publish_one(
 
 fn normalize_archive_for_publish(archive: &mut BuiltArchive) {
     let version = normalize_publish_version(&archive.version);
-    if version != archive.version {
-        archive.version = version;
-        archive.filename = tarball_filename(&archive.name, &archive.version);
-    }
+    archive.version = version;
+    archive.filename = tarball_filename(&archive.name, &archive.version);
+}
+
+fn published_name(manifest: &PackageJson) -> miette::Result<String> {
+    let manifest_name = manifest
+        .name
+        .as_deref()
+        .ok_or_else(|| miette!("package.json has no `name`"))?;
+    Ok(manifest
+        .extra
+        .get("publishConfig")
+        .and_then(|value| value.as_object())
+        .and_then(|config| config.get("name"))
+        .and_then(|value| value.as_str())
+        .unwrap_or(manifest_name)
+        .to_string())
 }
 
 fn build_archive_for_publish(pkg_dir: &Path) -> miette::Result<BuiltArchive> {
@@ -601,16 +611,26 @@ fn build_archive_for_publish(pkg_dir: &Path) -> miette::Result<BuiltArchive> {
     let manifest_bytes = std::fs::read(&manifest_path)
         .into_diagnostic()
         .wrap_err_with(|| format!("failed to read {}", manifest_path.display()))?;
+    let manifest: PackageJson = serde_json::from_slice(&manifest_bytes)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to parse {}", manifest_path.display()))?;
+    let name = published_name(&manifest)
+        .wrap_err_with(|| format!("publish: invalid {}", manifest_path.display()))?;
     let mut manifest_json: serde_json::Value =
         serde_json::from_slice(&manifest_bytes).into_diagnostic()?;
+    if let Some(obj) = manifest_json.as_object_mut() {
+        obj.insert("name".into(), name.clone().into());
+    }
     let Some(raw_version) = manifest_json.get("version").and_then(|v| v.as_str()) else {
-        return build_archive(pkg_dir);
+        let mut archive = build_archive_with_package_json(
+            pkg_dir,
+            Some(serde_json::to_vec_pretty(&manifest_json).into_diagnostic()?),
+        )?;
+        archive.name = name;
+        archive.filename = tarball_filename(&archive.name, &archive.version);
+        return Ok(archive);
     };
     let version = normalize_publish_version(raw_version);
-    if version == raw_version {
-        return build_archive(pkg_dir);
-    }
-
     if let Some(obj) = manifest_json.as_object_mut() {
         obj.insert("version".into(), version.into());
     }
@@ -618,6 +638,7 @@ fn build_archive_for_publish(pkg_dir: &Path) -> miette::Result<BuiltArchive> {
     package_json.push(b'\n');
 
     let mut archive = build_archive_with_package_json(pkg_dir, Some(package_json))?;
+    archive.name = name;
     normalize_archive_for_publish(&mut archive);
     Ok(archive)
 }
@@ -1059,6 +1080,7 @@ fn build_publish_body(
     let obj = version_doc
         .as_object_mut()
         .ok_or_else(|| miette!("manifest did not serialize to a JSON object"))?;
+    obj.insert("name".into(), archive.name.clone().into());
     obj.insert("version".into(), archive.version.clone().into());
     obj.insert(
         "_id".into(),
@@ -1584,6 +1606,45 @@ mod tests {
         assert_eq!(archive.version, "2026.5.16");
         assert_eq!(archive.filename, "jdxcode-mise-linux-x64-2026.5.16.tgz");
         assert_eq!(package_json["version"], "2026.5.16");
+    }
+
+    #[test]
+    fn publish_config_name_renames_only_the_published_artifact() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("package.json"),
+            r#"{
+                "name": "workspace-name",
+                "version": "1.2.3",
+                "publishConfig": {"name": "@scope/published-name"}
+            }"#,
+        )
+        .unwrap();
+        std::fs::write(tmp.path().join("README.md"), "renamed").unwrap();
+
+        let manifest = PackageJson::from_path(&tmp.path().join("package.json")).unwrap();
+        assert_eq!(manifest.name.as_deref(), Some("workspace-name"));
+        assert_eq!(published_name(&manifest).unwrap(), "@scope/published-name");
+
+        let archive = build_archive_for_publish(tmp.path()).unwrap();
+        let gz = flate2::read::GzDecoder::new(archive.tarball.as_slice());
+        let mut tar = tar::Archive::new(gz);
+        let mut package_json = None;
+        for entry in tar.entries().unwrap() {
+            let mut entry = entry.unwrap();
+            if entry.path().unwrap() == std::path::Path::new("package/package.json") {
+                let mut contents = String::new();
+                std::io::Read::read_to_string(&mut entry, &mut contents).unwrap();
+                package_json = Some(contents);
+                break;
+            }
+        }
+        let package_json: serde_json::Value =
+            serde_json::from_str(&package_json.expect("package.json in tarball")).unwrap();
+
+        assert_eq!(archive.name, "@scope/published-name");
+        assert_eq!(archive.filename, "scope-published-name-1.2.3.tgz");
+        assert_eq!(package_json["name"], "@scope/published-name");
     }
 
     #[test]

--- a/test/publish.bats
+++ b/test/publish.bats
@@ -205,7 +205,7 @@ NODE
 	assert_output "Bearer fallback-token"
 }
 
-@test "aube publish exchanges OIDC token for post-hook package name" {
+@test "aube publish preflights and exchanges OIDC token for post-hook package name" {
 	_write_publishable_pkg
 	cat >rewrite-name.mjs <<'NODE'
 import fs from 'node:fs';
@@ -220,7 +220,7 @@ import http from 'node:http';
 import fs from 'node:fs';
 
 const server = http.createServer((req, res) => {
-  if (req.method === 'GET' && req.url === '/publish-smoke') {
+  if (req.method === 'GET' && req.url === '/publish-renamed') {
     res.statusCode = 404;
     res.end('{}');
     return;

--- a/test/publish.bats
+++ b/test/publish.bats
@@ -405,7 +405,12 @@ const server = http.createServer((req, res) => {
     res.end(JSON.stringify(existing));
     return;
   }
-  if (req.method === 'PUT' && req.url === '/publish-smoke') {
+  if (req.method === 'GET' && req.url === '/publish-renamed') {
+    res.statusCode = 404;
+    res.end('{}');
+    return;
+  }
+  if (req.method === 'PUT' && (req.url === '/publish-smoke' || req.url === '/publish-renamed')) {
     let size = 0;
     req.on('data', (c) => { size += c.length; });
     req.on('end', () => {
@@ -439,7 +444,7 @@ _stop_publish_server() {
 	fi
 }
 
-@test "aube publish refuses to re-publish a version already on the registry" {
+@test "aube publish runs hooks before refusing to re-publish a version" {
 	_write_publishable_pkg
 	node -e "const fs=require('fs'); const m=require('./package.json'); m.scripts={prepublishOnly:'node -e \\'require(\\\"fs\\\").writeFileSync(\\\"lifecycle.marker\\\", \\\"ran\\\")\\''}; fs.writeFileSync('package.json', JSON.stringify(m, null, 2))"
 	_start_publish_server
@@ -452,13 +457,63 @@ _stop_publish_server() {
 	[ "$rc" -ne 0 ]
 	assert_output --partial "publish-smoke@0.1.0 is already on"
 	assert_output --partial "--force"
-	assert_file_not_exists lifecycle.marker
-	# The pre-flight must short-circuit before the PUT; the mock
+	assert_file_exists lifecycle.marker
+	# The final pre-flight must short-circuit before the PUT; the mock
 	# server only logs PUTs to this file.
 	[ ! -s publish-server-put.log ] || {
 		echo "unexpected PUT: $(cat publish-server-put.log)" >&2
 		false
 	}
+}
+
+@test "aube publish uses a hook-mutated target when the initial version exists" {
+	_write_publishable_pkg
+	cat >rewrite-name.mjs <<'NODE'
+import fs from 'node:fs';
+const m = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+m.publishConfig = { name: 'publish-renamed' };
+fs.writeFileSync('package.json', JSON.stringify(m, null, 2));
+NODE
+	node -e "const fs=require('fs'); const m=require('./package.json'); m.scripts={prepublishOnly:'node ./rewrite-name.mjs'}; fs.writeFileSync('package.json', JSON.stringify(m, null, 2))"
+	_start_publish_server
+	port="$(cat publish-server-port)"
+	echo "//127.0.0.1:${port}/:_authToken=fake" >.npmrc
+
+	run aube publish --no-git-checks --registry "http://127.0.0.1:${port}/"
+	rc=$status
+	_stop_publish_server
+	[ "$rc" -eq 0 ]
+	assert_output --partial "+ publish-renamed@0.1.0"
+	run grep -c "^/publish-renamed " publish-server-put.log
+	assert_success
+	[ "$output" = "1" ]
+}
+
+@test "aube publish -r skips hooks for an already-published version" {
+	mkdir -p packages/smoke
+	cat >package.json <<-'EOF'
+		{"name":"root","version":"0.0.0","private":true}
+	EOF
+	cat >pnpm-workspace.yaml <<-'EOF'
+		packages:
+		  - packages/*
+	EOF
+	(
+		cd packages/smoke
+		_write_publishable_pkg
+		node -e "const fs=require('fs'); const m=require('./package.json'); m.scripts={prepublishOnly:'node -e \\'require(\\\"fs\\\").writeFileSync(\\\"lifecycle.marker\\\", \\\"ran\\\")\\''}; fs.writeFileSync('package.json', JSON.stringify(m, null, 2))"
+	)
+	_start_publish_server
+	port="$(cat publish-server-port)"
+	echo "//127.0.0.1:${port}/:_authToken=fake" >.npmrc
+
+	run aube publish -r --no-git-checks --registry "http://127.0.0.1:${port}/"
+	rc=$status
+	_stop_publish_server
+	[ "$rc" -eq 0 ]
+	assert_output --partial "= publish-smoke@0.1.0 (already on registry, skipping)"
+	assert_file_not_exists packages/smoke/lifecycle.marker
+	[ ! -s publish-server-put.log ]
 }
 
 @test "aube publish --force re-publishes past the existence check" {

--- a/test/publish.bats
+++ b/test/publish.bats
@@ -441,6 +441,7 @@ _stop_publish_server() {
 
 @test "aube publish refuses to re-publish a version already on the registry" {
 	_write_publishable_pkg
+	node -e "const fs=require('fs'); const m=require('./package.json'); m.scripts={prepublishOnly:'node -e \\'require(\\\"fs\\\").writeFileSync(\\\"lifecycle.marker\\\", \\\"ran\\\")\\''}; fs.writeFileSync('package.json', JSON.stringify(m, null, 2))"
 	_start_publish_server
 	port="$(cat publish-server-port)"
 	echo "//127.0.0.1:${port}/:_authToken=fake" >.npmrc
@@ -451,6 +452,7 @@ _stop_publish_server() {
 	[ "$rc" -ne 0 ]
 	assert_output --partial "publish-smoke@0.1.0 is already on"
 	assert_output --partial "--force"
+	assert_file_not_exists lifecycle.marker
 	# The pre-flight must short-circuit before the PUT; the mock
 	# server only logs PUTs to this file.
 	[ ! -s publish-server-put.log ] || {


### PR DESCRIPTION
## Summary

- honor `publishConfig.name` for registry-facing publish operations
- rewrite the packed manifest and tarball filename to the published name
- preserve the original manifest name as the workspace and lockfile identity
- cover scoped published names with a focused archive regression test

## Why

pnpm 11.18 added `publishConfig.name` so a workspace package can publish under a different registry name without renaming the project in its workspace. Aube already honored the other `publishConfig` fields but still used the manifest name for registry checks, routing, archive metadata, and upload.

## Validation

- `cargo test -p aube commands::publish::tests --features publish`
- `cargo clippy -p aube --all-targets --features publish -- -D warnings`
- `cargo fmt --check`

Upstream: https://github.com/pnpm/pnpm/releases/tag/v11.18.0

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core publish routing, registry existence checks, and tarball metadata; behavior changes for already-published and hook-mutated packages, though covered by new unit and BATS tests.
> 
> **Overview**
> Adds **`publishConfig.name`** so registry checks, PUT URLs, tarball filename, embedded `package.json`, and publish body metadata use the published name while the on-disk workspace **`name`** stays unchanged.
> 
> Refactors publish around a **`PublishTarget`** (`resolve_publish_target` / `published_name`). **Recursive** `-r` publish still skips lifecycle scripts and tarball work when the *initial* target is already on the registry; **single-package** publish runs **pre-publish hooks first**, then re-resolves the target and re-checks the registry so hooks that change name (including via `publishConfig`) or version are honored—e.g. publishing under a renamed target when the original version already exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e45297c7197bae9c4822e2e8cc866beb0b858b53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Publishing now supports custom artifact names via `publishConfig.name`, reflected across the packaged tarball, archive filename, and the registry publish target.

* **Bug Fixes**
  * Improved handling of version/metadata normalization so packaged contents and registry version records stay consistent with the resolved publish identity.
  * Ensures lifecycle hooks run in the correct order, even when the target version is already present, and avoids unnecessary uploads.

* **Tests**
  * Expanded publish/hook coverage, including OIDC post-hook preflight behavior and “already published” lifecycle expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->