### PR TITLE
feat(install): run pnpm devPreinstall hook

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -4178,7 +4178,7 @@ Mirrors pnpm's `--global-pnpmfile <path>`. The global hook runs first and the lo
         long_help #"""
 Skip lifecycle scripts.
 
-Accepted for pnpm parity — dep scripts are already gated by `allowBuilds`, so the flag is currently a no-op, but scripts that wrap `pnpm update --ignore-scripts` keep working without complaint.
+Skips the root `pnpm:devPreinstall` hook and all approved dependency build scripts in the chained install.
 """#
     }
     flag --lockfile-only help="Refresh the lockfile without populating `node_modules`" {

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -280,7 +280,7 @@ Conflicts with `--no-save`, which only snapshots `package.json` and the lockfile
 """#
         arg <PKG>
     }
-    flag --ignore-scripts help="Skip lifecycle scripts (no-op; aube already skips by default)" hide=#true
+    flag --ignore-scripts help="Skip root and approved dependency lifecycle scripts" hide=#true
     flag --no-save help="Install without persisting the dependency to `package.json`" {
         long_help #"""
 Install without persisting the dependency to `package.json`.

--- a/crates/aube/src/commands/add/filtered.rs
+++ b/crates/aube/src/commands/add/filtered.rs
@@ -83,6 +83,7 @@ pub(super) async fn run(
         install_opts.ignore_scripts = args.ignore_scripts;
         install_opts.workspace_filter = filter.clone();
         install_opts.run_dev_preinstall = true;
+        install_opts.script_command = "add";
         // See the sibling `aube add` codepath for why this flag is set:
         // live OSV API on the resolved transitives.
         install_opts.osv_transitive_check = true;

--- a/crates/aube/src/commands/add/filtered.rs
+++ b/crates/aube/src/commands/add/filtered.rs
@@ -80,6 +80,7 @@ pub(super) async fn run(
             &mut install_opts,
             args.dangerously_allow_all_builds,
         );
+        install_opts.ignore_scripts = args.ignore_scripts;
         install_opts.workspace_filter = filter.clone();
         install_opts.run_dev_preinstall = true;
         // See the sibling `aube add` codepath for why this flag is set:

--- a/crates/aube/src/commands/add/filtered.rs
+++ b/crates/aube/src/commands/add/filtered.rs
@@ -81,6 +81,7 @@ pub(super) async fn run(
             args.dangerously_allow_all_builds,
         );
         install_opts.workspace_filter = filter.clone();
+        install_opts.run_dev_preinstall = true;
         // See the sibling `aube add` codepath for why this flag is set:
         // live OSV API on the resolved transitives.
         install_opts.osv_transitive_check = true;

--- a/crates/aube/src/commands/add/mod.rs
+++ b/crates/aube/src/commands/add/mod.rs
@@ -246,7 +246,7 @@ pub struct AddArgs {
         value_parser = parse_deny_build_value,
     )]
     pub deny_build: Vec<String>,
-    /// Skip lifecycle scripts (no-op; aube already skips by default).
+    /// Skip root and approved dependency lifecycle scripts.
     #[arg(long, hide = true)]
     pub ignore_scripts: bool,
     /// Install without persisting the dependency to `package.json`.
@@ -365,7 +365,7 @@ pub async fn run(
         save_workspace_protocol,
         no_save_workspace_protocol,
         workspace,
-        ignore_scripts: _,
+        ignore_scripts,
         no_save,
         ignore_workspace_root_check,
         save_catalog,
@@ -568,6 +568,7 @@ pub async fn run(
     let mut install_opts =
         install::InstallOptions::with_mode(super::chained_frozen_mode(install::FrozenMode::Fix));
     apply_dangerously_allow_all_builds(&mut install_opts, dangerously_allow_all_builds);
+    install_opts.ignore_scripts = ignore_scripts;
     install_opts.run_dev_preinstall = true;
     install_opts.osv_transitive_check = true;
     let pipeline_result: miette::Result<()> =

--- a/crates/aube/src/commands/add/mod.rs
+++ b/crates/aube/src/commands/add/mod.rs
@@ -128,6 +128,7 @@ pub async fn add_to_project(
             install_options.project_dir = Some(project_dir.to_path_buf());
             install_options.ignore_scripts = options.ignore_scripts;
             install_options.run_dev_preinstall = true;
+            install_options.script_command = "add";
             install_options.force = options.force;
             install_options.dep_selection = options.dep_selection;
             install_options.osv_transitive_check = options.osv_transitive_check && !options.offline;
@@ -570,6 +571,7 @@ pub async fn run(
     apply_dangerously_allow_all_builds(&mut install_opts, dangerously_allow_all_builds);
     install_opts.ignore_scripts = ignore_scripts;
     install_opts.run_dev_preinstall = true;
+    install_opts.script_command = "add";
     install_opts.osv_transitive_check = true;
     let pipeline_result: miette::Result<()> =
         install::run_with_project_lock(install_opts, &lock).await;

--- a/crates/aube/src/commands/add/mod.rs
+++ b/crates/aube/src/commands/add/mod.rs
@@ -127,6 +127,7 @@ pub async fn add_to_project(
             let mut install_options = install::InstallOptions::with_mode(install::FrozenMode::Fix);
             install_options.project_dir = Some(project_dir.to_path_buf());
             install_options.ignore_scripts = options.ignore_scripts;
+            install_options.run_dev_preinstall = true;
             install_options.force = options.force;
             install_options.dep_selection = options.dep_selection;
             install_options.osv_transitive_check = options.osv_transitive_check && !options.offline;

--- a/crates/aube/src/commands/add/mod.rs
+++ b/crates/aube/src/commands/add/mod.rs
@@ -567,6 +567,7 @@ pub async fn run(
     let mut install_opts =
         install::InstallOptions::with_mode(super::chained_frozen_mode(install::FrozenMode::Fix));
     apply_dangerously_allow_all_builds(&mut install_opts, dangerously_allow_all_builds);
+    install_opts.run_dev_preinstall = true;
     install_opts.osv_transitive_check = true;
     let pipeline_result: miette::Result<()> =
         install::run_with_project_lock(install_opts, &lock).await;

--- a/crates/aube/src/commands/ci.rs
+++ b/crates/aube/src/commands/ci.rs
@@ -91,6 +91,7 @@ pub async fn run(args: CiArgs) -> miette::Result<()> {
         workspace_filter: aube_workspace::selector::EffectiveFilter::default(),
         skip_root_lifecycle: false,
         run_dev_preinstall: true,
+        script_command: "install",
         // `aube ci` is the canonical "lockfile is law" path —
         // strict frozen, no drift allowed. Don't force the live
         // API; install::run's fresh-resolution detection and the

--- a/crates/aube/src/commands/ci.rs
+++ b/crates/aube/src/commands/ci.rs
@@ -90,6 +90,7 @@ pub async fn run(args: CiArgs) -> miette::Result<()> {
         build_policy_override: None,
         workspace_filter: aube_workspace::selector::EffectiveFilter::default(),
         skip_root_lifecycle: false,
+        run_dev_preinstall: true,
         // `aube ci` is the canonical "lockfile is law" path —
         // strict frozen, no drift allowed. Don't force the live
         // API; install::run's fresh-resolution detection and the

--- a/crates/aube/src/commands/deploy/mod.rs
+++ b/crates/aube/src/commands/deploy/mod.rs
@@ -342,6 +342,7 @@ pub async fn run(
             workspace_filter: aube_workspace::selector::EffectiveFilter::default(),
             skip_root_lifecycle: false,
             run_dev_preinstall: true,
+            script_command: "install",
             // Deploys are lockfile-driven by definition. Don't
             // force the live API; install::run's fresh-resolution
             // detection still kicks in if the resolver picks a

--- a/crates/aube/src/commands/deploy/mod.rs
+++ b/crates/aube/src/commands/deploy/mod.rs
@@ -341,6 +341,7 @@ pub async fn run(
             build_policy_override: None,
             workspace_filter: aube_workspace::selector::EffectiveFilter::default(),
             skip_root_lifecycle: false,
+            run_dev_preinstall: true,
             // Deploys are lockfile-driven by definition. Don't
             // force the live API; install::run's fresh-resolution
             // detection still kicks in if the resolver picks a

--- a/crates/aube/src/commands/install/args.rs
+++ b/crates/aube/src/commands/install/args.rs
@@ -300,6 +300,7 @@ impl InstallArgs {
             // chained-call constructor (`with_mode`) is where commands
             // with package args opt into skipping them.
             skip_root_lifecycle: false,
+            run_dev_preinstall: true,
             // Argumentless `aube install` doesn't force the live-API
             // transitive gate by itself. `install::run` still runs
             // the gate when it detects fresh resolution (no
@@ -429,6 +430,10 @@ pub struct InstallOptions {
     /// git-prepare install — that one's "root" IS the git dep itself and
     /// running its `prepare` is the whole point.
     pub skip_root_lifecycle: bool,
+    /// Run the root-only `pnpm:devPreinstall` hook before resolution.
+    /// Unlike ordinary root lifecycle hooks, pnpm also runs this for
+    /// `add` and `update`; other chained install callers leave it disabled.
+    pub run_dev_preinstall: bool,
     /// Run the post-resolve transitive OSV `MAL-*` gate against
     /// the live OSV API (not the mirror). Flipped on by commands
     /// whose whole point is fresh resolution — `aube add` and
@@ -489,6 +494,9 @@ impl InstallOptions {
             // the only construction path that runs them and it goes
             // through `InstallArgs::into_options`, not here.
             skip_root_lifecycle: true,
+            // Chained callers opt in individually. pnpm runs this hook for
+            // add/update, but not for unrelated internal installs.
+            run_dev_preinstall: false,
             // Default `false`. `aube add` and `aube update` flip
             // this on at construction. Other chained callers
             // (remove, dedupe, patch_commit, ...) leave it off so

--- a/crates/aube/src/commands/install/args.rs
+++ b/crates/aube/src/commands/install/args.rs
@@ -301,6 +301,7 @@ impl InstallArgs {
             // with package args opt into skipping them.
             skip_root_lifecycle: false,
             run_dev_preinstall: true,
+            script_command: "install",
             // Argumentless `aube install` doesn't force the live-API
             // transitive gate by itself. `install::run` still runs
             // the gate when it detects fresh resolution (no
@@ -434,6 +435,10 @@ pub struct InstallOptions {
     /// Unlike ordinary root lifecycle hooks, pnpm also runs this for
     /// `add` and `update`; other chained install callers leave it disabled.
     pub run_dev_preinstall: bool,
+    /// Top-level package-manager command exposed to lifecycle scripts as
+    /// `npm_command`. Chained callers override the install default so hooks
+    /// can distinguish `add` and `update`.
+    pub script_command: &'static str,
     /// Run the post-resolve transitive OSV `MAL-*` gate against
     /// the live OSV API (not the mirror). Flipped on by commands
     /// whose whole point is fresh resolution — `aube add` and
@@ -497,6 +502,7 @@ impl InstallOptions {
             // Chained callers opt in individually. pnpm runs this hook for
             // add/update, but not for unrelated internal installs.
             run_dev_preinstall: false,
+            script_command: "install",
             // Default `false`. `aube add` and `aube update` flip
             // this on at construction. Other chained callers
             // (remove, dedupe, patch_commit, ...) leave it off so

--- a/crates/aube/src/commands/install/git_prepare.rs
+++ b/crates/aube/src/commands/install/git_prepare.rs
@@ -114,6 +114,7 @@ pub(super) async fn run_git_dep_prepare(
     // Treat this as if it were an argumentless `aube install` against the
     // dep's clone directory.
     opts.skip_root_lifecycle = false;
+    opts.run_dev_preinstall = true;
     let spec = spec.to_string();
     tokio::task::spawn_blocking(move || {
         let runtime = tokio::runtime::Builder::new_current_thread()

--- a/crates/aube/src/commands/install/lifecycle.rs
+++ b/crates/aube/src/commands/install/lifecycle.rs
@@ -15,23 +15,30 @@ pub(super) async fn run_root_lifecycle(
     manifest: &aube_manifest::PackageJson,
     hook: aube_scripts::LifecycleHook,
 ) -> miette::Result<()> {
+    run_root_lifecycle_script(project_dir, modules_dir_name, manifest, hook.script_name()).await
+}
+
+/// Run a named root-package lifecycle script.
+///
+/// Most install hooks use [`aube_scripts::LifecycleHook`], but pnpm's
+/// root-only `pnpm:devPreinstall` hook is intentionally outside the npm
+/// lifecycle enum. Keeping the spawn and error path here makes the special
+/// hook behave exactly like the ordinary root lifecycle.
+pub(super) async fn run_root_lifecycle_script(
+    project_dir: &std::path::Path,
+    modules_dir_name: &str,
+    manifest: &aube_manifest::PackageJson,
+    script_name: &str,
+) -> miette::Result<()> {
     // Only announce when the hook is actually defined, so projects without
     // lifecycle scripts don't get noise in their install output.
-    if !manifest.scripts.contains_key(hook.script_name()) {
+    if !manifest.scripts.contains_key(script_name) {
         return Ok(());
     }
-    tracing::debug!("Running {} script...", hook.script_name());
-    aube_scripts::run_root_hook(project_dir, modules_dir_name, manifest, hook)
+    tracing::debug!("Running {script_name} script...");
+    aube_scripts::run_root_script_by_name(project_dir, modules_dir_name, manifest, script_name)
         .await
-        .map_err(|e| {
-            // Old message was just the bare error string. User got
-            // a cryptic "exit status 1" with no hook name, no script
-            // path, nothing. Tag with which hook fired so the log
-            // line is self-documenting. This is the common case
-            // (failed preinstall on `aube install`) so the regression
-            // really hurt triage.
-            miette!("root {} script failed: {e}", hook.script_name())
-        })?;
+        .map_err(|e| miette!("root {script_name} script failed: {e}"))?;
     Ok(())
 }
 

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -622,7 +622,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
         .await?;
     }
     if !opts.ignore_scripts {
-        super::configure_script_settings(&settings_ctx, Some("install"));
+        super::configure_script_settings(&settings_ctx, Some(opts.script_command));
     }
 
     let layout::InstallLayoutConfig {

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -744,22 +744,12 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     // lockfile/workspace root and never fans out to member manifests.
     // The warm fast path returned above, so an already-current repeat
     // install naturally skips it.
-    if !opts.dry_run && !opts.ignore_scripts && !lockfile_only_effective && opts.run_dev_preinstall
-    {
-        // Normal CLI installs already normalize `cwd` to the workspace root.
-        // Explicit `project_dir` calls from embedders or chained commands may
-        // still point at a member, so resolve the root again at this boundary.
-        let root_dir = crate::dirs::find_workspace_root(&cwd).unwrap_or_else(|| cwd.clone());
-        let root_manifest = if root_dir == cwd {
-            None
-        } else {
-            Some(super::load_manifest_or_default(&root_dir)?)
-        };
-        run_root_lifecycle_script(
-            &root_dir,
-            &modules_dir_name,
-            root_manifest.as_ref().unwrap_or(&manifest),
-            "pnpm:devPreinstall",
+    if opts.run_dev_preinstall {
+        run_dev_preinstall(
+            &cwd,
+            opts.ignore_scripts,
+            opts.dry_run,
+            lockfile_only_effective,
         )
         .await?;
     }
@@ -2515,6 +2505,32 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
         );
     }
     Ok(())
+}
+
+/// Run pnpm's root-only pre-resolution hook from the workspace/lockfile root.
+///
+/// Kept as a command-level boundary because `update` resolves before chaining
+/// into the install pipeline and must invoke the same hook before its resolver.
+pub(crate) async fn run_dev_preinstall(
+    project_dir: &std::path::Path,
+    ignore_scripts: bool,
+    dry_run: bool,
+    lockfile_only: bool,
+) -> miette::Result<()> {
+    if ignore_scripts || dry_run || lockfile_only {
+        return Ok(());
+    }
+    let root_dir =
+        crate::dirs::find_workspace_root(project_dir).unwrap_or_else(|| project_dir.to_path_buf());
+    let root_manifest = super::load_manifest_or_default(&root_dir)?;
+    let modules_dir_name = super::resolve_modules_dir_name_for_cwd(&root_dir);
+    run_root_lifecycle_script(
+        &root_dir,
+        &modules_dir_name,
+        &root_manifest,
+        "pnpm:devPreinstall",
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -744,10 +744,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     // lockfile/workspace root and never fans out to member manifests.
     // The warm fast path returned above, so an already-current repeat
     // install naturally skips it.
-    if !opts.dry_run
-        && !opts.ignore_scripts
-        && !lockfile_only_effective
-        && !opts.skip_root_lifecycle
+    if !opts.dry_run && !opts.ignore_scripts && !lockfile_only_effective && opts.run_dev_preinstall
     {
         // Normal CLI installs already normalize `cwd` to the workspace root.
         // Explicit `project_dir` calls from embedders or chained commands may

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -52,7 +52,8 @@ pub(crate) use lifecycle::{
     run_dep_lifecycle_scripts,
 };
 use lifecycle::{
-    resolve_link_strategy, run_import_on_blocking, run_root_lifecycle, validate_required_scripts,
+    resolve_link_strategy, run_import_on_blocking, run_root_lifecycle, run_root_lifecycle_script,
+    validate_required_scripts,
 };
 
 pub(crate) fn resolve_active_lockfile_dir(
@@ -737,6 +738,19 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
             (build_policy, policy_warnings)
         };
     let inherited_build_policy_for_git_prepare = Some(std::sync::Arc::new(build_policy.clone()));
+
+    // pnpm's root-only pre-resolution hook. Unlike the ordinary
+    // `preinstall` lifecycle below, this runs exactly once from the
+    // lockfile/workspace root and never fans out to member manifests.
+    // The warm fast path returned above, so an already-current repeat
+    // install naturally skips it.
+    if !opts.dry_run
+        && !opts.ignore_scripts
+        && !lockfile_only_effective
+        && !opts.skip_root_lifecycle
+    {
+        run_root_lifecycle_script(&cwd, &modules_dir_name, &manifest, "pnpm:devPreinstall").await?;
+    }
 
     // 1b. Project `preinstall` lifecycle hooks.
     //     Workspace installs run the hook for every physical importer

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -750,6 +750,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
             opts.ignore_scripts,
             opts.dry_run,
             lockfile_only_effective,
+            None,
         )
         .await?;
     }
@@ -2516,12 +2517,17 @@ pub(crate) async fn run_dev_preinstall(
     ignore_scripts: bool,
     dry_run: bool,
     lockfile_only: bool,
+    initialize_environment_for: Option<&str>,
 ) -> miette::Result<()> {
     if ignore_scripts || dry_run || lockfile_only {
         return Ok(());
     }
     let root_dir =
         crate::dirs::find_workspace_root(project_dir).unwrap_or_else(|| project_dir.to_path_buf());
+    if let Some(command) = initialize_environment_for {
+        crate::runtime::ensure_for_cwd(&root_dir).await?;
+        super::configure_script_settings_for_cwd(&root_dir, Some(command))?;
+    }
     let root_manifest = super::load_manifest_or_default(&root_dir)?;
     let modules_dir_name = super::resolve_modules_dir_name_for_cwd(&root_dir);
     run_root_lifecycle_script(

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -749,7 +749,22 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
         && !lockfile_only_effective
         && !opts.skip_root_lifecycle
     {
-        run_root_lifecycle_script(&cwd, &modules_dir_name, &manifest, "pnpm:devPreinstall").await?;
+        // Normal CLI installs already normalize `cwd` to the workspace root.
+        // Explicit `project_dir` calls from embedders or chained commands may
+        // still point at a member, so resolve the root again at this boundary.
+        let root_dir = crate::dirs::find_workspace_root(&cwd).unwrap_or_else(|| cwd.clone());
+        let root_manifest = if root_dir == cwd {
+            None
+        } else {
+            Some(super::load_manifest_or_default(&root_dir)?)
+        };
+        run_root_lifecycle_script(
+            &root_dir,
+            &modules_dir_name,
+            root_manifest.as_ref().unwrap_or(&manifest),
+            "pnpm:devPreinstall",
+        )
+        .await?;
     }
 
     // 1b. Project `preinstall` lifecycle hooks.

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -859,6 +859,7 @@ pub async fn run(
     chained.ignore_pnpmfile = args.ignore_pnpmfile;
     chained.pnpmfile = args.pnpmfile.clone();
     chained.global_pnpmfile = args.global_pnpmfile.clone();
+    chained.run_dev_preinstall = true;
     // `aube update` is one of the canonical fresh-resolution
     // entry points — by design it pulls newer versions than the
     // lockfile pins. Route the post-resolve transitive set

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -205,7 +205,14 @@ async fn run_inner(
     }
     let lock = super::take_install_project_lock(&cwd)?;
     if !args.dev_preinstall_already_run {
-        install::run_dev_preinstall(&cwd, args.ignore_scripts, false, args.lockfile_only).await?;
+        install::run_dev_preinstall(
+            &cwd,
+            args.ignore_scripts,
+            false,
+            args.lockfile_only,
+            Some("update"),
+        )
+        .await?;
     }
     let manifest_path = cwd.join("package.json");
 
@@ -1364,7 +1371,14 @@ async fn run_filtered(
     reject_unsupported_pkg_specs(&args.packages)?;
     let cwd = crate::dirs::cwd()?;
     let (root, matched) = super::select_workspace_packages(&cwd, filter, "update")?;
-    install::run_dev_preinstall(&root, args.ignore_scripts, false, args.lockfile_only).await?;
+    install::run_dev_preinstall(
+        &root,
+        args.ignore_scripts,
+        false,
+        args.lockfile_only,
+        Some("update"),
+    )
+    .await?;
     args.dev_preinstall_already_run = true;
     let shared_workspace_lockfile = resolve_shared_workspace_lockfile(&root)?;
     let root_manifest = if shared_workspace_lockfile {

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -1569,6 +1569,7 @@ fn chained_install_options(args: &UpdateArgs) -> install::InstallOptions {
     chained.pnpmfile = args.pnpmfile.clone();
     chained.global_pnpmfile = args.global_pnpmfile.clone();
     chained.ignore_scripts = args.ignore_scripts;
+    chained.script_command = "update";
     // Fresh update resolutions should receive the same live OSV check
     // whether the install is per-project or deferred to the workspace root.
     chained.osv_transitive_check = true;

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -76,12 +76,13 @@ pub struct UpdateArgs {
     pub ignore_pnpmfile: bool,
     /// Skip lifecycle scripts.
     ///
-    /// Accepted for pnpm parity — dep scripts are already gated by
-    /// `allowBuilds`, so the flag is currently a no-op, but scripts
-    /// that wrap `pnpm update --ignore-scripts` keep working without
-    /// complaint.
+    /// Skips the root `pnpm:devPreinstall` hook and all approved
+    /// dependency build scripts in the chained install.
     #[arg(long, hide = true)]
     pub ignore_scripts: bool,
+    /// Internal recursive-update marker: the workspace root hook already ran.
+    #[arg(skip)]
+    dev_preinstall_already_run: bool,
     /// Refresh the lockfile without populating `node_modules`.
     ///
     /// Re-resolves the full graph (direct + transitive) and writes
@@ -123,7 +124,6 @@ pub async fn run(
     args.network.install_overrides();
     args.lockfile.install_overrides();
     args.virtual_store.install_overrides();
-    let _ = args.ignore_scripts; // parity no-op: dep scripts already gated by allowBuilds
     if let Some(depth) = args.depth.as_deref() {
         // pnpm's `--depth Infinity` is the only useful value; the
         // intermediate ones (`--depth 1`, `--depth 2`) have semantics
@@ -188,6 +188,9 @@ pub async fn run(
         cwd = root;
     }
     let lock = super::take_install_project_lock(&cwd)?;
+    if !args.dev_preinstall_already_run {
+        install::run_dev_preinstall(&cwd, args.ignore_scripts, false, args.lockfile_only).await?;
+    }
     let manifest_path = cwd.join("package.json");
 
     let mut manifest = aube_manifest::PackageJson::from_path(&manifest_path)
@@ -859,7 +862,7 @@ pub async fn run(
     chained.ignore_pnpmfile = args.ignore_pnpmfile;
     chained.pnpmfile = args.pnpmfile.clone();
     chained.global_pnpmfile = args.global_pnpmfile.clone();
-    chained.run_dev_preinstall = true;
+    chained.ignore_scripts = args.ignore_scripts;
     // `aube update` is one of the canonical fresh-resolution
     // entry points — by design it pulls newer versions than the
     // lockfile pins. Route the post-resolve transitive set
@@ -1318,12 +1321,14 @@ fn with_update_settings_ctx<T>(
 }
 
 async fn run_filtered(
-    args: UpdateArgs,
+    mut args: UpdateArgs,
     filter: &aube_workspace::selector::EffectiveFilter,
 ) -> miette::Result<Option<i32>> {
     reject_unsupported_pkg_specs(&args.packages)?;
     let cwd = crate::dirs::cwd()?;
     let (root, matched) = super::select_workspace_packages(&cwd, filter, "update")?;
+    install::run_dev_preinstall(&root, args.ignore_scripts, false, args.lockfile_only).await?;
+    args.dev_preinstall_already_run = true;
     let shared_workspace_lockfile = resolve_shared_workspace_lockfile(&root)?;
     let root_manifest = if shared_workspace_lockfile {
         Some(super::load_manifest_or_default(&root)?)

--- a/crates/aube/src/embed.rs
+++ b/crates/aube/src/embed.rs
@@ -141,6 +141,7 @@ pub async fn install(options: InstallOptions) -> Result<()> {
     command_options.dep_selection = options.dep_selection;
     command_options.ignore_scripts = options.ignore_scripts;
     command_options.skip_root_lifecycle = !options.run_root_lifecycle;
+    command_options.run_dev_preinstall = options.run_root_lifecycle;
     command_options.dry_run = options.dry_run;
     command_options.lockfile_only = options.lockfile_only;
     command_options.force = options.force;

--- a/crates/aube/tests/embed.rs
+++ b/crates/aube/tests/embed.rs
@@ -121,6 +121,42 @@ async fn facade_adds_local_package_to_workspace_member() {
 }
 
 #[tokio::test]
+async fn facade_add_runs_root_dev_preinstall() {
+    initialize_test_host();
+    let (workspace, app) = workspace_fixture();
+    std::fs::write(
+        workspace.path().join("package.json"),
+        r#"{
+  "private": true,
+  "scripts": {
+    "pnpm:devPreinstall": "printf ran > embedded-dev-preinstall.marker"
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    aube::embed::add(
+        &app,
+        &["library@workspace:*".to_string()],
+        aube::embed::AddToProjectOptions {
+            offline: true,
+            control: InstallControl::silent(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        workspace
+            .path()
+            .join("embedded-dev-preinstall.marker")
+            .is_file()
+    );
+}
+
+#[tokio::test]
 async fn cancelled_manifest_mutation_is_rolled_back() {
     initialize_test_host();
     let (workspace, app) = workspace_fixture();

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -12434,7 +12434,7 @@
             "name": "ignore-scripts",
             "usage": "--ignore-scripts",
             "help": "Skip lifecycle scripts",
-            "help_long": "Skip lifecycle scripts.\n\nAccepted for pnpm parity — dep scripts are already gated by `allowBuilds`, so the flag is currently a no-op, but scripts that wrap `pnpm update --ignore-scripts` keep working without complaint.",
+            "help_long": "Skip lifecycle scripts.\n\nSkips the root `pnpm:devPreinstall` hook and all approved dependency build scripts in the chained install.",
             "help_first_line": "Skip lifecycle scripts",
             "short": [],
             "long": [

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -667,8 +667,8 @@
           {
             "name": "ignore-scripts",
             "usage": "--ignore-scripts",
-            "help": "Skip lifecycle scripts (no-op; aube already skips by default)",
-            "help_first_line": "Skip lifecycle scripts (no-op; aube already skips by default)",
+            "help": "Skip root and approved dependency lifecycle scripts",
+            "help_first_line": "Skip root and approved dependency lifecycle scripts",
             "short": [],
             "long": [
               "ignore-scripts"

--- a/test/add.bats
+++ b/test/add.bats
@@ -278,6 +278,32 @@ EOF
 	assert_failure
 }
 
+@test "aube add --filter --ignore-scripts skips root pnpm:devPreinstall" {
+	cat >pnpm-workspace.yaml <<-'EOF'
+		packages:
+		  - packages/*
+	EOF
+	cat >package.json <<-'EOF'
+		{
+		  "name": "root",
+		  "version": "0.0.0",
+		  "private": true,
+		  "scripts": {
+		    "pnpm:devPreinstall": "node -e 'require(\"fs\").writeFileSync(\"dev-preinstall.marker\", \"ran\")'"
+		  }
+		}
+	EOF
+	mkdir -p packages/dashboard
+	cat >packages/dashboard/package.json <<-'EOF'
+		{"name": "dashboard", "version": "0.0.0", "private": true}
+	EOF
+
+	run aube add is-odd --filter=dashboard --ignore-scripts
+	assert_success
+	assert_file_exists packages/dashboard/node_modules/is-odd/index.js
+	assert_file_not_exists dev-preinstall.marker
+}
+
 @test "aube add -D: moves dep from dependencies to devDependencies" {
 	cat >package.json <<'EOF'
 {

--- a/test/install.bats
+++ b/test/install.bats
@@ -880,13 +880,20 @@ JSON
 	assert_file_exists node_modules/is-odd/package.json
 }
 
-@test "aube add --ignore-scripts is accepted (no-op)" {
-	_setup_basic_fixture
-	# Use a tiny package that doesn't actually have scripts; flag should
-	# just pass through without erroring.
+@test "aube add --ignore-scripts skips pnpm:devPreinstall" {
+	cat >package.json <<-'EOF'
+		{
+		  "name": "add-ignore-scripts",
+		  "version": "1.0.0",
+		  "scripts": {
+		    "pnpm:devPreinstall": "node -e 'require(\"fs\").writeFileSync(\"dev-preinstall.marker\", \"ran\")'"
+		  }
+		}
+	EOF
 	run aube add --ignore-scripts --save-dev is-number
 	assert_success
 	assert_file_exists node_modules/is-number/package.json
+	assert_file_not_exists dev-preinstall.marker
 }
 
 @test "aube install --prefer-offline reuses cached metadata" {

--- a/test/install.bats
+++ b/test/install.bats
@@ -1035,6 +1035,7 @@ JSON
   "name": "preinstall-test",
   "version": "1.0.0",
   "scripts": {
+    "pnpm:devPreinstall": "echo DEV_PREINSTALL_RAN > dev-preinstall.marker",
     "preinstall": "echo PREINSTALL_RAN > preinstall.marker"
   },
   "dependencies": { "is-odd": "^3.0.1" }
@@ -1043,6 +1044,7 @@ JSON
 	run aube install --lockfile-only
 	assert_success
 	assert_file_exists aube-lock.yaml
+	assert [ ! -e dev-preinstall.marker ]
 	assert [ ! -e preinstall.marker ]
 }
 

--- a/test/lifecycle_scripts.bats
+++ b/test/lifecycle_scripts.bats
@@ -108,7 +108,7 @@ JSON
   "name": "dev-preinstall-add",
   "version": "1.0.0",
   "scripts": {
-    "pnpm:devPreinstall": "node -e 'require(\"fs\").writeFileSync(\"dev.marker\", \"ran\")'",
+    "pnpm:devPreinstall": "node -e 'require(\"fs\").writeFileSync(\"dev.marker\", process.env.npm_command)'",
     "postinstall": "node -e 'require(\"fs\").writeFileSync(\"postinstall.marker\", \"ran\")'"
   }
 }
@@ -116,7 +116,8 @@ JSON
 	echo "trustPolicy=off" >>.npmrc
 	run aube add is-odd
 	assert_success
-	assert_file_exists dev.marker
+	run cat dev.marker
+	assert_output "add"
 	assert_file_not_exists postinstall.marker
 }
 

--- a/test/lifecycle_scripts.bats
+++ b/test/lifecycle_scripts.bats
@@ -102,6 +102,24 @@ JSON
 	assert_output "1"
 }
 
+@test "aube add runs pnpm:devPreinstall without ordinary root hooks" {
+	cat >package.json <<'JSON'
+{
+  "name": "dev-preinstall-add",
+  "version": "1.0.0",
+  "scripts": {
+    "pnpm:devPreinstall": "node -e 'require(\"fs\").writeFileSync(\"dev.marker\", \"ran\")'",
+    "postinstall": "node -e 'require(\"fs\").writeFileSync(\"postinstall.marker\", \"ran\")'"
+  }
+}
+JSON
+	echo "trustPolicy=off" >>.npmrc
+	run aube add is-odd
+	assert_success
+	assert_file_exists dev.marker
+	assert_file_not_exists postinstall.marker
+}
+
 @test "aube install runs root postinstall hook after deps are linked" {
 	cat >package.json <<'JSON'
 {

--- a/test/lifecycle_scripts.bats
+++ b/test/lifecycle_scripts.bats
@@ -29,6 +29,79 @@ JSON
 	assert_file_exists preinstall.marker
 }
 
+@test "aube install runs pnpm:devPreinstall before root preinstall" {
+	cat >package.json <<'JSON'
+{
+  "name": "dev-preinstall-test",
+  "version": "1.0.0",
+  "scripts": {
+    "pnpm:devPreinstall": "node -e 'require(\"fs\").writeFileSync(\"order.log\", \"dev\\n\")'",
+    "preinstall": "node -e 'require(\"fs\").appendFileSync(\"order.log\", \"pre\\n\")'"
+  },
+  "dependencies": {
+    "is-odd": "^3.0.1"
+  }
+}
+JSON
+	run aube install
+	assert_success
+	run cat order.log
+	assert_output "dev
+pre"
+}
+
+@test "aube install runs pnpm:devPreinstall only at the workspace root" {
+	cat >package.json <<'JSON'
+{
+  "name": "dev-preinstall-workspace",
+  "version": "1.0.0",
+  "scripts": {
+    "pnpm:devPreinstall": "node -e 'require(\"fs\").writeFileSync(\"root.marker\", \"ran\")'"
+  }
+}
+JSON
+	cat >pnpm-workspace.yaml <<'YAML'
+packages:
+  - packages/*
+YAML
+	mkdir -p packages/app
+	cat >packages/app/package.json <<'JSON'
+{
+  "name": "dev-preinstall-member",
+  "version": "1.0.0",
+  "scripts": {
+    "pnpm:devPreinstall": "node -e 'require(\"fs\").writeFileSync(\"member.marker\", \"ran\")'"
+  }
+}
+JSON
+	run aube install
+	assert_success
+	assert_file_exists root.marker
+	assert_file_not_exists packages/app/member.marker
+}
+
+@test "aube install skips pnpm:devPreinstall on warm repeats" {
+	cat >package.json <<'JSON'
+{
+  "name": "dev-preinstall-warm",
+  "version": "1.0.0",
+  "scripts": {
+    "pnpm:devPreinstall": "node -e 'require(\"fs\").appendFileSync(\"runs.log\", \"run\\n\")'"
+  },
+  "dependencies": {
+    "is-odd": "^3.0.1"
+  }
+}
+JSON
+	echo "trustPolicy=off" >>.npmrc
+	run aube install
+	assert_success
+	run aube install
+	assert_success
+	run wc -l <runs.log
+	assert_output "1"
+}
+
 @test "aube install runs root postinstall hook after deps are linked" {
 	cat >package.json <<'JSON'
 {
@@ -357,6 +430,7 @@ JSON
   "name": "lifecycle-test",
   "version": "1.0.0",
   "scripts": {
+    "pnpm:devPreinstall": "node -e 'require(\"fs\").writeFileSync(\"should-not-exist\", \"x\")'",
     "preinstall": "node -e 'require(\"fs\").writeFileSync(\"should-not-exist\", \"x\")'",
     "postinstall": "node -e 'require(\"fs\").writeFileSync(\"should-not-exist\", \"x\")'"
   },

--- a/test/lifecycle_scripts.bats
+++ b/test/lifecycle_scripts.bats
@@ -98,7 +98,7 @@ JSON
 	assert_success
 	run aube install
 	assert_success
-	run wc -l <runs.log
+	run grep -c '^run$' runs.log
 	assert_output "1"
 }
 

--- a/test/lifecycle_scripts.bats
+++ b/test/lifecycle_scripts.bats
@@ -74,7 +74,7 @@ YAML
   }
 }
 JSON
-	run aube install
+	run bash -c "cd packages/app && aube install"
 	assert_success
 	assert_file_exists root.marker
 	assert_file_not_exists packages/app/member.marker

--- a/test/update.bats
+++ b/test/update.bats
@@ -68,6 +68,26 @@ EOF
 	assert_file_exists node_modules/is-odd/index.js
 }
 
+@test "aube update runs pnpm:devPreinstall" {
+	_setup_outdated_project
+	cat >package.json <<'EOF'
+{
+  "name": "test-update",
+  "version": "0.0.0",
+  "scripts": {
+    "pnpm:devPreinstall": "node -e 'require(\"fs\").writeFileSync(\"dev.marker\", \"ran\")'"
+  },
+  "dependencies": {
+    "is-odd": ">=0.1.0"
+  }
+}
+EOF
+
+	run aube update is-odd
+	assert_success
+	assert_file_exists dev.marker
+}
+
 @test "aube update: reports version change in output" {
 	_setup_outdated_project
 

--- a/test/update.bats
+++ b/test/update.bats
@@ -103,6 +103,25 @@ EOF
 	assert_file_not_exists dev.marker
 }
 
+@test "aube update configures the devPreinstall script environment" {
+	cat >package.json <<'EOF'
+{
+  "name": "test-update",
+  "version": "0.0.0",
+  "scripts": {
+    "pnpm:devPreinstall": "node -e 'require(\"fs\").writeFileSync(\"env.marker\", `${process.env.npm_command}\\n${process.env.npm_node_execpath}\\n`)'"
+  }
+}
+EOF
+
+	run aube update
+	assert_success
+	run sed -n '1p' env.marker
+	assert_output "update"
+	run sed -n '2p' env.marker
+	assert_output --regexp '.+node.*'
+}
+
 @test "aube update from a workspace member runs only the root pnpm:devPreinstall" {
 	mkdir -p packages/app
 	cat >pnpm-workspace.yaml <<'YAML'

--- a/test/update.bats
+++ b/test/update.bats
@@ -68,24 +68,70 @@ EOF
 	assert_file_exists node_modules/is-odd/index.js
 }
 
-@test "aube update runs pnpm:devPreinstall" {
-	_setup_outdated_project
+@test "aube update runs pnpm:devPreinstall before resolution" {
+	cat >package.json <<'EOF'
+{
+  "name": "test-update",
+  "version": "0.0.0",
+  "scripts": {
+    "pnpm:devPreinstall": "node -e 'require(\"fs\").mkdirSync(\"generated\"); require(\"fs\").writeFileSync(\"generated/package.json\", JSON.stringify({name:\"generated\",version:\"1.0.0\"}))'"
+  },
+  "dependencies": {
+    "generated": "file:./generated"
+  }
+}
+EOF
+
+	run aube update
+	assert_success
+	assert_file_exists generated/package.json
+}
+
+@test "aube update --ignore-scripts skips pnpm:devPreinstall" {
 	cat >package.json <<'EOF'
 {
   "name": "test-update",
   "version": "0.0.0",
   "scripts": {
     "pnpm:devPreinstall": "node -e 'require(\"fs\").writeFileSync(\"dev.marker\", \"ran\")'"
-  },
-  "dependencies": {
-    "is-odd": ">=0.1.0"
   }
 }
 EOF
 
-	run aube update is-odd
+	run aube update --ignore-scripts
 	assert_success
-	assert_file_exists dev.marker
+	assert_file_not_exists dev.marker
+}
+
+@test "aube update from a workspace member runs only the root pnpm:devPreinstall" {
+	mkdir -p packages/app
+	cat >pnpm-workspace.yaml <<'YAML'
+packages:
+  - packages/*
+YAML
+	cat >package.json <<'JSON'
+{
+  "name": "root",
+  "version": "1.0.0",
+  "scripts": {
+    "pnpm:devPreinstall": "node -e 'require(\"fs\").writeFileSync(\"root.marker\", \"ran\")'"
+  }
+}
+JSON
+	cat >packages/app/package.json <<'JSON'
+{
+  "name": "app",
+  "version": "1.0.0",
+  "scripts": {
+    "pnpm:devPreinstall": "node -e 'require(\"fs\").writeFileSync(\"member.marker\", \"ran\")'"
+  }
+}
+JSON
+
+	run bash -c "cd packages/app && aube update"
+	assert_success
+	assert_file_exists root.marker
+	assert_file_not_exists packages/app/member.marker
 }
 
 @test "aube update: reports version change in output" {


### PR DESCRIPTION
## Summary

- run the root package's `pnpm:devPreinstall` script before ordinary `preinstall`
- run the special hook once from the workspace/lockfile root rather than for every member
- skip it on warm no-op installs, `--ignore-scripts`, `--lockfile-only`, and dry runs
- share the existing root lifecycle execution and error path

## Why

`pnpm:devPreinstall` lets a workspace prepare files that dependency resolution or linking expects. Aube previously ignored the hook even though it presents a pnpm-compatible install surface.

## Validation

- `cargo test -p aube install:: --lib`
- `cargo clippy -p aube --all-targets --features publish -- -D warnings`
- focused BATS coverage for ordering, workspace root-only behavior, warm repeats, `--ignore-scripts`, and `--lockfile-only`
- `cargo fmt --check`

Upstream: https://github.com/pnpm/pnpm/releases/tag/v11.18.0

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Lifecycle hooks run arbitrary user code before resolution; mis-timed or duplicate execution could break installs, though gating and workspace-root-only behavior mirror pnpm.
> 
> **Overview**
> **Adds pnpm’s root-only `pnpm:devPreinstall` hook** so it runs once from the workspace/lockfile root before ordinary `preinstall`, including on chained **`add`** and **`update`** (with `npm_command` set to `add` / `update`). **`update`** invokes the shared helper before resolution; filtered workspace updates avoid running it twice. The hook is skipped on warm no-op installs, **`--ignore-scripts`**, **`--lockfile-only`**, and dry runs.
> 
> **`--ignore-scripts` is no longer documented as a no-op**: it is forwarded through **`add`** / **`update`** chained installs and skips root hooks plus approved dependency build scripts. Install options gain **`run_dev_preinstall`** and **`script_command`**; the embed API maps root lifecycle to dev preinstall where appropriate.
> 
> Root lifecycle execution is refactored to **`run_root_script_by_name`** so the special script shares the same spawn/error path as normal hooks. CLI/KDL/docs and BATS/embed tests cover ordering, workspace scoping, and flag behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95d76006a04716d9d800e10b5b0b0a3187d2e25f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running the root-level `pnpm:devPreinstall` lifecycle script during installation.
  * The script runs before `preinstall`, only at the workspace root, and only once per installation context.

* **Bug Fixes**
  * Ensured the script is skipped during dry runs, lockfile-only installs, and when scripts are disabled.

* **Tests**
  * Added coverage for execution order, workspace scoping, repeat installs, and ignored scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->