### PR TITLE
security: strip Unicode formatting from terminal output

### DIFF
--- a/crates/aube-util/src/lib.rs
+++ b/crates/aube-util/src/lib.rs
@@ -23,6 +23,7 @@ pub use identity::{AUBE, Embedder, cmd, embedder, prog, set_embedder};
 pub mod path;
 pub mod pkg;
 pub mod snapshot;
+pub mod terminal;
 pub mod url;
 
 use serde::{Deserialize, Deserializer};

--- a/crates/aube-util/src/terminal.rs
+++ b/crates/aube-util/src/terminal.rs
@@ -1,0 +1,107 @@
+//! Terminal-safe rendering helpers for untrusted registry and manifest text.
+
+use std::borrow::Cow;
+
+/// Strip Unicode formatting characters while preserving terminal styling
+/// emitted by trusted formatters.
+pub fn strip_formatting(text: &str) -> Cow<'_, str> {
+    if text.chars().any(is_format_character) {
+        Cow::Owned(
+            text.chars()
+                .filter(|ch| !is_format_character(*ch))
+                .collect(),
+        )
+    } else {
+        Cow::Borrowed(text)
+    }
+}
+
+/// Strip control and Unicode formatting characters before displaying text,
+/// preserving newlines and tabs for multi-line output.
+pub fn sanitize(text: &str) -> Cow<'_, str> {
+    if text
+        .chars()
+        .any(|ch| is_format_character(ch) || ch.is_control() && ch != '\n' && ch != '\t')
+    {
+        Cow::Owned(
+            text.chars()
+                .filter(|ch| {
+                    !is_format_character(*ch) && (!ch.is_control() || *ch == '\n' || *ch == '\t')
+                })
+                .collect(),
+        )
+    } else {
+        Cow::Borrowed(text)
+    }
+}
+
+/// Strip every control and Unicode formatting character from a single-line
+/// terminal field.
+pub fn sanitize_inline(text: &str) -> Cow<'_, str> {
+    if text
+        .chars()
+        .any(|ch| ch.is_control() || is_format_character(ch))
+    {
+        Cow::Owned(
+            text.chars()
+                .filter(|ch| !ch.is_control() && !is_format_character(*ch))
+                .collect(),
+        )
+    } else {
+        Cow::Borrowed(text)
+    }
+}
+
+fn is_format_character(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{00AD}'
+            | '\u{0600}'..='\u{0605}'
+            | '\u{061C}'
+            | '\u{06DD}'
+            | '\u{070F}'
+            | '\u{0890}'..='\u{0891}'
+            | '\u{08E2}'
+            | '\u{180E}'
+            | '\u{200B}'..='\u{200F}'
+            | '\u{202A}'..='\u{202E}'
+            | '\u{2060}'..='\u{2064}'
+            | '\u{2066}'..='\u{206F}'
+            | '\u{FEFF}'
+            | '\u{FFF9}'..='\u{FFFB}'
+            | '\u{110BD}'
+            | '\u{110CD}'
+            | '\u{13430}'..='\u{1343F}'
+            | '\u{1BCA0}'..='\u{1BCA3}'
+            | '\u{1D173}'..='\u{1D17A}'
+            | '\u{E0001}'
+            | '\u{E0020}'..='\u{E007F}',
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{sanitize, sanitize_inline, strip_formatting};
+    use std::borrow::Cow;
+
+    #[test]
+    fn strips_unicode_format_characters() {
+        let text = "safe\u{00AD}\u{202E}\u{2066}\u{E0020}text";
+        assert_eq!(sanitize(text), "safetext");
+        assert_eq!(sanitize_inline(text), "safetext");
+        assert_eq!(strip_formatting(text), "safetext");
+    }
+
+    #[test]
+    fn multiline_sanitizer_preserves_newlines_and_tabs() {
+        let text = "safe\n\ttext";
+        assert_eq!(sanitize(text), text);
+        assert_eq!(sanitize_inline(text), "safetext");
+    }
+
+    #[test]
+    fn borrows_text_that_does_not_need_sanitizing() {
+        assert!(matches!(sanitize("safe text"), Cow::Borrowed(_)));
+        assert!(matches!(sanitize_inline("safe text"), Cow::Borrowed(_)));
+    }
+}

