### PR TITLE
fix(update): honor release age in upgrade reports

### DIFF
--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -129,7 +129,7 @@ pub(crate) use manifest_io::{
     write_manifest_dep_sections, write_manifest_json,
 };
 pub(crate) use package_spec::{
-    encode_package_name, resolve_version, split_name_spec, wanted_version,
+    encode_package_name, policy_version, resolve_version, split_name_spec,
 };
 pub(crate) use project_lock::take_install_project_lock;
 pub(crate) use project_lock::take_project_lock;

--- a/crates/aube/src/commands/outdated.rs
+++ b/crates/aube/src/commands/outdated.rs
@@ -8,7 +8,7 @@
 //!
 //! Pure read: no state changes, no `node_modules/` writes, no project lock.
 
-use super::{DepFilter, make_client, packument_cache_dir};
+use super::{DepFilter, make_client};
 use aube_lockfile::{DepType, DirectDep, dep_type_label};
 use aube_registry::Packument;
 use clap::Args;
@@ -445,7 +445,18 @@ async fn collect_rows(
     }
 
     let client = std::sync::Arc::new(make_client(cwd));
-    let cache_dir = packument_cache_dir();
+    let (minimum_release_age, registry_supports_time) = super::with_settings_ctx(cwd, |ctx| {
+        (
+            super::install::resolve_minimum_release_age(ctx, None),
+            aube_settings::resolved::registry_supports_time_field(ctx),
+        )
+    });
+    let needs_time = minimum_release_age.is_some() && !registry_supports_time;
+    let cache_dir = if needs_time {
+        super::packument_full_cache_dir_for_cwd(cwd)
+    } else {
+        super::packument_cache_dir_for_cwd(cwd)
+    };
 
     // Fetch every packument in parallel via a JoinSet. Failures are surfaced
     // per-row so a single missing package doesn't sink the whole report.
@@ -455,7 +466,13 @@ async fn collect_rows(
         let cache_dir = cache_dir.clone();
         let name = dep.name.clone();
         set.spawn(async move {
-            let result = client.fetch_packument_cached(&name, &cache_dir).await;
+            let result = if needs_time {
+                client
+                    .fetch_packument_with_time_cached(&name, &cache_dir)
+                    .await
+            } else {
+                client.fetch_packument_cached(&name, &cache_dir).await
+            };
             (name, result)
         });
     }
