### PR TITLE
feat(embed): allow runtimes to leave PATH unchanged

### DIFF
--- a/crates/aube/src/runtime.rs
+++ b/crates/aube/src/runtime.rs
@@ -232,6 +232,7 @@ pub struct EmbedderEnv {
 #[derive(Debug, Clone, Default)]
 pub struct EmbedderRuntime {
     bin_dir: Option<PathBuf>,
+    path_unchanged: bool,
     bin_dir_precedes_project_bins: bool,
     node_program: Option<PathBuf>,
     node_execpath: Option<PathBuf>,
@@ -274,6 +275,15 @@ impl EmbedderRuntime {
     /// program's parent (e.g. a shim dir separate from the real bin).
     pub fn path_dir(mut self, dir: impl Into<PathBuf>) -> Self {
         self.bin_dir = Some(dir.into());
+        self.path_unchanged = false;
+        self
+    }
+
+    /// Leave PATH unchanged while still using `node_program` for direct
+    /// spawns and exporting it as `NODE`. Bare `node` commands then resolve
+    /// from the inherited PATH by explicit host choice.
+    pub fn without_path(mut self) -> Self {
+        self.path_unchanged = true;
         self
     }
 
@@ -336,18 +346,19 @@ impl EmbedderRuntime {
         let node_program = self
             .node_program
             .clone()
-            .or_else(|| self.bin_dir.as_ref().map(|d| d.join(node_exe)))
+            .or_else(|| self.bin_dir.as_ref().map(|dir| dir.join(node_exe)))
             .map(|p| abs(&p));
-        let bin_dir = self
-            .bin_dir
-            .clone()
-            .or_else(|| {
+        let bin_dir = if self.path_unchanged {
+            None
+        } else {
+            self.bin_dir.clone().or_else(|| {
                 node_program
                     .as_ref()
                     .and_then(|p| p.parent())
                     .map(Path::to_path_buf)
             })
-            .map(|p| abs(&p));
+        }
+        .map(|p| abs(&p));
         let node_execpath = self
             .node_execpath
             .clone()
@@ -1300,6 +1311,56 @@ mod tests {
         assert_eq!(ctx.version.as_deref(), Some("24.4.1"));
         assert_eq!(ctx.env.len(), 1);
         assert_eq!(ctx.env[0].merge, EnvMerge::Append);
+    }
+
+    #[test]
+    fn wrapper_can_leave_path_unchanged() {
+        let ctx = EmbedderRuntime::wrapper("/shim/node")
+            .real_node("/real/node")
+            .without_path()
+            .resolve();
+        assert_eq!(ctx.bin_dir, None);
+        assert_eq!(
+            ctx.node_program.as_deref(),
+            Some(abs("/shim/node").as_path())
+        );
+        assert_eq!(
+            ctx.node_execpath.as_deref(),
+            Some(abs("/real/node").as_path())
+        );
+        assert!(ctx.bin_dir_precedes_project_bins);
+    }
+
+    #[test]
+    fn last_path_builder_call_wins() {
+        let explicit = EmbedderRuntime::wrapper("/shim/node")
+            .without_path()
+            .path_dir("/custom/bin")
+            .resolve();
+        assert_eq!(
+            explicit.bin_dir.as_deref(),
+            Some(abs("/custom/bin").as_path())
+        );
+
+        let unchanged = EmbedderRuntime::wrapper("/shim/node")
+            .path_dir("/custom/bin")
+            .without_path()
+            .resolve();
+        assert_eq!(unchanged.bin_dir, None);
+    }
+
+    #[test]
+    fn selector_without_path_keeps_selected_node() {
+        let node_exe = if cfg!(windows) { "node.exe" } else { "node" };
+        let ctx = EmbedderRuntime::selector("/opt/node/bin")
+            .without_path()
+            .resolve();
+        assert_eq!(ctx.bin_dir, None);
+        assert_eq!(
+            ctx.node_program.as_deref(),
+            Some(abs("/opt/node/bin").join(node_exe).as_path())
+        );
+        assert_eq!(ctx.node_execpath, ctx.node_program);
     }
 
     #[tokio::test]

--- a/docs/embedding/rust.md
+++ b/docs/embedding/rust.md
@@ -132,6 +132,11 @@ let runtime = EmbedderRuntime::wrapper("/opt/mytool/shim/node")
     .env_append("NODE_OPTIONS", "--import /opt/mytool/preload.mjs");
 ```
 
+Use `.without_path()` when the host should set `NODE` and use the wrapper for
+direct aube spawns but intentionally leave bare `node` resolution to the
+inherited `PATH`. Calling `.path_dir(...)` later restores an explicit PATH
+entry; the last path builder call wins.
+
 `internal_node` splits off the node aube's *internal* machinery spawns —
 pnpmfile hooks, the security scanner, version probes — so those hot paths run
 on the real binary while user-facing spawns (scripts, `NODE`, `aube node`)


### PR DESCRIPTION
## Summary

- add `EmbedderRuntime::without_path()` to preserve the inherited `PATH`
- continue using the configured runtime for direct aube spawns and `NODE`
- make `path_dir(...)` and `without_path()` follow last-call-wins builder semantics
- document and test wrapper and selector behavior

## Why

Embedding hosts may need to supply the Node program and npm exec path without changing how bare `node` commands resolve. Previously, wrapper runtimes always derived a PATH entry from `node_program.parent()`, so that configuration was not expressible.

This is a stacked follow-up to #1188 and targets its branch so this PR contains only the explicit PATH opt-out. It can be retargeted to `main` after #1188 merges.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive embedder builder API with unchanged defaults; only affects hosts that opt in via `without_path()`.
> 
> **Overview**
> Adds **`EmbedderRuntime::without_path()`** so embedding hosts can keep the inherited **`PATH`** while still setting **`NODE`**, **`npm_node_execpath`**, and using the configured program for direct aube spawns. Wrapper runtimes no longer always prepend the shim’s parent directory to **`PATH`**.
> 
> **`path_dir(...)`** and **`without_path()`** use **last-call-wins** builder semantics ( **`path_dir`** clears the opt-out; **`without_path`** wins if called last). **`selector`** with **`without_path()`** still resolves **`node_program`** from the bin dir but does not prepend it to **`PATH`**.
> 
> Docs and unit tests cover wrapper, selector, and builder ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a36c67a6389a95a7af9bc333c2a8f7f399bc82dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->