### PR TITLE
fix(embed): keep wrapper node first on PATH

### DIFF
--- a/crates/aube-scripts/src/lib.rs
+++ b/crates/aube-scripts/src/lib.rs
@@ -36,15 +36,9 @@ pub struct ScriptSettings {
     pub script_shell: Option<PathBuf>,
     pub unsafe_perm: Option<bool>,
     pub shell_emulator: bool,
-    /// Directory of the project's resolved Node runtime. Selectors place it
-    /// after project `.bin` directories; wrappers can move it ahead via
-    /// `node_bin_dir_precedes_project_bins`. `None` when no runtime switching
-    /// is active.
+    /// Directory of the project's resolved Node runtime. `None` when no
+    /// runtime switching is active.
     pub node_bin_dir: Option<PathBuf>,
-    /// Put `node_bin_dir` before project-local `.bin` directories.
-    /// Wrapping runtimes need this so a local `node` cannot bypass their shim;
-    /// selectors leave this false so project-local binaries still win.
-    pub node_bin_dir_precedes_project_bins: bool,
     /// The node exported as `NODE` (npm parity) — the program a
     /// script's `$NODE` / bare `node` re-spawns. A wrapper's shim; the
     /// real binary otherwise.
@@ -148,10 +142,16 @@ impl Drop for ScriptJailHomeCleanup {
     }
 }
 
-static SCRIPT_SETTINGS: std::sync::OnceLock<std::sync::RwLock<ScriptSettings>> =
+#[derive(Debug, Clone, Default)]
+struct ScriptSettingsState {
+    settings: ScriptSettings,
+    node_bin_dir_precedes_project_bins: bool,
+}
+
+static SCRIPT_SETTINGS: std::sync::OnceLock<std::sync::RwLock<ScriptSettingsState>> =
     std::sync::OnceLock::new();
 
