### PR TITLE
fix(runtime): keep activated shims in script PATH

### DIFF
--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -1123,9 +1123,13 @@ async fn build_script_command(
     let bin_dir = super::project_modules_dir(cwd).join(".bin");
     let node_gyp_bin_dir = super::install::node_gyp_bootstrap::lazy_shim_bin_dir(&bin_dir)?;
     let runtime_bin_dirs = crate::runtime::path_entries();
+    let activated_shim_dir = crate::tool_shims::activated_shim_dir();
     let path = std::env::var_os("PATH").unwrap_or_default();
-    let mut entries =
-        Vec::with_capacity(2 + usize::from(node_gyp_bin_dir.is_some()) + runtime_bin_dirs.len());
+    let mut entries = Vec::with_capacity(
+        2 + usize::from(node_gyp_bin_dir.is_some())
+            + usize::from(activated_shim_dir.is_some())
+            + runtime_bin_dirs.len(),
+    );
     entries.push(bin_dir);
     if let Some(dir) = node_gyp_bin_dir {
         entries.push(dir);
@@ -1134,6 +1138,14 @@ async fn build_script_command(
     // project-local bins — scripts running `node` get the pinned
     // version.
     entries.extend(runtime_bin_dirs);
+    // Startup removes the activated shim directory from aube's own PATH
+    // so internal runtime probes cannot rediscover aube recursively. Package
+    // scripts are user commands, though, and must retain the shell activation
+    // contract so `pnpm` / `npm` / `yarn` continue to route through aube.
+    // A nested shim invocation sanitizes its own process PATH before probing.
+    if let Some(dir) = activated_shim_dir {
+        entries.push(dir);
+    }
     entries.extend(std::env::split_paths(&path));
     let new_path = std::env::join_paths(entries).unwrap_or(path);
     let script_dir = if cwd.is_absolute() {

--- a/crates/aube/src/tool_shims.rs
+++ b/crates/aube/src/tool_shims.rs
@@ -31,7 +31,16 @@ pub(crate) fn shim_dir() -> Option<PathBuf> {
 pub(crate) fn activated_shim_dir() -> Option<PathBuf> {
     std::env::var_os(SHIM_DIR_ENV)
         .filter(|value| !value.is_empty())
-        .map(PathBuf::from)
+        .and_then(single_path_entry)
+}
+
+fn single_path_entry(value: OsString) -> Option<PathBuf> {
+    let path = PathBuf::from(&value);
+    let mut entries = std::env::split_paths(&value);
+    if entries.next().as_deref() != Some(path.as_path()) || entries.next().is_some() {
+        return None;
+    }
+    Some(path)
 }
 
 pub(crate) fn sanitize_process_path() {
@@ -135,5 +144,12 @@ mod tests {
         } else {
             assert_eq!(node, "node");
         }
+    }
+
+    #[test]
+    fn rejects_multiple_entries_as_a_shim_dir() {
+        let value = std::env::join_paths([Path::new("first"), Path::new("second")])
+            .expect("test paths should join");
+        assert_eq!(single_path_entry(value), None);
     }
 }

--- a/crates/aube/src/tool_shims.rs
+++ b/crates/aube/src/tool_shims.rs
@@ -28,6 +28,12 @@ pub(crate) fn shim_dir() -> Option<PathBuf> {
     Some(data_home.join(ns).join("shims"))
 }
 
+pub(crate) fn activated_shim_dir() -> Option<PathBuf> {
+    std::env::var_os(SHIM_DIR_ENV)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
 pub(crate) fn sanitize_process_path() {
     let Some(path) = path_without_shim_dir(std::env::var_os("PATH")) else {
         return;
@@ -40,8 +46,8 @@ pub(crate) fn sanitize_process_path() {
 }
 
 fn path_without_shim_dir(path: Option<OsString>) -> Option<OsString> {
-    let shim_dir = std::env::var_os(SHIM_DIR_ENV).filter(|v| !v.is_empty())?;
-    strip_path_entry(path?, Path::new(&shim_dir))
+    let shim_dir = activated_shim_dir()?;
+    strip_path_entry(path?, &shim_dir)
 }
 
 fn strip_path_entry(path: OsString, entry_to_remove: &Path) -> Option<OsString> {

--- a/test/runtime.bats
+++ b/test/runtime.bats
@@ -303,7 +303,7 @@ _basic_project() {
 		{
 		  "name": "runtime-test",
 		  "version": "0.0.0",
-		  "scripts": { "nested-pnpm": "pnpm --version" }
+		  "scripts": { "nested-pnpm": "command -v pnpm" }
 		}
 	JSON
 	run aube activate bash
@@ -312,7 +312,7 @@ _basic_project() {
 
 	run aube run --no-install nested-pnpm
 	assert_success
-	assert_output --regexp '^[0-9]+\.[0-9]+\.[0-9]+'
+	assert_output "$AUBE_SHIM_DIR/pnpm"
 }
 
 @test "pnpm-11 lockfile with a runtime pin installs without fetching node from the registry" {

--- a/test/runtime.bats
+++ b/test/runtime.bats
@@ -298,6 +298,23 @@ _basic_project() {
 	refute [ -e pnpm-lock.yaml ]
 }
 
+@test "activated pnpm shim remains available inside package scripts" {
+	cat >package.json <<-'JSON'
+		{
+		  "name": "runtime-test",
+		  "version": "0.0.0",
+		  "scripts": { "nested-pnpm": "pnpm --version" }
+		}
+	JSON
+	run aube activate bash
+	assert_success
+	eval "$output"
+
+	run aube run --no-install nested-pnpm
+	assert_success
+	assert_output --regexp '^[0-9]+\.[0-9]+\.[0-9]+'
+}
+
 @test "pnpm-11 lockfile with a runtime pin installs without fetching node from the registry" {
 	# Compat: the synthetic `node` importer dep must be routed into the
 	# runtime-pin table, not resolved as an npm package. The pinned


### PR DESCRIPTION
## Summary

- restore the activated aube shim directory to package-script `PATH` after project-local and selected-runtime bins
- keep aube's startup PATH sanitization intact for internal runtime probes
- add BATS coverage for invoking `pnpm` from an `aube run` script

## Root cause

`aube activate` prepends `AUBE_SHIM_DIR`, but aube removes that entry from its own process PATH at startup to prevent internal probes from recursively resolving tool shims. `build_script_command` then inherited the sanitized PATH, so user package scripts could no longer resolve `pnpm`, `npm`, or `yarn` through the activated shims.

Fixes the behavior reported in discussion #1186.

## Validation

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `mise run test:bats test/runtime.bats --filter 'activated pnpm shim remains available inside package scripts'`

The complete `test/runtime.bats` file also ran the new regression successfully; two unrelated existing cases failed because this environment's mise `node` shim points to an uninstalled runtime.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped PATH assembly for script spawns plus stricter `AUBE_SHIM_DIR` parsing; behavior change is restoring expected shell activation for user scripts, not altering auth or install logic.
> 
> **Overview**
> Fixes **activated `pnpm` / `npm` / `yarn` shims disappearing inside `aube run` scripts** after startup PATH sanitization.
> 
> `build_script_command` now **re-appends** the directory from `AUBE_SHIM_DIR` (via new `activated_shim_dir()`) onto the script child `PATH`, placed after project `.bin`, node-gyp shims, and pinned runtime bins but before the inherited PATH. **aube’s own process PATH stays sanitized** so internal runtime probes do not recurse through shims.
> 
> `tool_shims` **centralizes** shim-dir parsing: `activated_shim_dir()` only accepts a **single** path entry (multi-entry values are rejected), and PATH stripping uses the same helper. A **BATS** case asserts `command -v pnpm` from a nested package script resolves to `$AUBE_SHIM_DIR/pnpm` after `aube activate`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2476f387096fd76b5e554b8095e48179390ddfee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed activated shell shims not being available inside package scripts.
  * Improved PATH handling to preserve shim availability during nested commands.
  * Added validation to reject invalid multi-entry shim directory settings.

* **Tests**
  * Added coverage confirming package scripts can invoke the `pnpm` shim after shell activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->