@@ -485,15 +502,22 @@ async fn collect_rows(
         // `latest` dist-tag (common on private registries) doesn't get
         // silently flagged as outdated. Drift detection treats an
         // unknown latest the same as "matches current".
-        let latest: Option<String> = packument.dist_tags.get("latest").cloned();
+        let latest = super::policy_version(
+            &packument,
+            &dep.name,
+            "latest",
+            minimum_release_age.as_ref(),
+        );
 
-        // Wanted = highest version in the packument that still satisfies the
-        // manifest range. Fall back to `current` when the range is unparseable
-        // (workspace:/file: specifiers, git URLs, etc.) so we don't lie.
+        // Wanted = the version an update would resolve inside the manifest
+        // range after applying minimumReleaseAge. Fall back to `current` when
+        // the range is unparseable so we don't lie.
         let wanted = dep
             .specifier
             .as_deref()
-            .and_then(|spec| super::wanted_version(&packument, spec))
+            .and_then(|spec| {
+                super::policy_version(&packument, &dep.name, spec, minimum_release_age.as_ref())
+            })
             .unwrap_or_else(|| current.clone());
 
         let latest_known = latest.is_some();

--- a/crates/aube/src/commands/package_spec.rs
+++ b/crates/aube/src/commands/package_spec.rs
@@ -1,63 +1,32 @@
-/// Pick the version of `packument` that an install would land on for
-/// `range_str` — the `Wanted` column of `aube outdated` and the upgrade
-/// target `aube update` offers.
+/// Pick the version a policy-aware update would actually resolve.
 ///
-/// Mirrors pnpm's `pickVersionByVersionRange`, which is also what the
-/// resolver's own `pick_version` implements, so the report can't promise
-/// a version the install won't produce:
-///
-/// 1. `dist-tags.latest` wins whenever it falls inside the range — the
-///    publisher used the tag to anchor the canonical install, and a
-///    higher version outside it is usually a hotfix on an old line or an
-///    unwithdrawn experiment.
-/// 2. Otherwise the highest satisfying version that isn't deprecated.
-/// 3. Otherwise the highest satisfying version, deprecated and all —
-///    the deprecation rule is a tiebreak, not a filter, so a range that
-///    only reaches deprecated versions still resolves.
-///
-/// Step 2 is what keeps `codemirror@6.65.7` — an accidentally mis-tagged
-/// republish of `5.65.7` that sorts above every genuine 6.x — from being
-/// offered as an upgrade to everyone on `^6`.
-///
-/// Returns the *original packument key* (not a round-tripped `Version`
-/// display string) so string comparisons against the lockfile's
-/// `current` — which also comes from a packument key — stay stable
-/// for versions whose `Display` differs from their original form
-/// (e.g. leading zeros in prerelease identifiers, build metadata
-/// that `Version` drops). Returns `None` for unparseable ranges
-/// (workspace:/file: specs, git URLs, etc.) so callers can fall
-/// back to the locked version.
-pub(crate) fn wanted_version(
+/// This delegates to the resolver's picker so dist-tag preference,
+/// deprecation handling, `minimumReleaseAge` exclusions, and strict-mode
+/// failures cannot drift between resolution and the human-facing commands.
+/// Both `outdated` and the interactive update picker use it so neither
+/// advertises a version that the resolver will reject moments later.
+pub(crate) fn policy_version(
     packument: &aube_registry::Packument,
+    registry_name: &str,
     range_str: &str,
+    minimum_release_age: Option<&aube_resolver::MinimumReleaseAge>,
 ) -> Option<String> {
-    let range = node_semver::Range::parse(range_str).ok()?;
-    if let Some(latest) = packument.dist_tags.get("latest")
-        && packument.versions.contains_key(latest)
-        && let Ok(v) = node_semver::Version::parse(latest)
-        && v.satisfies(&range)
-    {
-        return Some(latest.clone());
+    // Human-facing update reports preserve an absent `latest` tag as
+    // unknown. The resolver itself may fall back to the highest stable
+    // release so installs remain possible, but presenting that fallback as
+    // the publisher's `latest` tag would make the report misleading.
+    if range_str == "latest" && !packument.dist_tags.contains_key("latest") {
+        return None;
     }
-    let mut best: Option<(&str, node_semver::Version, bool)> = None;
-    for (ver_str, meta) in &packument.versions {
-        let Ok(v) = node_semver::Version::parse(ver_str) else {
-            continue;
-        };
-        if !v.satisfies(&range) {
-            continue;
-        }
-        let live = meta.deprecated.is_none();
-        let outranks = match &best {
-            None => true,
-            Some((_, _, best_live)) if live != *best_live => live,
-            Some((_, best_v, _)) => v > *best_v,
-        };
-        if outranks {
-            best = Some((ver_str.as_str(), v, live));
-        }
+    match aube_resolver::pick_version_for_add(
+        packument,
+        registry_name,
+        range_str,
+        minimum_release_age,
+    ) {
+        aube_resolver::PickResult::Found(meta) => Some(meta.version.clone()),
+        aube_resolver::PickResult::NoMatch | aube_resolver::PickResult::AgeGated => None,
     }
-    best.map(|(key, _, _)| key.to_string())
 }
 
 /// Resolve a version spec against a full packument. Returns the concrete
@@ -136,6 +105,10 @@ pub(crate) fn encode_package_name(name: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn wanted_version(packument: &aube_registry::Packument, range: &str) -> Option<String> {
+        policy_version(packument, &packument.name, range, None)
+    }
 
     fn packument(json: serde_json::Value) -> aube_registry::Packument {
         serde_json::from_value(json).expect("test packument parses")
@@ -244,6 +217,36 @@ mod tests {
             Some("4.2.11")
         );
         assert_eq!(wanted_version(&codemirror(), "*").as_deref(), Some("6.0.2"));
+    }
+
+    #[test]
+    fn policy_version_skips_fresh_latest_release() {
+        let package = packument(serde_json::json!({
+            "name": "demo",
+            "dist-tags": { "latest": "2.0.0" },
+            "versions": {
+                "1.0.0": { "name": "demo", "version": "1.0.0" },
+                "2.0.0": { "name": "demo", "version": "2.0.0" }
+            },
+            "time": {
+                "1.0.0": "2000-01-01T00:00:00.000Z",
+                "2.0.0": "2999-01-01T00:00:00.000Z"
+            }
+        }));
+        let minimum_release_age = aube_resolver::MinimumReleaseAge {
+            minutes: 1440,
+            exclude: aube_resolver::PackageVersionPolicy::default(),
+            strict: false,
+        };
+
+        assert_eq!(
+            policy_version(&package, "demo", "latest", Some(&minimum_release_age)).as_deref(),
+            Some("1.0.0")
+        );
+        assert_eq!(
+            policy_version(&package, "demo", "*", Some(&minimum_release_age)).as_deref(),
+            Some("1.0.0")
+        );
     }
 
     #[test]

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -1118,7 +1118,18 @@ async fn pick_update_interactively(
     }
 
     let client = std::sync::Arc::new(super::make_client(cwd));
-    let cache_dir = super::packument_cache_dir();
+    let (minimum_release_age, registry_supports_time) = super::with_settings_ctx(cwd, |ctx| {
+        (
+            super::install::resolve_minimum_release_age(ctx, None),
+            aube_settings::resolved::registry_supports_time_field(ctx),
+        )
+    });
+    let needs_time = minimum_release_age.is_some() && !registry_supports_time;
+    let cache_dir = if needs_time {
+        super::packument_full_cache_dir_for_cwd(cwd)
+    } else {
+        super::packument_cache_dir_for_cwd(cwd)
+    };
     let mut set = tokio::task::JoinSet::new();
     for key in &registry_keys {
         let real_name = real_name_from_spec(key, specifiers.get(key.as_str()));
@@ -1126,7 +1137,13 @@ async fn pick_update_interactively(
         let client = client.clone();
         let cache_dir = cache_dir.clone();
         set.spawn(async move {
-            let result = client.fetch_packument_cached(&real_name, &cache_dir).await;
+            let result = if needs_time {
+                client
+                    .fetch_packument_with_time_cached(&real_name, &cache_dir)
+                    .await
+            } else {
+                client.fetch_packument_cached(&real_name, &cache_dir).await
+            };
             (key_owned, result)
         });
     }
@@ -1162,15 +1179,20 @@ async fn pick_update_interactively(
         let current = existing
             .and_then(|g| lookup_pkg(g, existing_importers, key, &real_name))
             .map(|p| p.version.as_str());
-        let registry_latest = packument.dist_tags.get("latest").map(String::as_str);
-        let wanted = super::wanted_version(packument, spec).or_else(|| current.map(str::to_owned));
+        let wanted =
+            super::policy_version(packument, &real_name, spec, minimum_release_age.as_ref())
+                .or_else(|| current.map(str::to_owned));
         // `--latest` rewrites past the manifest range, so the picker
-        // shows the dist-tag latest as the target. Without `--latest`
+        // shows the newest policy-eligible release. Without `--latest`
         // we only refresh inside the range, so target = wanted.
         let target = if latest {
-            registry_latest
-                .map(str::to_owned)
-                .or_else(|| wanted.clone())
+            super::policy_version(
+                packument,
+                &real_name,
+                "latest",
+                minimum_release_age.as_ref(),
+            )
+            .or_else(|| wanted.clone())
         } else {
             wanted.clone()
         };

--- a/test/outdated.bats
+++ b/test/outdated.bats
@@ -93,6 +93,22 @@ EOF
 	refute_output --partial "is-odd  "
 }
 
+@test "aube outdated does not report releases blocked by minimumReleaseAge" {
+	_write_pkg_with_old_is_odd
+	echo "minimumReleaseAge=0" >.npmrc
+	run aube install
+	assert_success
+
+	cat >.npmrc <<'EOF'
+minimumReleaseAge=999999999
+minimumReleaseAgeStrict=true
+EOF
+	run aube outdated
+	assert_success
+	assert_output --partial "up to date"
+	refute_output --partial "3.0.1"
+}
+
 @test "aube outdated does not propose a downgrade off a deprecated latest" {
 	# is-odd@3.0.1 is both the `latest` dist-tag and deprecated
 	# ("please use is-even") in the fixture registry. pnpm returns the


### PR DESCRIPTION
## Summary

- make `aube outdated` and `aube update --interactive` apply the effective `minimumReleaseAge` policy
- fetch full timestamp-bearing packuments when the registry's abbreviated metadata cannot carry publish times
- share the resolver's version picker so reports honor dist-tag, deprecation, exclusion, and strict-mode semantics
- add regression coverage for releases blocked by the age gate

## Root cause

Both human-facing commands calculated available versions directly from abbreviated registry metadata. That bypassed the age policy, while the update resolver correctly applied it afterward, so the picker could offer an update that selecting would not install.

Fixes the behavior reported in https://github.com/jdx/aube/discussions/1191.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `mise run test:bats test/outdated.bats`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches user-facing version reporting for outdated and interactive update and ties it to resolver semantics; behavior changes are intentional but could surprise users who relied on raw registry latest before age policy applied.
> 
> **Overview**
> **`aube outdated` and `aube update --interactive` now compute Wanted/Latest and picker targets with the same rules as install resolution**, including effective `minimumReleaseAge`, instead of reading raw dist-tags and a local semver scan.
> 
> The local **`wanted_version`** helper is replaced by **`policy_version`**, which calls **`aube_resolver::pick_version_for_add`** so dist-tag preference, deprecation, age gating, and strict mode cannot diverge between reports and the resolver. Missing **`latest`** dist-tags stay **(unknown)** in reports rather than showing resolver fallbacks.
> 
> When age policy needs publish times and abbreviated metadata lacks them, both commands load project settings via **`with_settings_ctx`**, resolve **`minimumReleaseAge`**, and fetch **full timestamped packuments** into the cwd-specific full cache instead of always using abbreviated cache.
> 
> Regression coverage adds a **`policy_version`** unit test for age-gated picks and a bats case that **`outdated`** does not surface versions blocked by **`minimumReleaseAge`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b28b0db424b73eb4a5d2b3f85954c8e82bd93d19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - `aube outdated` now excludes releases that are too new according to `minimumReleaseAge`.
  - `aube update` and interactive version selection now consistently apply release-age and strict-mode policies.
  - “Latest” resolution no longer falls back unexpectedly when a registry does not provide a latest version tag.
  - Registry metadata is fetched with time-aware handling when required, improving accuracy for release-age policies.
- **Tests**
  - Added coverage confirming blocked releases are not reported as available updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->