-type ScriptSettingsSlot = std::sync::Arc<std::sync::RwLock<ScriptSettings>>;
+type ScriptSettingsSlot = std::sync::Arc<std::sync::RwLock<ScriptSettingsState>>;
 
 tokio::task_local! {
     static INSTALL_SCRIPT_SETTINGS: ScriptSettingsSlot;
@@ -161,7 +161,7 @@ tokio::task_local! {
 pub async fn scope<F: std::future::Future>(future: F) -> F::Output {
     INSTALL_SCRIPT_SETTINGS
         .scope(
-            std::sync::Arc::new(std::sync::RwLock::new(ScriptSettings::default())),
+            std::sync::Arc::new(std::sync::RwLock::new(ScriptSettingsState::default())),
             future,
         )
         .await
@@ -180,39 +180,58 @@ pub fn scope_current<F: std::future::Future>(
     }
 }
 
-fn script_settings_lock() -> &'static std::sync::RwLock<ScriptSettings> {
-    SCRIPT_SETTINGS.get_or_init(|| std::sync::RwLock::new(ScriptSettings::default()))
+fn script_settings_lock() -> &'static std::sync::RwLock<ScriptSettingsState> {
+    SCRIPT_SETTINGS.get_or_init(|| std::sync::RwLock::new(ScriptSettingsState::default()))
 }
 
 /// Replace the current install's script settings snapshot, or the process-wide
 /// fallback when called outside an install scope.
 pub fn set_script_settings(settings: ScriptSettings) {
+    set_script_settings_with_path_order(settings, false);
+}
+
+/// Replace the script settings and control whether the runtime bin directory
+/// precedes project-local bins. Wrapping runtimes use `true` so a local `node`
+/// cannot bypass their shim; selectors use `false`.
+#[doc(hidden)]
+pub fn set_script_settings_with_path_order(
+    settings: ScriptSettings,
+    node_bin_dir_precedes_project_bins: bool,
+) {
+    let state = ScriptSettingsState {
+        settings,
+        node_bin_dir_precedes_project_bins,
+    };
     if INSTALL_SCRIPT_SETTINGS
         .try_with(|slot| match slot.write() {
-            Ok(mut guard) => *guard = settings.clone(),
-            Err(poisoned) => *poisoned.into_inner() = settings.clone(),
+            Ok(mut guard) => *guard = state.clone(),
+            Err(poisoned) => *poisoned.into_inner() = state.clone(),
         })
         .is_ok()
     {
         return;
     }
     match script_settings_lock().write() {
-        Ok(mut guard) => *guard = settings,
-        Err(poisoned) => *poisoned.into_inner() = settings,
+        Ok(mut guard) => *guard = state,
+        Err(poisoned) => *poisoned.into_inner() = state,
     }
 }
 
-fn script_settings() -> ScriptSettings {
-    if let Ok(settings) = INSTALL_SCRIPT_SETTINGS.try_with(|slot| match slot.read() {
+fn script_settings_state() -> ScriptSettingsState {
+    if let Ok(state) = INSTALL_SCRIPT_SETTINGS.try_with(|slot| match slot.read() {
         Ok(guard) => guard.clone(),
         Err(poisoned) => poisoned.into_inner().clone(),
     }) {
-        return settings;
+        return state;
     }
     match script_settings_lock().read() {
         Ok(guard) => guard.clone(),
         Err(poisoned) => poisoned.into_inner().clone(),
     }
+}
+
+fn script_settings() -> ScriptSettings {
+    script_settings_state().settings
 }
 
 #[cfg(test)]
@@ -226,14 +245,23 @@ mod scoped_settings_tests {
         let second_barrier = std::sync::Arc::clone(&barrier);
 
         let first = scope(async move {
-            set_script_settings(ScriptSettings {
-                command: Some("first".to_string()),
-                ..ScriptSettings::default()
-            });
+            set_script_settings_with_path_order(
+                ScriptSettings {
+                    command: Some("first".to_string()),
+                    ..ScriptSettings::default()
+                },
+                true,
+            );
             first_barrier.wait().await;
-            tokio::spawn(scope_current(async { script_settings().command }))
-                .await
-                .unwrap()
+            tokio::spawn(scope_current(async {
+                let state = script_settings_state();
+                (
+                    state.settings.command,
+                    state.node_bin_dir_precedes_project_bins,
+                )
+            }))
+            .await
+            .unwrap()
         });
         let second = scope(async move {
             set_script_settings(ScriptSettings {
@@ -241,14 +269,22 @@ mod scoped_settings_tests {
                 ..ScriptSettings::default()
             });
             second_barrier.wait().await;
-            tokio::spawn(scope_current(async { script_settings().command }))
-                .await
-                .unwrap()
+            tokio::spawn(scope_current(async {
+                let state = script_settings_state();
+                (
+                    state.settings.command,
+                    state.node_bin_dir_precedes_project_bins,
+                )
+            }))
+            .await
+            .unwrap()
         });
 
         let (first, second) = tokio::join!(first, second);
-        assert_eq!(first.as_deref(), Some("first"));
-        assert_eq!(second.as_deref(), Some("second"));
+        assert_eq!(first.0.as_deref(), Some("first"));
+        assert!(first.1);
+        assert_eq!(second.0.as_deref(), Some("second"));
+        assert!(!second.1);
     }
 }
 
@@ -1132,7 +1168,8 @@ pub async fn run_script(
     // `"node_modules"` at the call site, but a workspace may have
     // configured something else.
     let project_bin = project_root.join(modules_dir_name).join(".bin");
-    let settings = script_settings();
+    let state = script_settings_state();
+    let settings = &state.settings;
     let path = std::env::var_os("PATH").unwrap_or_default();
     let mut project_bins: Vec<PathBuf> = Vec::with_capacity(extra_bin_dirs.len() + 1);
     for dir in extra_bin_dirs {
@@ -1142,7 +1179,7 @@ pub async fn run_script(
     let mut entries = order_path_entries(
         project_bins,
         settings.node_bin_dir.as_deref(),
-        settings.node_bin_dir_precedes_project_bins,
+        state.node_bin_dir_precedes_project_bins,
     );
     entries.extend(std::env::split_paths(&path));
     let new_path = std::env::join_paths(entries).unwrap_or(path);
@@ -1152,8 +1189,8 @@ pub async fn run_script(
             .map_err(|e| Error::Spawn(script_name.to_string(), e.to_string()))?;
     }
     let mut cmd = match (jail, jail_home.as_deref()) {
-        (Some(jail), Some(home)) => spawn_jailed_shell(script_cmd, &settings, jail, home),
-        _ => spawn_shell_with_settings(script_cmd, &settings),
+        (Some(jail), Some(home)) => spawn_jailed_shell(script_cmd, settings, jail, home),
+        _ => spawn_shell_with_settings(script_cmd, settings),
     };
     cmd.current_dir(script_dir)
         .stderr(child_stderr())
@@ -1180,7 +1217,7 @@ pub async fn run_script(
             script_name,
             &jail.env,
         );
-        apply_script_settings_env(&mut cmd, &settings);
+        apply_script_settings_env(&mut cmd, settings);
     }
 
     // npm-compat manifest env, applied last so it survives the jail's

--- a/crates/aube-scripts/src/lib.rs
+++ b/crates/aube-scripts/src/lib.rs
@@ -36,11 +36,15 @@ pub struct ScriptSettings {
     pub script_shell: Option<PathBuf>,
     pub unsafe_perm: Option<bool>,
     pub shell_emulator: bool,
-    /// Directory of the project's resolved Node runtime, prepended to
-    /// PATH after the project `.bin` so the switched node beats the
-    /// system one while project-local binaries still win. `None` when
-    /// no runtime switching is active.
+    /// Directory of the project's resolved Node runtime. Selectors place it
+    /// after project `.bin` directories; wrappers can move it ahead via
+    /// `node_bin_dir_precedes_project_bins`. `None` when no runtime switching
+    /// is active.
     pub node_bin_dir: Option<PathBuf>,
+    /// Put `node_bin_dir` before project-local `.bin` directories.
+    /// Wrapping runtimes need this so a local `node` cannot bypass their shim;
+    /// selectors leave this false so project-local binaries still win.
+    pub node_bin_dir_precedes_project_bins: bool,
     /// The node exported as `NODE` (npm parity) — the program a
     /// script's `$NODE` / bare `node` re-spawns. A wrapper's shim; the
     /// real binary otherwise.
@@ -260,6 +264,50 @@ pub fn prepend_paths(bin_dirs: &[PathBuf]) -> std::ffi::OsString {
     let mut entries: Vec<PathBuf> = bin_dirs.to_vec();
     entries.extend(std::env::split_paths(&path));
     std::env::join_paths(entries).unwrap_or(path)
+}
+
+/// Place a runtime bin directory around project-local bin directories.
+/// Wrappers lead so a local `node` cannot bypass their shim; selectors follow
+/// so package-provided commands retain normal precedence.
+pub fn order_path_entries(
+    mut project_bins: Vec<PathBuf>,
+    runtime_bin: Option<&Path>,
+    runtime_precedes_project_bins: bool,
+) -> Vec<PathBuf> {
+    let Some(runtime_bin) = runtime_bin else {
+        return project_bins;
+    };
+    if runtime_precedes_project_bins {
+        project_bins.insert(0, runtime_bin.to_path_buf());
+    } else {
+        project_bins.push(runtime_bin.to_path_buf());
+    }
+    project_bins
+}
+
+#[cfg(test)]
+mod path_entry_tests {
+    use super::*;
+
+    #[test]
+    fn wrapper_runtime_leads_project_bins() {
+        let runtime = Path::new("/shim");
+        let project = PathBuf::from("/project/node_modules/.bin");
+        assert_eq!(
+            order_path_entries(vec![project.clone()], Some(runtime), true),
+            vec![runtime.to_path_buf(), project]
+        );
+    }
+
+    #[test]
+    fn selector_runtime_follows_project_bins() {
+        let runtime = Path::new("/opt/node/bin");
+        let project = PathBuf::from("/project/node_modules/.bin");
+        assert_eq!(
+            order_path_entries(vec![project.clone()], Some(runtime), false),
+            vec![project, runtime.to_path_buf()]
+        );
+    }
 }
 
 /// Spawn a shell command line. On Unix we go through `sh -c`, on
@@ -1086,18 +1134,16 @@ pub async fn run_script(
     let project_bin = project_root.join(modules_dir_name).join(".bin");
     let settings = script_settings();
     let path = std::env::var_os("PATH").unwrap_or_default();
-    let mut entries: Vec<PathBuf> = Vec::with_capacity(extra_bin_dirs.len() + 2);
+    let mut project_bins: Vec<PathBuf> = Vec::with_capacity(extra_bin_dirs.len() + 1);
     for dir in extra_bin_dirs {
-        entries.push(dir.to_path_buf());
+        project_bins.push(dir.to_path_buf());
     }
-    entries.push(project_bin);
-    // The switched Node runtime sits between project bins and the
-    // inherited PATH: scripts spawning `node` (directly or via
-    // `#!/usr/bin/env node`) get the project's pinned version, while
-    // anything installed into `.bin` still wins.
-    if let Some(dir) = &settings.node_bin_dir {
-        entries.push(dir.clone());
-    }
+    project_bins.push(project_bin);
+    let mut entries = order_path_entries(
+        project_bins,
+        settings.node_bin_dir.as_deref(),
+        settings.node_bin_dir_precedes_project_bins,
+    );
     entries.extend(std::env::split_paths(&path));
     let new_path = std::env::join_paths(entries).unwrap_or(path);
     let jail_home = jail.map(|j| jail_home(&j.package_dir));

--- a/crates/aube/src/commands/dlx.rs
+++ b/crates/aube/src/commands/dlx.rs
@@ -250,8 +250,7 @@ pub async fn run_in(
         // globally. Read the same setting here so the scratch bin dir
         // matches where the install actually wrote the bins.
         let bin_dir = super::project_modules_dir(&project_dir).join(".bin");
-        let mut path_dirs = vec![bin_dir];
-        path_dirs.extend(crate::runtime::path_entries());
+        let path_dirs = crate::runtime::path_entries_with_project_bins(vec![bin_dir]);
         let new_path = aube_scripts::prepend_paths(&path_dirs);
         let mut cmd = aube_scripts::spawn_shell(&line);
         crate::runtime::apply_child_env(&mut cmd);

--- a/crates/aube/src/commands/exec.rs
+++ b/crates/aube/src/commands/exec.rs
@@ -411,8 +411,7 @@ pub(crate) fn build_bin_command(
                 .collect::<Vec<_>>()
                 .join(" ");
             let bin_dir = super::project_modules_dir(cwd).join(".bin");
-            let mut path_dirs = vec![bin_dir];
-            path_dirs.extend(crate::runtime::path_entries());
+            let path_dirs = crate::runtime::path_entries_with_project_bins(vec![bin_dir]);
             let new_path = aube_scripts::prepend_paths(&path_dirs);
             let mut cmd = aube_scripts::spawn_shell(&line);
             cmd.env("PATH", &new_path);

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -1130,9 +1130,8 @@ async fn build_script_command(
         project_bins.push(dir);
     }
     let mut entries = crate::runtime::path_entries_with_project_bins(project_bins);
-    entries.reserve(
-        usize::from(activated_shim_dir.is_some()) + std::env::split_paths(&path).count(),
-    );
+    entries
+        .reserve(usize::from(activated_shim_dir.is_some()) + std::env::split_paths(&path).count());
     // Startup removes the activated shim directory from aube's own PATH
     // so internal runtime probes cannot rediscover aube recursively. Package
     // scripts are user commands, though, and must retain the shell activation

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -1122,22 +1122,17 @@ async fn build_script_command(
 
     let bin_dir = super::project_modules_dir(cwd).join(".bin");
     let node_gyp_bin_dir = super::install::node_gyp_bootstrap::lazy_shim_bin_dir(&bin_dir)?;
-    let runtime_bin_dirs = crate::runtime::path_entries();
     let activated_shim_dir = crate::tool_shims::activated_shim_dir();
     let path = std::env::var_os("PATH").unwrap_or_default();
-    let mut entries = Vec::with_capacity(
-        2 + usize::from(node_gyp_bin_dir.is_some())
-            + usize::from(activated_shim_dir.is_some())
-            + runtime_bin_dirs.len(),
-    );
-    entries.push(bin_dir);
+    let mut project_bins = Vec::with_capacity(1 + usize::from(node_gyp_bin_dir.is_some()));
+    project_bins.push(bin_dir);
     if let Some(dir) = node_gyp_bin_dir {
-        entries.push(dir);
+        project_bins.push(dir);
     }
-    // The switched Node runtime beats the inherited PATH but loses to
-    // project-local bins — scripts running `node` get the pinned
-    // version.
-    entries.extend(runtime_bin_dirs);
+    let mut entries = crate::runtime::path_entries_with_project_bins(project_bins);
+    entries.reserve(
+        usize::from(activated_shim_dir.is_some()) + std::env::split_paths(&path).count(),
+    );
     // Startup removes the activated shim directory from aube's own PATH
     // so internal runtime probes cannot rediscover aube recursively. Package
     // scripts are user commands, though, and must retain the shell activation

--- a/crates/aube/src/commands/script_settings.rs
+++ b/crates/aube/src/commands/script_settings.rs
@@ -44,6 +44,9 @@ pub(crate) fn configure_script_settings(
         unsafe_perm,
         shell_emulator,
         node_bin_dir: runtime.as_ref().and_then(|r| r.bin_dir.clone()),
+        node_bin_dir_precedes_project_bins: runtime
+            .as_ref()
+            .is_some_and(|r| r.bin_dir_precedes_project_bins),
         node_program: runtime
             .as_ref()
             .and_then(|r| r.node_program.clone())

--- a/crates/aube/src/commands/script_settings.rs
+++ b/crates/aube/src/commands/script_settings.rs
@@ -38,34 +38,36 @@ pub(crate) fn configure_script_settings(
         .and_then(non_empty_string)
         .or_else(|| https_proxy.clone());
     let no_proxy = aube_settings::resolved::no_proxy(ctx).and_then(non_empty_string);
-    aube_scripts::set_script_settings(aube_scripts::ScriptSettings {
-        node_options,
-        script_shell,
-        unsafe_perm,
-        shell_emulator,
-        node_bin_dir: runtime.as_ref().and_then(|r| r.bin_dir.clone()),
-        node_bin_dir_precedes_project_bins: runtime
+    aube_scripts::set_script_settings_with_path_order(
+        aube_scripts::ScriptSettings {
+            node_options,
+            script_shell,
+            unsafe_perm,
+            shell_emulator,
+            node_bin_dir: runtime.as_ref().and_then(|r| r.bin_dir.clone()),
+            node_program: runtime
+                .as_ref()
+                .and_then(|r| r.node_program.clone())
+                .or_else(aube_runtime::node_on_path),
+            node_execpath: runtime
+                .as_ref()
+                .and_then(|r| r.node_execpath.clone().or_else(|| r.node_program.clone()))
+                .or_else(aube_runtime::node_on_path),
+            extra_env: crate::runtime::embedder_extra_env(),
+            command: command.map(str::to_string),
+            // `npm_config_node_gyp` parity: hand every lifecycle script a
+            // runnable node-gyp stand-in. The shim is written once into
+            // aube's cache; a write failure here is non-fatal (the var just
+            // stays unset, matching pre-parity behavior).
+            node_gyp_js: super::install::node_gyp_bootstrap::lazy_js_shim_path().ok(),
+            http_proxy,
+            https_proxy,
+            no_proxy,
+        },
+        runtime
             .as_ref()
             .is_some_and(|r| r.bin_dir_precedes_project_bins),
-        node_program: runtime
-            .as_ref()
-            .and_then(|r| r.node_program.clone())
-            .or_else(aube_runtime::node_on_path),
-        node_execpath: runtime
-            .as_ref()
-            .and_then(|r| r.node_execpath.clone().or_else(|| r.node_program.clone()))
-            .or_else(aube_runtime::node_on_path),
-        extra_env: crate::runtime::embedder_extra_env(),
-        command: command.map(str::to_string),
-        // `npm_config_node_gyp` parity: hand every lifecycle script a
-        // runnable node-gyp stand-in. The shim is written once into
-        // aube's cache; a write failure here is non-fatal (the var just
-        // stays unset, matching pre-parity behavior).
-        node_gyp_js: super::install::node_gyp_bootstrap::lazy_js_shim_path().ok(),
-        http_proxy,
-        https_proxy,
-        no_proxy,
-    });
+    );
 }
 
 /// Load `.npmrc` + workspace settings for `cwd` and push them into the

--- a/crates/aube/src/runtime.rs
+++ b/crates/aube/src/runtime.rs
@@ -68,6 +68,10 @@ pub struct RuntimeContext {
     /// Directory to prepend to PATH for child processes. `None` means
     /// no switching (ambient node already satisfies, or no config).
     pub bin_dir: Option<PathBuf>,
+    /// Whether `bin_dir` must precede project-local `.bin` directories.
+    /// Wrappers require this so a dependency-provided `node` cannot bypass
+    /// the shim; selectors deliberately keep project-local binaries first.
+    pub bin_dir_precedes_project_bins: bool,
     /// The node aube spawns and exports as `NODE`: the program a
     /// script's bare `node` / `$NODE` resolves to. For a selector this
     /// is the real binary; for a wrapper it is the shim. `None` falls
@@ -112,6 +116,7 @@ impl RuntimeContext {
     fn path_fallback() -> RuntimeContext {
         RuntimeContext {
             bin_dir: None,
+            bin_dir_precedes_project_bins: false,
             node_program: None,
             node_execpath: None,
             internal_node: None,
@@ -227,6 +232,7 @@ pub struct EmbedderEnv {
 #[derive(Debug, Clone, Default)]
 pub struct EmbedderRuntime {
     bin_dir: Option<PathBuf>,
+    bin_dir_precedes_project_bins: bool,
     node_program: Option<PathBuf>,
     node_execpath: Option<PathBuf>,
     internal_node: Option<PathBuf>,
@@ -253,6 +259,7 @@ impl EmbedderRuntime {
     pub fn wrapper(node_program: impl Into<PathBuf>) -> Self {
         Self {
             node_program: Some(node_program.into()),
+            bin_dir_precedes_project_bins: true,
             ..Default::default()
         }
     }
@@ -349,6 +356,7 @@ impl EmbedderRuntime {
         let internal_node = self.internal_node.clone().map(|p| abs(&p));
         RuntimeContext {
             bin_dir,
+            bin_dir_precedes_project_bins: self.bin_dir_precedes_project_bins,
             node_program,
             node_execpath,
             internal_node,
@@ -475,6 +483,20 @@ pub fn path_entries() -> Vec<PathBuf> {
         .and_then(|c| c.bin_dir.clone())
         .into_iter()
         .collect()
+}
+
+/// Place the active runtime PATH entry around project-local `.bin`
+/// directories. Wrappers lead so a local `node` cannot bypass the shim;
+/// selectors follow so package-provided commands retain normal precedence.
+pub fn path_entries_with_project_bins(project_bins: Vec<PathBuf>) -> Vec<PathBuf> {
+    let Some(context) = current() else {
+        return project_bins;
+    };
+    aube_scripts::order_path_entries(
+        project_bins,
+        context.bin_dir.as_deref(),
+        context.bin_dir_precedes_project_bins,
+    )
 }
 
 /// The binary to probe for a node version when one wasn't supplied: the
@@ -859,6 +881,7 @@ async fn resolve_context(
         }
         Some(res) => RuntimeContext {
             bin_dir: res.bin_dir.clone(),
+            bin_dir_precedes_project_bins: false,
             // A resolved runtime is a selector: `NODE` and
             // `npm_node_execpath` are the same binary.
             node_program: Some(res.node_bin.clone()),
@@ -1245,6 +1268,7 @@ mod tests {
             Some(bin.join(node_exe).as_path())
         );
         assert_eq!(ctx.node_execpath, ctx.node_program);
+        assert!(!ctx.bin_dir_precedes_project_bins);
         assert_eq!(ctx.source, RuntimeSource::Embedder);
     }
 
@@ -1260,6 +1284,7 @@ mod tests {
         // execpath is the real binary node-gyp reads; internal spawns
         // (pnpmfile, scanner) skip the wrapper hop.
         assert_eq!(ctx.bin_dir.as_deref(), Some(abs("/shim").as_path()));
+        assert!(ctx.bin_dir_precedes_project_bins);
         assert_eq!(
             ctx.node_program.as_deref(),
             Some(abs("/shim/node").as_path())
@@ -1380,6 +1405,25 @@ mod tests {
             assert_eq!(node_program(), bin.join(node_exe));
         })
         .await;
+    }
+
+    #[tokio::test]
+    async fn wrapper_path_leads_while_selector_follows_project_bins() {
+        let project_bin = abs("/project/node_modules/.bin");
+
+        let wrapper_entries =
+            with_embedder_runtime(Some(EmbedderRuntime::wrapper("/shim/node")), async {
+                path_entries_with_project_bins(vec![project_bin.clone()])
+            })
+            .await;
+        assert_eq!(wrapper_entries, vec![abs("/shim"), project_bin.clone()]);
+
+        let selector_entries =
+            with_embedder_runtime(Some(EmbedderRuntime::selector("/opt/node/bin")), async {
+                path_entries_with_project_bins(vec![project_bin.clone()])
+            })
+            .await;
+        assert_eq!(selector_entries, vec![project_bin, abs("/opt/node/bin")]);
     }
 
     #[test]

--- a/docs/embedding/rust.md
+++ b/docs/embedding/rust.md
@@ -107,8 +107,8 @@ manages Node itself describes how Node should be invoked with an
 `EmbedderRuntime`.
 
 A host that merely selects a toolchain (a version manager) uses `selector` —
-the bin directory goes on `PATH` and its `node` is both `NODE` and
-`npm_node_execpath`:
+the bin directory goes on `PATH` after project-local `.bin` directories, and
+its `node` is both `NODE` and `npm_node_execpath`:
 
 ```rust
 use aube::embed::EmbedderRuntime;
@@ -117,8 +117,9 @@ let runtime = EmbedderRuntime::selector("/opt/mytool/node-24.4.1/bin");
 ```
 
 A host that *wraps* Node — an instrumenting runtime, a transpiling loader, a
-sandbox — uses `wrapper`. The shim is `NODE` and goes on `PATH` so a script's
-`node` / `$NODE` stays wrapped, while `real_node` is exported as
+sandbox — uses `wrapper`. The shim is `NODE` and leads `PATH` so a script's
+`node` / `$NODE` stays wrapped even when a dependency provides a `node` bin,
+while `real_node` is exported as
 `npm_node_execpath` so `node-gyp` builds against the real binary. Use
 `env_append` to add a `NODE_OPTIONS` preload without dropping the user's value
 (`env_set` overwrites):


### PR DESCRIPTION
## Summary

- preserve whether an embedder runtime is a selector or a wrapper when resolving its PATH entry
- put wrapper shims ahead of dependency and project `.bin` directories while retaining selector precedence
- share the ordering logic across lifecycle scripts, `run`, and shell-mode `exec`/`dlx`
- document and test both PATH-ordering modes

## Why

A wrapper runtime could be bypassed when a dependency or project exposed a `.bin/node`, because every runtime bin directory was placed after local package bins. This silently defeated instrumentation, transpilation, or sandboxing supplied by the embedding host.

This addresses the gap reported in [Discussion #1083](https://github.com/jdx/aube/discussions/1083#discussioncomment-17835314).

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how PATH is built for all script and shell spawns when a runtime is active; behavior shift is intentional for wrappers but could surprise projects that relied on a local `node` overriding the embedder shim.
> 
> **Overview**
> Fixes **wrapper embedder runtimes** being silently bypassed when a dependency or project exposed a `node` (or other binary) under `node_modules/.bin`, which defeated instrumentation/sandbox shims.
> 
> **PATH ordering** is now explicit per runtime kind: **`EmbedderRuntime::wrapper`** sets `bin_dir_precedes_project_bins` so the shim directory is **prepended** before project-local bins; **selectors** and resolved version-manager runtimes keep the old rule—**`.bin` first**, runtime bin after. Shared helper **`order_path_entries`** / **`path_entries_with_project_bins`** apply the same rules in lifecycle **`run_script`**, **`aube run`**, shell-mode **`exec`/`dlx`**, and script settings via **`set_script_settings_with_path_order`**.
> 
> Docs in **`docs/embedding/rust.md`** describe selector vs wrapper PATH behavior; unit tests cover both orderings and scoped script settings propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad90f9e27d0cf5d7259126427f00bba64aaf0172. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved PATH handling for scripts and shell commands, with configurable ordering between the active Node runtime and project-local binaries.
  * Wrapper runtimes now prioritize their Node runtime binaries, while selector runtimes preserve project-local binary precedence.
  * Enhanced support for Node-related shims and `node-gyp` builds.

* **Documentation**
  * Clarified runtime PATH ordering, Node shims, and `real_node` behavior in embedding documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->