### PR TITLE
ci: reduce redundant workflow runs

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -16,3 +16,11 @@ self-hosted-runner:
     - namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
     - namespace-profile-endev-linux-amd64-large;overrides.cache-tag=aube-rust-linux
     - namespace-profile-endev-linux-arm64-large;overrides.cache-tag=aube-rust-linux-arm64
+
+paths:
+  .github/workflows/ci.yml:
+    # actionlint 1.7.12 predates GitHub's native parallel step groups.
+    # Remove this once actionlint recognizes the `parallel` keyword.
+    ignore:
+      - 'step must run script with "run" section or run action with "uses" section'
+      - 'property "(semver|ffi)" is not defined in object type'

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -22,5 +22,4 @@ paths:
     # actionlint 1.7.12 predates GitHub's native parallel step groups.
     # Remove this once actionlint recognizes the `parallel` keyword.
     ignore:
-      - 'step must run script with "run" section or run action with "uses" section'
-      - 'property "(semver|ffi)" is not defined in object type'
+      - '^step must run script with "run" section or run action with "uses" section$'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
   pull_request:
   push:
     branches: ["main"]
-    tags: ["*"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -199,7 +198,8 @@ jobs:
   # tests assert native OS sandbox behavior that does not match the
   # Namespace runner profiles.
   # Each shard downloads the OS-matched debug binary from `build` and
-  # invokes mise-task ci:bats:nonserial with its shard index.
+  # invokes mise-task ci:bats:nonserial with its shard index. mise provisions
+  # rush as the parallel driver on both platforms.
   #
   # retry handles the rare BATS flake (process teardown racing npm
   # cache writes, etc.); the Buildkite side has the same retry:1.
@@ -245,12 +245,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Install GNU parallel (ubuntu)
-        if: startsWith(matrix.os, 'ubuntu')
-        run: sudo apt-get update && sudo apt-get install -y parallel
-      - name: Install GNU parallel (macos)
-        if: startsWith(matrix.os, 'macos')
-        run: brew install parallel
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1 # zizmor: ignore[cache-poisoning] PRs restore only; saves are restricted to main
         with:
           cache_save: ${{ github.ref == 'refs/heads/main' }}
@@ -290,12 +284,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Install GNU parallel (ubuntu)
-        if: startsWith(matrix.os, 'ubuntu')
-        run: sudo apt-get update && sudo apt-get install -y parallel
-      - name: Install GNU parallel (macos)
-        if: startsWith(matrix.os, 'macos')
-        run: brew install parallel
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1 # zizmor: ignore[cache-poisoning] PRs restore only; saves are restricted to main
         with:
           cache_save: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,23 +154,26 @@ jobs:
           if printf '%s' "$PR_LABELS" | grep -q '"breaking-api"'; then breaking=true; fi
           echo "breaking=$breaking" >> "$GITHUB_OUTPUT"
           echo "breaking override: $breaking"
-      - name: Rust embedding API — cargo-semver-checks
-        id: semver
-        continue-on-error: true
-        # Version pinned in bin/cargo-semver-checks (mise tool-stub).
-        run: |
-          ./bin/cargo-semver-checks semver-checks \
-            --baseline-rev origin/main \
-            --package aube-codes --package aube-settings --package aube-util
-      - name: C ABI — frozen export set
-        id: ffi
-        continue-on-error: true
-        run: |
-          cargo build --locked --profile ffi -p aube-ffi
-          grep -vE '^[[:space:]]*(#|$)' crates/aube-ffi/abi-symbols.txt | sort -u > /tmp/abi-expected.txt
-          nm -D --defined-only --extern-only target/ffi/libaube_ffi.so \
-            | awk '{ print $3 }' | grep '^aube_' | sort -u > /tmp/abi-actual.txt
-          diff -u /tmp/abi-expected.txt /tmp/abi-actual.txt
+      # These checks use independent build profiles and outputs. Keep them on
+      # one Namespace runner while overlapping their work.
+      - parallel:
+          - name: Rust embedding API — cargo-semver-checks
+            id: semver
+            continue-on-error: true
+            # Version pinned in bin/cargo-semver-checks (mise tool-stub).
+            run: |
+              ./bin/cargo-semver-checks semver-checks \
+                --baseline-rev origin/main \
+                --package aube-codes --package aube-settings --package aube-util
+          - name: C ABI — frozen export set
+            id: ffi
+            continue-on-error: true
+            run: |
+              cargo build --locked --profile ffi -p aube-ffi
+              grep -vE '^[[:space:]]*(#|$)' crates/aube-ffi/abi-symbols.txt | sort -u > /tmp/abi-expected.txt
+              nm -D --defined-only --extern-only target/ffi/libaube_ffi.so \
+                | awk '{ print $3 }' | grep '^aube_' | sort -u > /tmp/abi-actual.txt
+              diff -u /tmp/abi-expected.txt /tmp/abi-actual.txt
       - name: Enforce API stability
         if: always()
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,35 +158,45 @@ jobs:
       # one Namespace runner while overlapping their work.
       - parallel:
           - name: Rust embedding API — cargo-semver-checks
-            id: semver
-            continue-on-error: true
             # Version pinned in bin/cargo-semver-checks (mise tool-stub).
             run: |
+              set +e
               ./bin/cargo-semver-checks semver-checks \
                 --baseline-rev origin/main \
                 --package aube-codes --package aube-settings --package aube-util
+              semver_status=$?
+              set -e
+              printf '%s\n' "$semver_status" > /tmp/semver-status
           - name: C ABI — frozen export set
-            id: ffi
-            continue-on-error: true
             run: |
-              cargo build --locked --profile ffi -p aube-ffi
-              grep -vE '^[[:space:]]*(#|$)' crates/aube-ffi/abi-symbols.txt | sort -u > /tmp/abi-expected.txt
-              nm -D --defined-only --extern-only target/ffi/libaube_ffi.so \
-                | awk '{ print $3 }' | grep '^aube_' | sort -u > /tmp/abi-actual.txt
-              diff -u /tmp/abi-expected.txt /tmp/abi-actual.txt
+              set +e
+              (
+                cargo build --locked --profile ffi -p aube-ffi &&
+                grep -vE '^[[:space:]]*(#|$)' crates/aube-ffi/abi-symbols.txt | sort -u > /tmp/abi-expected.txt &&
+                nm -D --defined-only --extern-only target/ffi/libaube_ffi.so \
+                  | awk '{ print $3 }' | grep '^aube_' | sort -u > /tmp/abi-actual.txt &&
+                diff -u /tmp/abi-expected.txt /tmp/abi-actual.txt
+              )
+              ffi_status=$?
+              set -e
+              printf '%s\n' "$ffi_status" > /tmp/ffi-status
       - name: Enforce API stability
         if: always()
         env:
-          SEMVER: ${{ steps.semver.outcome }}
-          FFI: ${{ steps.ffi.outcome }}
           BREAKING: ${{ steps.gate.outputs.breaking }}
         run: |
+          if [ ! -s /tmp/semver-status ] || [ ! -s /tmp/ffi-status ]; then
+            echo "::error::one or more API stability checks did not report a result"
+            exit 1
+          fi
+          SEMVER=$(cat /tmp/semver-status)
+          FFI=$(cat /tmp/ffi-status)
           fail=0
-          if [ "$FFI" = failure ]; then
+          if [ "$FFI" -ne 0 ]; then
             echo "::error::C ABI exports drifted from crates/aube-ffi/abi-symbols.txt. Update the manifest to match; removing or renaming an export is a breaking change — also mark the PR breaking (a '!' in the title or the 'breaking-api' label)."
             fail=1
           fi
-          if [ "$SEMVER" = failure ]; then
+          if [ "$SEMVER" -ne 0 ]; then
             if [ "$BREAKING" = true ]; then
               echo "::notice::Rust embedding API compatibility check failed; allowed because this PR is marked breaking. Inspect the cargo-semver-checks output to confirm the failure is expected."
             else

--- a/.github/workflows/ffi.yml
+++ b/.github/workflows/ffi.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "crates/aube-ffi/**"
       - "crates/aube-codes/**"
+      - "!crates/aube-codes/CHANGELOG.md"
       - "crates/aube/src/lib.rs"
       - "crates/aube/src/embed.rs"
       - "crates/aube/src/commands/add/mod.rs"
@@ -19,6 +20,7 @@ on:
     paths:
       - "crates/aube-ffi/**"
       - "crates/aube-codes/**"
+      - "!crates/aube-codes/CHANGELOG.md"
       - "crates/aube/src/lib.rs"
       - "crates/aube/src/embed.rs"
       - "crates/aube/src/commands/add/mod.rs"

--- a/.github/workflows/node-addon.yml
+++ b/.github/workflows/node-addon.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "crates/aube-node/**"
       - "crates/aube-codes/**"
+      - "!crates/aube-codes/CHANGELOG.md"
       - "crates/aube-registry/src/config/**"
       - "crates/aube-registry/src/lib.rs"
       - "crates/aube/src/lib.rs"
@@ -21,6 +22,7 @@ on:
     paths:
       - "crates/aube-node/**"
       - "crates/aube-codes/**"
+      - "!crates/aube-codes/CHANGELOG.md"
       - "crates/aube-registry/src/config/**"
       - "crates/aube-registry/src/lib.rs"
       - "crates/aube/src/lib.rs"

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -32,7 +32,9 @@ env:
 jobs:
   compare:
     name: Compare instruction counts
-    if: github.event_name == 'pull_request'
+    # release-plz PRs only contain generated release metadata and changelogs.
+    # Measuring them repeats the same binary already measured on main.
+    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-plz-')
     # Same runner class as perf.yml and perf-backfill.yml. Absolute counts shift
     # between machine types by more than a real regression does, so a comparison
     # across runner classes is not a comparison — tak refuses to make one, and

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -33,8 +33,10 @@ jobs:
   compare:
     name: Compare instruction counts
     # release-plz PRs only contain generated release metadata and changelogs.
-    # Measuring them repeats the same binary already measured on main.
-    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-plz-')
+    # Measuring them repeats the same binary already measured on main. Restrict
+    # the exemption to release-plz branches in this repository so a fork cannot
+    # bypass the comparison by choosing the same branch prefix.
+    if: github.event_name == 'pull_request' && !(startsWith(github.head_ref, 'release-plz-') && github.event.pull_request.head.repo.full_name == github.repository)
     # Same runner class as perf.yml and perf-backfill.yml. Absolute counts shift
     # between machine types by more than a real regression does, so a comparison
     # across runner classes is not a comparison — tak refuses to make one, and

--- a/mise-tasks/ci/bats/nonserial
+++ b/mise-tasks/ci/bats/nonserial
@@ -29,7 +29,7 @@ BATS_REPORT_FILENAME="$report_name" ./test/bats/bin/bats \
 	--report-formatter junit \
 	--output "$report_dir" \
 	--jobs "$jobs" \
-	--parallel-binary-name parallel \
+	--parallel-binary-name rush \
 	--filter-tags "!serial" \
 	"${test_files[@]}" || status=$?
 


### PR DESCRIPTION
## Summary

- stop changelog-only release updates from triggering the full FFI and Node addon matrices
- skip instruction-count benchmarks for generated release-plz PRs
- avoid repeating full CI for release tags whose commit already ran on main
- use the mise-managed rush driver for BATS and remove redundant GNU Parallel installs
- run the independent Rust API and C ABI stability checks concurrently on one runner

## Why

The generated release PR updates `crates/aube-codes/CHANGELOG.md`, which matched the broad `crates/aube-codes/**` filters. A recent synchronization consumed about 97 runner-minutes in node-addon, 102 in FFI, and 12 in perf despite containing no relevant binary changes. Full tag CI added another roughly 59 runner-minutes for a commit already tested on main.

This should save about 210 runner-minutes per release-PR synchronization, plus about 59 runner-minutes per release tag. GitHub native parallel steps should additionally reduce the API-stability job from about 13.3 minutes to roughly 8 minutes without adding a runner.

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/ffi.yml .github/workflows/node-addon.yml .github/workflows/perf-pr.yml`
- `shellcheck mise-tasks/ci/bats/nonserial`
- `git diff --check`
- BATS/rush smoke invocation

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when workflows run and how API-stability results are collected; a parallel step crash could fail the gate via missing status files, but application code is untouched.
> 
> **Overview**
> Cuts **duplicate CI** by dropping **`push: tags`** from the main `ci` workflow, excluding **`crates/aube-codes/CHANGELOG.md`** from FFI and node-addon path filters, and **skipping perf-pr** for in-repo `release-plz-*` branches so generated release syncs do not re-run heavy matrices or instruction benchmarks.
> 
> In **`api-stability`**, **cargo-semver-checks** and the **C ABI export diff** now run under GitHub’s **`parallel`** step group on one runner; each writes an exit code to `/tmp`, and **Enforce API stability** fails if either file is missing or non-zero (replacing `continue-on-error` + `steps.*.outcome`).
> 
> **BATS** non-serial shards use **`rush`** via mise (`--parallel-binary-name rush`) and no longer **`apt`/`brew install parallel`** on Ubuntu/macOS jobs. **actionlint** ignores a false positive until it understands **`parallel`** steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d1a99058b8750e4dcae15f85256187eef716fec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI Improvements**
  * Improved BATS sharded execution by switching the parallel driver, while keeping existing reporting and shard selection behavior.
  * Tightened CI triggers to run only for the intended branch and to ignore runs when the changelog is the only change.
  * Refined “release-plz” performance comparisons to avoid bypassing checks on forks by applying the exemption only when appropriate.
* **Stability Checks**
  * Made API stability enforcement more reliable by running Rust semver verification and C ABI export-set comparison in parallel and failing when either check indicates instability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->