### PR TITLE
fix(registry): honor NODE_EXTRA_CA_CERTS in the supply-chain probe clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.19",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +461,7 @@ dependencies = [
  "miette",
  "node-semver",
  "proptest",
+ "rcgen",
  "reqwest",
  "serde",
  "serde_json",
@@ -431,6 +471,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
+ "tokio-rustls",
  "tracing",
  "wiremock",
  "yaml_serde",
@@ -654,7 +695,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -662,6 +703,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -1402,6 +1452,20 @@ dependencies = [
  "flagset",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -3065,6 +3129,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3324,7 +3397,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
- "bit-vec",
+ "bit-vec 0.8.0",
  "bitflags 2.13.1",
  "num-traits",
  "rand 0.9.5",
@@ -3606,6 +3679,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "aws-lc-rs",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3808,6 +3894,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3827,6 +3922,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki",
@@ -4809,6 +4905,7 @@ dependencies = [
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -4816,6 +4913,16 @@ name = "time-core"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"
@@ -5909,6 +6016,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "aws-lc-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.19",
+ "time",
+]
+
+[[package]]
 name = "x509-tsp"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5991,6 +6116,16 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-iter",
  "tree-sitter-yaml",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
+ "time",
 ]
 
 [[package]]

--- a/crates/aube-registry/Cargo.toml
+++ b/crates/aube-registry/Cargo.toml
@@ -53,3 +53,5 @@ tar = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 wiremock = "0.6"
 proptest = "1"
+rcgen = { version = "0.14.8", default-features = false, features = ["crypto", "aws_lc_rs"] }
+tokio-rustls = "0.26"

--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -25,6 +25,7 @@ mod slow_tarball_tests;
 pub use cache::CachedPackumentLookup;
 use dist_tags::*;
 pub use endpoints::PackageSearchResult;
+pub(crate) use http::probe_client_builder;
 use http::*;
 use parse::parse_full_response;
 

--- a/crates/aube-registry/src/client/http.rs
+++ b/crates/aube-registry/src/client/http.rs
@@ -101,6 +101,25 @@ pub(super) fn load_node_extra_ca_certs() -> Vec<reqwest::Certificate> {
     }
 }
 
+/// Trust roots for the auxiliary probe clients — live OSV
+/// (`api.osv.dev`), the OSV bloom/mirror dumps, and the npmjs
+/// downloads API (`api.npmjs.org`).
+///
+/// Those clients are built outside [`RegistryClient`], so they miss
+/// the `NODE_EXTRA_CA_CERTS` roots every registry client gets from
+/// `from_config_with_policy`. Behind a TLS-terminating proxy that is
+/// the difference between a working probe and a handshake failure —
+/// and under the default `advisoryCheck = on` a probe failure fails
+/// *open*, so the `MAL-*` gate silently stops running on a host that
+/// is configured correctly and online.
+pub(crate) fn probe_client_builder() -> reqwest::ClientBuilder {
+    let mut builder = aube_util::http::with_webpki_root_fallback(reqwest::Client::builder());
+    for cert in load_node_extra_ca_certs() {
+        builder = builder.add_root_certificate(cert);
+    }
+    builder
+}
+
 /// HTTP/1.1-only variant for tarball downloads. Tarballs are large
 /// opaque blobs where h2 multiplexing buys nothing: there are no
 /// compressible headers, and a single slow tarball stream causes
