### PR TITLE
fix(runtime): preserve workspace bins through nested shims

### DIFF
--- a/crates/aube/src/commands/exec.rs
+++ b/crates/aube/src/commands/exec.rs
@@ -1,7 +1,7 @@
 use super::ensure_installed_in;
 use clap::Args;
 use miette::{Context, IntoDiagnostic, miette};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Default, Args)]
 pub struct ExecArgs {
@@ -140,7 +140,7 @@ pub async fn run_in(
         return run_filtered(&cwd, &bin, &args, shell_mode, parallel, &filter, recursive).await;
     }
 
-    let bin_path = super::project_modules_dir(&cwd).join(".bin").join(&bin);
+    let bin_path = bin_path_for_project(&cwd, &bin);
     // Non-recursive `aube exec` is a terminal single-tool run with no
     // post-run work, so the standalone binary hands off via image
     // replacement; embedded hosts / Windows fall back to a supervised child.
@@ -175,7 +175,7 @@ async fn run_filtered(
     }
 
     for pkg in matched {
-        let bin_path = super::project_modules_dir(&pkg.dir).join(".bin").join(bin);
+        let bin_path = bin_path_for_project(&pkg.dir, bin);
         // Sequential fanout bails on the first non-zero exit, matching the
         // previous behavior where the inner `exec` terminated the process.
         if let Some(code) = exec_bin(&pkg.dir, &bin_path, bin, args, shell_mode).await? {
@@ -200,7 +200,7 @@ async fn run_filtered_parallel(
 
     if !shell_mode {
         for pkg in &matched {
-            let bin_path = super::project_modules_dir(&pkg.dir).join(".bin").join(bin);
+            let bin_path = bin_path_for_project(&pkg.dir, bin);
             if !bin_path.exists() {
                 let name = pkg
                     .name
@@ -249,7 +249,7 @@ async fn run_filtered_parallel(
         };
         let prereq_rxs = prereq_rxs_iter.next().expect("one rx vec per package");
         let done_tx = senders_iter.next().expect("one sender per package");
-        let bin_path = super::project_modules_dir(&pkg.dir).join(".bin").join(bin);
+        let bin_path = bin_path_for_project(&pkg.dir, bin);
         let dir = pkg.dir.clone();
         let bin = bin.to_string();
         let args = args.to_vec();
@@ -391,6 +391,27 @@ fn bin_not_found_error(bin: &str) -> miette::Report {
     )
 }
 
+fn project_bin_dirs(cwd: &Path) -> Vec<PathBuf> {
+    let local = super::project_modules_dir(cwd).join(".bin");
+    let mut dirs = vec![local.clone()];
+    if let Some(root) = crate::dirs::find_workspace_root(cwd) {
+        let root = super::project_modules_dir(&root).join(".bin");
+        if root != local {
+            dirs.push(root);
+        }
+    }
+    dirs
+}
+
+fn bin_path_for_project(cwd: &Path, bin: &str) -> PathBuf {
+    let local = super::project_modules_dir(cwd).join(".bin").join(bin);
+    let dirs = project_bin_dirs(cwd);
+    dirs.iter()
+        .map(|dir| dir.join(bin))
+        .find(|path| path.exists())
+        .unwrap_or(local)
+}
+
 /// Assemble the `tokio::process::Command` that runs `bin`, shared by the
 /// supervised (`spawn_and_wait`) and image-replacing (`exec_bin_terminal`)
 /// paths. Callers own the bin-exists check.
@@ -410,24 +431,15 @@ pub(crate) fn build_bin_command(
                 .chain(args.iter().map(|arg| aube_scripts::shell_quote_arg(arg)))
                 .collect::<Vec<_>>()
                 .join(" ");
-            let bin_dir = super::project_modules_dir(cwd).join(".bin");
-            let path_dirs = crate::runtime::path_entries_with_project_bins(vec![bin_dir]);
-            let new_path = aube_scripts::prepend_paths(&path_dirs);
-            let mut cmd = aube_scripts::spawn_shell(&line);
-            cmd.env("PATH", &new_path);
-            cmd
+            aube_scripts::spawn_shell(&line)
         } else {
             let exec_path = resolve_exec_shim(bin_path);
             let mut cmd = tokio::process::Command::new(exec_path);
             cmd.args(args);
-            // `#!/usr/bin/env node` shebangs resolve through the child's PATH
-            // so the generated shim must see the project's switched runtime.
-            let runtime_dirs = crate::runtime::path_entries();
-            if !runtime_dirs.is_empty() {
-                cmd.env("PATH", aube_scripts::prepend_paths(&runtime_dirs));
-            }
             cmd
         };
+    let path_dirs = crate::runtime::path_entries_with_project_bins(project_bin_dirs(cwd));
+    command.env("PATH", aube_scripts::prepend_paths(&path_dirs));
     crate::runtime::apply_child_env(&mut command);
     command
         .current_dir(cwd)

--- a/crates/aube/src/commands/node.rs
+++ b/crates/aube/src/commands/node.rs
@@ -14,7 +14,7 @@ pub struct NodeArgs {
 
 pub async fn run(args: NodeArgs) -> miette::Result<Option<i32>> {
     crate::runtime::ensure_for_cwd(&crate::dirs::cwd()?).await?;
-    let node = crate::runtime::node_program();
+    let node = resolved_node_program();
 
     #[cfg(unix)]
     let mut cmd = std::process::Command::new(&node);
@@ -22,9 +22,9 @@ pub async fn run(args: NodeArgs) -> miette::Result<Option<i32>> {
     let mut cmd = tokio::process::Command::new(&node);
 
     cmd.args(&args.args);
-    let runtime_dirs = crate::runtime::path_entries();
-    if !runtime_dirs.is_empty() {
-        cmd.env("PATH", aube_scripts::prepend_paths(&runtime_dirs));
+    let child_path_entries = crate::runtime::node_child_path_entries();
+    if !child_path_entries.is_empty() {
+        cmd.env("PATH", aube_scripts::prepend_paths(&child_path_entries));
     }
     // `NODE` / `npm_node_execpath` and any embedder env (e.g. a wrapper's
     // `NODE_OPTIONS` preload), so a direct `aube node` is invoked the same
@@ -70,13 +70,13 @@ pub async fn run_spawn(
         None => crate::dirs::cwd()?,
     };
     crate::runtime::ensure_for_cwd(&cwd).await?;
-    let node = crate::runtime::node_program();
+    let node = resolved_node_program();
     let mut cmd = tokio::process::Command::new(&node);
     cmd.args(&args);
     cmd.current_dir(&cwd);
-    let runtime_dirs = crate::runtime::path_entries();
-    if !runtime_dirs.is_empty() {
-        cmd.env("PATH", aube_scripts::prepend_paths(&runtime_dirs));
+    let child_path_entries = crate::runtime::node_child_path_entries();
+    if !child_path_entries.is_empty() {
+        cmd.env("PATH", aube_scripts::prepend_paths(&child_path_entries));
     }
     for (key, value) in crate::runtime::child_env_vars() {
         cmd.env(key, value);
@@ -95,4 +95,15 @@ pub async fn run_spawn(
             )
         })?;
     Ok(status.code())
+}
+
+fn resolved_node_program() -> PathBuf {
+    let node = crate::runtime::node_program();
+    let is_activated_shim = crate::tool_shims::activated_shim_dir()
+        .is_some_and(|dir| node.parent() == Some(dir.as_path()));
+    if node.components().count() == 1 || is_activated_shim {
+        aube_runtime::node_on_path().unwrap_or(node)
+    } else {
+        node
+    }
 }

--- a/crates/aube/src/runtime.rs
+++ b/crates/aube/src/runtime.rs
@@ -496,6 +496,28 @@ pub fn path_entries() -> Vec<PathBuf> {
         .collect()
 }
 
+/// PATH entries for a Node process dispatched through the activated tool
+/// shim. The real Node executable is resolved before these entries are
+/// applied, so restoring the tool shim cannot recurse into `aube node`.
+/// Wrapping embedder runtimes still lead so their descendant `node` spawns
+/// remain wrapped; selectors leave the activated package-manager shims first.
+pub(crate) fn node_child_path_entries() -> Vec<PathBuf> {
+    let context = current();
+    let mut entries = context
+        .as_ref()
+        .and_then(|c| c.bin_dir.clone())
+        .into_iter()
+        .collect::<Vec<_>>();
+    if let Some(dir) = crate::tool_shims::activated_shim_dir() {
+        if context.is_some_and(|c| c.bin_dir_precedes_project_bins) {
+            entries.push(dir);
+        } else {
+            entries.insert(0, dir);
+        }
+    }
+    entries
+}
+
 /// Place the active runtime PATH entry around project-local `.bin`
 /// directories. Wrappers lead so a local `node` cannot bypass the shim;
 /// selectors follow so package-provided commands retain normal precedence.

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -90,6 +90,33 @@ EOF
 	assert_file_not_exist packages/sentinel-ran
 }
 
+@test "aube exec -r finds binaries installed at the workspace root" {
+	cat >pnpm-workspace.yaml <<'EOF'
+packages:
+  - packages/*
+EOF
+	cat >package.json <<'EOF'
+{"name":"root","version":"0.0.0","private":true}
+EOF
+	mkdir -p packages/a node_modules/.bin
+	cat >packages/a/package.json <<'EOF'
+{"name":"a","version":"0.0.0"}
+EOF
+	cat >node_modules/.bin/root-tool <<'EOF'
+#!/bin/sh
+echo "root-tool:${PWD##*/}"
+EOF
+	chmod +x node_modules/.bin/root-tool
+
+	run aube -r exec --no-install root-tool
+	assert_success
+	assert_output "root-tool:a"
+
+	run aube -r exec --parallel --no-install root-tool
+	assert_success
+	assert_output --partial "root-tool:a"
+}
+
 # Regression: terminating the aube process must tear down the tool it
 # launched instead of orphaning it under init. See discussion #1059.
 #

--- a/test/runtime.bats
+++ b/test/runtime.bats
@@ -315,6 +315,33 @@ _basic_project() {
 	assert_output "$AUBE_SHIM_DIR/pnpm"
 }
 
+@test "activated pnpm shim remains available to node descendants" {
+	cat >package.json <<-'JSON'
+		{
+		  "name": "runtime-test",
+		  "version": "0.0.0",
+		  "scripts": {
+		    "nested-pnpm": "\"$AUBE_SHIM_DIR/node\""
+		  }
+		}
+	JSON
+	mkdir -p "$TEST_TEMP_DIR/real-node"
+	cat >"$TEST_TEMP_DIR/real-node/node" <<'SH'
+#!/bin/sh
+command -v pnpm
+pnpm --version >/dev/null
+SH
+	chmod +x "$TEST_TEMP_DIR/real-node/node"
+	export PATH="$TEST_TEMP_DIR/real-node:$PATH"
+	run aube activate bash
+	assert_success
+	eval "$output"
+
+	run aube run --no-install nested-pnpm
+	assert_success
+	assert_output "$AUBE_SHIM_DIR/pnpm"
+}
+
 @test "pnpm-11 lockfile with a runtime pin installs without fetching node from the registry" {
 	# Compat: the synthetic `node` importer dep must be routed into the
 	# runtime-pin table, not resolved as an npm package. The pinned


### PR DESCRIPTION
## Summary

- fall back to the workspace-root `node_modules/.bin` for recursive and member-local execs
- put member and workspace-root bin directories on PATH for exec descendants
- restore activated package-manager shims after `aube node` resolves the real Node executable
- preserve wrapper-runtime PATH precedence while avoiding node-shim recursion
- cover sequential/parallel recursive exec and Node-grandchild package-manager spawns

## Root cause

Recursive exec resolved binaries only from each member's `.bin`, unlike pnpm's workspace-root `extraBinPaths` behavior. Separately, the activated `node` shim sanitized the shim directory before handing off to real Node, so Node tools such as Rspack could not subsequently spawn `pnpm`.

## Validation

- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- focused BATS regressions for workspace-root exec and Node-descendant shim propagation

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches exec PATH assembly and Node resolution paths used by scripts and nested spawns; behavior is regression-tested but affects runtime/shim ordering across workspaces and activation.
> 
> **Overview**
> Recursive **`aube exec`** now resolves binaries from the member’s `node_modules/.bin` first, then the **workspace root** `.bin` when present, matching pnpm-style `extraBinPaths`. **`build_bin_command`** always sets child **`PATH`** from member plus root bin dirs (via `path_entries_with_project_bins`) instead of only wiring PATH in shell mode or for native shims.
> 
> **`aube node`** resolves the real Node binary before applying PATH (`resolved_node_program`), and uses **`node_child_path_entries`** so activated **pnpm/npm/yarn** shims stay visible to Node descendants without re-entering the `node` shim. BATS cover workspace-root recursive exec and pnpm reachable from a Node grandchild under activation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1818243e8aa5065ee5656e6e9a218ce2b436b1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command resolution for project and workspace-local binaries across sequential, parallel, and terminal execution.
  * Improved Node executable resolution while preserving explicitly specified paths.
  * Ensured activated package-manager shims remain available to Node child processes.

* **Tests**
  * Added coverage for recursive execution of workspace-level binaries.
  * Added coverage for package-manager shim resolution through Node descendants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->