### PR TITLE
fix(add): trust exact popular package names

### DIFF
--- a/crates/aube/src/commands/add_supply_chain.rs
+++ b/crates/aube/src/commands/add_supply_chain.rs
@@ -840,7 +840,11 @@ fn find_similar_package_name(name: &str, corpus: &str) -> Option<PackageNameSugg
     let mut best: Option<PackageNameSuggestion> = None;
     for (index, candidate) in corpus.lines().enumerate() {
         if name == candidate {
-            continue;
+            // A name in the popularity corpus is established in its own
+            // right. Do not flag it because it also resembles a lower-ranked
+            // package (for example, esbuild -> msbuild or @types/node ->
+            // @types/code).
+            return None;
         }
         let Some((requested_part, candidate_part)) = comparable_name_parts(name, candidate) else {
             continue;
@@ -1395,6 +1399,18 @@ mod tests {
     fn similar_name_skips_exact_and_distant_names() {
         assert_eq!(
             find_similar_package_name("lodash", "lodash\nexpress\n"),
+            None
+        );
+    }
+
+    #[test]
+    fn popular_package_is_not_flagged_by_a_lower_ranked_similar_name() {
+        assert_eq!(
+            find_similar_package_name("esbuild", "esbuild\nmsbuild\n"),
+            None
+        );
+        assert_eq!(
+            find_similar_package_name("@types/node", "@types/node\n@types/code\n"),
             None
         );
     }


### PR DESCRIPTION
## Summary

- stop the similar-name gate once the requested name exactly matches the popularity corpus
- preserve typo detection for names that are not themselves established packages
- add regressions for `esbuild` versus `msbuild` and `@types/node` versus `@types/code`

## Root cause

The scanner skipped an exact corpus match and continued examining lower-ranked names. That let a legitimate top-100,000 package be rejected merely because a less-popular package had a nearby spelling.

## Impact

`aube add esbuild` and `aube add @types/node` no longer require `--allow-low-downloads` solely because of those lower-ranked lookalikes. Genuine misspellings still go through the existing confirmation or refusal path.

## Validation

- `cargo fmt --check`
- `cargo test -p aube`
- `cargo clippy -p aube --all-targets -- -D warnings`
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small logic change in reputation gating with targeted tests; reduces false positives without weakening detection for unknown package names.
> 
> **Overview**
> Fixes the **`aube add` similar-name supply-chain gate** so a requested name that **exactly appears** in the top-100k popularity corpus is treated as established and **not** compared to lower-ranked lookalikes.
> 
> Previously, an exact corpus hit only skipped that line and the scan could still suggest a less popular near-spelling (e.g. **`esbuild`** vs **`msbuild`**, **`@types/node`** vs **`@types/code`**), which could block or prompt installs without `--allow-low-downloads`. **`find_similar_package_name`** now returns no suggestion on an exact match; typo detection for names **not** in the corpus is unchanged.
> 
> Adds unit regressions for those two cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5d00d9c26c1a767fc1ca9285c4930f334f16408. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package matching to prioritize exact name matches.
  * Prevented lower-ranked similar packages from being incorrectly reported when the requested package is already recognized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->