@@ -354,7 +373,15 @@ pub(super) fn force_full_packument() -> bool {
 mod tests {
     use super::{build_http_client, load_node_extra_ca_certs};
     use crate::config::{FetchPolicy, NpmConfig};
+    use rcgen::{
+        BasicConstraints, CertificateParams, CertifiedIssuer, DnType, ExtendedKeyUsagePurpose,
+        IsCa, KeyPair, KeyUsagePurpose,
+    };
     use std::ffi::{OsStr, OsString};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio_rustls::TlsAcceptor;
+    use tokio_rustls::rustls::ServerConfig;
+    use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer};
 
     /// A minimal self-signed certificate. Lives in
     /// `tests/fixtures/test-ca.pem` so the base64 body stays out of the
@@ -452,5 +479,213 @@ mod tests {
         env.set("/aube/does-not-exist.pem");
         assert!(load_node_extra_ca_certs().is_empty());
         // `env` restores NODE_EXTRA_CA_CERTS on drop, even on panic.
+    }
+
+    /// Smallest valid HTTP/1.1 reply. The trust test only cares that the
+    /// handshake completed, so the response carries no body.
+    const HTTP_OK: &[u8] = b"HTTP/1.1 200 OK\r\ncontent-length: 0\r\nconnection: close\r\n\r\n";
+
+    /// A throwaway CA plus a loopback HTTPS listener whose leaf chains
+    /// only to it. Neither the OS trust store nor the webpki bundle
+    /// `with_webpki_root_fallback` merges in issued this chain, so a
+    /// completed handshake against the listener is proof that the CA
+    /// reached the client through `NODE_EXTRA_CA_CERTS`.
+    struct PrivateCaServer {
+        /// PEM bundle holding the CA certificate — the file the test
+        /// points `NODE_EXTRA_CA_CERTS` at.
+        ca_bundle: std::path::PathBuf,
+        url: String,
+        /// Owns `ca_bundle`'s parent; dropping it removes the bundle.
+        _dir: tempfile::TempDir,
+        /// The accept loop runs until the test's runtime is dropped.
+        _accept_loop: tokio::task::JoinHandle<()>,
+    }
+
+    impl PrivateCaServer {
+        async fn start() -> Self {
+            let dir = tempfile::tempdir().expect("temp dir");
+            let (ca_pem, leaf_chain, leaf_key) = issue_private_chain();
+
+            let ca_bundle = dir.path().join("private-ca.pem");
+            std::fs::write(&ca_bundle, ca_pem).expect("write ca bundle");
+
+            let mut config = ServerConfig::builder()
+                .with_no_client_auth()
+                .with_single_cert(leaf_chain, leaf_key)
+                .expect("server tls config");
+            // reqwest offers h2 first; pin h1 so `HTTP_OK` is a valid
+            // reply on whatever ALPN negotiates.
+            config.alpn_protocols = vec![b"http/1.1".to_vec()];
+            let acceptor = TlsAcceptor::from(std::sync::Arc::new(config));
+
+            let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+                .await
+                .expect("bind loopback listener");
+            let port = listener.local_addr().expect("listener address").port();
+
+            let accept_loop = tokio::spawn(async move {
+                while let Ok((tcp, _)) = listener.accept().await {
+                    let acceptor = acceptor.clone();
+                    tokio::spawn(async move {
+                        // A refused handshake is the untrusted arm doing
+                        // its job, not a harness failure.
+                        let Ok(mut tls) = acceptor.accept(tcp).await else {
+                            return;
+                        };
+                        let mut request = [0u8; 1024];
+                        let _ = tls.read(&mut request).await;
+                        let _ = tls.write_all(HTTP_OK).await;
+                        let _ = tls.shutdown().await;
+                    });
+                }
+            });
+
+            PrivateCaServer {
+                ca_bundle,
+                // `localhost`, not the bare IP: every platform verifier
+                // matches a dNSName SAN, IP SAN support is spottier.
+                url: format!("https://localhost:{port}/"),
+                _dir: dir,
+                _accept_loop: accept_loop,
+            }
+        }
+    }
+
+    /// Mint a throwaway CA and a `localhost` leaf signed by it, in the
+    /// shapes the two sides need: the CA as a PEM bundle for
+    /// `NODE_EXTRA_CA_CERTS`, the leaf chain and key as DER for rustls.
+    fn issue_private_chain() -> (String, Vec<CertificateDer<'static>>, PrivateKeyDer<'static>) {
+        let mut ca_params = CertificateParams::new(Vec::<String>::new()).expect("ca params");
+        ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        ca_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+        ca_params
+            .distinguished_name
+            .push(DnType::CommonName, "aube probe-client test ca");
+        let ca_key = KeyPair::generate().expect("ca key");
+        let ca = CertifiedIssuer::self_signed(ca_params, ca_key).expect("self-signed ca");
+
+        let mut leaf_params =
+            CertificateParams::new(vec!["localhost".to_string()]).expect("leaf params");
+        leaf_params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
+        leaf_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
+        leaf_params.use_authority_key_identifier_extension = true;
+        leaf_params
+            .distinguished_name
+            .push(DnType::CommonName, "localhost");
+        let leaf_key = KeyPair::generate().expect("leaf key");
+        let leaf = leaf_params.signed_by(&leaf_key, &ca).expect("leaf cert");
+
+        (
+            pem_block(ca.der()),
+            vec![leaf.der().clone()],
+            PrivateKeyDer::Pkcs8(leaf_key.serialize_der().into()),
+        )
+    }
+
+    /// PEM-wrap a DER certificate. rcgen's `pem` feature does this, but
+    /// it costs a dependency for six lines and `base64` is already one.
+    fn pem_block(der: &CertificateDer<'_>) -> String {
+        use base64::Engine as _;
+
+        let body = base64::engine::general_purpose::STANDARD.encode(der);
+        let mut pem = String::from("-----BEGIN CERTIFICATE-----\n");
+        for line in body.as_bytes().chunks(64) {
+            pem.push_str(&String::from_utf8_lossy(line));
+            pem.push('\n');
+        }
+        pem.push_str("-----END CERTIFICATE-----\n");
+        pem
+    }
+
+    /// Every probe-client constructor in the crate, built fresh so each
+    /// reads the `NODE_EXTRA_CA_CERTS` currently in the environment.
+    /// Naming the three constructors instead of testing
+    /// `probe_client_builder` once is the point: a constructor that
+    /// stops routing through the shared builder is the regression this
+    /// guards. Construction is also the non-fatal check — an unreadable
+    /// bundle must still yield a client, matching `build_http_client`.
+    fn probe_clients() -> Vec<(&'static str, reqwest::Client)> {
+        vec![
+            (
+                "supply_chain::build_probe_client",
+                crate::supply_chain::build_probe_client().expect("probe client"),
+            ),
+            (
+                "OsvMirror::build_client",
+                crate::osv_mirror::OsvMirror::build_client().expect("osv mirror client"),
+            ),
+            (
+                "OsvBloomClient::build_client",
+                crate::osv_bloom_client::OsvBloomClient::build_client().expect("osv bloom client"),
+            ),
+        ]
+    }
+
+    /// Flatten an error and its `source` chain into one string. reqwest
+    /// hides the rustls reason (`invalid peer certificate: UnknownIssuer`)
+    /// two layers down, so the top-level message alone can't tell a
+    /// certificate rejection from a connection refusal.
+    fn error_chain(error: &dyn std::error::Error) -> String {
+        let mut chain = error.to_string();
+        let mut source = error.source();
+        while let Some(cause) = source {
+            chain.push_str(": ");
+            chain.push_str(&cause.to_string());
+            source = cause.source();
+        }
+        chain
+    }
+
+    /// Each probe client reaches a host behind a private CA only when
+    /// `NODE_EXTRA_CA_CERTS` names that CA — the trust propagation
+    /// `probe_client_builder` exists to guarantee.
+    ///
+    /// Constructing the clients proves nothing here: that succeeds with
+    /// or without the roots. So all three constructors make a real
+    /// HTTPS request against a listener whose leaf chains only to a
+    /// throwaway CA, and the request has to fail with a certificate
+    /// error before the bundle is configured and succeed after. Revert
+    /// any constructor to a bare `reqwest::Client::builder()` and the
+    /// second arm fails.
+    #[test]
+    fn probe_clients_trust_the_ca_named_by_node_extra_ca_certs() {
+        let env = EnvVarGuard::acquire();
+        // `block_on` rather than `#[tokio::test]`: `EnvVarGuard` holds a
+        // std mutex, which must not be held across an await point.
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime");
+
+        rt.block_on(async {
+            let server = PrivateCaServer::start().await;
+
+            // Nothing in the default trust store issued this leaf, so
+            // every probe client has to reject it.
+            env.set("/aube/does-not-exist.pem");
+            for (name, client) in probe_clients() {
+                let error = client
+                    .get(&server.url)
+                    .send()
+                    .await
+                    .err()
+                    .unwrap_or_else(|| panic!("{name} trusted a CA it was never given"));
+                let reason = error_chain(&error);
+                assert!(
+                    reason.to_lowercase().contains("certificate"),
+                    "{name} failed for the wrong reason: {reason}"
+                );
+            }
+
+            // Same request, same listener, bundle configured: the
+            // handshake now has to complete.
+            env.set(&server.ca_bundle);
+            for (name, client) in probe_clients() {
+                let response = client.get(&server.url).send().await.unwrap_or_else(|e| {
+                    panic!("{name} rejected the configured CA: {}", error_chain(&e))
+                });
+                assert_eq!(response.status(), reqwest::StatusCode::OK, "{name}");
+            }
+        });
     }
 }

