### PR TITLE
fix(update): warn when release age hides upgrades

### DIFF
--- a/crates/aube-codes/src/warnings.rs
+++ b/crates/aube-codes/src/warnings.rs
@@ -44,6 +44,8 @@ pub const WARN_AUBE_MANAGED_CONFIG_ENFORCED: &str = "WARN_AUBE_MANAGED_CONFIG_EN
 
 // ── update / prerelease ─────────────────────────────────────────────
 pub const WARN_AUBE_PRERELEASE_CHECK_SKIPPED: &str = "WARN_AUBE_PRERELEASE_CHECK_SKIPPED";
+pub const WARN_AUBE_MINIMUM_RELEASE_AGE_BLOCKED_UPDATE: &str =
+    "WARN_AUBE_MINIMUM_RELEASE_AGE_BLOCKED_UPDATE";
 pub const WARN_AUBE_WORKSPACE_PACKAGE_MISSING_NAME: &str =
     "WARN_AUBE_WORKSPACE_PACKAGE_MISSING_NAME";
 
@@ -310,6 +312,12 @@ pub const ALL: &[CodeMeta] = &[
         name: WARN_AUBE_PRERELEASE_CHECK_SKIPPED,
         category: category::UPDATE_PRERELEASE,
         description: "`aube update` couldn't fetch the packument or got a non-semver `latest` tag; preserved-prerelease check skipped for that package.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: WARN_AUBE_MINIMUM_RELEASE_AGE_BLOCKED_UPDATE,
+        category: category::UPDATE_PRERELEASE,
+        description: "One or more newer package versions were hidden because they have not satisfied `minimumReleaseAge` yet.",
         exit_code: None,
     },
     CodeMeta {

--- a/crates/aube-resolver/src/direct_dep_info.rs
+++ b/crates/aube-resolver/src/direct_dep_info.rs
@@ -8,6 +8,12 @@ use crate::Resolver;
 use aube_lockfile::LockfileGraph;
 use std::collections::HashMap;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgeGatedUpdate {
+    pub name: String,
+    pub version: String,
+}
+
 /// Subset of packument facts the install summary printer wants to
 /// render next to a direct-dependency line. Returned only for direct
 /// deps where at least one signal is set — the printer skips the badge
@@ -37,6 +43,56 @@ pub struct DirectDepInfo {
 }
 
 impl Resolver {
+    /// Return direct updates that an ungated resolve would select but the
+    /// active `minimumReleaseAge` policy hides. The selected gated version
+    /// must match the resolved graph, which avoids mislabeling a difference
+    /// caused by an override, lockfile preference, or another resolver rule.
+    pub fn age_gated_updates(&self, graph: &LockfileGraph) -> Vec<AgeGatedUpdate> {
+        let Some(minimum_release_age) = self.minimum_release_age.as_ref() else {
+            return Vec::new();
+        };
+        let mut updates = Vec::new();
+        for deps in graph.importers.values() {
+            for dep in deps {
+                let Some(pkg) = graph.packages.get(&dep.dep_path) else {
+                    continue;
+                };
+                if pkg.local_source.is_some() {
+                    continue;
+                }
+                let Some(packument) = self.cache.get(pkg.registry_name()) else {
+                    continue;
+                };
+                let Some(range) = dep.specifier.as_deref() else {
+                    continue;
+                };
+                let crate::PickResult::Found(selected) = crate::pick_version_for_add(
+                    packument,
+                    pkg.registry_name(),
+                    range,
+                    Some(minimum_release_age),
+                ) else {
+                    continue;
+                };
+                if selected.version != pkg.version {
+                    continue;
+                }
+                let crate::PickResult::Found(ungated) =
+                    crate::pick_version_for_add(packument, pkg.registry_name(), range, None)
+                else {
+                    continue;
+                };
+                if is_newer(&ungated.version, &selected.version) {
+                    updates.push(AgeGatedUpdate {
+                        name: dep.name.clone(),
+                        version: ungated.version.clone(),
+                    });
+                }
+            }
+        }
+        updates
+    }
+
     /// Snapshot per-direct-dep packument facts so the install summary
     /// printer can render them inline after the resolver — and its
     /// packument cache — is dropped. Keys are `DirectDep::dep_path`;
@@ -88,6 +144,16 @@ fn is_prerelease(version: &str) -> bool {
     node_semver::Version::parse(version)
         .map(|v| !v.pre_release.is_empty())
         .unwrap_or(false)
+}
+
+fn is_newer(candidate: &str, selected: &str) -> bool {
+    match (
+        node_semver::Version::parse(candidate),
+        node_semver::Version::parse(selected),
+    ) {
+        (Ok(candidate), Ok(selected)) => candidate > selected,
+        _ => candidate != selected,
+    }
 }
 
 #[cfg(test)]

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -20,7 +20,7 @@ mod semver_util;
 mod trust;
 mod types;
 
-pub use direct_dep_info::DirectDepInfo;
+pub use direct_dep_info::{AgeGatedUpdate, DirectDepInfo};
 pub use error::{AgeGateDetails, CatalogDetails, Error, ExoticSubdepDetails, NoMatchDetails};
 pub use local_source::resolve_exec_script_path;
 pub use package_ext::is_deprecation_allowed;

--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -558,6 +558,17 @@ impl<'a> ResolveDriver<'a> {
         // versions bypass the cutoff entirely (the prior behavior).
         let cutoff_for_pkg = self.published_by.as_deref();
         let exempt_cutoff = self.time_cutoff.as_deref();
+        // A cutoff-aware `latest` request must remain a range over all
+        // versions. Resolving the dist-tag to its exact version first would
+        // leave no mature alternative for the age gate to select and, in
+        // lenient mode, would admit the quarantined tag through the
+        // lowest-satisfying fallback. Keep dist-tag preference inside
+        // `pick_version`; `*` only broadens the fallback candidate set.
+        let version_range = if task.range == "latest" && cutoff_for_pkg.is_some() {
+            "*"
+        } else {
+            task.range.as_str()
+        };
         // Strict semantics in two cases:
         //   - `minimumReleaseAgeStrict=true` (the user opted in
         //     to hard failures), or
@@ -600,7 +611,7 @@ impl<'a> ResolveDriver<'a> {
             })?;
             let pick = pick_version(
                 packument,
-                &task.range,
+                version_range,
                 locked_version,
                 pick_lowest,
                 cutoff_for_pkg,
@@ -677,7 +688,7 @@ impl<'a> ResolveDriver<'a> {
         let picked_ref = prefer_non_vulnerable_pick(
             task.registry_name(),
             packument,
-            &task.range,
+            version_range,
             &selected_pick,
             pick_lowest,
             cutoff_for_pkg,

--- a/crates/aube-resolver/src/semver_util.rs
+++ b/crates/aube-resolver/src/semver_util.rs
@@ -50,6 +50,7 @@ pub fn pick_version_for_add<'a>(
     minimum_release_age: Option<&crate::MinimumReleaseAge>,
 ) -> PickResult<'a> {
     let cutoff = minimum_release_age.and_then(|m| m.cutoff());
+    let range = registry_alias_range(range);
     let range = if range == "latest" && cutoff.is_some() {
         "*"
     } else {
@@ -76,6 +77,20 @@ pub fn pick_version_for_add<'a>(
         strict,
         is_age_exempt,
     )
+}
+
+/// Return the version tail from an `npm:` alias spec. Resolution preprocesses
+/// this protocol before picking; report-only callers use this entry point
+/// directly, so normalize it here as well.
+fn registry_alias_range(range: &str) -> &str {
+    if let Some(rest) = range.strip_prefix("npm:") {
+        match rest.rfind('@') {
+            Some(at) if at > 0 => &rest[at + 1..],
+            _ => "latest",
+        }
+    } else {
+        range
+    }
 }
 
 /// Pick the best version from a packument that satisfies the given range.

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -4585,6 +4585,35 @@ fn direct_dep_info_empty_when_no_packument_cached() {
     assert!(info.is_empty(), "no packument cached → empty map");
 }
 
+#[test]
+fn age_gated_updates_reports_hidden_direct_release() {
+    let mut packument = make_packument("foo", &["1.0.0", "2.0.0"], "2.0.0");
+    packument
+        .time
+        .insert("1.0.0".to_string(), "2000-01-01T00:00:00.000Z".to_string());
+    packument
+        .time
+        .insert("2.0.0".to_string(), "2999-01-01T00:00:00.000Z".to_string());
+
+    let mut resolver =
+        direct_dep_info_resolver().with_minimum_release_age(Some(MinimumReleaseAge {
+            minutes: 1440,
+            ..Default::default()
+        }));
+    resolver.cache.insert("foo".to_string(), packument);
+
+    let pkg = mk_locked("foo", "1.0.0", &[], &[]);
+    let graph = direct_dep_info_graph(&[("foo", "foo@1.0.0", "latest")], &[pkg]);
+
+    assert_eq!(
+        resolver.age_gated_updates(&graph),
+        vec![AgeGatedUpdate {
+            name: "foo".to_string(),
+            version: "2.0.0".to_string(),
+        }]
+    );
+}
+
 #[tokio::test]
 async fn optional_dep_is_skipped_while_required_dep_resolves() {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -4586,7 +4586,7 @@ fn direct_dep_info_empty_when_no_packument_cached() {
 }
 
 #[test]
-fn age_gated_updates_reports_hidden_direct_release() {
+fn age_gated_updates_reports_hidden_aliased_direct_release() {
     let mut packument = make_packument("foo", &["1.0.0", "2.0.0"], "2.0.0");
     packument
         .time
@@ -4602,13 +4602,17 @@ fn age_gated_updates_reports_hidden_direct_release() {
         }));
     resolver.cache.insert("foo".to_string(), packument);
 
-    let pkg = mk_locked("foo", "1.0.0", &[], &[]);
-    let graph = direct_dep_info_graph(&[("foo", "foo@1.0.0", "latest")], &[pkg]);
+    let mut pkg = mk_locked("foo-alias", "1.0.0", &[], &[]);
+    pkg.alias_of = Some("foo".to_string());
+    let graph = direct_dep_info_graph(
+        &[("foo-alias", "foo-alias@1.0.0", "npm:foo@latest")],
+        &[pkg],
+    );
 
     assert_eq!(
         resolver.age_gated_updates(&graph),
         vec![AgeGatedUpdate {
-            name: "foo".to_string(),
+            name: "foo-alias".to_string(),
             version: "2.0.0".to_string(),
         }]
     );

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -129,8 +129,8 @@ pub(crate) use manifest_io::{
     write_manifest_dep_sections, write_manifest_json,
 };
 pub(crate) use package_spec::{
-    encode_package_name, policy_version_info, resolve_version, split_name_spec,
-    warn_age_gated_updates,
+    encode_package_name, policy_version_info, record_age_gated_update, resolve_version,
+    split_name_spec, warn_age_gated_updates,
 };
 pub(crate) use project_lock::take_install_project_lock;
 pub(crate) use project_lock::take_project_lock;

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -129,7 +129,8 @@ pub(crate) use manifest_io::{
     write_manifest_dep_sections, write_manifest_json,
 };
 pub(crate) use package_spec::{
-    encode_package_name, policy_version, resolve_version, split_name_spec,
+    encode_package_name, policy_version_info, resolve_version, split_name_spec,
+    warn_age_gated_updates,
 };
 pub(crate) use project_lock::take_install_project_lock;
 pub(crate) use project_lock::take_project_lock;

--- a/crates/aube/src/commands/outdated.rs
+++ b/crates/aube/src/commands/outdated.rs
@@ -484,6 +484,7 @@ async fn collect_rows(
     }
 
     let mut rows: Vec<Row> = Vec::new();
+    let mut blocked_updates = BTreeMap::new();
     for dep in &roots {
         let packument = packuments.remove(&dep.name);
         let current = match graph.get_package(&dep.dep_path) {
@@ -502,22 +503,30 @@ async fn collect_rows(
         // `latest` dist-tag (common on private registries) doesn't get
         // silently flagged as outdated. Drift detection treats an
         // unknown latest the same as "matches current".
-        let latest = super::policy_version(
+        let latest_info = super::policy_version_info(
             &packument,
             &dep.name,
             "latest",
             minimum_release_age.as_ref(),
         );
+        if let Some(blocked) = latest_info.blocked {
+            blocked_updates.insert(dep.name.clone(), blocked);
+        }
+        let latest = latest_info.selected;
 
         // Wanted = the version an update would resolve inside the manifest
         // range after applying minimumReleaseAge. Fall back to `current` when
         // the range is unparseable so we don't lie.
-        let wanted = dep
-            .specifier
-            .as_deref()
-            .and_then(|spec| {
-                super::policy_version(&packument, &dep.name, spec, minimum_release_age.as_ref())
-            })
+        let wanted_info = dep.specifier.as_deref().map(|spec| {
+            super::policy_version_info(&packument, &dep.name, spec, minimum_release_age.as_ref())
+        });
+        if let Some(blocked) = wanted_info.as_ref().and_then(|info| info.blocked.as_ref()) {
+            blocked_updates
+                .entry(dep.name.clone())
+                .or_insert_with(|| blocked.clone());
+        }
+        let wanted = wanted_info
+            .and_then(|info| info.selected)
             .unwrap_or_else(|| current.clone());
 
         let latest_known = latest.is_some();
@@ -537,6 +546,7 @@ async fn collect_rows(
             });
         }
     }
+    super::warn_age_gated_updates(&blocked_updates);
 
     Ok((rows, true))
 }

--- a/crates/aube/src/commands/outdated.rs
+++ b/crates/aube/src/commands/outdated.rs
@@ -465,13 +465,19 @@ async fn collect_rows(
         let client = client.clone();
         let cache_dir = cache_dir.clone();
         let name = dep.name.clone();
+        let registry_name = graph
+            .get_package(&dep.dep_path)
+            .map(|pkg| pkg.registry_name().to_string())
+            .unwrap_or_else(|| name.clone());
         set.spawn(async move {
             let result = if needs_time {
                 client
-                    .fetch_packument_with_time_cached(&name, &cache_dir)
+                    .fetch_packument_with_time_cached(&registry_name, &cache_dir)
                     .await
             } else {
-                client.fetch_packument_cached(&name, &cache_dir).await
+                client
+                    .fetch_packument_cached(&registry_name, &cache_dir)
+                    .await
             };
             (name, result)
         });
@@ -487,10 +493,7 @@ async fn collect_rows(
     let mut blocked_updates = BTreeMap::new();
     for dep in &roots {
         let packument = packuments.remove(&dep.name);
-        let current = match graph.get_package(&dep.dep_path) {
-            Some(p) => p.version.clone(),
-            None => "(missing)".to_string(),
-        };
+        let current = graph.get_package(&dep.dep_path).map(|p| p.version.clone());
         let packument = match packument {
             Some(Ok(p)) => p,
             Some(Err(e)) => {
@@ -505,12 +508,13 @@ async fn collect_rows(
         // unknown latest the same as "matches current".
         let latest_info = super::policy_version_info(
             &packument,
-            &dep.name,
+            &packument.name,
             "latest",
             minimum_release_age.as_ref(),
+            current.as_deref(),
         );
         if let Some(blocked) = latest_info.blocked {
-            blocked_updates.insert(dep.name.clone(), blocked);
+            super::record_age_gated_update(&mut blocked_updates, dep.name.clone(), blocked);
         }
         let latest = latest_info.selected;
 
@@ -518,13 +522,18 @@ async fn collect_rows(
         // range after applying minimumReleaseAge. Fall back to `current` when
         // the range is unparseable so we don't lie.
         let wanted_info = dep.specifier.as_deref().map(|spec| {
-            super::policy_version_info(&packument, &dep.name, spec, minimum_release_age.as_ref())
+            super::policy_version_info(
+                &packument,
+                &packument.name,
+                spec,
+                minimum_release_age.as_ref(),
+                current.as_deref(),
+            )
         });
         if let Some(blocked) = wanted_info.as_ref().and_then(|info| info.blocked.as_ref()) {
-            blocked_updates
-                .entry(dep.name.clone())
-                .or_insert_with(|| blocked.clone());
+            super::record_age_gated_update(&mut blocked_updates, dep.name.clone(), blocked.clone());
         }
+        let current = current.unwrap_or_else(|| "(missing)".to_string());
         let wanted = wanted_info
             .and_then(|info| info.selected)
             .unwrap_or_else(|| current.clone());

--- a/crates/aube/src/commands/package_spec.rs
+++ b/crates/aube/src/commands/package_spec.rs
@@ -1,3 +1,9 @@
+#[derive(Debug, Clone)]
+pub(crate) struct PolicyVersion {
+    pub(crate) selected: Option<String>,
+    pub(crate) blocked: Option<String>,
+}
+
 /// Pick the version a policy-aware update would actually resolve.
 ///
 /// This delegates to the resolver's picker so dist-tag preference,
@@ -5,20 +11,23 @@
 /// failures cannot drift between resolution and the human-facing commands.
 /// Both `outdated` and the interactive update picker use it so neither
 /// advertises a version that the resolver will reject moments later.
-pub(crate) fn policy_version(
+pub(crate) fn policy_version_info(
     packument: &aube_registry::Packument,
     registry_name: &str,
     range_str: &str,
     minimum_release_age: Option<&aube_resolver::MinimumReleaseAge>,
-) -> Option<String> {
+) -> PolicyVersion {
     // Human-facing update reports preserve an absent `latest` tag as
     // unknown. The resolver itself may fall back to the highest stable
     // release so installs remain possible, but presenting that fallback as
     // the publisher's `latest` tag would make the report misleading.
     if range_str == "latest" && !packument.dist_tags.contains_key("latest") {
-        return None;
+        return PolicyVersion {
+            selected: None,
+            blocked: None,
+        };
     }
-    match aube_resolver::pick_version_for_add(
+    let selected = match aube_resolver::pick_version_for_add(
         packument,
         registry_name,
         range_str,
@@ -26,7 +35,46 @@ pub(crate) fn policy_version(
     ) {
         aube_resolver::PickResult::Found(meta) => Some(meta.version.clone()),
         aube_resolver::PickResult::NoMatch | aube_resolver::PickResult::AgeGated => None,
+    };
+    let blocked = minimum_release_age.and_then(|_| {
+        let ungated =
+            match aube_resolver::pick_version_for_add(packument, registry_name, range_str, None) {
+                aube_resolver::PickResult::Found(meta) => Some(meta.version.clone()),
+                aube_resolver::PickResult::NoMatch | aube_resolver::PickResult::AgeGated => None,
+            }?;
+        is_newer_than_selected(&ungated, selected.as_deref()).then_some(ungated)
+    });
+    PolicyVersion { selected, blocked }
+}
+
+fn is_newer_than_selected(candidate: &str, selected: Option<&str>) -> bool {
+    let Some(selected) = selected else {
+        return true;
+    };
+    match (
+        node_semver::Version::parse(candidate),
+        node_semver::Version::parse(selected),
+    ) {
+        (Ok(candidate), Ok(selected)) => candidate > selected,
+        _ => candidate != selected,
     }
+}
+
+pub(crate) fn warn_age_gated_updates(blocked: &std::collections::BTreeMap<String, String>) {
+    if blocked.is_empty() {
+        return;
+    }
+    let packages = blocked
+        .iter()
+        .map(|(name, version)| format!("{name}@{version}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    tracing::warn!(
+        code = aube_codes::warnings::WARN_AUBE_MINIMUM_RELEASE_AGE_BLOCKED_UPDATE,
+        count = blocked.len(),
+        packages,
+        "updates hidden by minimumReleaseAge: {packages}"
+    );
 }
 
 /// Resolve a version spec against a full packument. Returns the concrete
@@ -107,7 +155,7 @@ mod tests {
     use super::*;
 
     fn wanted_version(packument: &aube_registry::Packument, range: &str) -> Option<String> {
-        policy_version(packument, &packument.name, range, None)
+        policy_version_info(packument, &packument.name, range, None).selected
     }
 
     fn packument(json: serde_json::Value) -> aube_registry::Packument {
@@ -240,13 +288,19 @@ mod tests {
         };
 
         assert_eq!(
-            policy_version(&package, "demo", "latest", Some(&minimum_release_age)).as_deref(),
+            policy_version_info(&package, "demo", "latest", Some(&minimum_release_age))
+                .selected
+                .as_deref(),
             Some("1.0.0")
         );
         assert_eq!(
-            policy_version(&package, "demo", "*", Some(&minimum_release_age)).as_deref(),
+            policy_version_info(&package, "demo", "*", Some(&minimum_release_age))
+                .selected
+                .as_deref(),
             Some("1.0.0")
         );
+        let info = policy_version_info(&package, "demo", "latest", Some(&minimum_release_age));
+        assert_eq!(info.blocked.as_deref(), Some("2.0.0"));
     }
 
     #[test]

--- a/crates/aube/src/commands/package_spec.rs
+++ b/crates/aube/src/commands/package_spec.rs
@@ -16,6 +16,7 @@ pub(crate) fn policy_version_info(
     registry_name: &str,
     range_str: &str,
     minimum_release_age: Option<&aube_resolver::MinimumReleaseAge>,
+    current_version: Option<&str>,
 ) -> PolicyVersion {
     // Human-facing update reports preserve an absent `latest` tag as
     // unknown. The resolver itself may fall back to the highest stable
@@ -27,7 +28,7 @@ pub(crate) fn policy_version_info(
             blocked: None,
         };
     }
-    let selected = match aube_resolver::pick_version_for_add(
+    let policy_selected = match aube_resolver::pick_version_for_add(
         packument,
         registry_name,
         range_str,
@@ -36,27 +37,49 @@ pub(crate) fn policy_version_info(
         aube_resolver::PickResult::Found(meta) => Some(meta.version.clone()),
         aube_resolver::PickResult::NoMatch | aube_resolver::PickResult::AgeGated => None,
     };
+    // An already-installed young release is allowed to remain in place.
+    // Never advertise a downgrade or call that same release "hidden".
+    let selected = match (policy_selected, current_version) {
+        (Some(selected), Some(current)) if is_newer(current, &selected) => {
+            Some(current.to_string())
+        }
+        (None, Some(current)) => Some(current.to_string()),
+        (selected, _) => selected,
+    };
     let blocked = minimum_release_age.and_then(|_| {
         let ungated =
             match aube_resolver::pick_version_for_add(packument, registry_name, range_str, None) {
                 aube_resolver::PickResult::Found(meta) => Some(meta.version.clone()),
                 aube_resolver::PickResult::NoMatch | aube_resolver::PickResult::AgeGated => None,
             }?;
-        is_newer_than_selected(&ungated, selected.as_deref()).then_some(ungated)
+        selected
+            .as_deref()
+            .is_some_and(|baseline| is_newer(&ungated, baseline))
+            .then_some(ungated)
     });
     PolicyVersion { selected, blocked }
 }
 
-fn is_newer_than_selected(candidate: &str, selected: Option<&str>) -> bool {
-    let Some(selected) = selected else {
-        return true;
-    };
+fn is_newer(candidate: &str, selected: &str) -> bool {
     match (
         node_semver::Version::parse(candidate),
         node_semver::Version::parse(selected),
     ) {
         (Ok(candidate), Ok(selected)) => candidate > selected,
         _ => candidate != selected,
+    }
+}
+
+pub(crate) fn record_age_gated_update(
+    blocked: &mut std::collections::BTreeMap<String, String>,
+    name: String,
+    version: String,
+) {
+    let replace = blocked
+        .get(&name)
+        .is_none_or(|existing| is_newer(&version, existing));
+    if replace {
+        blocked.insert(name, version);
     }
 }
 
@@ -155,7 +178,7 @@ mod tests {
     use super::*;
 
     fn wanted_version(packument: &aube_registry::Packument, range: &str) -> Option<String> {
-        policy_version_info(packument, &packument.name, range, None).selected
+        policy_version_info(packument, &packument.name, range, None, None).selected
     }
 
     fn packument(json: serde_json::Value) -> aube_registry::Packument {
@@ -288,19 +311,49 @@ mod tests {
         };
 
         assert_eq!(
-            policy_version_info(&package, "demo", "latest", Some(&minimum_release_age))
+            policy_version_info(&package, "demo", "latest", Some(&minimum_release_age), None,)
                 .selected
                 .as_deref(),
             Some("1.0.0")
         );
         assert_eq!(
-            policy_version_info(&package, "demo", "*", Some(&minimum_release_age))
+            policy_version_info(&package, "demo", "*", Some(&minimum_release_age), None)
                 .selected
                 .as_deref(),
             Some("1.0.0")
         );
-        let info = policy_version_info(&package, "demo", "latest", Some(&minimum_release_age));
+        let info =
+            policy_version_info(&package, "demo", "latest", Some(&minimum_release_age), None);
         assert_eq!(info.blocked.as_deref(), Some("2.0.0"));
+
+        let installed = policy_version_info(
+            &package,
+            "demo",
+            "latest",
+            Some(&minimum_release_age),
+            Some("2.0.0"),
+        );
+        assert_eq!(installed.selected.as_deref(), Some("2.0.0"));
+        assert_eq!(installed.blocked, None);
+
+        let alias = policy_version_info(
+            &package,
+            "demo",
+            "npm:demo@latest",
+            Some(&minimum_release_age),
+            None,
+        );
+        assert_eq!(alias.selected.as_deref(), Some("1.0.0"));
+        assert_eq!(alias.blocked.as_deref(), Some("2.0.0"));
+    }
+
+    #[test]
+    fn blocked_update_map_keeps_the_newest_version() {
+        let mut blocked = std::collections::BTreeMap::new();
+        record_age_gated_update(&mut blocked, "demo".to_string(), "2.0.0".to_string());
+        record_age_gated_update(&mut blocked, "demo".to_string(), "3.0.0".to_string());
+        record_age_gated_update(&mut blocked, "demo".to_string(), "1.0.0".to_string());
+        assert_eq!(blocked.get("demo").map(String::as_str), Some("3.0.0"));
     }
 
     #[test]

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -1192,8 +1192,13 @@ async fn pick_update_interactively(
         let current = existing
             .and_then(|g| lookup_pkg(g, existing_importers, key, &real_name))
             .map(|p| p.version.as_str());
-        let wanted_info =
-            super::policy_version_info(packument, &real_name, spec, minimum_release_age.as_ref());
+        let wanted_info = super::policy_version_info(
+            packument,
+            &real_name,
+            spec,
+            minimum_release_age.as_ref(),
+            current,
+        );
         // `--latest` rewrites past the manifest range, so the picker
         // shows the newest policy-eligible release. Without `--latest`
         // we only refresh inside the range, so target = wanted.
@@ -1203,6 +1208,7 @@ async fn pick_update_interactively(
                 &real_name,
                 "latest",
                 minimum_release_age.as_ref(),
+                current,
             )
         } else {
             wanted_info.clone()

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -722,7 +722,19 @@ async fn run_inner(
         .await
         .map_err(miette::Report::new)
         .wrap_err("failed to resolve dependencies")?;
+    let age_gated_updates = if args.interactive {
+        Vec::new()
+    } else {
+        resolver.age_gated_updates(&graph)
+    };
     drop(resolver);
+    let targeted: BTreeSet<&str> = manifest_keys_to_update.iter().map(String::as_str).collect();
+    let blocked_updates = age_gated_updates
+        .into_iter()
+        .filter(|update| targeted.contains(update.name.as_str()))
+        .map(|update| (update.name, update.version))
+        .collect();
+    super::warn_age_gated_updates(&blocked_updates);
     // Drain the readPackage stderr forwarders so resolve-time `ctx.log`
     // records flush to stdout before afterAllResolved emits its own.
     crate::pnpmfile::ReadPackageHostChain::drain_forwarders(read_package_forwarders).await;
@@ -1167,6 +1179,7 @@ async fn pick_update_interactively(
         .description("Space to toggle, Enter to confirm")
         .filterable(true);
     let mut shown = BTreeSet::new();
+    let mut blocked_updates = BTreeMap::new();
     for key in &registry_keys {
         let spec = specifiers
             .get(key.as_str())
@@ -1179,23 +1192,28 @@ async fn pick_update_interactively(
         let current = existing
             .and_then(|g| lookup_pkg(g, existing_importers, key, &real_name))
             .map(|p| p.version.as_str());
-        let wanted =
-            super::policy_version(packument, &real_name, spec, minimum_release_age.as_ref())
-                .or_else(|| current.map(str::to_owned));
+        let wanted_info =
+            super::policy_version_info(packument, &real_name, spec, minimum_release_age.as_ref());
         // `--latest` rewrites past the manifest range, so the picker
         // shows the newest policy-eligible release. Without `--latest`
         // we only refresh inside the range, so target = wanted.
-        let target = if latest {
-            super::policy_version(
+        let target_info = if latest {
+            super::policy_version_info(
                 packument,
                 &real_name,
                 "latest",
                 minimum_release_age.as_ref(),
             )
-            .or_else(|| wanted.clone())
         } else {
-            wanted.clone()
+            wanted_info.clone()
         };
+        if let Some(blocked) = target_info.blocked {
+            blocked_updates.insert((*key).clone(), blocked);
+        }
+        let target = target_info
+            .selected
+            .or(wanted_info.selected)
+            .or_else(|| current.map(str::to_owned));
         let (Some(current), Some(target)) = (current, target.as_deref()) else {
             continue;
         };
@@ -1211,6 +1229,7 @@ async fn pick_update_interactively(
         );
         shown.insert((*key).clone());
     }
+    super::warn_age_gated_updates(&blocked_updates);
     if shown.is_empty() {
         return Ok(Some(InteractiveSelection {
             selected: BTreeSet::new(),

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -687,6 +687,12 @@
       "exit_code": null
     },
     {
+      "name": "WARN_AUBE_MINIMUM_RELEASE_AGE_BLOCKED_UPDATE",
+      "category": "Update / prerelease",
+      "description": "One or more newer package versions were hidden because they have not satisfied `minimumReleaseAge` yet.",
+      "exit_code": null
+    },
+    {
       "name": "WARN_AUBE_WORKSPACE_PACKAGE_MISSING_NAME",
       "category": "Update / prerelease",
       "description": "A discovered workspace package had no `name` field, so update skipped local workspace version registration for it.",

--- a/test/outdated.bats
+++ b/test/outdated.bats
@@ -106,7 +106,7 @@ EOF
 	run aube outdated
 	assert_success
 	assert_output --partial "up to date"
-	refute_output --partial "3.0.1"
+	assert_output --partial "updates hidden by minimumReleaseAge: is-odd@3.0.1"
 }
 
 @test "aube outdated does not propose a downgrade off a deprecated latest" {

--- a/test/outdated.bats
+++ b/test/outdated.bats
@@ -93,6 +93,28 @@ EOF
 	refute_output --partial "is-odd  "
 }
 
+@test "aube outdated does not report an installed young release as hidden" {
+	cat >package.json <<-'EOF'
+		{
+		  "name": "outdated-young-installed",
+		  "version": "1.0.0",
+		  "dependencies": { "is-odd": "3.0.1" }
+		}
+	EOF
+	run aube install
+	assert_success
+
+	cat >.npmrc <<'EOF'
+minimumReleaseAge=999999999
+minimumReleaseAgeStrict=true
+EOF
+	run aube outdated
+	assert_success
+	assert_output --partial "up to date"
+	refute_output --partial "updates hidden by minimumReleaseAge"
+	refute_output --partial "3.0.0"
+}
+
 @test "aube outdated does not report releases blocked by minimumReleaseAge" {
 	_write_pkg_with_old_is_odd
 	echo "minimumReleaseAge=0" >.npmrc

--- a/test/update.bats
+++ b/test/update.bats
@@ -68,6 +68,24 @@ EOF
 	assert_file_exists node_modules/is-odd/index.js
 }
 
+@test "aube update warns when minimumReleaseAge hides a newer version" {
+	_setup_outdated_project
+	# Put the cutoff between is-odd@3.0.0 and 3.0.1.
+	age_minutes="$(node -e "console.log(Math.floor((Date.now() - Date.parse('2018-05-31T08:00:00.000Z')) / 60000))")"
+	cat >pnpm-workspace.yaml <<EOF
+packages:
+  - "."
+minimumReleaseAge: $age_minutes
+minimumReleaseAgeStrict: true
+EOF
+
+	run aube update --latest --lockfile-only is-odd
+	assert_success
+	assert_output --partial "updates hidden by minimumReleaseAge: is-odd@3.0.1"
+	run grep 'is-odd@3.0.0' aube-lock.yaml
+	assert_success
+}
+
 @test "aube update runs pnpm:devPreinstall before resolution" {
 	cat >package.json <<'EOF'
 {


### PR DESCRIPTION
## Summary

- emit one aggregated `WARN_AUBE_MINIMUM_RELEASE_AGE_BLOCKED_UPDATE` warning when `outdated`, interactive update, or plain `aube up` hides newer releases behind `minimumReleaseAge`
- keep `aube up --latest` inside the age-gated candidate range so it selects the newest mature version instead of admitting the quarantined dist-tag
- compare resolver outcomes before warning so overrides, lockfile preference, and other resolver rules do not produce false positives
- add resolver and Bats regression coverage and document the stable warning code

Follow-up to #1192 and the behavior discussed in https://github.com/jdx/aube/discussions/1191.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `mise run test:bats test/outdated.bats test/update.bats` (43 passed)

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes resolver `latest` behavior under `minimumReleaseAge` and update/outdated reporting paths; supply-chain policy adjacent but covered by tests and mostly additive warnings.
> 
> **Overview**
> **`minimumReleaseAge` now surfaces hidden upgrades** instead of silently omitting them from reports. `aube outdated`, non-interactive `aube update`, and the interactive update picker emit one aggregated **`WARN_AUBE_MINIMUM_RELEASE_AGE_BLOCKED_UPDATE`** listing packages whose newer versions are still quarantined (e.g. `updates hidden by minimumReleaseAge: is-odd@3.0.1`).
> 
> **Policy-aware version reporting** replaces the old `policy_version` helper with **`policy_version_info`**, which returns both the version the resolver would pick (**selected**) and any newer ungated candidate (**blocked**). Installed “young” releases are not mislabeled as hidden or downgraded; **`outdated`** fetches packuments by **registry name** (aliases) and compares gated vs ungated picks like the resolver.
> 
> **Resolver fixes** treat **`latest`** as **`*`** when an age cutoff is active so lenient mode cannot admit a quarantined dist-tag; **`npm:`** alias ranges are normalized in **`pick_version_for_add`**. **`Resolver::age_gated_updates`** compares gated vs ungated picks only when the gated choice matches the resolved graph, limiting false positives from overrides or lockfile preference.
> 
> Regression coverage includes resolver unit tests, **`package_spec`** tests, Bats for **`outdated`** / **`update`**, and the new warning code in **`docs/error-codes.data.json`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dded49295e021993e2590a3daa412ce2fdfb368c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `aube outdated` and `aube update` now identify newer dependency versions hidden by `minimumReleaseAge`.
  - Clear warnings show which package versions are blocked and when they may become available.
  - Detection works with aliased dependencies and respects the currently installed version.
  - Version selection for `latest` updates now behaves correctly when release-age restrictions apply.

- **Bug Fixes**
  - Prevented age restrictions from incorrectly suggesting or hiding installed dependency versions.
  - Improved handling of registry aliases during update checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->