### PR TITLE
feat(packaging): add android arm64 npm package

### DIFF
--- a/npm/installArchSpecificPackage.js
+++ b/npm/installArchSpecificPackage.js
@@ -24,7 +24,10 @@ function main() {
     // into the global prefix when the user ran `npm i -g @endevco/aube`.
     process.env.npm_config_global = 'false';
 
-    var platform = process.platform; // darwin | linux | win32
+    // Android (Termux) resolves to `@endevco/aube-android-arm64`, which
+    // carries the static musl binary. Do not remap it onto `linux`: the
+    // glibc build cannot load under bionic.
+    var platform = process.platform; // android | darwin | linux | win32
     var arch = process.arch;         // arm64 | x64
     // On Linux, `process.report` exposes `glibcVersionRuntime` when the
     // runtime linked against glibc; its absence means musl (Alpine,

--- a/npm/scripts/publish.mjs
+++ b/npm/scripts/publish.mjs
@@ -41,13 +41,17 @@ const stageRoot = resolve(npmDir, '.stage');
 // `libc` is only set on Linux targets; it feeds both the published
 // package name suffix (`-musl`) and the `libc` field in the generated
 // package.json so npm picks the right variant if ever listed as an
-// optional dep. Absence of `libc` = not applicable (darwin/win32).
+// optional dep. Absence of `libc` = not applicable (darwin/win32/android).
 const TARGETS = [
     { triple: 'aarch64-apple-darwin',       os: 'darwin', cpu: 'arm64',                 ext: '.tar.gz', exe: '' },
     { triple: 'x86_64-unknown-linux-gnu',   os: 'linux',  cpu: 'x64',   libc: 'glibc',  ext: '.tar.gz', exe: '' },
     { triple: 'aarch64-unknown-linux-gnu',  os: 'linux',  cpu: 'arm64', libc: 'glibc',  ext: '.tar.gz', exe: '' },
     { triple: 'x86_64-unknown-linux-musl',  os: 'linux',  cpu: 'x64',   libc: 'musl',   ext: '.tar.gz', exe: '' },
     { triple: 'aarch64-unknown-linux-musl', os: 'linux',  cpu: 'arm64', libc: 'musl',   ext: '.tar.gz', exe: '' },
+    // Termux reports platform `android` and links bionic, so npm resolves
+    // its libc as undefined. Reuse the musl artifact under a dedicated
+    // package with no `libc` field, which npm can install there.
+    { triple: 'aarch64-unknown-linux-musl', os: 'android', cpu: 'arm64',                ext: '.tar.gz', exe: '' },
     { triple: 'x86_64-pc-windows-msvc',     os: 'win32',  cpu: 'x64',                   ext: '.zip',    exe: '.exe' },
     { triple: 'aarch64-pc-windows-msvc',    os: 'win32',  cpu: 'arm64',                 ext: '.zip',    exe: '.exe' },
 ];


### PR DESCRIPTION
### Description

Termux reports `process.platform === 'android'`, so `installArchSpecificPackage.js` already resolves `@endevco/aube-android-arm64`. That package isn't published, so `npm i -g @endevco/aube` fails there.

This publishes it from the existing `aarch64-unknown-linux-musl` artifact. No new build target, and no change to how the install script resolves names.

### Why a dedicated package

Widening `os` on `linux-arm64-musl` does not work. npm resolves libc as undefined on bionic, so `libc: ["musl"]` rejects the install even with `android` present:

```
wanted {"os":"android,linux","cpu":"arm64","libc":"musl"} (current: {"os":"android","cpu":"arm64"})
Valid libc:  musl
Actual libc: undefined
```

Making that work means dropping the package's `libc`, weakening metadata for every Alpine user to serve Termux. j178/prek#1979 shipped exactly that, then j178/prek#1982 reverted it for a dedicated package. (vercel/turborepo#12735 widened `os` instead, but turbo's platform packages carry no `libc` field.)

### Verification

On a physical aarch64 Android device under Termux:

- The musl binary runs unmodified (`1.35.0 linux-arm64`, no `INTERP` segment). The glibc build cannot: it requests `/lib/ld-linux-aarch64.so.1`.
- Packed probe packages: `os:["linux"] libc:["musl"]` and `os:["android","linux"] libc:["musl"]` both give `EBADPLATFORM`; `os:["android"]` with no `libc` installs.
- The real installer resolves `@endevco/aube-android-arm64`, and the real `platformPkgName` generates that same name with `{"os":["android"],"cpu":["arm64"]}` from the musl asset.

`publish.mjs` is not exercised end to end, since that needs published release assets and npm credentials.

### Notes

- Two targets now share a `triple`. Staging paths key on `<os>-<cpu>[-musl]`, so nothing collides; the only cost is fetching the musl asset twice per release.
- arm64 only, matching prek. `crates/aube-ffi/npm/index.js` and `crates/aube-node/npm/index.js` have the same gap; happy to follow up if you want them covered.

---

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5[1m]; version: 2.1.220.*