--- a/crates/aube-registry/src/osv_bloom_client.rs
+++ b/crates/aube-registry/src/osv_bloom_client.rs
@@ -422,11 +422,9 @@ impl OsvBloomClient {
     }
 
     pub fn build_client() -> Result<reqwest::Client, BloomError> {
-        Ok(
-            aube_util::http::with_webpki_root_fallback(reqwest::Client::builder())
-                .timeout(FETCH_TIMEOUT)
-                .build()?,
-        )
+        Ok(crate::client::probe_client_builder()
+            .timeout(FETCH_TIMEOUT)
+            .build()?)
     }
 
     fn load_state(&self) -> LocalState {

--- a/crates/aube-registry/src/osv_mirror.rs
+++ b/crates/aube-registry/src/osv_mirror.rs
@@ -330,11 +330,9 @@ impl OsvMirror {
     /// 60s budget the bulk dump needs — the live-OSV probe's 8s
     /// timeout would never let a fresh sync finish.
     pub fn build_client() -> Result<reqwest::Client, MirrorError> {
-        Ok(
-            aube_util::http::with_webpki_root_fallback(reqwest::Client::builder())
-                .timeout(FETCH_TIMEOUT)
-                .build()?,
-        )
+        Ok(crate::client::probe_client_builder()
+            .timeout(FETCH_TIMEOUT)
+            .build()?)
     }
 
     /// Load the on-disk index, falling back to an empty default

--- a/crates/aube-registry/src/supply_chain.rs
+++ b/crates/aube-registry/src/supply_chain.rs
@@ -164,11 +164,9 @@ struct NpmDownloadsResponse {
 /// `aube add a b c` can reuse a single client + connection pool
 /// across all per-package downloads requests.
 pub fn build_probe_client() -> Result<reqwest::Client, SupplyChainError> {
-    Ok(
-        aube_util::http::with_webpki_root_fallback(reqwest::Client::builder())
-            .timeout(PROBE_TIMEOUT)
-            .build()?,
-    )
+    Ok(crate::client::probe_client_builder()
+        .timeout(PROBE_TIMEOUT)
+        .build()?)
 }
 
 /// Probe OSV for `MAL-*` advisories on every candidate against a


### PR DESCRIPTION
**If you run `aube add` behind a company proxy that inspects TLS, the malware check can be skipped and the install still reports success.** The registry client trusts the proxy's certificate, but the three clients that make the advisory calls don't, so those requests fail and the check is treated as "couldn't reach the service".

## What's wrong

`RegistryClient` reads `NODE_EXTRA_CA_CERTS` and adds it as a trust root to every client it builds (`client/http.rs`, `load_node_extra_ca_certs`). Three other clients don't, because they're built straight from `reqwest::Client::builder()`:

- `supply_chain::build_probe_client` — live OSV `MAL-*` queries and the npmjs weekly-downloads probe
- `OsvBloomClient::build_client` — bloom prefilter dump
- `OsvMirror::build_client` — bulk OSV mirror dump

Behind a TLS-terminating proxy (a corporate MITM, Socket Firewall, mitmproxy) the registry fetches work, because that client trusts the proxy's CA. The three probes fail their TLS handshake, because they only have the OS store plus the webpki bundle.

Since `advisoryCheck` defaults to `on`, and `on` fails open on a fetch error so offline machines aren't blocked, the result is that the advisory check doesn't run and the install still succeeds. The user sees one `WARN_AUBE_ADVISORY_CHECK_FAILED` line. Setting `AUBE_ADVISORY_CHECK=required` surfaces it as an error instead.

## The fix

Add `probe_client_builder()` next to `load_node_extra_ca_certs()` in `client/http.rs`, and build the three probe clients from it. Each keeps its own timeout — the only change is that the `NODE_EXTRA_CA_CERTS` roots now reach them too.

<details>
<summary>Evidence: before and after, against mitmdump</summary>

Reproduced on released aube 1.37.0 (`@endevco/aube`) in a container, with `mitmdump` as the proxy and `NODE_EXTRA_CA_CERTS` pointing at its CA. Throwaway `HOME` and `XDG_*` on every run.

**Before:**

```
no proxy, AUBE_ADVISORY_CHECK=required                exit=0
mitm + CA, AUBE_ADVISORY_CHECK=required               exit=49  ERR_AUBE_ADVISORY_CHECK_FAILED
mitm + CA, advisoryCheck default (on)                 exit=0   (check did not run)

what the proxy saw:
   3 TLS handshake failed — api.osv.dev
   1 TLS handshake failed — api.npmjs.org
   1 HEAD https://registry.npmjs.org/
   1 GET  https://registry.npmjs.org/lodash
   1 GET  https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz
```

Same process, same proxy, same env: the registry hosts complete, `api.osv.dev` and `api.npmjs.org` don't.

**After:**

```
patched, mitm + CA, AUBE_ADVISORY_CHECK=required      exit=0
   2 POST https://api.osv.dev/v1/querybatch
   1 GET  https://api.npmjs.org/downloads/point/last-week/lodash
   (registry traffic unchanged)

patched, mitm, NODE_EXTRA_CA_CERTS unset              exit=49
```

That last run is the one worth checking: the patch adds a trust root, it doesn't weaken verification. With no CA configured, the probe still refuses the proxy.

</details>

<details>
<summary>Note: the metadata path is fine</summary>

This started as a suspicion that npm version resolution was ignoring proxy settings. It isn't. `NpmConfig::load` folds `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` and the `npm_config_*` spellings into the config, and `build_http_client` installs them after `.no_proxy()`. Packument queries transit the proxy on every aube-registry release back to 1.30. The only proxy-related gap is the trust store on the three probe clients.

</details>

## Not covered here

Two adjacent gaps left alone to keep the diff small — happy to fold either in if you'd prefer:

- `aube-runtime`'s node-download client (`crates/aube-runtime/src/http.rs`) has the same shape and would also miss the CA behind a MITM proxy. It fails loudly rather than quietly, and the loader lives in `aube-registry`, so sharing it means promoting the helper into `aube-util::http` next to `with_webpki_root_fallback`.
- The probe clients don't see `.npmrc`'s `cafile` / `ca` / `strict-ssl` either, since they hold no `NpmConfig`. That needs a signature change, which felt like your call.

Related: #983 covers the neighbouring question of passing proxy config down to lifecycle scripts.

## Tests

The regression test proves trust, not construction. `probe_clients_trust_the_ca_named_by_node_extra_ca_certs` (in `client/http.rs`) mints a throwaway CA and serves a loopback HTTPS listener whose leaf certificate chains only to that CA. Neither the OS trust store nor the webpki bundle issued that chain, so a completed handshake is only possible when the CA reached the client through `NODE_EXTRA_CA_CERTS`.

All three constructors are driven against the same listener, in two arms:

- `NODE_EXTRA_CA_CERTS` pointing at a path that does not exist: `supply_chain::build_probe_client`, `OsvMirror::build_client`, and `OsvBloomClient::build_client` all still build (an unreadable bundle stays non-fatal), and the request has to fail with a *certificate* error rather than any error.
- `NODE_EXTRA_CA_CERTS` pointing at the CA bundle: the same request from each of the three clients has to return 200.

Naming the three constructors instead of testing `probe_client_builder()` once is deliberate: a future constructor that stops routing through the shared builder is the bug this PR fixes, and a test of the helper alone would not catch it.

Mutation-checked. Reverting each constructor to the old bare `reqwest::Client::builder()`, one at a time, fails the test, and the panic names the constructor that was reverted (`OsvMirror::build_client rejected the configured CA: invalid peer certificate: UnknownIssuer`).

Two new **dev-dependencies** were needed, since nothing already in the lockfile can issue an X.509 chain and the alternative was committing a TLS private key to the repo:

- `rcgen` (MIT OR Apache-2.0), `default-features = false`, `features = ["crypto", "aws_lc_rs"]` so it reuses the `aws-lc-rs` rustls already pulls.
- `tokio-rustls` for the listener, which reqwest already compiles via `hyper-rustls`.

Net new crates compiled: `rcgen` and its `yasna` dependency. The rest of the `Cargo.lock` growth is rcgen's optional dependencies, which Cargo records but never builds under these features.

`cargo test -p aube-registry`: 231 lib + 11 + 1 integration, 0 failed. `cargo clippy -p aube-registry -p aube --all-targets -- -D warnings` clean, `cargo fmt --check` clean.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.0.58.*



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auxiliary HTTPS connections now support certificates provided through `NODE_EXTRA_CA_CERTS`.
  * Probe clients consistently use the configured certificate authorities when connecting to private or internal services.

* **Bug Fixes**
  * Improved TLS trust handling for OSV data, mirror, and supply-chain connections.
  * Preserved existing connection timeouts and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->