### PR TITLE
fix(patch): preserve existing patches and refresh hashes

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -2823,6 +2823,8 @@ cmd patch-commit help="Generate a `.patch` file from a `aube patch` edit directo
 Where to write the generated `.patch` file, relative to the project root.
 
 Defaults to `patches`.
+
+Ignored when the dependency already has a declared patch path; the existing path is always reused in that case.
 """#
         arg <DIR>
     }

--- a/crates/aube-codes/src/errors.rs
+++ b/crates/aube-codes/src/errors.rs
@@ -16,6 +16,7 @@ pub const ERR_AUBE_NO_LOCKFILE: &str = "ERR_AUBE_NO_LOCKFILE";
 pub const ERR_AUBE_LOCKFILE_PARSE: &str = "ERR_AUBE_LOCKFILE_PARSE";
 pub const ERR_AUBE_LOCKFILE_UNSUPPORTED_FORMAT: &str = "ERR_AUBE_LOCKFILE_UNSUPPORTED_FORMAT";
 pub const ERR_AUBE_RESOLUTION_SHAPE_MISMATCH: &str = "ERR_AUBE_RESOLUTION_SHAPE_MISMATCH";
+pub const ERR_AUBE_LOCKFILE_CONFIG_MISMATCH: &str = "ERR_AUBE_LOCKFILE_CONFIG_MISMATCH";
 
 // ── resolver ─────────────────────────────────────────────────────────
 pub const ERR_AUBE_NO_MATCHING_VERSION: &str = "ERR_AUBE_NO_MATCHING_VERSION";
@@ -169,6 +170,12 @@ pub const ALL: &[CodeMeta] = &[
         category: category::LOCKFILE,
         description: "A registry-style lockfile dependency path is backed by a git, local directory, or direct tarball resolution.",
         exit_code: Some(13),
+    },
+    CodeMeta {
+        name: ERR_AUBE_LOCKFILE_CONFIG_MISMATCH,
+        category: category::LOCKFILE,
+        description: "A frozen install found configuration, such as patch-file content, that no longer matches the lockfile.",
+        exit_code: Some(14),
     },
     // Resolver
     CodeMeta {

--- a/crates/aube/src/commands/install/resolve.rs
+++ b/crates/aube/src/commands/install/resolve.rs
@@ -170,6 +170,10 @@ pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::R
         }
     }
     let fresh = !force_resolve
+        && match parsed {
+            Ok((g, k)) => matches!(check_patch_drift(cwd, g, k)?, DriftStatus::Fresh),
+            Err(_) => true,
+        }
         && matches!(
             parsed,
             Ok((g, k))
@@ -295,6 +299,9 @@ pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::R
         }
     }
     let lo_write_kind = source_kind_before.unwrap_or(LockfileKind::Aube);
+    if matches!(lo_write_kind, LockfileKind::Pnpm) {
+        graph.patched_dependencies = crate::patches::read_patched_dependencies(cwd)?;
+    }
     // Same runtime-pin recording as the main install path.
     crate::runtime::refresh_lockfile_pin(
         &mut graph,
@@ -443,6 +450,13 @@ pub(super) fn select_lockfile_result(
                          help: run without --frozen-lockfile to update the lockfile"
                     ));
                 }
+                if let DriftStatus::Stale { reason } = check_patch_drift(cwd, graph, kind)? {
+                    return Err(miette!(
+                        code = aube_codes::errors::ERR_AUBE_LOCKFILE_CONFIG_MISMATCH,
+                        "lockfile is out of date with patchedDependencies: {reason}\n\
+                         help: run without --frozen-lockfile to update the lockfile"
+                    ));
+                }
                 if let DriftStatus::Stale { reason } = graph.check_drift_workspace_for_kind(
                     manifests,
                     &ws_config.overrides,
@@ -477,6 +491,13 @@ pub(super) fn select_lockfile_result(
                             "Lockfile out of date with workspace catalogs ({reason}), re-resolving..."
                         );
                         Ok(Err(aube_lockfile::Error::NotFound(cwd.to_path_buf())))
+                    } else if let DriftStatus::Stale { reason } =
+                        check_patch_drift(cwd, graph, *kind)?
+                    {
+                        tracing::debug!(
+                            "Lockfile out of date with patchedDependencies ({reason}), re-resolving..."
+                        );
+                        Ok(Err(aube_lockfile::Error::NotFound(cwd.to_path_buf())))
                     } else {
                         match graph.check_drift_workspace_for_kind(
                             manifests,
@@ -498,6 +519,22 @@ pub(super) fn select_lockfile_result(
             }
         }
     }
+}
+
+fn check_patch_drift(
+    cwd: &Path,
+    graph: &LockfileGraph,
+    kind: LockfileKind,
+) -> miette::Result<DriftStatus> {
+    if !matches!(kind, LockfileKind::Pnpm) {
+        return Ok(DriftStatus::Fresh);
+    }
+    Ok(
+        match crate::patches::pnpm_patch_hash_drift(cwd, &graph.patched_dependencies)? {
+            Some(reason) => DriftStatus::Stale { reason },
+            None => DriftStatus::Fresh,
+        },
+    )
 }
 
 fn active_lockfile_has_conflict_markers(lockfile_dir: &Path) -> bool {

--- a/crates/aube/src/commands/patch.rs
+++ b/crates/aube/src/commands/patch.rs
@@ -71,6 +71,20 @@ pub async fn run(args: PatchArgs) -> Result<()> {
     let vstore_max_len = super::resolve_virtual_store_dir_max_length_for_cwd(&cwd);
     let pkg_dir = find_pnpm_entry(&pnpm_dir, &name, &version, vstore_max_len)?;
 
+    // The edit snapshot must represent the currently declared patch.
+    // In particular, a prior patch-commit can have updated the patch
+    // and lockfile before its convenience relink failed. Refuse to
+    // snapshot that stale tree: appending a diff based on it would
+    // produce hunks against the wrong baseline.
+    if let Some(reason) = crate::state::check_needs_install(&cwd) {
+        return Err(miette!(
+            code = aube_codes::errors::ERR_AUBE_PATCH_FAILED,
+            "installed package tree is out of date ({reason}); run `{}` before `{}`",
+            aube_util::cmd("install"),
+            aube_util::cmd("patch")
+        ));
+    }
+
     // Build the edit + source dirs. Defaults live under
     // `<tmp>/aube-patch-<name>-<version>-<pid>/` so concurrent
     // `aube patch` runs in different terminals don't collide.

--- a/crates/aube/src/commands/patch_commit.rs
+++ b/crates/aube/src/commands/patch_commit.rs
@@ -101,10 +101,15 @@ pub async fn run(args: PatchCommitArgs) -> Result<()> {
     if !combined_patch.is_empty() && !combined_patch.ends_with('\n') {
         combined_patch.push('\n');
     }
-    combined_patch.push_str(&patch);
-    aube_util::fs_atomic::atomic_write(&abs_path, combined_patch.as_bytes())
-        .into_diagnostic()
-        .map_err(|e| miette!("failed to write {}: {e}", abs_path.display()))?;
+    // A failed best-effort snapshot cleanup can leave the edit tree
+    // behind. Make retrying the exact patch-commit idempotent instead
+    // of appending its incremental hunks a second time.
+    if !had_existing_patch || !combined_patch.ends_with(&patch) {
+        combined_patch.push_str(&patch);
+        aube_util::fs_atomic::atomic_write(&abs_path, combined_patch.as_bytes())
+            .into_diagnostic()
+            .map_err(|e| miette!("failed to write {}: {e}", abs_path.display()))?;
+    }
 
     // Manifest write failure means the patch on disk is not
     // referenced anywhere. Restore the prior patch if there was one

--- a/crates/aube/src/commands/patch_commit.rs
+++ b/crates/aube/src/commands/patch_commit.rs
@@ -28,6 +28,9 @@ pub struct PatchCommitArgs {
     /// project root.
     ///
     /// Defaults to `patches`.
+    ///
+    /// Ignored when the dependency already has a declared patch path;
+    /// the existing path is always reused in that case.
     #[arg(long, value_name = "DIR", default_value = "patches")]
     pub patches_dir: PathBuf,
 }
@@ -101,6 +104,20 @@ pub async fn run(args: PatchCommitArgs) -> Result<()> {
     if !combined_patch.is_empty() && !combined_patch.ends_with('\n') {
         combined_patch.push('\n');
     }
+
+    // Invalidate freshness before mutating the patch. Declared patch
+    // paths can live outside the default patches/ directory covered by
+    // the settings fingerprint, and an install failure before a
+    // lockfile rewrite must not leave run/exec treating old linked
+    // contents as current.
+    crate::state::remove_state(&cwd).map_err(|e| {
+        miette!(
+            code = aube_codes::errors::ERR_AUBE_PATCH_FAILED,
+            "failed to invalidate install state before updating {}: {e}",
+            abs_path.display()
+        )
+    })?;
+
     // A failed best-effort snapshot cleanup can leave the edit tree
     // behind. Make retrying the exact patch-commit idempotent instead
     // of appending its incremental hunks a second time.
@@ -122,10 +139,26 @@ pub async fn run(args: PatchCommitArgs) -> Result<()> {
             Err(e) => {
                 match &prior_patch {
                     Some(bytes) => {
-                        let _ = aube_util::fs_atomic::atomic_write(&abs_path, bytes);
+                        if let Err(restore_err) =
+                            aube_util::fs_atomic::atomic_write(&abs_path, bytes)
+                        {
+                            eprintln!(
+                                "warning: failed to restore prior patch {}: {restore_err}; \
+                                 check the patch file and manifest manually",
+                                abs_path.display()
+                            );
+                        }
                     }
                     None => {
-                        let _ = std::fs::remove_file(&abs_path);
+                        if let Err(remove_err) = std::fs::remove_file(&abs_path)
+                            && remove_err.kind() != std::io::ErrorKind::NotFound
+                        {
+                            eprintln!(
+                                "warning: failed to remove orphaned patch {}: {remove_err}; \
+                                 check the patch file and manifest manually",
+                                abs_path.display()
+                            );
+                        }
                     }
                 }
                 return Err(e);

--- a/crates/aube/src/commands/patch_commit.rs
+++ b/crates/aube/src/commands/patch_commit.rs
@@ -1,7 +1,7 @@
 //! `aube patch-commit <dir>` — diff a `aube patch` edit directory
-//! against its frozen source snapshot, write the unified diff to
-//! `<project>/<patches-dir>/<name>@<version>.patch`, record the entry
-//! under `pnpm.patchedDependencies` in `package.json`, and re-run
+//! against its frozen source snapshot, write the unified diff to the
+//! package's declared patch path (or a new file under `patches-dir`),
+//! record a new `patchedDependencies` entry when needed, and re-run
 //! install so the patched files land in the linked tree.
 //!
 //! The patch format is git-compatible: each per-file hunk is wrapped
@@ -9,7 +9,10 @@
 //! through `git apply` as well as aube's own applier in `aube-linker`.
 
 use crate::commands::patch::{PatchState, read_state};
-use crate::patches::upsert_patched_dependency;
+use crate::patches::{
+    is_safe_patch_rel, read_patched_dependencies, remove_patched_dependency,
+    upsert_patched_dependency,
+};
 use clap::Args;
 use miette::{IntoDiagnostic, Result, miette};
 use std::collections::BTreeSet;
@@ -52,60 +55,91 @@ pub async fn run(args: PatchCommitArgs) -> Result<()> {
         ));
     }
 
-    let safe_name = state.name.replace('/', "+");
-    let file_name = format!("{safe_name}@{}.patch", state.version);
-    let rel_dir = args.patches_dir.clone();
-    let abs_dir = cwd.join(&rel_dir);
-    std::fs::create_dir_all(&abs_dir)
+    let key = format!("{}@{}", state.name, state.version);
+    let declared = read_patched_dependencies(&cwd)?;
+    let existing_rel_path = declared.get(&key);
+    let had_existing_patch = existing_rel_path.is_some();
+    let rel_path = existing_rel_path.cloned().unwrap_or_else(|| {
+        let safe_name = state.name.replace('/', "+");
+        let file_name = format!("{safe_name}@{}.patch", state.version);
+        format!(
+            "{}/{file_name}",
+            args.patches_dir.to_string_lossy().replace('\\', "/")
+        )
+    });
+    if !is_safe_patch_rel(&rel_path) {
+        return Err(miette!(
+            "refusing unsafe patch path for {key}: {rel_path:?} (absolute, UNC, or contains `..`)"
+        ));
+    }
+    let abs_path = cwd.join(&rel_path);
+    let abs_dir = abs_path
+        .parent()
+        .ok_or_else(|| miette!("patch path {} has no parent", abs_path.display()))?;
+    std::fs::create_dir_all(abs_dir)
         .into_diagnostic()
         .map_err(|e| miette!("failed to create {}: {e}", abs_dir.display()))?;
-    let abs_path = abs_dir.join(&file_name);
+
     // Snapshot any existing patch so a re-patch can be rolled back to
     // the previous content if the manifest write fails. atomic_write
     // replaces unconditionally, so without the snapshot a re-patch
     // failure would leave the manifest pointing at a path that lost
     // its old content.
-    let prior_patch = std::fs::read(&abs_path).ok();
-    aube_util::fs_atomic::atomic_write(&abs_path, patch.as_bytes())
+    let prior_patch = match std::fs::read(&abs_path) {
+        Ok(bytes) => Some(bytes),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound && !had_existing_patch => None,
+        Err(e) => {
+            return Err(miette!(
+                "failed to read existing patch {}: {e}",
+                abs_path.display()
+            ));
+        }
+    };
+    let mut combined_patch = match &prior_patch {
+        Some(bytes) if had_existing_patch => String::from_utf8(bytes.clone())
+            .into_diagnostic()
+            .map_err(|e| miette!("existing patch {} is not UTF-8: {e}", abs_path.display()))?,
+        _ => String::new(),
+    };
+    if !combined_patch.is_empty() && !combined_patch.ends_with('\n') {
+        combined_patch.push('\n');
+    }
+    combined_patch.push_str(&patch);
+    aube_util::fs_atomic::atomic_write(&abs_path, combined_patch.as_bytes())
         .into_diagnostic()
         .map_err(|e| miette!("failed to write {}: {e}", abs_path.display()))?;
 
-    // Use forward slashes in the manifest entry. Field is portable
-    // across platforms and pnpm always writes it that way.
-    let rel_path = format!(
-        "{}/{file_name}",
-        rel_dir.to_string_lossy().replace('\\', "/")
-    );
-    let key = format!("{}@{}", state.name, state.version);
     // Manifest write failure means the patch on disk is not
     // referenced anywhere. Restore the prior patch if there was one
     // (re-patch path), else remove the orphan.
-    let manifest_path = match upsert_patched_dependency(&cwd, &key, &rel_path) {
-        Ok(p) => p,
-        Err(e) => {
-            match prior_patch {
-                Some(bytes) => {
-                    let _ = aube_util::fs_atomic::atomic_write(&abs_path, &bytes);
+    let manifest_path = if had_existing_patch {
+        None
+    } else {
+        match upsert_patched_dependency(&cwd, &key, &rel_path) {
+            Ok(p) => Some(p),
+            Err(e) => {
+                match &prior_patch {
+                    Some(bytes) => {
+                        let _ = aube_util::fs_atomic::atomic_write(&abs_path, bytes);
+                    }
+                    None => {
+                        let _ = std::fs::remove_file(&abs_path);
+                    }
                 }
-                None => {
-                    let _ = std::fs::remove_file(&abs_path);
-                }
+                return Err(e);
             }
-            return Err(e);
         }
     };
 
-    let manifest_label = manifest_path
-        .file_name()
-        .map(|f| f.to_string_lossy().into_owned())
-        .unwrap_or_else(|| manifest_path.display().to_string());
     eprintln!("Wrote {}", abs_path.display());
-    eprintln!("Recorded {key} -> {rel_path} in {manifest_label}");
-
-    // Drop the snapshot tempdir now that we've captured the diff —
-    // matches pnpm's behavior of cleaning up after a successful commit.
-    if let Some(parent) = state.user_dir.parent() {
-        let _ = std::fs::remove_dir_all(parent);
+    if let Some(manifest_path) = manifest_path {
+        let manifest_label = manifest_path
+            .file_name()
+            .map(|f| f.to_string_lossy().into_owned())
+            .unwrap_or_else(|| manifest_path.display().to_string());
+        eprintln!("Recorded {key} -> {rel_path} in {manifest_label}");
+    } else {
+        eprintln!("Updated {key} at {rel_path}");
     }
 
     // Re-run install so the new patch is applied. We deliberately
@@ -114,7 +148,29 @@ pub async fn run(args: PatchCommitArgs) -> Result<()> {
     let opts = crate::commands::install::InstallOptions::with_mode(
         crate::commands::install::FrozenMode::Prefer,
     );
-    crate::commands::install::run(opts).await?;
+    if let Err(e) = crate::commands::install::run(opts).await {
+        if had_existing_patch {
+            if let Some(bytes) = prior_patch {
+                let _ = aube_util::fs_atomic::atomic_write(&abs_path, &bytes);
+            }
+        } else if remove_patched_dependency(&cwd, &key).is_ok() {
+            match prior_patch {
+                Some(bytes) => {
+                    let _ = aube_util::fs_atomic::atomic_write(&abs_path, &bytes);
+                }
+                None => {
+                    let _ = std::fs::remove_file(&abs_path);
+                }
+            }
+        }
+        return Err(e);
+    }
+
+    // Keep the edit snapshot available until both the patch write and
+    // relink succeed so a failed commit remains recoverable.
+    if let Some(parent) = state.user_dir.parent() {
+        let _ = std::fs::remove_dir_all(parent);
+    }
 
     Ok(())
 }

--- a/crates/aube/src/commands/patch_commit.rs
+++ b/crates/aube/src/commands/patch_commit.rs
@@ -9,10 +9,7 @@
 //! through `git apply` as well as aube's own applier in `aube-linker`.
 
 use crate::commands::patch::{PatchState, read_state};
-use crate::patches::{
-    is_safe_patch_rel, read_patched_dependencies, remove_patched_dependency,
-    upsert_patched_dependency,
-};
+use crate::patches::{is_safe_patch_rel, read_patched_dependencies, upsert_patched_dependency};
 use clap::Args;
 use miette::{IntoDiagnostic, Result, miette};
 use std::collections::BTreeSet;
@@ -142,35 +139,20 @@ pub async fn run(args: PatchCommitArgs) -> Result<()> {
         eprintln!("Updated {key} at {rel_path}");
     }
 
+    // The patch and declaration are now committed. Drop the edit
+    // snapshot before relinking so an unrelated install failure cannot
+    // lead the user to recommit the same incremental diff.
+    if let Some(parent) = state.user_dir.parent() {
+        let _ = std::fs::remove_dir_all(parent);
+    }
+
     // Re-run install so the new patch is applied. We deliberately
     // avoid touching the lockfile here — the patch only changes
     // file contents, not the resolved graph.
     let opts = crate::commands::install::InstallOptions::with_mode(
         crate::commands::install::FrozenMode::Prefer,
     );
-    if let Err(e) = crate::commands::install::run(opts).await {
-        if had_existing_patch {
-            if let Some(bytes) = prior_patch {
-                let _ = aube_util::fs_atomic::atomic_write(&abs_path, &bytes);
-            }
-        } else if remove_patched_dependency(&cwd, &key).is_ok() {
-            match prior_patch {
-                Some(bytes) => {
-                    let _ = aube_util::fs_atomic::atomic_write(&abs_path, &bytes);
-                }
-                None => {
-                    let _ = std::fs::remove_file(&abs_path);
-                }
-            }
-        }
-        return Err(e);
-    }
-
-    // Keep the edit snapshot available until both the patch write and
-    // relink succeed so a failed commit remains recoverable.
-    if let Some(parent) = state.user_dir.parent() {
-        let _ = std::fs::remove_dir_all(parent);
-    }
+    crate::commands::install::run(opts).await?;
 
     Ok(())
 }

--- a/crates/aube/src/patches.rs
+++ b/crates/aube/src/patches.rs
@@ -44,7 +44,7 @@ impl ResolvedPatch {
 /// prefixes, NUL bytes, and any `..` component. Used as a read-side
 /// guard so a hostile manifest cannot point the patch loader at
 /// arbitrary files (e.g. `/etc/passwd` or `\\server\share\secret`).
-fn is_safe_patch_rel(rel: &str) -> bool {
+pub(crate) fn is_safe_patch_rel(rel: &str) -> bool {
     if rel.is_empty() || rel.contains('\0') {
         return false;
     }

--- a/crates/aube/src/patches.rs
+++ b/crates/aube/src/patches.rs
@@ -330,6 +330,59 @@ pub fn read_patched_dependencies(cwd: &Path) -> Result<BTreeMap<String, String>>
     Ok(out)
 }
 
+/// Compare pnpm's recorded patch-content hashes with the currently
+/// declared patch files. A pnpm lockfile keeps the content hash in its
+/// `patchedDependencies` values, while the manifest/workspace config
+/// keeps the path; checking both catches in-place edits that don't
+/// otherwise change dependency resolution.
+pub fn pnpm_patch_hash_drift(
+    cwd: &Path,
+    recorded: &BTreeMap<String, String>,
+) -> Result<Option<String>> {
+    let declared = read_patched_dependencies(cwd)?;
+    for (selector, rel) in &declared {
+        let Some(expected) = recorded.get(selector) else {
+            return Ok(Some(format!(
+                "patched dependency {selector} is missing from pnpm-lock.yaml"
+            )));
+        };
+        // Legacy path-only pnpm entries carry no hash to validate. Leave
+        // them fresh when the declaration still names the same path.
+        if expected == rel {
+            continue;
+        }
+        if !is_safe_patch_rel(rel) {
+            return Err(miette!(
+                "refusing unsafe patch path for {selector}: {rel:?} (absolute, UNC, or contains `..`)"
+            ));
+        }
+        let path = cwd.join(rel);
+        let content = std::fs::read_to_string(&path)
+            .into_diagnostic()
+            .map_err(|e| {
+                miette!(
+                    "failed to read patch file {} for {selector}: {e}",
+                    path.display()
+                )
+            })?;
+        let normalized = content.replace("\r\n", "\n");
+        let mut hasher = Sha256::new();
+        hasher.update(normalized.as_bytes());
+        let actual = hex::encode(hasher.finalize());
+        if !expected.eq_ignore_ascii_case(&actual) {
+            return Ok(Some(format!(
+                "patched dependency {selector} has changed content"
+            )));
+        }
+    }
+    if let Some(selector) = recorded.keys().find(|key| !declared.contains_key(*key)) {
+        return Ok(Some(format!(
+            "patched dependency {selector} is no longer declared"
+        )));
+    }
+    Ok(None)
+}
+
 fn read_package_json_patched_dependencies(cwd: &Path) -> Result<BTreeMap<String, String>> {
     let manifest_path = cwd.join("package.json");
     if !manifest_path.exists() {

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -8192,7 +8192,7 @@
             "name": "patches-dir",
             "usage": "--patches-dir <DIR>",
             "help": "Where to write the generated `.patch` file, relative to the project root",
-            "help_long": "Where to write the generated `.patch` file, relative to the project root.\n\nDefaults to `patches`.",
+            "help_long": "Where to write the generated `.patch` file, relative to the project root.\n\nDefaults to `patches`.\n\nIgnored when the dependency already has a declared patch path; the existing path is always reused in that case.",
             "help_first_line": "Where to write the generated `.patch` file, relative to the project root",
             "short": [],
             "long": [

--- a/docs/cli/patch-commit.md
+++ b/docs/cli/patch-commit.md
@@ -22,4 +22,6 @@ Where to write the generated `.patch` file, relative to the project root.
 
 Defaults to `patches`.
 
+Ignored when the dependency already has a declared patch path; the existing path is always reused in that case.
+
 **Default:** `patches`

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -25,6 +25,12 @@
       "exit_code": 13
     },
     {
+      "name": "ERR_AUBE_LOCKFILE_CONFIG_MISMATCH",
+      "category": "Lockfile",
+      "description": "A frozen install found configuration, such as patch-file content, that no longer matches the lockfile.",
+      "exit_code": 14
+    },
+    {
       "name": "ERR_AUBE_NO_MATCHING_VERSION",
       "category": "Resolver",
       "description": "No published version of the named package satisfies the requested range.",

--- a/test/patch.bats
+++ b/test/patch.bats
@@ -64,6 +64,63 @@ EOF
 	assert_failure
 }
 
+@test "patch-commit extends an existing patch at its declared path" {
+	cat >package.json <<'EOF'
+{
+  "name": "patch-existing-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "is-odd": "3.0.1"
+  }
+}
+EOF
+	cat >pnpm-workspace.yaml <<'EOF'
+packages:
+  - .
+EOF
+
+	run aube install --ignore-scripts
+	assert_success
+
+	run aube patch is-odd@3.0.1
+	assert_success
+	edit_dir="$(echo "$output" | grep -oE '/[^ ]*/user' | head -1)"
+	echo "// existing-patch-marker" >>"$edit_dir/index.js"
+
+	run aube patch-commit --patches-dir patches/custom "$edit_dir"
+	assert_success
+	generated_patch="patches/custom/is-odd@3.0.1.patch"
+	declared_patch="patches/is-odd__3.0.1.patch"
+	mv "$generated_patch" "$declared_patch"
+	sed -i "s#$generated_patch#$declared_patch#" pnpm-workspace.yaml
+
+	run aube patch is-odd@3.0.1
+	assert_success
+	edit_dir="$(echo "$output" | grep -oE '/[^ ]*/user' | head -1)"
+	run grep -q "existing-patch-marker" "$edit_dir/index.js"
+	assert_success
+	echo "// second-patch-marker" >>"$edit_dir/index.js"
+
+	run aube patch-commit "$edit_dir"
+	assert_success
+	assert [ -f "$declared_patch" ]
+	assert [ ! -f "patches/is-odd@3.0.1.patch" ]
+	run grep -q '^+// existing-patch-marker' "$declared_patch"
+	assert_success
+	run grep -q '^+// second-patch-marker' "$declared_patch"
+	assert_success
+	run grep -Fq "$declared_patch" pnpm-workspace.yaml
+	assert_success
+
+	rm -rf node_modules
+	run aube install --ignore-scripts
+	assert_success
+	run grep -q "existing-patch-marker" node_modules/is-odd/index.js
+	assert_success
+	run grep -q "second-patch-marker" node_modules/is-odd/index.js
+	assert_success
+}
+
 # A patch declared against a package's registry name must apply when the
 # package is installed under an npm alias. Regression for discussion
 # #1082: the patch map is keyed by the registry selector

--- a/test/patch.bats
+++ b/test/patch.bats
@@ -122,6 +122,59 @@ EOF
 	assert_success
 }
 
+@test "pnpm patch hash drift fails frozen install and refreshes plain install" {
+	cat >package.json <<'EOF'
+{
+  "name": "patch-hash-drift-test",
+  "version": "1.0.0",
+  "dependencies": { "is-odd": "3.0.1" }
+}
+EOF
+	cat >pnpm-workspace.yaml <<'EOF'
+packages:
+  - .
+patchedDependencies:
+  is-odd@3.0.1: patches/is-odd@3.0.1.patch
+EOF
+	mkdir patches
+	cat >patches/is-odd@3.0.1.patch <<'EOF'
+diff --git a/index.js b/index.js
+index 79d1f22a8e7a27efb8841bb83cb682ea1ff3a59c..1e33b4cf949b73bde8861ad65de71b4e46360259 100644
+--- a/index.js
++++ b/index.js
+@@ -24,1 +24,2 @@ module.exports = function isOdd(value) {
+ };
++module.exports.patched = 'v1';
+EOF
+	cat >pnpm-lock.yaml <<'EOF'
+lockfileVersion: '9.0'
+importers:
+  .: {}
+EOF
+
+	run aube install --no-frozen-lockfile --ignore-scripts
+	assert_success
+	old_hash="$(awk '$1 == "is-odd@3.0.1:" && NF == 2 { print $2; exit }' pnpm-lock.yaml)"
+	assert_equal "${#old_hash}" 64
+
+	sed -i.bak "s/patched = 'v1'/patched = 'v2'/" patches/is-odd@3.0.1.patch
+	rm patches/is-odd@3.0.1.patch.bak
+
+	run aube install --frozen-lockfile --ignore-scripts
+	assert_failure
+	assert_output --partial "ERR_AUBE_LOCKFILE_CONFIG_MISMATCH"
+
+	run aube install --ignore-scripts
+	assert_success
+	new_hash="$(awk '$1 == "is-odd@3.0.1:" && NF == 2 { print $2; exit }' pnpm-lock.yaml)"
+	assert_equal "${#new_hash}" 64
+	[ "$new_hash" != "$old_hash" ]
+	run grep -Fq "version: 3.0.1(patch_hash=$new_hash)" pnpm-lock.yaml
+	assert_success
+	run node -e 'if (require("is-odd").patched !== "v2") process.exit(1)'
+	assert_success
+}
+
 # A patch declared against a package's registry name must apply when the
 # package is installed under an npm alias. Regression for discussion
 # #1082: the patch map is keyed by the registry selector

--- a/test/patch.bats
+++ b/test/patch.bats
@@ -92,7 +92,8 @@ EOF
 	generated_patch="patches/custom/is-odd@3.0.1.patch"
 	declared_patch="patches/is-odd__3.0.1.patch"
 	mv "$generated_patch" "$declared_patch"
-	sed -i "s#$generated_patch#$declared_patch#" pnpm-workspace.yaml
+	sed -i.bak "s#$generated_patch#$declared_patch#" pnpm-workspace.yaml
+	rm pnpm-workspace.yaml.bak
 
 	run aube patch is-odd@3.0.1
 	assert_success

--- a/test/patch.bats
+++ b/test/patch.bats
@@ -94,6 +94,8 @@ EOF
 	mv "$generated_patch" "$declared_patch"
 	sed -i.bak "s#$generated_patch#$declared_patch#" pnpm-workspace.yaml
 	rm pnpm-workspace.yaml.bak
+	run aube install --ignore-scripts
+	assert_success
 
 	run aube patch is-odd@3.0.1
 	assert_success
@@ -101,15 +103,19 @@ EOF
 	run grep -q "existing-patch-marker" "$edit_dir/index.js"
 	assert_success
 	echo "// second-patch-marker" >>"$edit_dir/index.js"
+	retry_parent="$BATS_TEST_TMPDIR/retry-edit"
+	cp -R "$(dirname "$edit_dir")" "$retry_parent"
 
 	run aube patch-commit "$edit_dir"
+	assert_success
+	run aube patch-commit "$retry_parent/user"
 	assert_success
 	assert [ -f "$declared_patch" ]
 	assert [ ! -f "patches/is-odd@3.0.1.patch" ]
 	run grep -q '^+// existing-patch-marker' "$declared_patch"
 	assert_success
-	run grep -q '^+// second-patch-marker' "$declared_patch"
-	assert_success
+	run grep -c '^+// second-patch-marker' "$declared_patch"
+	assert_output "1"
 	run grep -Fq "$declared_patch" pnpm-workspace.yaml
 	assert_success
 


### PR DESCRIPTION
## Summary

- reuse an existing `patchedDependencies` path during `patch-commit`
- compose new edits after the existing patch so the result still applies to pristine package contents
- keep the committed patch and declaration authoritative when the convenience relink fails
- validate pnpm patch-content hashes during lockfile freshness checks
- reject edited patches in frozen mode and refresh their lockfile identities in plain installs

## Root cause

`aube patch` snapshots the linked, already-patched package. `patch-commit` previously diffed against that snapshot but always wrote the incremental diff to a newly generated filename and repointed the declaration. The incremental hunks therefore could not apply to pristine package contents, and the original patch became orphaned.

After editing a declared patch in place, lockfile freshness checks also compared dependency/config metadata but not the patch file's current SHA-256 against pnpm's recorded hash. The linker used the new bytes while the lockfile retained the old identity.

Addresses the behavior reported in discussions [#1195](https://github.com/jdx/aube/discussions/1195) and [#1197](https://github.com/jdx/aube/discussions/1197).

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --quiet`
- `mise run test:bats test/patch.bats` (10 tests)

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install lockfile drift and patch-commit persistence paths; mistakes could break frozen CI or corrupt patch files, but behavior is guarded with hash checks, safe-path validation, and rollback on manifest failure.
> 
> **Overview**
> **`patch-commit`** now writes to the dependency’s existing `patchedDependencies` path when one is declared (`--patches-dir` only applies to first-time patches), **appends** new hunks onto the current patch file so the result still applies to pristine package sources, skips manifest updates when the entry already exists, and invalidates install state before updating the file. Retries are idempotent (no duplicate hunks), the edit snapshot is removed after a successful commit, and manifest failures restore the prior patch with warnings.
> 
> **`aube patch`** refuses to start when `check_needs_install` says the linked tree is stale, so commits are not based on an out-of-date install.
> 
> **Install / lockfile freshness** for pnpm lockfiles adds **`pnpm_patch_hash_drift`**: declared patch files are SHA-256’d and compared to hashes recorded in `pnpm-lock.yaml`. Mismatch triggers re-resolve on normal install, **`ERR_AUBE_LOCKFILE_CONFIG_MISMATCH`** (exit 14) under frozen lockfile, and inclusion in the “fresh lockfile” gate. Pnpm lockfile writes also hydrate `graph.patched_dependencies` from the workspace manifest.
> 
> Docs and error metadata document the new code and `--patches-dir` behavior; **bats** cover extending an existing patch path and patch-hash drift on frozen vs plain install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e08e67ee00f5668fbb47d010a61a04ff7e656690. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Existing dependency patches can be extended at their declared paths without creating duplicates.
  - Patch changes are detected and synchronized with the lockfile during installation.
  - Configured patch directories are ignored when a dependency already declares a patch path.
- **Bug Fixes**
  - Preserves existing patch content and prevents duplicate entries.
  - Prevents patch creation when the installed package tree is outdated.
  - Safely handles failed manifest updates without leaving partial patch changes.
- **Error Handling**
  - Frozen installs report a clear lockfile mismatch when patch content changes.
- **Documentation**
  - Documented patch path reuse and the new lockfile mismatch error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->