--- a/crates/aube-util/src/terminal.rs
+++ b/crates/aube-util/src/terminal.rs
@@ -5,6 +5,9 @@ use std::borrow::Cow;
 /// Strip Unicode formatting characters while preserving terminal styling
 /// emitted by trusted formatters.
 pub fn strip_formatting(text: &str) -> Cow<'_, str> {
+    if text.is_ascii() {
+        return Cow::Borrowed(text);
+    }
     if text.chars().any(is_format_character) {
         Cow::Owned(
             text.chars()
@@ -19,6 +22,9 @@ pub fn strip_formatting(text: &str) -> Cow<'_, str> {
 /// Strip control and Unicode formatting characters before displaying text,
 /// preserving newlines and tabs for multi-line output.
 pub fn sanitize(text: &str) -> Cow<'_, str> {
+    if is_safe_ascii::<true>(text) {
+        return Cow::Borrowed(text);
+    }
     if text
         .chars()
         .any(|ch| is_format_character(ch) || ch.is_control() && ch != '\n' && ch != '\t')
@@ -38,10 +44,7 @@ pub fn sanitize(text: &str) -> Cow<'_, str> {
 /// Strip every control and Unicode formatting character from a single-line
 /// terminal field.
 pub fn sanitize_inline(text: &str) -> Cow<'_, str> {
-    if text
-        .chars()
-        .any(|ch| ch.is_control() || is_format_character(ch))
-    {
+    if needs_inline_sanitization(text) {
         Cow::Owned(
             text.chars()
                 .filter(|ch| !ch.is_control() && !is_format_character(*ch))
@@ -50,6 +53,22 @@ pub fn sanitize_inline(text: &str) -> Cow<'_, str> {
     } else {
         Cow::Borrowed(text)
     }
+}
+
+/// Whether a single-line terminal field needs sanitization.
+pub fn needs_inline_sanitization(text: &str) -> bool {
+    !is_safe_ascii::<false>(text)
+        && text
+            .chars()
+            .any(|ch| ch.is_control() || is_format_character(ch))
+}
+
+#[inline]
+fn is_safe_ascii<const MULTILINE: bool>(text: &str) -> bool {
+    text.bytes().all(|byte| {
+        byte.is_ascii()
+            && (!byte.is_ascii_control() || MULTILINE && (byte == b'\n' || byte == b'\t'))
+    })
 }
 
 fn is_format_character(ch: char) -> bool {

--- a/crates/aube/src/commands/list.rs
+++ b/crates/aube/src/commands/list.rs
@@ -553,6 +553,7 @@ fn render_default_for_importer(
     }
 
     let grouped = group_roots(graph, importer, filter, args.pattern.as_deref());
+    let sanitize_tree = graph_needs_terminal_sanitization(graph);
     if grouped.prod.is_empty() && grouped.dev.is_empty() && grouped.optional.is_empty() {
         println!("(no dependencies)");
         return Ok(());
@@ -560,7 +561,14 @@ fn render_default_for_importer(
 
     if !grouped.prod.is_empty() {
         println!("dependencies:");
-        render_section(graph, &grouped.prod, args, vstore_max_len, vstore_prefix)?;
+        render_section(
+            graph,
+            &grouped.prod,
+            args,
+            vstore_max_len,
+            vstore_prefix,
+            sanitize_tree,
+        )?;
     }
     if !grouped.optional.is_empty() {
         if !grouped.prod.is_empty() {
@@ -573,6 +581,7 @@ fn render_default_for_importer(
             args,
             vstore_max_len,
             vstore_prefix,
+            sanitize_tree,
         )?;
     }
     if !grouped.dev.is_empty() {
@@ -580,7 +589,14 @@ fn render_default_for_importer(
             println!();
         }
         println!("devDependencies:");
-        render_section(graph, &grouped.dev, args, vstore_max_len, vstore_prefix)?;
+        render_section(
+            graph,
+            &grouped.dev,
+            args,
+            vstore_max_len,
+            vstore_prefix,
+            sanitize_tree,
+        )?;
     }
 
     Ok(())
@@ -637,6 +653,7 @@ fn render_section(
     args: &ListArgs,
     vstore_max_len: usize,
     vstore_prefix: &str,
+    sanitize_tree: bool,
 ) -> miette::Result<()> {
     let last_idx = roots.len().saturating_sub(1);
     for (i, dep) in roots.iter().enumerate() {
@@ -644,8 +661,16 @@ fn render_section(
         let connector = if is_last { "└── " } else { "├── " };
         let pkg = graph.get_package(&dep.dep_path);
         let version = pkg.map(|p| p.version.as_str()).unwrap_or("?");
-        let name = aube_util::terminal::sanitize_inline(&dep.name);
-        let version = aube_util::terminal::sanitize_inline(version);
+        let name = if sanitize_tree {
+            aube_util::terminal::sanitize_inline(&dep.name)
+        } else {
+            std::borrow::Cow::Borrowed(dep.name.as_str())
+        };
+        let version = if sanitize_tree {
+            aube_util::terminal::sanitize_inline(version)
+        } else {
+            std::borrow::Cow::Borrowed(version)
+        };
         let extra = if args.long {
             format!(
                 "  ({vstore_prefix}{})",
@@ -676,6 +701,7 @@ fn render_section(
                 &mut visited,
                 vstore_max_len,
                 vstore_prefix,
+                sanitize_tree,
             );
         }
     }
@@ -692,6 +718,7 @@ fn render_subtree(
     visited: &mut BTreeSet<String>,
     vstore_max_len: usize,
     vstore_prefix: &str,
+    sanitize_tree: bool,
 ) {
     if current_depth > args.depth.max {
         return;
@@ -702,8 +729,17 @@ fn render_subtree(
         let is_last = i == last;
         let connector = if is_last { "└── " } else { "├── " };
         let dep_path = format!("{name}@{version}");
-        let display_name = aube_util::terminal::sanitize_inline(name);
-        let display_version = aube_util::terminal::sanitize_inline(version);
+        let (display_name, display_version) = if sanitize_tree {
+            (
+                aube_util::terminal::sanitize_inline(name),
+                aube_util::terminal::sanitize_inline(version),
+            )
+        } else {
+            (
+                std::borrow::Cow::Borrowed(name.as_str()),
+                std::borrow::Cow::Borrowed(version.as_str()),
+            )
+        };
         let extra = if args.long {
             format!(
                 "  ({vstore_prefix}{})",
@@ -734,11 +770,27 @@ fn render_subtree(
                     visited,
                     vstore_max_len,
                     vstore_prefix,
+                    sanitize_tree,
                 );
             }
             visited.remove(&dep_path);
         }
     }
+}
+
+fn graph_needs_terminal_sanitization(graph: &LockfileGraph) -> bool {
+    graph
+        .importers
+        .values()
+        .flatten()
+        .any(|dep| aube_util::terminal::needs_inline_sanitization(&dep.name))
+        || graph.packages.values().any(|pkg| {
+            aube_util::terminal::needs_inline_sanitization(&pkg.version)
+                || pkg.dependencies.iter().any(|(name, version)| {
+                    aube_util::terminal::needs_inline_sanitization(name)
+                        || aube_util::terminal::needs_inline_sanitization(version)
+                })
+        })
 }
 
 /// JSON output: a single array with one entry per root importer (matching
@@ -1042,5 +1094,26 @@ mod tests {
             a_obj.get("dependencies").is_none(),
             "cycled node should not recurse further"
         );
+    }
+
+    #[test]
+    fn tree_sanitization_scan_detects_formatting_in_dependency_labels() {
+        let safe = LockfileGraph {
+            packages: BTreeMap::from([(
+                "root@1.0.0".to_string(),
+                mk_pkg("root", "1.0.0", &[("child", "2.0.0")]),
+            )]),
+            ..Default::default()
+        };
+        assert!(!graph_needs_terminal_sanitization(&safe));
+
+        let unsafe_graph = LockfileGraph {
+            packages: BTreeMap::from([(
+                "root@1.0.0".to_string(),
+                mk_pkg("root", "1.0.0", &[("chi\u{202E}ld", "2.0.0")]),
+            )]),
+            ..Default::default()
+        };
+        assert!(graph_needs_terminal_sanitization(&unsafe_graph));
     }
 }

--- a/crates/aube/src/commands/list.rs
+++ b/crates/aube/src/commands/list.rs
@@ -475,6 +475,8 @@ fn run_global(args: &ListArgs) -> miette::Result<()> {
             println!("{}", layout.pkg_dir.display());
             let last_idx = rows.len().saturating_sub(1);
             for (i, (name, version, path)) in rows.iter().enumerate() {
+                let name = aube_util::terminal::sanitize_inline(name);
+                let version = aube_util::terminal::sanitize_inline(version);
                 let connector = if i == last_idx {
                     "└── "
                 } else {
@@ -537,6 +539,8 @@ fn render_default_for_importer(
 ) -> miette::Result<()> {
     let project_name = manifest.name.as_deref().unwrap_or("(unnamed)");
     let project_version = manifest.version.as_deref().unwrap_or("");
+    let project_name = aube_util::terminal::sanitize_inline(project_name);
+    let project_version = aube_util::terminal::sanitize_inline(project_version);
     let project_path = cwd.display();
     println!("{project_name}@{project_version} {project_path}");
     println!();
@@ -640,6 +644,8 @@ fn render_section(
         let connector = if is_last { "└── " } else { "├── " };
         let pkg = graph.get_package(&dep.dep_path);
         let version = pkg.map(|p| p.version.as_str()).unwrap_or("?");
+        let name = aube_util::terminal::sanitize_inline(&dep.name);
+        let version = aube_util::terminal::sanitize_inline(version);
         let extra = if args.long {
             format!(
                 "  ({vstore_prefix}{})",
@@ -651,7 +657,7 @@ fn render_section(
         } else {
             String::new()
         };
-        println!("{connector}{} {version}{extra}", dep.name);
+        println!("{connector}{name} {version}{extra}");
 
         if args.depth.includes_transitive()
             && let Some(pkg) = pkg
@@ -696,6 +702,8 @@ fn render_subtree(
         let is_last = i == last;
         let connector = if is_last { "└── " } else { "├── " };
         let dep_path = format!("{name}@{version}");
+        let display_name = aube_util::terminal::sanitize_inline(name);
+        let display_version = aube_util::terminal::sanitize_inline(version);
         let extra = if args.long {
             format!(
                 "  ({vstore_prefix}{})",
@@ -711,7 +719,7 @@ fn render_subtree(
         } else {
             ""
         };
-        println!("{prefix}{connector}{name} {version}{extra}{cycle_marker}");
+        println!("{prefix}{connector}{display_name} {display_version}{extra}{cycle_marker}");
 
         if cycle_marker.is_empty() {
             visited.insert(dep_path.clone());

--- a/crates/aube/src/commands/list.rs
+++ b/crates/aube/src/commands/list.rs
@@ -672,13 +672,16 @@ fn render_section(
             std::borrow::Cow::Borrowed(version)
         };
         let extra = if args.long {
-            format!(
-                "  ({vstore_prefix}{})",
-                aube_lockfile::dep_path_filename::dep_path_to_filename(
-                    &dep.dep_path,
-                    vstore_max_len,
-                )
-            )
+            let filename = aube_lockfile::dep_path_filename::dep_path_to_filename(
+                &dep.dep_path,
+                vstore_max_len,
+            );
+            let filename = if sanitize_tree {
+                aube_util::terminal::sanitize_inline(&filename)
+            } else {
+                std::borrow::Cow::Borrowed(filename.as_str())
+            };
+            format!("  ({vstore_prefix}{filename})")
         } else {
             String::new()
         };
@@ -741,10 +744,14 @@ fn render_subtree(
             )
         };
         let extra = if args.long {
-            format!(
-                "  ({vstore_prefix}{})",
-                aube_lockfile::dep_path_filename::dep_path_to_filename(&dep_path, vstore_max_len,)
-            )
+            let filename =
+                aube_lockfile::dep_path_filename::dep_path_to_filename(&dep_path, vstore_max_len);
+            let filename = if sanitize_tree {
+                aube_util::terminal::sanitize_inline(&filename)
+            } else {
+                std::borrow::Cow::Borrowed(filename.as_str())
+            };
+            format!("  ({vstore_prefix}{filename})")
         } else {
             String::new()
         };
@@ -779,18 +786,16 @@ fn render_subtree(
 }
 
 fn graph_needs_terminal_sanitization(graph: &LockfileGraph) -> bool {
-    graph
-        .importers
-        .values()
-        .flatten()
-        .any(|dep| aube_util::terminal::needs_inline_sanitization(&dep.name))
-        || graph.packages.values().any(|pkg| {
-            aube_util::terminal::needs_inline_sanitization(&pkg.version)
-                || pkg.dependencies.iter().any(|(name, version)| {
-                    aube_util::terminal::needs_inline_sanitization(name)
-                        || aube_util::terminal::needs_inline_sanitization(version)
-                })
-        })
+    graph.importers.values().flatten().any(|dep| {
+        aube_util::terminal::needs_inline_sanitization(&dep.name)
+            || aube_util::terminal::needs_inline_sanitization(&dep.dep_path)
+    }) || graph.packages.values().any(|pkg| {
+        aube_util::terminal::needs_inline_sanitization(&pkg.version)
+            || pkg.dependencies.iter().any(|(name, version)| {
+                aube_util::terminal::needs_inline_sanitization(name)
+                    || aube_util::terminal::needs_inline_sanitization(version)
+            })
+    })
 }
 
 /// JSON output: a single array with one entry per root importer (matching
@@ -1106,6 +1111,20 @@ mod tests {
             ..Default::default()
         };
         assert!(!graph_needs_terminal_sanitization(&safe));
+
+        let unsafe_path_graph = LockfileGraph {
+            importers: BTreeMap::from([(
+                ".".to_string(),
+                vec![DirectDep {
+                    name: "child".to_string(),
+                    dep_path: "child@2.0.0\u{202E}".to_string(),
+                    dep_type: DepType::Production,
+                    specifier: Some("2.0.0".to_string()),
+                }],
+            )]),
+            ..Default::default()
+        };
+        assert!(graph_needs_terminal_sanitization(&unsafe_path_graph));
 
         let unsafe_graph = LockfileGraph {
             packages: BTreeMap::from([(

--- a/crates/aube/src/commands/outdated.rs
+++ b/crates/aube/src/commands/outdated.rs
@@ -94,7 +94,7 @@ pub struct OutdatedArgs {
     pub network: crate::cli_args::NetworkArgs,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 struct Row {
     // Skipped on serialize — the outer `render_json` map is keyed by
     // name, so duplicating it inside each entry would diverge from
@@ -623,6 +623,25 @@ fn render_table(rows: &[Row], long: bool) {
         println!("All dependencies up to date.");
         return;
     }
+
+    let rows: Vec<Row> = rows
+        .iter()
+        .cloned()
+        .map(|mut row| {
+            row.name = aube_util::terminal::sanitize_inline(&row.name).into_owned();
+            row.current = aube_util::terminal::sanitize_inline(&row.current).into_owned();
+            row.wanted = aube_util::terminal::sanitize_inline(&row.wanted).into_owned();
+            row.latest = aube_util::terminal::sanitize_inline(&row.latest).into_owned();
+            row.specifier = row
+                .specifier
+                .map(|value| aube_util::terminal::sanitize_inline(&value).into_owned());
+            row.importer = row
+                .importer
+                .map(|value| aube_util::terminal::sanitize_inline(&value).into_owned());
+            row
+        })
+        .collect();
+    let rows = rows.as_slice();
 
     // Compute column widths.
     let name_w = rows.iter().map(|r| r.name.len()).max().unwrap_or(7).max(7);

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -1139,9 +1139,10 @@ async fn pick_update_interactively(
             continue;
         }
         let label = format!("{} {key} {current} → {target}", dep_bucket(manifest, key),);
+        let label = aube_util::terminal::sanitize_inline(&label);
         picker = picker.option(
             demand::DemandOption::new((*key).clone())
-                .label(&label)
+                .label(label.as_ref())
                 .selected(true),
         );
         shown += 1;

--- a/crates/aube/src/commands/view.rs
+++ b/crates/aube/src/commands/view.rs
@@ -14,6 +14,16 @@ use clap::Args;
 use miette::{Context, IntoDiagnostic, miette};
 use serde_json::Value;
 
+macro_rules! terminal_println {
+    () => {
+        println!()
+    };
+    ($($arg:tt)*) => {{
+        let rendered = format!($($arg)*);
+        println!("{}", aube_util::terminal::sanitize(&rendered));
+    }};
+}
+
 pub const AFTER_LONG_HELP: &str = "\
 Examples:
 
@@ -150,12 +160,12 @@ fn dotted_get<'a>(mut value: &'a Value, path: &str) -> Option<&'a Value> {
 /// field lookups.
 fn print_value(value: &Value) {
     match value {
-        Value::String(s) => println!("{s}"),
+        Value::String(s) => terminal_println!("{s}"),
         Value::Null => {}
-        Value::Bool(_) | Value::Number(_) => println!("{value}"),
+        Value::Bool(_) | Value::Number(_) => terminal_println!("{value}"),
         _ => {
             let json = serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string());
-            println!("{json}");
+            terminal_println!("{json}");
         }
     }
 }
@@ -186,19 +196,21 @@ fn print_summary(packument: &Value, version_meta: &Value, name: &str, version: &
         .map(|o| o.len())
         .unwrap_or(0);
 
-    println!("{name}@{version} | {license} | deps: {deps_count} | versions: {versions_count}");
+    terminal_println!(
+        "{name}@{version} | {license} | deps: {deps_count} | versions: {versions_count}"
+    );
 
     if let Some(desc) = version_meta.get("description").and_then(|v| v.as_str())
         && !desc.is_empty()
     {
-        println!();
-        println!("{desc}");
+        terminal_println!();
+        terminal_println!("{desc}");
     }
 
     if let Some(home) = version_meta.get("homepage").and_then(|v| v.as_str())
         && !home.is_empty()
     {
-        println!("{home}");
+        terminal_println!("{home}");
     }
 
     if let Some(keywords) = version_meta.get("keywords").and_then(|v| v.as_array())
@@ -209,8 +221,8 @@ fn print_summary(packument: &Value, version_meta: &Value, name: &str, version: &
             .filter_map(|k| k.as_str().map(String::from))
             .collect();
         if !kws.is_empty() {
-            println!();
-            println!("keywords: {}", kws.join(", "));
+            terminal_println!();
+            terminal_println!("keywords: {}", kws.join(", "));
         }
     }
 
@@ -221,14 +233,14 @@ fn print_summary(packument: &Value, version_meta: &Value, name: &str, version: &
             _ => vec![],
         };
         if !names.is_empty() {
-            println!();
-            println!("bin: {}", names.join(", "));
+            terminal_println!();
+            terminal_println!("bin: {}", names.join(", "));
         }
     }
 
     if let Some(dist) = version_meta.get("dist").and_then(|v| v.as_object()) {
-        println!();
-        println!("dist");
+        terminal_println!();
+        terminal_println!("dist");
         for key in [
             "tarball",
             "shasum",
@@ -241,7 +253,7 @@ fn print_summary(packument: &Value, version_meta: &Value, name: &str, version: &
                     Value::String(s) => s.clone(),
                     _ => v.to_string(),
                 };
-                println!(".{key}: {display}");
+                terminal_println!(".{key}: {display}");
             }
         }
     }
@@ -249,11 +261,11 @@ fn print_summary(packument: &Value, version_meta: &Value, name: &str, version: &
     if let Some(deps) = version_meta.get("dependencies").and_then(|v| v.as_object())
         && !deps.is_empty()
     {
-        println!();
-        println!("dependencies:");
+        terminal_println!();
+        terminal_println!("dependencies:");
         for (k, v) in deps {
             if let Some(range) = v.as_str() {
-                println!("{k}: {range}");
+                terminal_println!("{k}: {range}");
             }
         }
     }
@@ -261,8 +273,8 @@ fn print_summary(packument: &Value, version_meta: &Value, name: &str, version: &
     if let Some(maintainers) = version_meta.get("maintainers").and_then(|v| v.as_array())
         && !maintainers.is_empty()
     {
-        println!();
-        println!("maintainers:");
+        terminal_println!();
+        terminal_println!("maintainers:");
         for m in maintainers {
             let who = m
                 .get("name")
@@ -270,9 +282,9 @@ fn print_summary(packument: &Value, version_meta: &Value, name: &str, version: &
                 .unwrap_or("<unknown>");
             let email = m.get("email").and_then(|v| v.as_str()).unwrap_or("");
             if email.is_empty() {
-                println!("- {who}");
+                terminal_println!("- {who}");
             } else {
-                println!("- {who} <{email}>");
+                terminal_println!("- {who} <{email}>");
             }
         }
     }
@@ -280,11 +292,11 @@ fn print_summary(packument: &Value, version_meta: &Value, name: &str, version: &
     if let Some(tags) = packument.get("dist-tags").and_then(|v| v.as_object())
         && !tags.is_empty()
     {
-        println!();
-        println!("dist-tags:");
+        terminal_println!();
+        terminal_println!("dist-tags:");
         for (k, v) in tags {
             if let Some(s) = v.as_str() {
-                println!("{k}: {s}");
+                terminal_println!("{k}: {s}");
             }
         }
     }

--- a/crates/aube/src/progress/mod.rs
+++ b/crates/aube/src/progress/mod.rs
@@ -934,10 +934,12 @@ impl InstallProgress {
                 if st.visible < TTY_MAX_VISIBLE_FETCH_ROWS {
                     st.visible += 1;
                     drop(st);
+                    let label = format!("{name}@{version}");
+                    let label = aube_util::terminal::sanitize_inline(&label);
                     let child = ProgressJobBuilder::new()
                         .body("  {{spinner()}} {{label | flex}}")
                         .body_text(None::<String>)
-                        .prop("label", &format!("{name}@{version}"))
+                        .prop("label", label.as_ref())
                         .status(ProgressStatus::Running)
                         .on_done(ProgressJobDoneBehavior::Hide)
                         .build();
@@ -1368,6 +1370,7 @@ impl Drop for FetchRow {
 /// instead, but this works without one.
 pub fn safe_eprintln(msg: &str) {
     use std::io::Write;
+    let msg = aube_util::terminal::sanitize(msg);
     let was_paused = clx::progress::is_paused();
     if !was_paused {
         clx::progress::pause();
@@ -1417,6 +1420,8 @@ impl Drop for PausingWriterGuard {
             return;
         }
         let buf = std::mem::take(&mut self.buf);
+        let text = String::from_utf8_lossy(&buf);
+        let sanitized = aube_util::terminal::strip_formatting(&text);
         // Pause *before* taking `TERM_LOCK`: `pause()` internally
         // calls `clear()`, which also grabs `TERM_LOCK`, and
         // `std::sync::Mutex` isn't reentrant — taking the lock first
@@ -1444,7 +1449,7 @@ impl Drop for PausingWriterGuard {
         // explicit annotation silences its `#[must_use]`.
         let _: () = clx::progress::with_terminal_lock(|| {
             let mut stderr = std::io::stderr().lock();
-            let _ = stderr.write_all(&buf);
+            let _ = stderr.write_all(sanitized.as_bytes());
             let _ = stderr.flush();
         });
         if !was_paused {


### PR DESCRIPTION
## Summary

- add allocation-free terminal sanitizers for control characters and the full Unicode `Cf` set
- sanitize registry- and manifest-derived text in install progress, warnings, `list`, `outdated`, interactive `update`, and human-readable `view` output
- preserve raw identifiers internally and leave JSON/machine-readable output unchanged

## Why

Unicode bidi overrides, isolates, and other formatting characters can visually reorder untrusted registry or manifest metadata in a terminal without using C0/C1 control bytes. Stripping them at display boundaries prevents deceptive output while retaining the exact package identifiers used for resolution and serialization.

## Validation

- `cargo test -p aube-util terminal`
- `cargo test -p aube --lib commands::list`
- `cargo test -p aube --lib commands::view::tests`
- `cargo test -p aube --lib commands::outdated`
- `cargo test -p aube --lib commands::update`
- `cargo clippy -p aube-util -p aube --all-targets -- -D warnings`
- `cargo fmt --check`

Upstream: https://github.com/pnpm/pnpm/commit/e1babf75f95e85358e8cf6587bb3096c124fcdf7
Release notes: https://github.com/pnpm/pnpm/releases/tag/v11.18.0

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-focused display-layer changes across several CLI surfaces; logic and JSON output are unchanged, but any missed human-output path could still allow deceptive terminal rendering.
> 
> **Overview**
> Adds **`aube_util::terminal`** helpers that strip Unicode formatting characters (bidi overrides, zero-width, etc.) and most control bytes before anything hits the TTY, while borrowing clean ASCII unchanged.
> 
> Human-facing commands now sanitize registry- and lockfile-derived strings at print time: **`list`** (global and tree views, with a graph scan so sanitization runs only when a label needs it), **`outdated`** tables, interactive **`update`** picker labels, human **`view`** output via a `terminal_println!` macro, and install **`progress`** (fetch row labels, `safe_eprintln`, and buffered stderr via `strip_formatting`). **JSON and other machine-readable paths are left as-is** so identifiers used for resolution and serialization stay exact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aabf89ca7603266d838e344f1a45c62e35330408. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->