### PR TITLE
fix(resolver): use local root version for peer context

### DIFF
--- a/crates/aube-resolver/src/peer_context.rs
+++ b/crates/aube-resolver/src/peer_context.rs
@@ -19,7 +19,7 @@
 
 use crate::version_satisfies;
 use crate::{FxHashMap, FxHashSet};
-use aube_lockfile::{DepType, DirectDep, LockedPackage, LockfileGraph};
+use aube_lockfile::{DepType, DirectDep, LocalSource, LockedPackage, LockfileGraph};
 use std::collections::{BTreeMap, BTreeSet};
 
 /// A peer dependency whose declared range doesn't match the version the
@@ -230,7 +230,7 @@ pub fn hoist_auto_installed_peers(mut graph: LockfileGraph) -> LockfileGraph {
 /// neighborhoods.
 ///
 /// Algorithm per visited package P, reached at some point in a DFS from an
-/// importer with `ancestor_scope: name -> dep_path_tail`:
+/// importer with `ancestor_scope: name -> peer provider`:
 ///
 ///  1. For each peer name declared by P, look it up in `ancestor_scope`
 ///     (nearest-ancestor-wins, since the scope is rebuilt per recursion).
@@ -603,7 +603,7 @@ pub(crate) fn dedupe_peer_variants(graph: LockfileGraph) -> LockfileGraph {
 /// for the wrapping fixed-point loop.
 ///
 /// Algorithm per visited package P, reached at some point in a DFS from an
-/// importer with `ancestor_scope: name -> dep_path_tail`:
+/// importer with `ancestor_scope: name -> peer provider`:
 ///
 ///  1. For each peer name declared by P, look it up in `ancestor_scope`
 ///     (nearest-ancestor-wins, since the scope is rebuilt per recursion).
@@ -650,10 +650,10 @@ fn apply_peer_contexts_once(
     // Computed once from the canonical input so it reflects the
     // contextualized state of every root dep on fixed-point iterations
     // 2+ — same logic as per-importer `importer_scope` below.
-    let root_scope: FxHashMap<String, String> = canonical
+    let root_scope: FxHashMap<String, PeerProvider> = canonical
         .importers
         .get(".")
-        .map(|deps| scope_map_from_deps(deps))
+        .map(|deps| scope_map_from_deps(&canonical, deps))
         .unwrap_or_default();
 
     for (importer_path, direct_deps) in &canonical.importers {
@@ -667,7 +667,7 @@ fn apply_peer_contexts_once(
         // it's already contextualized, and passing the plain version
         // would make descendants look up keys that don't exist in the
         // (now-nested) graph.
-        let importer_scope = scope_map_from_deps(direct_deps);
+        let importer_scope = scope_map_from_deps(&canonical, direct_deps);
 
         let mut new_deps = Vec::with_capacity(direct_deps.len());
         for dep in direct_deps {
@@ -748,12 +748,45 @@ fn canonical_tail(s: &str) -> &str {
     s.split('(').next().unwrap_or(s)
 }
 
-/// Build a `name → contextualized tail` map from a direct-dep slice.
-/// The tail is the dep_path with the `{name}@` prefix stripped, which
-/// on pass 1 is equal to `pkg.version` and on pass 2+ carries the
-/// nested peer-context suffix. Used both for the root scope and for
-/// each importer's own scope inside `apply_peer_contexts_once`.
-fn scope_map_from_deps(deps: &[DirectDep]) -> FxHashMap<String, String> {
+/// A peer provider's graph target and semver identity.
+///
+/// Those are normally the same tail. For linked directories, the target
+/// remains the content-addressed local dep path while peer matching and
+/// suffixes use the target manifest's version.
+#[derive(Debug, Clone)]
+struct PeerProvider {
+    /// Tail used to find and link the package in the graph.
+    target_tail: String,
+    /// Tail used for semver checks and the consumer's peer suffix.
+    context_tail: String,
+}
+
+fn peer_provider(graph: &LockfileGraph, name: &str, target_tail: &str) -> PeerProvider {
+    let context_tail =
+        aube_lockfile::resolve_dep_edge(name, target_tail, |key| graph.packages.contains_key(key))
+            .and_then(|key| graph.packages.get(&key))
+            .filter(|pkg| {
+                matches!(
+                    pkg.local_source,
+                    Some(LocalSource::Directory(_) | LocalSource::Link(_) | LocalSource::Portal(_))
+                )
+            })
+            .map(|pkg| pkg.version.clone())
+            .unwrap_or_else(|| target_tail.to_string());
+    PeerProvider {
+        target_tail: target_tail.to_string(),
+        context_tail,
+    }
+}
+
+/// Build a `name → provider` map from a direct-dependency slice.
+///
+/// Used for the workspace root and for each importer's own scope inside
+/// `apply_peer_contexts_once`.
+fn scope_map_from_deps(
+    graph: &LockfileGraph,
+    deps: &[DirectDep],
+) -> FxHashMap<String, PeerProvider> {
     let mut out = FxHashMap::with_capacity_and_hasher(deps.len(), Default::default());
     for d in deps {
         let prefix_len = d.name.len() + 1;
@@ -765,7 +798,7 @@ fn scope_map_from_deps(deps: &[DirectDep]) -> FxHashMap<String, String> {
         } else {
             d.dep_path.clone()
         };
-        out.insert(d.name.clone(), tail);
+        out.insert(d.name.clone(), peer_provider(graph, &d.name, &tail));
     }
     out
 }
@@ -1538,8 +1571,8 @@ fn visit_peer_context<'g>(
     input_dep_path: &str,
     graph: &'g LockfileGraph,
     name_index: &FxHashMap<&'g str, Vec<&'g LockedPackage>>,
-    ancestor_scope: &FxHashMap<String, String>,
-    root_scope: &FxHashMap<String, String>,
+    ancestor_scope: &FxHashMap<String, PeerProvider>,
+    root_scope: &FxHashMap<String, PeerProvider>,
     out_packages: &mut BTreeMap<String, LockedPackage>,
     visiting: &mut FxHashSet<String>,
     options: &PeerContextOptions,
@@ -1618,27 +1651,30 @@ fn visit_peer_context<'g>(
     // global-virtual-store singleton in two and surfacing at runtime as a
     // duplicate-instance "Cannot find module". Matching pnpm's *deduped*
     // output — bare — keeps the singleton intact.
-    let mut peer_context: Vec<(String, String)> = Vec::new();
+    let mut peer_context: Vec<(String, PeerProvider)> = Vec::new();
     for (peer_name, declared_range) in &pkg.peer_dependencies {
-        let satisfies_declared = |v: &str| -> bool {
+        let satisfies_declared = |provider: &PeerProvider| -> bool {
             // The tail may carry a nested peer suffix on fixed-point
             // iterations 2+; strip it before checking the semver.
-            let canonical = canonical_tail(v);
+            let canonical = canonical_tail(&provider.context_tail);
             version_satisfies(canonical, declared_range)
         };
 
         let from_ancestor = ancestor_scope
             .get(peer_name)
-            .filter(|v| satisfies_declared(v))
+            .filter(|provider| satisfies_declared(provider))
             .cloned();
         let from_ancestor_incompatible = ancestor_scope.get(peer_name).cloned();
 
         let from_pkg_deps = pkg
             .dependencies
             .get(peer_name)
-            .filter(|v| satisfies_declared(v))
-            .cloned();
-        let from_pkg_deps_incompatible = pkg.dependencies.get(peer_name).cloned();
+            .map(|tail| peer_provider(graph, peer_name, tail))
+            .filter(|provider| satisfies_declared(provider));
+        let from_pkg_deps_incompatible = pkg
+            .dependencies
+            .get(peer_name)
+            .map(|tail| peer_provider(graph, peer_name, tail));
 
         // `resolve-peers-from-workspace-root`: fall back to the root
         // importer's direct deps before the graph-wide scan. Common in
@@ -1649,7 +1685,7 @@ fn visit_peer_context<'g>(
         let from_root = if options.resolve_from_workspace_root {
             root_scope
                 .get(peer_name)
-                .filter(|v| satisfies_declared(v))
+                .filter(|provider| satisfies_declared(provider))
                 .cloned()
         } else {
             None
@@ -1683,12 +1719,13 @@ fn visit_peer_context<'g>(
                         .strip_prefix(&format!("{}@", p.name))
                         .map(|s| s.to_string())
                         .unwrap_or_else(|| p.version.clone());
-                    node_semver::Version::parse(&p.version)
-                        .ok()
-                        .map(|ver| (ver, tail))
+                    node_semver::Version::parse(&p.version).ok().map(|ver| {
+                        let provider = peer_provider(graph, peer_name, &tail);
+                        (ver, provider)
+                    })
                 })
                 .max_by(|a, b| a.0.cmp(&b.0))
-                .map(|(_, tail)| tail)
+                .map(|(_, provider)| provider)
         };
 
         // pnpm resolves an *optional* peer (one flagged
@@ -1716,8 +1753,8 @@ fn visit_peer_context<'g>(
                 .or_else(from_graph_scan)
                 .or(from_root_incompatible)
         };
-        if let Some(version) = resolved {
-            peer_context.push((peer_name.clone(), version));
+        if let Some(provider) = resolved {
+            peer_context.push((peer_name.clone(), provider));
         }
     }
     peer_context.sort_by(|a, b| a.0.cmp(&b.0));
@@ -1743,12 +1780,12 @@ fn visit_peer_context<'g>(
     // `dedupe_peer_suffixes` after cycle detection is done.
     let suffix: String = peer_context
         .iter()
-        .map(|(n, v)| {
-            let cycles_back = contains_canonical_back_ref(v, &canonical_base);
+        .map(|(n, provider)| {
+            let cycles_back = contains_canonical_back_ref(&provider.context_tail, &canonical_base);
             let display_v = if cycles_back {
-                canonical_tail(v).to_string()
+                canonical_tail(&provider.context_tail).to_string()
             } else {
-                v.clone()
+                provider.context_tail.clone()
             };
             format!("({n}@{display_v})")
         })
@@ -1783,11 +1820,11 @@ fn visit_peer_context<'g>(
     // serialize as `(react-dom@18.2.0(react@18.2.0))`. That's the
     // nested form pnpm writes.
     let mut child_scope = ancestor_scope.clone();
-    for (name, version) in &pkg.dependencies {
-        child_scope.insert(name.clone(), version.clone());
+    for (name, tail) in &pkg.dependencies {
+        child_scope.insert(name.clone(), peer_provider(graph, name, tail));
     }
-    for (name, version) in &peer_context {
-        child_scope.insert(name.clone(), version.clone());
+    for (name, provider) in &peer_context {
+        child_scope.insert(name.clone(), provider.clone());
     }
 
     // Recurse into each child, rewriting its dependency map entry to
@@ -1801,7 +1838,8 @@ fn visit_peer_context<'g>(
     // sibling symlink target inconsistent with the peer-context claim.
     // When the ancestor's version doesn't satisfy the declared range,
     // `detect_unmet_peers` will flag it as a warning after the pass.
-    let peer_context_versions: FxHashMap<String, String> = peer_context.iter().cloned().collect();
+    let peer_context_versions: FxHashMap<String, PeerProvider> =
+        peer_context.iter().cloned().collect();
 
     let mut new_dependencies: BTreeMap<String, String> = BTreeMap::new();
     let mut visited_dep_names: FxHashSet<String> = FxHashSet::default();
@@ -1811,7 +1849,7 @@ fn visit_peer_context<'g>(
         // peer context (which may be nested). Otherwise we use the
         // tail we already have — also possibly nested on a 2nd pass.
         let lookup_tail = match peer_context_versions.get(child_name) {
-            Some(v) => v.clone(),
+            Some(provider) => provider.target_tail.clone(),
             None => child_version_tail.clone(),
         };
         let child_canonical_dep_path = format!("{child_name}@{lookup_tail}");
@@ -1840,11 +1878,11 @@ fn visit_peer_context<'g>(
     // have been in `pkg.dependencies` at all (no auto-install needed).
     // Wire them as deps now so the linker creates the sibling symlink
     // and the lockfile snapshot records them.
-    for (peer_name, peer_version) in &peer_context {
+    for (peer_name, provider) in &peer_context {
         if visited_dep_names.contains(peer_name) {
             continue;
         }
-        let child_canonical_dep_path = format!("{peer_name}@{peer_version}");
+        let child_canonical_dep_path = format!("{peer_name}@{}", provider.target_tail);
         let child_new = visit_peer_context(
             &child_canonical_dep_path,
             graph,
@@ -1859,7 +1897,7 @@ fn visit_peer_context<'g>(
             let new_tail = new_dep_path
                 .strip_prefix(&format!("{peer_name}@"))
                 .map(|s| s.to_string())
-                .unwrap_or_else(|| peer_version.clone());
+                .unwrap_or_else(|| provider.target_tail.clone());
             new_dependencies.insert(peer_name.clone(), new_tail);
         }
     }
@@ -1992,6 +2030,59 @@ mod tests {
         assert!(
             out.packages.contains_key("plugin@1.0.0(theme@1.0.0)"),
             "a required peer should still resolve through the graph-wide scan"
+        );
+    }
+
+    #[test]
+    fn linked_workspace_root_peer_uses_manifest_version_and_local_target() {
+        let mut g = LockfileGraph::default();
+        g.importers.insert(
+            ".".to_string(),
+            vec![DirectDep {
+                name: "theme".to_string(),
+                dep_path: "theme@link+0123456789abcdef".to_string(),
+                dep_type: DepType::Production,
+                specifier: Some("link:theme".to_string()),
+            }],
+        );
+        g.importers.insert(
+            "packages/app".to_string(),
+            vec![DirectDep {
+                name: "plugin".to_string(),
+                dep_path: "plugin@1.0.0".to_string(),
+                dep_type: DepType::Production,
+                specifier: Some("1.0.0".to_string()),
+            }],
+        );
+        g.packages.insert(
+            "theme@link+0123456789abcdef".to_string(),
+            LockedPackage {
+                name: "theme".to_string(),
+                version: "4.10.0".to_string(),
+                dep_path: "theme@link+0123456789abcdef".to_string(),
+                local_source: Some(LocalSource::Link("theme".into())),
+                ..Default::default()
+            },
+        );
+        let mut plugin = locked("plugin", &[]);
+        plugin
+            .peer_dependencies
+            .insert("theme".to_string(), "^4.0.0".to_string());
+        plugin
+            .peer_dependencies_meta
+            .insert("theme".to_string(), PeerDepMeta { optional: true });
+        g.packages.insert(plugin.dep_path.clone(), plugin);
+
+        let out = apply_peer_contexts(g, &PeerContextOptions::default()).expect("peer pass");
+
+        let plugin = out
+            .packages
+            .get("plugin@1.0.0(theme@4.10.0)")
+            .expect("linked root dependency should satisfy the peer at its manifest version");
+        assert_eq!(
+            plugin.dependencies.get("theme").map(String::as_str),
+            Some("link+0123456789abcdef"),
+            "the peer suffix uses the manifest version while the linker keeps the local target"
         );
     }
 }


### PR DESCRIPTION
## Summary

- keep linked directory dep paths as the graph and linker target
- use the linked package manifest version for peer range matching and peer-context suffixes
- cover an optional peer supplied by a linked workspace-root dependency

## Why

pnpm 11.18.0 fixed workspace-root peer resolution so linked packages are evaluated using their own manifest version instead of their `link:`/`file:` reference. Aube previously treated its content-addressed local dep path as the version, preventing a compatible linked root dependency from satisfying a peer.

## Validation

- `cargo test -p aube-resolver`
- `cargo test -p aube-resolver peer_context`
- `cargo clippy -p aube-resolver --all-targets -- -D warnings`
- `cargo fmt --check`

Upstream: https://github.com/pnpm/pnpm/pull/13387
Release notes: https://github.com/pnpm/pnpm/releases/tag/v11.18.0

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core peer-context DFS and dependency tail rewriting; incorrect target/context split could break linker targets or peer suffix parity, though scope is limited to linked locals and adds targeted tests.
> 
> **Overview**
> **Peer context** in `peer_context.rs` no longer treats a linked package’s content-addressed dep path (`link+…`) as its semver version when resolving peers from the workspace root or ancestor scope.
> 
> The pass introduces a **`PeerProvider`** with **`target_tail`** (graph keys and `dependencies` wiring) and **`context_tail`** (range checks and `(peer@ver)` suffixes). For **directory/link/portal** locals, `context_tail` comes from the locked package’s **manifest `version`** via `resolve_dep_edge`, while **`target_tail`** stays the local hash tail.
> 
> Scope maps, child recursion, and declared-peer overrides now use this split so a root **`link:theme`** at manifest **4.10.0** can satisfy **`^4.0.0`** and emit **`plugin@1.0.0(theme@4.10.0)`** while still linking **`theme`** to **`link+…`**. A unit test covers optional peers supplied from a linked root dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ab3c1a0245c5b949b6ccb720c8e247918bc3098. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved peer dependency resolution for linked workspace packages.
  * Peer version checks now use the package’s declared manifest version where appropriate.
  * Preserved local linking targets to ensure dependencies continue resolving and linking correctly.
  * Improved peer-context handling for nested dependencies and cyclic references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->