### PR TITLE
fix(licenses): resolve packages from hoisted layout

### DIFF
--- a/crates/aube/src/commands/install/finalize.rs
+++ b/crates/aube/src/commands/install/finalize.rs
@@ -391,6 +391,9 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
                 layout: state::WriteStateLayout {
                     graph: graph_for_link,
                     node_linker,
+                    hoisting_limits: crate::commands::settings_hoisting_limits_to_linker(
+                        aube_settings::resolved::hoisting_limits(settings_ctx),
+                    ),
                     modules_dir_name,
                     aube_dir,
                     virtual_store_dir_max_length,

--- a/crates/aube/src/commands/licenses.rs
+++ b/crates/aube/src/commands/licenses.rs
@@ -106,7 +106,35 @@ pub async fn run(args: LicensesArgs) -> miette::Result<()> {
     let filtered = graph.filter_deps(|d| filter.keeps(d.dep_type));
 
     let aube_dir = super::resolve_virtual_store_dir_for_cwd(&cwd);
-    let rows = collect_rows(&aube_dir, &filtered, args.long);
+    // Prefer the recorded layout over current config: the install may have
+    // used a one-shot `--node-linker=hoisted` override.
+    let installed_hoisted = crate::state::read_state_layout(&cwd)
+        .map(|layout| matches!(layout.linker, crate::state::InstallLayoutMode::Hoisted))
+        .unwrap_or_else(|| {
+            super::with_settings_ctx(&cwd, |ctx| {
+                matches!(
+                    aube_settings::resolved::node_linker(ctx),
+                    aube_settings::resolved::NodeLinker::Hoisted
+                )
+            })
+        });
+    let hoisted_placements = if installed_hoisted {
+        let modules_dir_name = super::resolve_modules_dir_name_for_cwd(&cwd);
+        let hoisting_limits = super::with_settings_ctx(&cwd, |ctx| {
+            super::settings_hoisting_limits_to_linker(aube_settings::resolved::hoisting_limits(ctx))
+        });
+        // Reconstruct from the full installed graph. Filtering first could
+        // change which conflicting version won a hoisted placement.
+        Some(aube_linker::HoistedPlacements::from_graph(
+            &cwd,
+            &graph,
+            &modules_dir_name,
+            hoisting_limits,
+        )?)
+    } else {
+        None
+    };
+    let rows = collect_rows(&aube_dir, &filtered, hoisted_placements.as_ref(), args.long);
 
     if args.json {
         render_json(&rows)?;
@@ -117,11 +145,16 @@ pub async fn run(args: LicensesArgs) -> miette::Result<()> {
     Ok(())
 }
 
-/// Walk every package in the filtered graph and read its license from the
-/// virtual-store manifest. Packages whose manifest can't be read (e.g.,
-/// `node_modules` not materialized yet) fall back to "UNKNOWN" so one
-/// missing file doesn't sink the whole report.
-fn collect_rows(aube_dir: &Path, graph: &LockfileGraph, long: bool) -> Vec<Row> {
+/// Walk every package in the filtered graph and read its installed manifest,
+/// using hoisted placements when applicable. Packages whose manifest can't be
+/// read (e.g., `node_modules` not materialized yet) fall back to "UNKNOWN" so
+/// one missing file doesn't sink the whole report.
+fn collect_rows(
+    aube_dir: &Path,
+    graph: &LockfileGraph,
+    hoisted_placements: Option<&aube_linker::HoistedPlacements>,
+    long: bool,
+) -> Vec<Row> {
     // Deduplicate by (name, version) so peer-context duplicates
     // (`react@18.2.0` vs `react@18.2.0(prop-types@15.8.1)`) only show once.
     let mut seen: BTreeSet<(String, String)> = BTreeSet::new();
@@ -131,7 +164,10 @@ fn collect_rows(aube_dir: &Path, graph: &LockfileGraph, long: bool) -> Vec<Row> 
         if !seen.insert((pkg.name.clone(), pkg.version.clone())) {
             continue;
         }
-        let pkg_dir = virtual_store_pkg_dir(aube_dir, &pkg.dep_path, &pkg.name);
+        let pkg_dir = hoisted_placements
+            .and_then(|placements| placements.package_dir(&pkg.dep_path))
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| virtual_store_pkg_dir(aube_dir, &pkg.dep_path, &pkg.name));
         let license = read_license(&pkg_dir);
         rows.push(Row {
             name: pkg.name.clone(),

--- a/crates/aube/src/commands/licenses.rs
+++ b/crates/aube/src/commands/licenses.rs
@@ -108,7 +108,10 @@ pub async fn run(args: LicensesArgs) -> miette::Result<()> {
     let aube_dir = super::resolve_virtual_store_dir_for_cwd(&cwd);
     // Prefer the recorded layout over current config: the install may have
     // used a one-shot `--node-linker=hoisted` override.
-    let installed_hoisted = crate::state::read_state_layout(&cwd)
+    let installed_layout = crate::state::read_state_layout(&cwd)
+        .or_else(|| crate::state::read_default_state_layout(&cwd));
+    let installed_hoisted = installed_layout
+        .as_ref()
         .map(|layout| matches!(layout.linker, crate::state::InstallLayoutMode::Hoisted))
         .unwrap_or_else(|| {
             super::with_settings_ctx(&cwd, |ctx| {
@@ -119,10 +122,31 @@ pub async fn run(args: LicensesArgs) -> miette::Result<()> {
             })
         });
     let hoisted_placements = if installed_hoisted {
-        let modules_dir_name = super::resolve_modules_dir_name_for_cwd(&cwd);
-        let hoisting_limits = super::with_settings_ctx(&cwd, |ctx| {
-            super::settings_hoisting_limits_to_linker(aube_settings::resolved::hoisting_limits(ctx))
-        });
+        let modules_dir_name = installed_layout
+            .as_ref()
+            .map(|layout| layout.modules_dir_name.as_str())
+            .filter(|name| !name.is_empty())
+            .map(str::to_owned)
+            .unwrap_or_else(|| super::resolve_modules_dir_name_for_cwd(&cwd));
+        let hoisting_limits = installed_layout
+            .as_ref()
+            .and_then(|layout| layout.hoisting_limits)
+            .map(|limits| match limits {
+                crate::state::InstallHoistingLimits::None => aube_linker::HoistingLimits::None,
+                crate::state::InstallHoistingLimits::Workspaces => {
+                    aube_linker::HoistingLimits::Workspaces
+                }
+                crate::state::InstallHoistingLimits::Dependencies => {
+                    aube_linker::HoistingLimits::Dependencies
+                }
+            })
+            .unwrap_or_else(|| {
+                super::with_settings_ctx(&cwd, |ctx| {
+                    super::settings_hoisting_limits_to_linker(
+                        aube_settings::resolved::hoisting_limits(ctx),
+                    )
+                })
+            });
         // Reconstruct from the full installed graph. Filtering first could
         // change which conflicting version won a hoisted placement.
         Some(aube_linker::HoistedPlacements::from_graph(

--- a/crates/aube/src/commands/licenses.rs
+++ b/crates/aube/src/commands/licenses.rs
@@ -127,8 +127,16 @@ pub async fn run(args: LicensesArgs) -> miette::Result<()> {
             .map(|layout| layout.modules_dir_name.as_str())
             .filter(|name| !name.is_empty())
             .map(str::to_owned)
-            .unwrap_or_else(|| super::resolve_modules_dir_name_for_cwd(&cwd));
-        let hoisting_limits = installed_layout
+            .or_else(|| {
+                installed_layout
+                    .as_ref()
+                    .and_then(|layout| infer_legacy_modules_dir_name(layout, &graph))
+            })
+            // A dependency-free legacy snapshot has no direct entry from
+            // which to infer the directory. The value is immaterial because
+            // there are no placements, so use the historical default.
+            .unwrap_or_else(|| "node_modules".to_string());
+        let recorded_hoisting_limits = installed_layout
             .as_ref()
             .and_then(|layout| layout.hoisting_limits)
             .map(|limits| match limits {
@@ -139,22 +147,15 @@ pub async fn run(args: LicensesArgs) -> miette::Result<()> {
                 crate::state::InstallHoistingLimits::Dependencies => {
                     aube_linker::HoistingLimits::Dependencies
                 }
-            })
-            .unwrap_or_else(|| {
-                super::with_settings_ctx(&cwd, |ctx| {
-                    super::settings_hoisting_limits_to_linker(
-                        aube_settings::resolved::hoisting_limits(ctx),
-                    )
-                })
             });
         // Reconstruct from the full installed graph. Filtering first could
         // change which conflicting version won a hoisted placement.
-        Some(aube_linker::HoistedPlacements::from_graph(
-            &cwd,
-            &graph,
-            &modules_dir_name,
-            hoisting_limits,
-        )?)
+        Some(match recorded_hoisting_limits {
+            Some(limits) => {
+                aube_linker::HoistedPlacements::from_graph(&cwd, &graph, &modules_dir_name, limits)?
+            }
+            None => legacy_hoisted_placements(&cwd, &graph, &modules_dir_name)?,
+        })
     } else {
         None
     };
@@ -167,6 +168,59 @@ pub async fn run(args: LicensesArgs) -> miette::Result<()> {
     }
 
     Ok(())
+}
+
+/// Infer `modulesDir` from the root importer's recorded direct entries in
+/// state written before the field was persisted explicitly.
+fn infer_legacy_modules_dir_name(
+    layout: &crate::state::InstallLayoutState,
+    graph: &LockfileGraph,
+) -> Option<String> {
+    let entries = layout.direct_entries.get(".")?;
+    let deps = graph.importers.get(".")?;
+    entries.iter().zip(deps).find_map(|(entry, dep)| {
+        let mut modules_dir = PathBuf::from(entry);
+        for _ in Path::new(&dep.name).components() {
+            if !modules_dir.pop() {
+                return None;
+            }
+        }
+        Some(modules_dir.to_string_lossy().into_owned())
+    })
+}
+
+/// Legacy layout state did not record `hoistingLimits`. Reconstruct every
+/// possible plan and choose the one that matches the most package directories
+/// on disk, instead of consulting mutable current settings.
+fn legacy_hoisted_placements(
+    cwd: &Path,
+    graph: &LockfileGraph,
+    modules_dir_name: &str,
+) -> Result<aube_linker::HoistedPlacements, aube_linker::Error> {
+    let mut best = None;
+    for limits in [
+        aube_linker::HoistingLimits::None,
+        aube_linker::HoistingLimits::Workspaces,
+        aube_linker::HoistingLimits::Dependencies,
+    ] {
+        let placements =
+            aube_linker::HoistedPlacements::from_graph(cwd, graph, modules_dir_name, limits)?;
+        let matches = graph
+            .packages
+            .keys()
+            .filter(|dep_path| placements.package_dir(dep_path).is_some())
+            .count();
+        if best
+            .as_ref()
+            .is_none_or(|(best_matches, _)| matches > *best_matches)
+        {
+            best = Some((matches, placements));
+        }
+    }
+    Ok(best.map_or_else(
+        aube_linker::HoistedPlacements::default,
+        |(_, placements)| placements,
+    ))
 }
 
 /// Walk every package in the filtered graph and read its installed manifest,

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -234,6 +234,13 @@ impl From<&InstallState> for FreshnessState {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InstallLayoutState {
     pub linker: InstallLayoutMode,
+    /// Tree-shaping settings captured from the successful install. Commands
+    /// that inspect the materialized tree must not reconstruct it from current
+    /// settings because `.npmrc` may have changed since installation.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub modules_dir_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hoisting_limits: Option<InstallHoistingLimits>,
     pub direct_entries: BTreeMap<String, Vec<String>>,
     pub packages: BTreeMap<String, InstalledPackageState>,
 }
@@ -243,6 +250,14 @@ pub struct InstallLayoutState {
 pub enum InstallLayoutMode {
     Isolated,
     Hoisted,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum InstallHoistingLimits {
+    None,
+    Workspaces,
+    Dependencies,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -604,6 +619,7 @@ fn member_lockfiles_stale(project_dir: &Path, state: &FreshnessState) -> Option<
 pub struct WriteStateLayout<'a> {
     pub graph: &'a aube_lockfile::LockfileGraph,
     pub node_linker: aube_linker::NodeLinker,
+    pub hoisting_limits: aube_linker::HoistingLimits,
     pub modules_dir_name: &'a str,
     pub aube_dir: &'a Path,
     pub virtual_store_dir_max_length: usize,
@@ -638,15 +654,7 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
     let (lockfile_hash, lockfile_snapshot_name) =
         snapshot_active_lockfile(project_dir, &state_path)?;
     let settings_hash = hash_settings(project_dir, cli_flags);
-    let install_layout = InstallLayoutState::from_graph(
-        project_dir,
-        layout.graph,
-        layout.node_linker,
-        layout.modules_dir_name,
-        layout.aube_dir,
-        layout.virtual_store_dir_max_length,
-        layout.placements,
-    );
+    let install_layout = InstallLayoutState::from_graph(project_dir, &layout);
 
     let package_json_shape_digests: BTreeMap<String, String> = package_json_hashes
         .keys()
@@ -776,6 +784,15 @@ pub fn read_state_package_content_hashes(project_dir: &Path) -> Option<BTreeMap<
 /// should take the normal path once to refresh derived metadata.
 pub fn read_state_layout(project_dir: &Path) -> Option<InstallLayoutState> {
     read_state(&state_dir(project_dir))?.layout
+}
+
+/// Read layout state from the default `node_modules` location.
+///
+/// This fallback is useful after `modulesDir` changes: resolving the current
+/// state path then points at the new, not-yet-installed tree while the state
+/// describing the materialized tree remains under `node_modules`.
+pub fn read_default_state_layout(project_dir: &Path) -> Option<InstallLayoutState> {
+    read_state(&project_dir.join(DEFAULT_STATE_DIR).join(state_dir_name()))?.layout
 }
 
 /// Read the LtHash accumulator digest the last install wrote, if
@@ -934,19 +951,17 @@ fn remove_legacy_state_file(state_path: &Path) -> Result<(), std::io::Error> {
 }
 
 impl InstallLayoutState {
-    fn from_graph(
-        project_dir: &Path,
-        graph: &aube_lockfile::LockfileGraph,
-        node_linker: aube_linker::NodeLinker,
-        modules_dir_name: &str,
-        aube_dir: &Path,
-        virtual_store_dir_max_length: usize,
-        placements: Option<&aube_linker::HoistedPlacements>,
-    ) -> Self {
-        let linker = match node_linker {
+    fn from_graph(project_dir: &Path, layout: &WriteStateLayout<'_>) -> Self {
+        let linker = match layout.node_linker {
             aube_linker::NodeLinker::Isolated => InstallLayoutMode::Isolated,
             aube_linker::NodeLinker::Hoisted => InstallLayoutMode::Hoisted,
         };
+        let hoisting_limits = matches!(layout.node_linker, aube_linker::NodeLinker::Hoisted)
+            .then_some(match layout.hoisting_limits {
+                aube_linker::HoistingLimits::None => InstallHoistingLimits::None,
+                aube_linker::HoistingLimits::Workspaces => InstallHoistingLimits::Workspaces,
+                aube_linker::HoistingLimits::Dependencies => InstallHoistingLimits::Dependencies,
+            });
         // Record each importer's direct-dependency symlinks — the root
         // (`.`) *and* every workspace member — relative to `project_dir`.
         // `verify_install_layout` walks these, so tracking members means a
@@ -955,11 +970,11 @@ impl InstallLayoutState {
         // <member>/node_modules && aube install` short-circuited to
         // "Already up to date" and never relinked the member.
         let mut direct_entries = BTreeMap::new();
-        for (importer, deps) in &graph.importers {
+        for (importer, deps) in &layout.graph.importers {
             let modules_base = if importer == "." {
-                project_dir.join(modules_dir_name)
+                project_dir.join(layout.modules_dir_name)
             } else {
-                project_dir.join(importer).join(modules_dir_name)
+                project_dir.join(importer).join(layout.modules_dir_name)
             };
             let entries = deps
                 .iter()
@@ -969,14 +984,15 @@ impl InstallLayoutState {
         }
 
         let mut packages = BTreeMap::new();
-        let direct_dep_paths: std::collections::BTreeSet<String> = graph
+        let direct_dep_paths: std::collections::BTreeSet<String> = layout
+            .graph
             .importers
             .get(".")
             .into_iter()
             .flat_map(|deps| deps.iter().map(|dep| dep.dep_path.clone()))
             .collect();
         for dep_path in direct_dep_paths {
-            let Some(pkg) = graph.packages.get(&dep_path) else {
+            let Some(pkg) = layout.graph.packages.get(&dep_path) else {
                 continue;
             };
             let is_link = matches!(
@@ -988,11 +1004,11 @@ impl InstallLayoutState {
                     project_dir.join(path).join("package.json")
                 }
                 _ => crate::commands::install::materialized_pkg_dir(
-                    aube_dir,
+                    layout.aube_dir,
                     &dep_path,
                     &pkg.name,
-                    virtual_store_dir_max_length,
-                    placements,
+                    layout.virtual_store_dir_max_length,
+                    layout.placements,
                 )
                 .join("package.json"),
             };
@@ -1010,6 +1026,8 @@ impl InstallLayoutState {
 
         Self {
             linker,
+            modules_dir_name: layout.modules_dir_name.to_string(),
+            hoisting_limits,
             direct_entries,
             packages,
         }
@@ -1354,9 +1372,10 @@ fn empty_blake3_hash() -> &'static str {
 mod tests {
     use super::{
         InstallLayoutMode, InstallLayoutState, InstallState, InstalledPackageState,
-        collect_package_json_hashes_from_manifests, empty_blake3_hash, fresh_state_file, hash_file,
-        hash_settings, install_state_file, member_lockfiles_stale, read_or_migrate_fresh_state,
-        relative_path_or_original, remove_state, verify_install_layout,
+        WriteStateLayout, collect_package_json_hashes_from_manifests, empty_blake3_hash,
+        fresh_state_file, hash_file, hash_settings, install_state_file, member_lockfiles_stale,
+        read_or_migrate_fresh_state, relative_path_or_original, remove_state,
+        verify_install_layout,
     };
     use std::collections::BTreeMap;
     use std::path::{Path, PathBuf};
@@ -1392,6 +1411,8 @@ mod tests {
             package_json_shape_digests: BTreeMap::new(),
             layout: Some(InstallLayoutState {
                 linker: InstallLayoutMode::Isolated,
+                modules_dir_name: String::new(),
+                hoisting_limits: None,
                 direct_entries: BTreeMap::new(),
                 packages: BTreeMap::from([(
                     "is-odd@3.0.1".to_string(),
@@ -1437,6 +1458,8 @@ mod tests {
 
         let state = InstallLayoutState {
             linker: InstallLayoutMode::Isolated,
+            modules_dir_name: String::new(),
+            hoisting_limits: None,
             direct_entries: BTreeMap::from([(
                 ".".to_string(),
                 vec!["node_modules/@scope/api".to_string()],
@@ -1466,6 +1489,8 @@ mod tests {
 
         let state = InstallLayoutState {
             linker: InstallLayoutMode::Isolated,
+            modules_dir_name: String::new(),
+            hoisting_limits: None,
             direct_entries: BTreeMap::from([(
                 ".".to_string(),
                 vec!["node_modules/@scope/api".to_string()],
@@ -1499,12 +1524,15 @@ mod tests {
 
         let layout = InstallLayoutState::from_graph(
             &project_dir,
-            &graph,
-            aube_linker::NodeLinker::Isolated,
-            "node_modules",
-            &aube_dir,
-            120,
-            None,
+            &WriteStateLayout {
+                graph: &graph,
+                node_linker: aube_linker::NodeLinker::Isolated,
+                hoisting_limits: aube_linker::HoistingLimits::None,
+                modules_dir_name: "node_modules",
+                aube_dir: &aube_dir,
+                virtual_store_dir_max_length: 120,
+                placements: None,
+            },
         );
 
         // The root importer's direct symlink sits under the workspace
@@ -1579,6 +1607,8 @@ mod tests {
             package_json_shape_digests: BTreeMap::from([(".".to_string(), "shape".to_string())]),
             layout: Some(InstallLayoutState {
                 linker: InstallLayoutMode::Isolated,
+                modules_dir_name: String::new(),
+                hoisting_limits: None,
                 direct_entries: BTreeMap::new(),
                 packages: BTreeMap::new(),
             }),

--- a/test/licenses.bats
+++ b/test/licenses.bats
@@ -143,6 +143,19 @@ EOF
 	refute_output --partial "UNKNOWN"
 }
 
+@test "aube licenses resolves packages from a hoisted install" {
+	_setup_basic_fixture
+	aube install --node-linker=hoisted
+
+	run aube licenses --long --json
+	assert_success
+	assert_output --partial '"name": "is-odd"'
+	assert_output --partial "/node_modules/is-odd"
+	assert_output --partial "/node_modules/is-even/node_modules/is-odd"
+	refute_output --partial "/node_modules/.aube/"
+	refute_output --partial '"license": "UNKNOWN"'
+}
+
 @test "aube licenses with no lockfile is a friendly no-op" {
 	cat >package.json <<'EOF'
 { "name": "lic-empty", "version": "0.0.0" }

--- a/test/licenses.bats
+++ b/test/licenses.bats
@@ -177,6 +177,30 @@ EOF
 	refute_output --partial '"license": "UNKNOWN"'
 }
 
+@test "aube licenses infers legacy hoisted layout without current settings" {
+	_setup_basic_fixture
+	cat >.npmrc <<'EOF'
+node-linker=hoisted
+hoisting-limits=dependencies
+EOF
+	aube install
+	jq 'del(.layout.modules_dir_name, .layout.hoisting_limits)' \
+		node_modules/.aube-state/state.json >state.json.tmp
+	mv state.json.tmp node_modules/.aube-state/state.json
+
+	cat >.npmrc <<'EOF'
+node-linker=isolated
+modules-dir=other_modules
+hoisting-limits=none
+EOF
+	run aube licenses --long --json
+	assert_success
+	assert_output --partial "/node_modules/is-odd"
+	assert_output --partial "/node_modules/is-even/node_modules/is-odd"
+	refute_output --partial "/other_modules/"
+	refute_output --partial '"license": "UNKNOWN"'
+}
+
 @test "aube licenses with no lockfile is a friendly no-op" {
 	cat >package.json <<'EOF'
 { "name": "lic-empty", "version": "0.0.0" }

--- a/test/licenses.bats
+++ b/test/licenses.bats
@@ -156,6 +156,27 @@ EOF
 	refute_output --partial '"license": "UNKNOWN"'
 }
 
+@test "aube licenses uses the recorded hoisted layout after settings change" {
+	_setup_basic_fixture
+	cat >.npmrc <<'EOF'
+node-linker=hoisted
+hoisting-limits=dependencies
+EOF
+	aube install
+
+	cat >.npmrc <<'EOF'
+node-linker=isolated
+modules-dir=other_modules
+hoisting-limits=none
+EOF
+	run aube licenses --long --json
+	assert_success
+	assert_output --partial "/node_modules/is-odd"
+	assert_output --partial "/node_modules/is-even/node_modules/is-odd"
+	refute_output --partial "/other_modules/"
+	refute_output --partial '"license": "UNKNOWN"'
+}
+
 @test "aube licenses with no lockfile is a friendly no-op" {
 	cat >package.json <<'EOF'
 { "name": "lic-empty", "version": "0.0.0" }


### PR DESCRIPTION
## Summary

- detect the linker layout recorded by the completed install
- resolve package manifests through reconstructed hoisted placements
- preserve the full graph while planning placements, then apply `--prod` / `--dev` filtering
- add regression coverage for root and nested hoisted dependencies

## Root cause

`aube licenses` always derived package paths from the isolated virtual store. A hoisted install does not create `node_modules/.aube`, so every manifest read failed and each dependency fell back to `UNKNOWN`.

This also respects installs made with the one-shot `--node-linker=hoisted` flag by preferring the stored install layout over current configuration.

Fixes the behavior reported in https://github.com/jdx/aube/discussions/1182.

## Validation

- `cargo test -p aube commands::licenses`
- `mise run test:bats test/licenses.bats`
- `cargo clippy -p aube --all-targets -- -D warnings`
- `cargo fmt --check`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes path resolution for a user-facing command and extends persisted install layout metadata; behavior is backward-compatible via serde defaults and legacy inference, but wrong placement reconstruction could still mis-report licenses on edge-case hoisted trees.
> 
> **Overview**
> **`aube licenses` no longer assumes an isolated virtual store.** It prefers the install layout snapshot in state (linker mode, `modulesDir`, hoisting limits), reconstructs hoisted placements from the **full** lockfile graph, then reads each package’s `package.json` from the on-disk hoisted path instead of `node_modules/.aube/...`—fixing hoisted installs where every license showed as `UNKNOWN`.
> 
> Install finalize now **persists** `modules_dir_name` and `hoisting_limits` into `InstallLayoutState`, and adds **`read_default_state_layout`** so layout can still be found under default `node_modules` after `modulesDir` moves. Older state without those fields is handled by inferring the modules directory from recorded direct entries and picking the hoisted plan that best matches existing directories on disk.
> 
> Bats coverage was added for hoisted installs, post-install `.npmrc` changes, and legacy layout JSON missing the new fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e2068af36a22bc8f91c0aa5e7d1b11c99cd1f51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `aube licenses` (including `--long --json`) to resolve packages using the recorded hoisted layout, keeping on-disk paths correct even if settings change later.
  * License extraction for hoisted installs is now more reliable, avoiding incorrect `"UNKNOWN"` results.
  * Hoisting limits and modules directory naming are persisted to ensure consistent reporting across runs.
* **Tests**
  * Added coverage for recorded hoisted layouts (including legacy inference) and for accurate path/license resolution under varying settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->