### PR TITLE
docs(link): global link registry lives in the cache dir, not $AUBE_HOME

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -2345,7 +2345,7 @@ cmd link help="Link a local package globally, or into the current project" effec
         long_help #"""
 Register into (or resolve from) the global link registry.
 
-The registry lives at `$AUBE_HOME/global-links`. Default behavior for bare `aube link` / `aube link <name>` — the flag exists for pnpm parity and makes the intent explicit.
+The registry lives at `$XDG_CACHE_HOME/aube/global-links`, `$HOME/.cache/aube/global-links` when `XDG_CACHE_HOME` is unset, or `%LOCALAPPDATA%\aube\global-links` on Windows. Default behavior for bare `aube link` / `aube link <name>` — the flag exists for pnpm parity and makes the intent explicit.
 """#
     }
     arg "[PACKAGE]" help="Package name, or path to a local directory" required=#false
@@ -4054,7 +4054,7 @@ cmd unlink help="Unlink a package (remove linked entries from node_modules)" eff
         long_help #"""
 Operate on the global link registry instead of the current project.
 
-`aube unlink -g` removes the current package's entry from `$AUBE_HOME/global-links`; `aube unlink -g <name>` removes the named entry.
+`aube unlink -g` removes the current package's entry from `$XDG_CACHE_HOME/aube/global-links`, `$HOME/.cache/aube/global-links` when `XDG_CACHE_HOME` is unset, or `%LOCALAPPDATA%\aube\global-links` on Windows; `aube unlink -g <name>` removes the named entry.
 """#
     }
     arg "[PACKAGE]" help="Package name to unlink (omit to unlink all linked dependencies)" required=#false

--- a/crates/aube/src/commands/link.rs
+++ b/crates/aube/src/commands/link.rs
@@ -8,9 +8,12 @@ pub struct LinkArgs {
     pub package: Option<String>,
     /// Register into (or resolve from) the global link registry.
     ///
-    /// The registry lives at `$AUBE_HOME/global-links`. Default
-    /// behavior for bare `aube link` / `aube link <name>` — the flag
-    /// exists for pnpm parity and makes the intent explicit.
+    /// The registry lives at `$XDG_CACHE_HOME/aube/global-links`,
+    /// `$HOME/.cache/aube/global-links` when `XDG_CACHE_HOME` is
+    /// unset, or `%LOCALAPPDATA%\aube\global-links` on Windows.
+    /// Default behavior for bare `aube link` /
+    /// `aube link <name>` — the flag exists for pnpm parity and makes
+    /// the intent explicit.
     #[arg(short = 'g', long)]
     pub global: bool,
 }

--- a/crates/aube/src/commands/unlink.rs
+++ b/crates/aube/src/commands/unlink.rs
@@ -9,8 +9,9 @@ pub struct UnlinkArgs {
     /// project.
     ///
     /// `aube unlink -g` removes the current package's entry from
-    /// `$AUBE_HOME/global-links`; `aube unlink -g <name>` removes the
-    /// named entry.
+    /// `$XDG_CACHE_HOME/aube/global-links`, `$HOME/.cache/aube/global-links`
+    /// when `XDG_CACHE_HOME` is unset, or `%LOCALAPPDATA%\aube\global-links`
+    /// on Windows; `aube unlink -g <name>` removes the named entry.
     #[arg(short = 'g', long)]
     pub global: bool,
 }

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -6793,7 +6793,7 @@
             "name": "global",
             "usage": "-g --global",
             "help": "Register into (or resolve from) the global link registry",
-            "help_long": "Register into (or resolve from) the global link registry.\n\nThe registry lives at `$AUBE_HOME/global-links`. Default behavior for bare `aube link` / `aube link <name>` — the flag exists for pnpm parity and makes the intent explicit.",
+            "help_long": "Register into (or resolve from) the global link registry.\n\nThe registry lives at `$XDG_CACHE_HOME/aube/global-links`, `$HOME/.cache/aube/global-links` when `XDG_CACHE_HOME` is unset, or `%LOCALAPPDATA%\\aube\\global-links` on Windows. Default behavior for bare `aube link` / `aube link <name>` — the flag exists for pnpm parity and makes the intent explicit.",
             "help_first_line": "Register into (or resolve from) the global link registry",
             "short": [
               "g"
@@ -12037,7 +12037,7 @@
             "name": "global",
             "usage": "-g --global",
             "help": "Operate on the global link registry instead of the current project",
-            "help_long": "Operate on the global link registry instead of the current project.\n\n`aube unlink -g` removes the current package's entry from `$AUBE_HOME/global-links`; `aube unlink -g <name>` removes the named entry.",
+            "help_long": "Operate on the global link registry instead of the current project.\n\n`aube unlink -g` removes the current package's entry from `$XDG_CACHE_HOME/aube/global-links`, `$HOME/.cache/aube/global-links` when `XDG_CACHE_HOME` is unset, or `%LOCALAPPDATA%\\aube\\global-links` on Windows; `aube unlink -g <name>` removes the named entry.",
             "help_first_line": "Operate on the global link registry instead of the current project",
             "short": [
               "g"

--- a/docs/cli/link.md
+++ b/docs/cli/link.md
@@ -19,4 +19,4 @@ Package name, or path to a local directory
 
 Register into (or resolve from) the global link registry.
 
-The registry lives at `$AUBE_HOME/global-links`. Default behavior for bare `aube link` / `aube link <name>` — the flag exists for pnpm parity and makes the intent explicit.
+The registry lives at `$XDG_CACHE_HOME/aube/global-links`, `$HOME/.cache/aube/global-links` when `XDG_CACHE_HOME` is unset, or `%LOCALAPPDATA%\aube\global-links` on Windows. Default behavior for bare `aube link` / `aube link <name>` — the flag exists for pnpm parity and makes the intent explicit.

--- a/docs/cli/unlink.md
+++ b/docs/cli/unlink.md
@@ -18,4 +18,4 @@ Package name to unlink (omit to unlink all linked dependencies)
 
 Operate on the global link registry instead of the current project.
 
-`aube unlink -g` removes the current package's entry from `$AUBE_HOME/global-links`; `aube unlink -g <name>` removes the named entry.
+`aube unlink -g` removes the current package's entry from `$XDG_CACHE_HOME/aube/global-links`, `$HOME/.cache/aube/global-links` when `XDG_CACHE_HOME` is unset, or `%LOCALAPPDATA%\aube\global-links` on Windows; `aube unlink -g <name>` removes the named entry.


### PR DESCRIPTION
The `-g/--global` help for `aube link` and `aube unlink` tells you the global link registry lives at `$AUBE_HOME/global-links`. It does not. It lives in the XDG cache directory — `$XDG_CACHE_HOME/aube/global-links`, falling back to `$HOME/.cache/aube/global-links`.

The cost of the wrong text is quiet. Someone who reads the help and redirects `AUBE_HOME` — to keep a scratch link out of their home directory in CI or a sandbox, say — still writes into their real cache directory, and has no reason to suspect it. This PR corrects the two doc comments and regenerates the rendered help so what you read matches what happens.

<details>
<summary><b>Where the path really comes from</b> — <code>global_links_dir()</code> joins onto the cache dir, not <code>$AUBE_HOME</code></summary>

The path is decided in `aube_store::dirs::global_links_dir()`:

```rust
pub fn global_links_dir() -> Option<PathBuf> {
    cache_dir().map(|d| d.join("global-links"))
}
```

`cache_dir()` is the XDG cache directory, so the registry has always been a cache-tier thing. `$AUBE_HOME` never entered into it. Only the doc comments said otherwise.

</details>

<details>
<summary><b>A separate bug this does not fix</b> — <code>AUBE_CACHE_DIR</code> did not relocate the registry on 1.35.0</summary>

While checking the behaviour on the released `@endevco/aube@1.35.0`, `aube link` wrote to the home cache directory even with **both** `AUBE_CACHE_DIR` and `AUBE_HOME` pointed elsewhere:

```
$ AUBE_CACHE_DIR=<override> AUBE_HOME=<override> aube link
Linked <home>/.cache/aube/global-links/my-linked-pkg -> <project>
```

Both override directories stayed empty. `XDG_CACHE_HOME` does relocate it correctly, so redirecting that is the working answer today — but `AUBE_CACHE_DIR` not being honoured here looks like it may be worth a change of its own.

Happy to start a Discussion for that part if it is useful. I kept this PR to the text so it stays reviewable on its own.

</details>

<details>
<summary><b>How the paths were checked</b> — one knob per run, in a container with an empty home</summary>

**Ran:** released `@endevco/aube@1.35.0` in a `node:24-trixie` container with a home directory that starts empty, setting one knob per run.

| Knobs set | Where the link registry landed |
|---|---|
| `AUBE_CACHE_DIR` + `AUBE_HOME` | `<home>/.cache/aube/global-links` (both overrides empty) |
| `XDG_CACHE_HOME` | `<override>/aube/global-links` (home untouched) |

Same shape for the store and cache tiers: `AUBE_STORE_DIR` and `AUBE_CACHE_DIR` both relocate their own tiers correctly, and `XDG_CACHE_HOME` + `XDG_DATA_HOME` together leave the home directory at zero entries.

</details>

<details>
<summary><b>How the generated docs were updated</b> — the same corrected text applied to all four rendered surfaces</summary>

The doc comments are the source; everything else is generated from them, so all of it had to move together.

| Surface | Why it needed the edit |
|---|---|
| `aube.usage.kdl` | the machine-readable usage spec the rendered help comes from |
| `docs/cli/link.md`, `docs/cli/unlink.md` | the published CLI reference pages |
| `docs/cli/commands.json` | the structured command index; re-validates as JSON |

The applied text matches what `mise run render` emits for the updated doc comments — the generator joins doc-comment lines with single spaces.

**No version or changelog changes**, leaving those to release-plz.

</details>

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.0.58.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated `link --global` and `unlink --global` guidance to use the XDG cache directory for the global link registry.
  - Documents `$HOME/.cache/aube/global-links` as the Unix fallback when `XDG_CACHE_HOME` is not set.
  - Added the Windows `%LOCALAPPDATA%\aube\global-links` location.
  - Refreshed command help and CLI reference documentation for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
