### PR TITLE
feat(sbom): include package license metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,6 +287,7 @@ dependencies = [
  "sigstore-oidc",
  "sigstore-sign",
  "sigstore-types",
+ "spdx",
  "strum",
  "tar",
  "tempfile",
@@ -4509,6 +4510,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f99e664ecd2d85a68c87e3c7a3cfe691f647ea9e835de984aba4d54a41f817d4"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "spdx"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8da593e30beb790fc9424502eb898320b44e5eb30367dbda1c1edde8e2f32d7"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ napi-build = "2.3.2"
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order", "raw_value"] }
+spdx = "0.13.4"
 yaml_serde = "0.10.4"
 # Comment- and format-preserving YAML edits. Used by aube-manifest /
 # aube to surgically rewrite user-authored workspace YAML files

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ napi-build = "2.3.2"
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order", "raw_value"] }
-spdx = "0.13.4"
+spdx = "0.13"
 yaml_serde = "0.10.4"
 # Comment- and format-preserving YAML edits. Used by aube-manifest /
 # aube to surgically rewrite user-authored workspace YAML files

--- a/crates/aube/Cargo.toml
+++ b/crates/aube/Cargo.toml
@@ -69,6 +69,7 @@ tokio-util = { workspace = true }
 miette = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+spdx = { workspace = true }
 yaml_serde = { workspace = true }
 base64 = { workspace = true }
 sha1 = { workspace = true }

--- a/crates/aube/src/commands/licenses.rs
+++ b/crates/aube/src/commands/licenses.rs
@@ -132,6 +132,7 @@ pub(super) fn collect_installed_metadata<'a>(
     // used a one-shot `--node-linker=hoisted` override.
     let installed_layout = crate::state::read_state_layout(cwd)
         .or_else(|| crate::state::read_default_state_layout(cwd));
+    let installed_licenses = crate::state::read_state_package_licenses(cwd);
     let virtual_store_dir_max_length = installed_layout
         .as_ref()
         .and_then(|layout| layout.virtual_store_dir_max_length)
@@ -221,10 +222,7 @@ pub(super) fn collect_installed_metadata<'a>(
                     )
                 }),
         };
-        let recorded_license = installed_layout
-            .as_ref()
-            .and_then(|layout| layout.package_licenses.get(dep_path))
-            .cloned();
+        let recorded_license = installed_licenses.get(dep_path).cloned();
         metadata.insert(
             dep_path.to_string(),
             InstalledPackageMetadata {

--- a/crates/aube/src/commands/licenses.rs
+++ b/crates/aube/src/commands/licenses.rs
@@ -128,11 +128,14 @@ pub(super) fn collect_installed_metadata<'a>(
     dep_paths: impl IntoIterator<Item = &'a str>,
 ) -> miette::Result<BTreeMap<String, InstalledPackageMetadata>> {
     let aube_dir = super::resolve_virtual_store_dir_for_cwd(cwd);
-    let virtual_store_dir_max_length = super::resolve_virtual_store_dir_max_length_for_cwd(cwd);
     // Prefer the recorded layout over current config: the install may have
     // used a one-shot `--node-linker=hoisted` override.
     let installed_layout = crate::state::read_state_layout(cwd)
         .or_else(|| crate::state::read_default_state_layout(cwd));
+    let virtual_store_dir_max_length = installed_layout
+        .as_ref()
+        .and_then(|layout| layout.virtual_store_dir_max_length)
+        .unwrap_or_else(|| super::resolve_virtual_store_dir_max_length_for_cwd(cwd));
     let installed_hoisted = installed_layout
         .as_ref()
         .map(|layout| matches!(layout.linker, crate::state::InstallLayoutMode::Hoisted))
@@ -331,48 +334,19 @@ fn virtual_store_pkg_dir(
 /// Accepts every shape real packages use in the wild:
 /// - `"license": "MIT"` — SPDX string
 /// - `"license": { "type": "MIT" }` — legacy object form still found on npm
-/// - `"licenses": [ { "type": "MIT" }, ... ]` — legacy array, pick the first
+/// - `"licenses": [ { "type": "MIT" }, ... ]` — legacy array
 ///
 /// Returns `None` when the manifest is unreadable or the field is missing.
 fn read_license(pkg_dir: &Path) -> Option<String> {
     let bytes = std::fs::read(pkg_dir.join("package.json")).ok()?;
     let manifest: ManifestLicenseFields = serde_json::from_slice(&bytes).ok()?;
-    manifest
-        .license
-        .and_then(LicenseField::into_string)
-        .or_else(|| {
-            manifest
-                .licenses
-                .into_iter()
-                .next()
-                .and_then(LicenseField::into_string)
-        })
+    license_from_values(manifest.license.as_ref(), manifest.licenses.as_ref())
 }
 
 #[derive(Deserialize)]
 struct ManifestLicenseFields {
-    license: Option<LicenseField>,
-    #[serde(default)]
-    licenses: Vec<LicenseField>,
-}
-
-#[derive(Deserialize)]
-#[serde(untagged)]
-enum LicenseField {
-    String(String),
-    Object {
-        #[serde(rename = "type")]
-        kind: Option<String>,
-    },
-}
-
-impl LicenseField {
-    fn into_string(self) -> Option<String> {
-        match self {
-            Self::String(license) => Some(license),
-            Self::Object { kind } => kind,
-        }
-    }
+    license: Option<serde_json::Value>,
+    licenses: Option<serde_json::Value>,
 }
 
 pub(super) fn license_from_values(
@@ -382,8 +356,9 @@ pub(super) fn license_from_values(
     license.and_then(extract_license).or_else(|| {
         licenses
             .and_then(|v| v.as_array())
-            .and_then(|arr| arr.first())
-            .and_then(extract_license)
+            .map(|arr| arr.iter().filter_map(extract_license).collect::<Vec<_>>())
+            .filter(|licenses| !licenses.is_empty())
+            .map(|licenses| licenses.join(" OR "))
     })
 }
 
@@ -474,8 +449,34 @@ mod tests {
         }))
         .unwrap();
         assert_eq!(
-            manifest.license.and_then(LicenseField::into_string),
+            license_from_values(manifest.license.as_ref(), manifest.licenses.as_ref()),
             Some("Apache-2.0".to_string())
+        );
+    }
+
+    #[test]
+    fn manifest_license_fields_keep_valid_primary_when_legacy_field_is_malformed() {
+        let manifest: ManifestLicenseFields = serde_json::from_value(serde_json::json!({
+            "license": "MIT",
+            "licenses": "not-an-array"
+        }))
+        .unwrap();
+        assert_eq!(
+            license_from_values(manifest.license.as_ref(), manifest.licenses.as_ref()),
+            Some("MIT".to_string())
+        );
+    }
+
+    #[test]
+    fn legacy_license_array_preserves_every_license() {
+        let value = serde_json::json!([
+            {"type": "MIT"},
+            {"type": "Apache-2.0"},
+            {"url": "ignored"}
+        ]);
+        assert_eq!(
+            license_from_values(None, Some(&value)),
+            Some("MIT OR Apache-2.0".to_string())
         );
     }
 }

--- a/crates/aube/src/commands/licenses.rs
+++ b/crates/aube/src/commands/licenses.rs
@@ -191,22 +191,49 @@ pub(super) fn collect_installed_metadata<'a>(
         let Some(pkg) = graph.get_package(dep_path) else {
             continue;
         };
-        let path = hoisted_placements
+        let recorded_link_dir = installed_layout
             .as_ref()
-            .and_then(|placements| placements.package_dir(dep_path))
-            .map(Path::to_path_buf)
-            .unwrap_or_else(|| {
-                virtual_store_pkg_dir(&aube_dir, dep_path, &pkg.name, virtual_store_dir_max_length)
+            .and_then(|layout| layout.packages.get(dep_path))
+            .filter(|package| package.link)
+            .and_then(|package| {
+                cwd.join(&package.package_json_path)
+                    .parent()
+                    .map(Path::to_path_buf)
             });
+        let linked = recorded_link_dir.is_some()
+            || matches!(
+                pkg.local_source.as_ref(),
+                Some(aube_lockfile::LocalSource::Link(_))
+            );
+        let path = match (pkg.local_source.as_ref(), recorded_link_dir) {
+            (Some(aube_lockfile::LocalSource::Link(path)), _) => cwd.join(path),
+            (None, Some(path)) => path,
+            _ => hoisted_placements
+                .as_ref()
+                .and_then(|placements| placements.package_dir(dep_path))
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| {
+                    virtual_store_pkg_dir(
+                        &aube_dir,
+                        dep_path,
+                        &pkg.name,
+                        virtual_store_dir_max_length,
+                    )
+                }),
+        };
+        let recorded_license = installed_layout
+            .as_ref()
+            .and_then(|layout| layout.package_licenses.get(dep_path))
+            .cloned();
         metadata.insert(
             dep_path.to_string(),
             InstalledPackageMetadata {
-                license: installed_layout
-                    .as_ref()
-                    .and_then(|layout| layout.package_licenses.get(dep_path))
-                    .cloned()
-                    .or_else(|| read_license(&path))
-                    .or_else(|| pkg.license.clone()),
+                license: if linked {
+                    read_license(&path).or(recorded_license)
+                } else {
+                    recorded_license.or_else(|| read_license(&path))
+                }
+                .or_else(|| pkg.license.clone()),
                 path,
             },
         );

--- a/crates/aube/src/commands/licenses.rs
+++ b/crates/aube/src/commands/licenses.rs
@@ -9,7 +9,7 @@ use super::DepFilter;
 use aube_lockfile::LockfileGraph;
 use clap::Args;
 use miette::{Context, IntoDiagnostic};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
@@ -128,6 +128,7 @@ pub(super) fn collect_installed_metadata<'a>(
     dep_paths: impl IntoIterator<Item = &'a str>,
 ) -> miette::Result<BTreeMap<String, InstalledPackageMetadata>> {
     let aube_dir = super::resolve_virtual_store_dir_for_cwd(cwd);
+    let virtual_store_dir_max_length = super::resolve_virtual_store_dir_max_length_for_cwd(cwd);
     // Prefer the recorded layout over current config: the install may have
     // used a one-shot `--node-linker=hoisted` override.
     let installed_layout = crate::state::read_state_layout(cwd)
@@ -191,7 +192,9 @@ pub(super) fn collect_installed_metadata<'a>(
             .as_ref()
             .and_then(|placements| placements.package_dir(dep_path))
             .map(Path::to_path_buf)
-            .unwrap_or_else(|| virtual_store_pkg_dir(&aube_dir, dep_path, &pkg.name));
+            .unwrap_or_else(|| {
+                virtual_store_pkg_dir(&aube_dir, dep_path, &pkg.name, virtual_store_dir_max_length)
+            });
         metadata.insert(
             dep_path.to_string(),
             InstalledPackageMetadata {
@@ -310,15 +313,15 @@ fn collect_rows(
 /// `aube_dir` is the resolved `virtualStoreDir` — the caller threads
 /// it in via `commands::resolve_virtual_store_dir_for_cwd` so a
 /// custom override lands on the same path the linker wrote to.
-fn virtual_store_pkg_dir(aube_dir: &Path, dep_path: &str, name: &str) -> PathBuf {
-    use aube_lockfile::dep_path_filename::{
-        DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH, dep_path_to_filename,
-    };
+fn virtual_store_pkg_dir(
+    aube_dir: &Path,
+    dep_path: &str,
+    name: &str,
+    virtual_store_dir_max_length: usize,
+) -> PathBuf {
+    use aube_lockfile::dep_path_filename::dep_path_to_filename;
     aube_dir
-        .join(dep_path_to_filename(
-            dep_path,
-            DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH,
-        ))
+        .join(dep_path_to_filename(dep_path, virtual_store_dir_max_length))
         .join("node_modules")
         .join(name)
 }
@@ -333,12 +336,43 @@ fn virtual_store_pkg_dir(aube_dir: &Path, dep_path: &str, name: &str) -> PathBuf
 /// Returns `None` when the manifest is unreadable or the field is missing.
 fn read_license(pkg_dir: &Path) -> Option<String> {
     let bytes = std::fs::read(pkg_dir.join("package.json")).ok()?;
-    let value: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
-    license_from_manifest(&value)
+    let manifest: ManifestLicenseFields = serde_json::from_slice(&bytes).ok()?;
+    manifest
+        .license
+        .and_then(LicenseField::into_string)
+        .or_else(|| {
+            manifest
+                .licenses
+                .into_iter()
+                .next()
+                .and_then(LicenseField::into_string)
+        })
 }
 
-pub(super) fn license_from_manifest(value: &serde_json::Value) -> Option<String> {
-    license_from_values(value.get("license"), value.get("licenses"))
+#[derive(Deserialize)]
+struct ManifestLicenseFields {
+    license: Option<LicenseField>,
+    #[serde(default)]
+    licenses: Vec<LicenseField>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum LicenseField {
+    String(String),
+    Object {
+        #[serde(rename = "type")]
+        kind: Option<String>,
+    },
+}
+
+impl LicenseField {
+    fn into_string(self) -> Option<String> {
+        match self {
+            Self::String(license) => Some(license),
+            Self::Object { kind } => kind,
+        }
+    }
 }
 
 pub(super) fn license_from_values(
@@ -428,5 +462,20 @@ mod tests {
     fn extract_license_missing_type() {
         let v = serde_json::json!({ "url": "..." });
         assert!(extract_license(&v).is_none());
+    }
+
+    #[test]
+    fn manifest_license_fields_skip_unrelated_manifest_data() {
+        let manifest: ManifestLicenseFields = serde_json::from_value(serde_json::json!({
+            "name": "example",
+            "dependencies": {"dep": "1.0.0"},
+            "scripts": {"postinstall": "node build.js"},
+            "license": {"type": "Apache-2.0", "url": "https://example.com/license"}
+        }))
+        .unwrap();
+        assert_eq!(
+            manifest.license.and_then(LicenseField::into_string),
+            Some("Apache-2.0".to_string())
+        );
     }
 }

--- a/crates/aube/src/commands/licenses.rs
+++ b/crates/aube/src/commands/licenses.rs
@@ -81,6 +81,11 @@ struct Row {
     path: Option<String>,
 }
 
+pub(super) struct InstalledPackageMetadata {
+    pub license: Option<String>,
+    pub path: PathBuf,
+}
+
 pub async fn run(args: LicensesArgs) -> miette::Result<()> {
     args.network.install_overrides();
     // `licenses ls` is pnpm-compat; it behaves identically to bare `licenses`.
@@ -104,17 +109,34 @@ pub async fn run(args: LicensesArgs) -> miette::Result<()> {
 
     let filter = DepFilter::from_flags(args.prod, args.dev);
     let filtered = graph.filter_deps(|d| filter.keeps(d.dep_type));
+    let installed_metadata =
+        collect_installed_metadata(&cwd, &graph, filtered.packages.keys().map(String::as_str))?;
+    let rows = collect_rows(&filtered, &installed_metadata, args.long);
 
-    let aube_dir = super::resolve_virtual_store_dir_for_cwd(&cwd);
+    if args.json {
+        render_json(&rows)?;
+    } else {
+        render_grouped(&rows, args.long);
+    }
+
+    Ok(())
+}
+
+pub(super) fn collect_installed_metadata<'a>(
+    cwd: &Path,
+    graph: &LockfileGraph,
+    dep_paths: impl IntoIterator<Item = &'a str>,
+) -> miette::Result<BTreeMap<String, InstalledPackageMetadata>> {
+    let aube_dir = super::resolve_virtual_store_dir_for_cwd(cwd);
     // Prefer the recorded layout over current config: the install may have
     // used a one-shot `--node-linker=hoisted` override.
-    let installed_layout = crate::state::read_state_layout(&cwd)
-        .or_else(|| crate::state::read_default_state_layout(&cwd));
+    let installed_layout = crate::state::read_state_layout(cwd)
+        .or_else(|| crate::state::read_default_state_layout(cwd));
     let installed_hoisted = installed_layout
         .as_ref()
         .map(|layout| matches!(layout.linker, crate::state::InstallLayoutMode::Hoisted))
         .unwrap_or_else(|| {
-            super::with_settings_ctx(&cwd, |ctx| {
+            super::with_settings_ctx(cwd, |ctx| {
                 matches!(
                     aube_settings::resolved::node_linker(ctx),
                     aube_settings::resolved::NodeLinker::Hoisted
@@ -130,7 +152,7 @@ pub async fn run(args: LicensesArgs) -> miette::Result<()> {
             .or_else(|| {
                 installed_layout
                     .as_ref()
-                    .and_then(|layout| infer_legacy_modules_dir_name(layout, &graph))
+                    .and_then(|layout| infer_legacy_modules_dir_name(layout, graph))
             })
             // A dependency-free legacy snapshot has no direct entry from
             // which to infer the directory. The value is immaterial because
@@ -152,22 +174,33 @@ pub async fn run(args: LicensesArgs) -> miette::Result<()> {
         // change which conflicting version won a hoisted placement.
         Some(match recorded_hoisting_limits {
             Some(limits) => {
-                aube_linker::HoistedPlacements::from_graph(&cwd, &graph, &modules_dir_name, limits)?
+                aube_linker::HoistedPlacements::from_graph(cwd, graph, &modules_dir_name, limits)?
             }
-            None => legacy_hoisted_placements(&cwd, &graph, &modules_dir_name)?,
+            None => legacy_hoisted_placements(cwd, graph, &modules_dir_name)?,
         })
     } else {
         None
     };
-    let rows = collect_rows(&aube_dir, &filtered, hoisted_placements.as_ref(), args.long);
 
-    if args.json {
-        render_json(&rows)?;
-    } else {
-        render_grouped(&rows, args.long);
+    let mut metadata = BTreeMap::new();
+    for dep_path in dep_paths {
+        let Some(pkg) = graph.get_package(dep_path) else {
+            continue;
+        };
+        let path = hoisted_placements
+            .as_ref()
+            .and_then(|placements| placements.package_dir(dep_path))
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| virtual_store_pkg_dir(&aube_dir, dep_path, &pkg.name));
+        metadata.insert(
+            dep_path.to_string(),
+            InstalledPackageMetadata {
+                license: read_license(&path).or_else(|| pkg.license.clone()),
+                path,
+            },
+        );
     }
-
-    Ok(())
+    Ok(metadata)
 }
 
 /// Infer `modulesDir` from the root importer's recorded direct entries in
@@ -223,14 +256,12 @@ fn legacy_hoisted_placements(
     ))
 }
 
-/// Walk every package in the filtered graph and read its installed manifest,
-/// using hoisted placements when applicable. Packages whose manifest can't be
-/// read (e.g., `node_modules` not materialized yet) fall back to "UNKNOWN" so
-/// one missing file doesn't sink the whole report.
+/// Walk every package in the filtered graph and render its collected metadata.
+/// Packages whose manifest couldn't be read fall back to "UNKNOWN" so one
+/// missing file doesn't sink the whole report.
 fn collect_rows(
-    aube_dir: &Path,
     graph: &LockfileGraph,
-    hoisted_placements: Option<&aube_linker::HoistedPlacements>,
+    installed_metadata: &BTreeMap<String, InstalledPackageMetadata>,
     long: bool,
 ) -> Vec<Row> {
     // Deduplicate by (name, version) so peer-context duplicates
@@ -242,17 +273,15 @@ fn collect_rows(
         if !seen.insert((pkg.name.clone(), pkg.version.clone())) {
             continue;
         }
-        let pkg_dir = hoisted_placements
-            .and_then(|placements| placements.package_dir(&pkg.dep_path))
-            .map(Path::to_path_buf)
-            .unwrap_or_else(|| virtual_store_pkg_dir(aube_dir, &pkg.dep_path, &pkg.name));
-        let license = read_license(&pkg_dir);
+        let metadata = installed_metadata.get(&pkg.dep_path);
         rows.push(Row {
             name: pkg.name.clone(),
             version: pkg.version.clone(),
-            license: license.unwrap_or_else(|| "UNKNOWN".to_string()),
+            license: metadata
+                .and_then(|metadata| metadata.license.clone())
+                .unwrap_or_else(|| "UNKNOWN".to_string()),
             path: if long {
-                Some(pkg_dir.display().to_string())
+                metadata.map(|metadata| metadata.path.display().to_string())
             } else {
                 None
             },
@@ -305,9 +334,19 @@ fn virtual_store_pkg_dir(aube_dir: &Path, dep_path: &str, name: &str) -> PathBuf
 fn read_license(pkg_dir: &Path) -> Option<String> {
     let bytes = std::fs::read(pkg_dir.join("package.json")).ok()?;
     let value: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
-    value.get("license").and_then(extract_license).or_else(|| {
-        value
-            .get("licenses")
+    license_from_manifest(&value)
+}
+
+pub(super) fn license_from_manifest(value: &serde_json::Value) -> Option<String> {
+    license_from_values(value.get("license"), value.get("licenses"))
+}
+
+pub(super) fn license_from_values(
+    license: Option<&serde_json::Value>,
+    licenses: Option<&serde_json::Value>,
+) -> Option<String> {
+    license.and_then(extract_license).or_else(|| {
+        licenses
             .and_then(|v| v.as_array())
             .and_then(|arr| arr.first())
             .and_then(extract_license)

--- a/crates/aube/src/commands/licenses.rs
+++ b/crates/aube/src/commands/licenses.rs
@@ -222,7 +222,7 @@ pub(super) fn collect_installed_metadata<'a>(
                     )
                 }),
         };
-        let recorded_license = installed_licenses.get(dep_path).cloned();
+        let recorded_license = installed_licenses.licenses.get(dep_path).cloned();
         metadata.insert(
             dep_path.to_string(),
             InstalledPackageMetadata {
@@ -235,6 +235,42 @@ pub(super) fn collect_installed_metadata<'a>(
                 path,
             },
         );
+    }
+    Ok(metadata)
+}
+
+pub(super) fn collect_installed_licenses<'a>(
+    cwd: &Path,
+    graph: &LockfileGraph,
+    dep_paths: impl IntoIterator<Item = &'a str>,
+) -> miette::Result<BTreeMap<String, InstalledPackageMetadata>> {
+    let installed = crate::state::read_state_package_licenses(cwd);
+    let mut metadata = BTreeMap::new();
+    let mut fallback_paths = Vec::new();
+    for dep_path in dep_paths {
+        let Some(pkg) = graph.get_package(dep_path) else {
+            continue;
+        };
+        let cached = installed.licenses.get(dep_path).cloned();
+        let license = if let Some(path) = installed.linked_package_dirs.get(dep_path) {
+            read_license(&cwd.join(path)).or(cached)
+        } else if cached.is_some() {
+            cached
+        } else {
+            fallback_paths.push(dep_path);
+            continue;
+        }
+        .or_else(|| pkg.license.clone());
+        metadata.insert(
+            dep_path.to_string(),
+            InstalledPackageMetadata {
+                license,
+                path: PathBuf::new(),
+            },
+        );
+    }
+    if !fallback_paths.is_empty() {
+        metadata.extend(collect_installed_metadata(cwd, graph, fallback_paths)?);
     }
     Ok(metadata)
 }

--- a/crates/aube/src/commands/licenses.rs
+++ b/crates/aube/src/commands/licenses.rs
@@ -201,7 +201,12 @@ pub(super) fn collect_installed_metadata<'a>(
         metadata.insert(
             dep_path.to_string(),
             InstalledPackageMetadata {
-                license: read_license(&path).or_else(|| pkg.license.clone()),
+                license: installed_layout
+                    .as_ref()
+                    .and_then(|layout| layout.package_licenses.get(dep_path))
+                    .cloned()
+                    .or_else(|| read_license(&path))
+                    .or_else(|| pkg.license.clone()),
                 path,
             },
         );
@@ -337,7 +342,7 @@ fn virtual_store_pkg_dir(
 /// - `"licenses": [ { "type": "MIT" }, ... ]` — legacy array
 ///
 /// Returns `None` when the manifest is unreadable or the field is missing.
-fn read_license(pkg_dir: &Path) -> Option<String> {
+pub(crate) fn read_license(pkg_dir: &Path) -> Option<String> {
     let bytes = std::fs::read(pkg_dir.join("package.json")).ok()?;
     let manifest: ManifestLicenseFields = serde_json::from_slice(&bytes).ok()?;
     license_from_values(manifest.license.as_ref(), manifest.licenses.as_ref())

--- a/crates/aube/src/commands/sbom.rs
+++ b/crates/aube/src/commands/sbom.rs
@@ -1,9 +1,9 @@
 //! `aube sbom` — emit a Software Bill of Materials for the installed graph.
 //!
-//! Reads the lockfile (no network, no linking), walks the root importer's
-//! direct deps transitively, and serializes the closure as either CycloneDX
-//! 1.5 JSON or SPDX 2.3 JSON. Pure read; does not touch `node_modules/` or
-//! take the project lock.
+//! Reads the lockfile and installed package manifests (no network, no linking),
+//! walks the root importer's direct deps transitively, and serializes the
+//! closure as either CycloneDX 1.5 JSON or SPDX 2.3 JSON. Pure read; does not
+//! modify `node_modules/` or take the project lock.
 
 use aube_lockfile::{DepType, DirectDep, LockedPackage, LockfileGraph};
 use clap::Args;
@@ -73,13 +73,24 @@ pub async fn run(args: SbomArgs) -> miette::Result<()> {
     } else {
         closure
     };
+    let installed_metadata = super::licenses::collect_installed_metadata(
+        &cwd,
+        &graph,
+        closure.keys().map(String::as_str),
+    )?;
 
     let json = match args.format {
         SbomFormat::Cyclonedx => {
             let dev_only = collect_dev_only_packages(&graph, graph.importers.values().flatten());
-            render_cyclonedx(&manifest, &closure, &dev_only, args.exclude_peers)?
+            render_cyclonedx(
+                &manifest,
+                &closure,
+                &installed_metadata,
+                &dev_only,
+                args.exclude_peers,
+            )?
         }
-        SbomFormat::Spdx => render_spdx(&manifest, &graph, filter, &closure)?,
+        SbomFormat::Spdx => render_spdx(&manifest, &graph, filter, &closure, &installed_metadata)?,
     };
 
     println!("{json}");
@@ -90,6 +101,7 @@ pub async fn run(args: SbomArgs) -> miette::Result<()> {
 fn render_cyclonedx(
     manifest: &aube_manifest::PackageJson,
     closure: &BTreeMap<String, &LockedPackage>,
+    installed_metadata: &BTreeMap<String, super::licenses::InstalledPackageMetadata>,
     dev_only: &BTreeMap<String, bool>,
     exclude_peers: bool,
 ) -> miette::Result<String> {
@@ -105,6 +117,12 @@ fn render_cyclonedx(
         c.insert("name".into(), pkg.name.clone().into());
         c.insert("version".into(), pkg.version.clone().into());
         c.insert("purl".into(), purl(&pkg.name, &pkg.version).into());
+        if let Some(license) = installed_metadata
+            .get(dep_path)
+            .and_then(|metadata| metadata.license.as_deref())
+        {
+            c.insert("licenses".into(), cyclonedx_licenses(license));
+        }
         if let Some(bugs_url) = bugs_url_from_extra(&pkg.extra_meta) {
             c.insert("externalReferences".into(), external_references(bugs_url));
         }
@@ -127,6 +145,9 @@ fn render_cyclonedx(
     root_component.insert("name".into(), root_name.into());
     if !root_version.is_empty() {
         root_component.insert("version".into(), root_version.clone().into());
+    }
+    if let Some(license) = manifest_license(manifest) {
+        root_component.insert("licenses".into(), cyclonedx_licenses(&license));
     }
     if let Some(bugs_url) = bugs_url_from_extra(&manifest.extra) {
         root_component.insert("externalReferences".into(), external_references(bugs_url));
@@ -171,6 +192,23 @@ fn cyclonedx_exclude_peers_property() -> serde_json::Value {
         "name": "cdx:npm:package:excludePeers",
         "value": "true",
     }])
+}
+
+fn cyclonedx_licenses(license: &str) -> serde_json::Value {
+    if spdx::license_id(license).is_some() {
+        serde_json::json!([{ "license": { "id": license } }])
+    } else if spdx::Expression::parse(license).is_ok() {
+        serde_json::json!([{ "expression": license }])
+    } else {
+        serde_json::json!([{ "license": { "name": license } }])
+    }
+}
+
+fn manifest_license(manifest: &aube_manifest::PackageJson) -> Option<String> {
+    super::licenses::license_from_values(
+        manifest.extra.get("license"),
+        manifest.extra.get("licenses"),
+    )
 }
 
 fn external_references(url: &str) -> serde_json::Value {
@@ -271,6 +309,7 @@ fn render_spdx(
     graph: &LockfileGraph,
     filter: DepFilter,
     closure: &BTreeMap<String, &LockedPackage>,
+    installed_metadata: &BTreeMap<String, super::licenses::InstalledPackageMetadata>,
 ) -> miette::Result<String> {
     let root_name = manifest.name.clone().unwrap_or_else(|| "(unnamed)".into());
     let root_version = manifest.version.clone().unwrap_or_default();
@@ -285,11 +324,11 @@ fn render_spdx(
     }
     root_pkg.insert("downloadLocation".into(), "NOASSERTION".into());
     root_pkg.insert("filesAnalyzed".into(), false.into());
-    // SPDX 2.3 §7.13/§7.15/§7.17 require these for every package, including
-    // the root. We don't read license info from the store yet, so everything
-    // is NOASSERTION.
     root_pkg.insert("licenseConcluded".into(), "NOASSERTION".into());
-    root_pkg.insert("licenseDeclared".into(), "NOASSERTION".into());
+    root_pkg.insert(
+        "licenseDeclared".into(),
+        spdx_declared_license(manifest_license(manifest).as_deref()).into(),
+    );
     root_pkg.insert("copyrightText".into(), "NOASSERTION".into());
     packages.push(serde_json::Value::Object(root_pkg));
 
@@ -319,7 +358,15 @@ fn render_spdx(
         p.insert("downloadLocation".into(), "NOASSERTION".into());
         p.insert("filesAnalyzed".into(), false.into());
         p.insert("licenseConcluded".into(), "NOASSERTION".into());
-        p.insert("licenseDeclared".into(), "NOASSERTION".into());
+        p.insert(
+            "licenseDeclared".into(),
+            spdx_declared_license(
+                installed_metadata
+                    .get(dep_path)
+                    .and_then(|metadata| metadata.license.as_deref()),
+            )
+            .into(),
+        );
         p.insert("copyrightText".into(), "NOASSERTION".into());
         p.insert(
             "externalRefs".into(),
@@ -397,6 +444,12 @@ fn render_spdx(
     serde_json::to_string_pretty(&doc)
         .into_diagnostic()
         .wrap_err("failed to serialize SPDX SBOM")
+}
+
+fn spdx_declared_license(license: Option<&str>) -> &str {
+    license
+        .filter(|license| spdx::Expression::parse(license).is_ok())
+        .unwrap_or("NOASSERTION")
 }
 
 /// Build a purl for an npm package. Scoped names encode the leading `@` as
@@ -482,6 +535,37 @@ mod tests {
     #[test]
     fn sanitize_spdx_id_strips_unsafe() {
         assert_eq!(sanitize_spdx_id("@babel/core@7.0.0"), "-babel-core-7.0.0");
+    }
+
+    #[test]
+    fn cyclonedx_licenses_distinguishes_ids_expressions_and_names() {
+        assert_eq!(
+            cyclonedx_licenses("MIT"),
+            serde_json::json!([{ "license": { "id": "MIT" } }])
+        );
+        assert_eq!(
+            cyclonedx_licenses("MIT OR Apache-2.0"),
+            serde_json::json!([{ "expression": "MIT OR Apache-2.0" }])
+        );
+        assert_eq!(
+            cyclonedx_licenses("SEE LICENSE IN LICENSE.md"),
+            serde_json::json!([{
+                "license": { "name": "SEE LICENSE IN LICENSE.md" }
+            }])
+        );
+    }
+
+    #[test]
+    fn spdx_declared_license_rejects_non_spdx_names() {
+        assert_eq!(
+            spdx_declared_license(Some("MIT OR Apache-2.0")),
+            "MIT OR Apache-2.0"
+        );
+        assert_eq!(
+            spdx_declared_license(Some("SEE LICENSE IN LICENSE.md")),
+            "NOASSERTION"
+        );
+        assert_eq!(spdx_declared_license(None), "NOASSERTION");
     }
 
     #[test]

--- a/crates/aube/src/commands/sbom.rs
+++ b/crates/aube/src/commands/sbom.rs
@@ -73,7 +73,7 @@ pub async fn run(args: SbomArgs) -> miette::Result<()> {
     } else {
         closure
     };
-    let installed_metadata = super::licenses::collect_installed_metadata(
+    let installed_metadata = super::licenses::collect_installed_licenses(
         &cwd,
         &graph,
         closure.keys().map(String::as_str),

--- a/crates/aube/src/commands/sbom.rs
+++ b/crates/aube/src/commands/sbom.rs
@@ -110,6 +110,7 @@ fn render_cyclonedx(
     let root_ref = format!("{root_name}@{root_version}");
 
     let mut components = Vec::new();
+    let mut license_cache = BTreeMap::new();
     for (dep_path, pkg) in closure {
         let mut c = serde_json::Map::new();
         c.insert("type".into(), "library".into());
@@ -121,7 +122,11 @@ fn render_cyclonedx(
             .get(dep_path)
             .and_then(|metadata| metadata.license.as_deref())
         {
-            c.insert("licenses".into(), cyclonedx_licenses(license));
+            let licenses = license_cache
+                .entry(license)
+                .or_insert_with(|| cyclonedx_licenses(license))
+                .clone();
+            c.insert("licenses".into(), licenses);
         }
         if let Some(bugs_url) = bugs_url_from_extra(&pkg.extra_meta) {
             c.insert("externalReferences".into(), external_references(bugs_url));

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -241,6 +241,11 @@ pub struct InstallLayoutState {
     pub modules_dir_name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hoisting_limits: Option<InstallHoistingLimits>,
+    /// Filename limit used when materializing the virtual store. This must be
+    /// read from install state because an environment or CLI override may no
+    /// longer be present when a later command inspects the installed tree.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub virtual_store_dir_max_length: Option<usize>,
     pub direct_entries: BTreeMap<String, Vec<String>>,
     pub packages: BTreeMap<String, InstalledPackageState>,
 }
@@ -1028,6 +1033,7 @@ impl InstallLayoutState {
             linker,
             modules_dir_name: layout.modules_dir_name.to_string(),
             hoisting_limits,
+            virtual_store_dir_max_length: Some(layout.virtual_store_dir_max_length),
             direct_entries,
             packages,
         }
@@ -1413,6 +1419,7 @@ mod tests {
                 linker: InstallLayoutMode::Isolated,
                 modules_dir_name: String::new(),
                 hoisting_limits: None,
+                virtual_store_dir_max_length: None,
                 direct_entries: BTreeMap::new(),
                 packages: BTreeMap::from([(
                     "is-odd@3.0.1".to_string(),
@@ -1460,6 +1467,7 @@ mod tests {
             linker: InstallLayoutMode::Isolated,
             modules_dir_name: String::new(),
             hoisting_limits: None,
+            virtual_store_dir_max_length: None,
             direct_entries: BTreeMap::from([(
                 ".".to_string(),
                 vec!["node_modules/@scope/api".to_string()],
@@ -1491,6 +1499,7 @@ mod tests {
             linker: InstallLayoutMode::Isolated,
             modules_dir_name: String::new(),
             hoisting_limits: None,
+            virtual_store_dir_max_length: None,
             direct_entries: BTreeMap::from([(
                 ".".to_string(),
                 vec!["node_modules/@scope/api".to_string()],
@@ -1609,6 +1618,7 @@ mod tests {
                 linker: InstallLayoutMode::Isolated,
                 modules_dir_name: String::new(),
                 hoisting_limits: None,
+                virtual_store_dir_max_length: None,
                 direct_entries: BTreeMap::new(),
                 packages: BTreeMap::new(),
             }),

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -1017,7 +1017,9 @@ impl InstallLayoutState {
                     layout.placements,
                 ),
             };
-            if let Some(license) = crate::commands::licenses::read_license(&package_dir) {
+            if let Some(license) = crate::commands::licenses::read_license(&package_dir)
+                .or_else(|| pkg.license.clone())
+            {
                 package_licenses.insert(dep_path.clone(), license);
             }
             if !direct_dep_paths.contains(dep_path) {

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -246,6 +246,11 @@ pub struct InstallLayoutState {
     /// longer be present when a later command inspects the installed tree.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub virtual_store_dir_max_length: Option<usize>,
+    /// Licenses captured from installed manifests. Inspection commands use
+    /// this snapshot instead of reopening every package manifest, while older
+    /// state files fall back to the materialized tree.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub package_licenses: BTreeMap<String, String>,
     pub direct_entries: BTreeMap<String, Vec<String>>,
     pub packages: BTreeMap<String, InstalledPackageState>,
 }
@@ -996,29 +1001,31 @@ impl InstallLayoutState {
             .into_iter()
             .flat_map(|deps| deps.iter().map(|dep| dep.dep_path.clone()))
             .collect();
-        for dep_path in direct_dep_paths {
-            let Some(pkg) = layout.graph.packages.get(&dep_path) else {
-                continue;
-            };
+        let mut package_licenses = BTreeMap::new();
+        for (dep_path, pkg) in &layout.graph.packages {
             let is_link = matches!(
                 pkg.local_source.as_ref(),
                 Some(aube_lockfile::LocalSource::Link(_))
             );
-            let package_json_path = match pkg.local_source.as_ref() {
-                Some(aube_lockfile::LocalSource::Link(path)) => {
-                    project_dir.join(path).join("package.json")
-                }
+            let package_dir = match pkg.local_source.as_ref() {
+                Some(aube_lockfile::LocalSource::Link(path)) => project_dir.join(path),
                 _ => crate::commands::install::materialized_pkg_dir(
                     layout.aube_dir,
-                    &dep_path,
+                    dep_path,
                     &pkg.name,
                     layout.virtual_store_dir_max_length,
                     layout.placements,
-                )
-                .join("package.json"),
+                ),
             };
+            if let Some(license) = crate::commands::licenses::read_license(&package_dir) {
+                package_licenses.insert(dep_path.clone(), license);
+            }
+            if !direct_dep_paths.contains(dep_path) {
+                continue;
+            }
+            let package_json_path = package_dir.join("package.json");
             packages.insert(
-                dep_path,
+                dep_path.clone(),
                 InstalledPackageState {
                     name: pkg.name.clone(),
                     version: pkg.version.clone(),
@@ -1034,6 +1041,7 @@ impl InstallLayoutState {
             modules_dir_name: layout.modules_dir_name.to_string(),
             hoisting_limits,
             virtual_store_dir_max_length: Some(layout.virtual_store_dir_max_length),
+            package_licenses,
             direct_entries,
             packages,
         }
@@ -1420,6 +1428,7 @@ mod tests {
                 modules_dir_name: String::new(),
                 hoisting_limits: None,
                 virtual_store_dir_max_length: None,
+                package_licenses: BTreeMap::new(),
                 direct_entries: BTreeMap::new(),
                 packages: BTreeMap::from([(
                     "is-odd@3.0.1".to_string(),
@@ -1468,6 +1477,7 @@ mod tests {
             modules_dir_name: String::new(),
             hoisting_limits: None,
             virtual_store_dir_max_length: None,
+            package_licenses: BTreeMap::new(),
             direct_entries: BTreeMap::from([(
                 ".".to_string(),
                 vec!["node_modules/@scope/api".to_string()],
@@ -1500,6 +1510,7 @@ mod tests {
             modules_dir_name: String::new(),
             hoisting_limits: None,
             virtual_store_dir_max_length: None,
+            package_licenses: BTreeMap::new(),
             direct_entries: BTreeMap::from([(
                 ".".to_string(),
                 vec!["node_modules/@scope/api".to_string()],
@@ -1619,6 +1630,7 @@ mod tests {
                 modules_dir_name: String::new(),
                 hoisting_limits: None,
                 virtual_store_dir_max_length: None,
+                package_licenses: BTreeMap::new(),
                 direct_entries: BTreeMap::new(),
                 packages: BTreeMap::new(),
             }),

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -251,6 +251,14 @@ pub struct InstallLayoutState {
     pub packages: BTreeMap<String, InstalledPackageState>,
 }
 
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct InstallLicenseState {
+    fingerprint: String,
+    pub licenses: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub linked_package_dirs: BTreeMap<String, String>,
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum InstallLayoutMode {
@@ -660,7 +668,7 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
     let (lockfile_hash, lockfile_snapshot_name) =
         snapshot_active_lockfile(project_dir, &state_path)?;
     let settings_hash = hash_settings(project_dir, cli_flags);
-    let (install_layout, package_licenses) = InstallLayoutState::from_graph(project_dir, &layout);
+    let install_layout = InstallLayoutState::from_graph(project_dir, &layout);
 
     let package_json_shape_digests: BTreeMap<String, String> = package_json_hashes
         .keys()
@@ -700,6 +708,7 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
     // to verify; empty for the default shared layout.
     let (member_lockfile_hashes, member_lockfile_meta) = collect_member_lockfile_state(project_dir);
     let local_directory_hashes = collect_local_directory_hashes(project_dir, layout.graph)?;
+    let license_fingerprint = license_state_fingerprint(&graph_lthash, &package_content_hashes);
 
     let state = InstallState {
         lockfile_hash,
@@ -721,13 +730,72 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
     };
 
     let fresh_state = FreshnessState::from(&state);
-    let license_json = serde_json::to_vec(&package_licenses)?;
-    aube_util::fs_atomic::atomic_write(&license_state_file(&state_path), &license_json)?;
+    if read_package_licenses(&state_path)
+        .as_ref()
+        .is_none_or(|licenses| licenses.fingerprint != license_fingerprint)
+    {
+        let license_state =
+            collect_package_license_state(project_dir, &layout, license_fingerprint);
+        let license_json = serde_json::to_vec(&license_state)?;
+        aube_util::fs_atomic::atomic_write(&license_state_file(&state_path), &license_json)?;
+    }
     let json = serde_json::to_string_pretty(&state)?;
     aube_util::fs_atomic::atomic_write(&install_state_file(&state_path), json.as_bytes())?;
     write_fresh_state(&state_path, &fresh_state)?;
 
     Ok(())
+}
+
+fn license_state_fingerprint(
+    graph_lthash: &str,
+    package_content_hashes: &BTreeMap<String, String>,
+) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(graph_lthash.as_bytes());
+    for (dep_path, content_hash) in package_content_hashes {
+        hasher.update(&(dep_path.len() as u64).to_le_bytes());
+        hasher.update(dep_path.as_bytes());
+        hasher.update(content_hash.as_bytes());
+    }
+    hasher.finalize().to_hex().to_string()
+}
+
+fn collect_package_license_state(
+    project_dir: &Path,
+    layout: &WriteStateLayout<'_>,
+    fingerprint: String,
+) -> InstallLicenseState {
+    let mut licenses = BTreeMap::new();
+    let mut linked_package_dirs = BTreeMap::new();
+    for (dep_path, pkg) in &layout.graph.packages {
+        let package_dir = match pkg.local_source.as_ref() {
+            Some(aube_lockfile::LocalSource::Link(path)) => {
+                let package_dir = project_dir.join(path);
+                linked_package_dirs.insert(
+                    dep_path.clone(),
+                    relative_path_or_original(&package_dir, project_dir),
+                );
+                package_dir
+            }
+            _ => crate::commands::install::materialized_pkg_dir(
+                layout.aube_dir,
+                dep_path,
+                &pkg.name,
+                layout.virtual_store_dir_max_length,
+                layout.placements,
+            ),
+        };
+        if let Some(license) =
+            crate::commands::licenses::read_license(&package_dir).or_else(|| pkg.license.clone())
+        {
+            licenses.insert(dep_path.clone(), license);
+        }
+    }
+    InstallLicenseState {
+        fingerprint,
+        licenses,
+        linked_package_dirs,
+    }
 }
 
 fn collect_local_directory_hashes(
@@ -796,7 +864,7 @@ pub fn read_state_layout(project_dir: &Path) -> Option<InstallLayoutState> {
 
 /// Read licenses captured at install time without adding them to the main
 /// freshness state parsed by every warm install.
-pub fn read_state_package_licenses(project_dir: &Path) -> BTreeMap<String, String> {
+pub fn read_state_package_licenses(project_dir: &Path) -> InstallLicenseState {
     let state_path = state_dir(project_dir);
     read_package_licenses(&state_path)
         .or_else(|| {
@@ -939,7 +1007,7 @@ fn license_state_file(state_path: &Path) -> PathBuf {
     state_path.join(LICENSE_STATE_FILE_NAME)
 }
 
-fn read_package_licenses(state_path: &Path) -> Option<BTreeMap<String, String>> {
+fn read_package_licenses(state_path: &Path) -> Option<InstallLicenseState> {
     let content = std::fs::read(license_state_file(state_path)).ok()?;
     serde_json::from_slice(&content).ok()
 }
@@ -979,10 +1047,7 @@ fn remove_legacy_state_file(state_path: &Path) -> Result<(), std::io::Error> {
 }
 
 impl InstallLayoutState {
-    fn from_graph(
-        project_dir: &Path,
-        layout: &WriteStateLayout<'_>,
-    ) -> (Self, BTreeMap<String, String>) {
+    fn from_graph(project_dir: &Path, layout: &WriteStateLayout<'_>) -> Self {
         let linker = match layout.node_linker {
             aube_linker::NodeLinker::Isolated => InstallLayoutMode::Isolated,
             aube_linker::NodeLinker::Hoisted => InstallLayoutMode::Hoisted,
@@ -1022,7 +1087,6 @@ impl InstallLayoutState {
             .into_iter()
             .flat_map(|deps| deps.iter().map(|dep| dep.dep_path.clone()))
             .collect();
-        let mut package_licenses = BTreeMap::new();
         for (dep_path, pkg) in &layout.graph.packages {
             let is_link = matches!(
                 pkg.local_source.as_ref(),
@@ -1038,11 +1102,6 @@ impl InstallLayoutState {
                     layout.placements,
                 ),
             };
-            if let Some(license) = crate::commands::licenses::read_license(&package_dir)
-                .or_else(|| pkg.license.clone())
-            {
-                package_licenses.insert(dep_path.clone(), license);
-            }
             if !direct_dep_paths.contains(dep_path) {
                 continue;
             }
@@ -1059,17 +1118,14 @@ impl InstallLayoutState {
             );
         }
 
-        (
-            Self {
-                linker,
-                modules_dir_name: layout.modules_dir_name.to_string(),
-                hoisting_limits,
-                virtual_store_dir_max_length: Some(layout.virtual_store_dir_max_length),
-                direct_entries,
-                packages,
-            },
-            package_licenses,
-        )
+        Self {
+            linker,
+            modules_dir_name: layout.modules_dir_name.to_string(),
+            hoisting_limits,
+            virtual_store_dir_max_length: Some(layout.virtual_store_dir_max_length),
+            direct_entries,
+            packages,
+        }
     }
 }
 
@@ -1564,7 +1620,7 @@ mod tests {
             ..Default::default()
         };
 
-        let (layout, _) = InstallLayoutState::from_graph(
+        let layout = InstallLayoutState::from_graph(
             &project_dir,
             &WriteStateLayout {
                 graph: &graph,

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 const DEFAULT_STATE_DIR: &str = "node_modules";
 const INSTALL_STATE_FILE_NAME: &str = "state.json";
 const FRESH_STATE_FILE_NAME: &str = "fresh.json";
+const LICENSE_STATE_FILE_NAME: &str = "licenses.json";
 
 /// The install-state directory name, `.<name>-state`. Standalone aube:
 /// `.aube-state`.
@@ -246,11 +247,6 @@ pub struct InstallLayoutState {
     /// longer be present when a later command inspects the installed tree.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub virtual_store_dir_max_length: Option<usize>,
-    /// Licenses captured from installed manifests. Inspection commands use
-    /// this snapshot instead of reopening every package manifest, while older
-    /// state files fall back to the materialized tree.
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub package_licenses: BTreeMap<String, String>,
     pub direct_entries: BTreeMap<String, Vec<String>>,
     pub packages: BTreeMap<String, InstalledPackageState>,
 }
@@ -664,7 +660,7 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
     let (lockfile_hash, lockfile_snapshot_name) =
         snapshot_active_lockfile(project_dir, &state_path)?;
     let settings_hash = hash_settings(project_dir, cli_flags);
-    let install_layout = InstallLayoutState::from_graph(project_dir, &layout);
+    let (install_layout, package_licenses) = InstallLayoutState::from_graph(project_dir, &layout);
 
     let package_json_shape_digests: BTreeMap<String, String> = package_json_hashes
         .keys()
@@ -725,6 +721,8 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
     };
 
     let fresh_state = FreshnessState::from(&state);
+    let license_json = serde_json::to_vec(&package_licenses)?;
+    aube_util::fs_atomic::atomic_write(&license_state_file(&state_path), &license_json)?;
     let json = serde_json::to_string_pretty(&state)?;
     aube_util::fs_atomic::atomic_write(&install_state_file(&state_path), json.as_bytes())?;
     write_fresh_state(&state_path, &fresh_state)?;
@@ -794,6 +792,17 @@ pub fn read_state_package_content_hashes(project_dir: &Path) -> Option<BTreeMap<
 /// should take the normal path once to refresh derived metadata.
 pub fn read_state_layout(project_dir: &Path) -> Option<InstallLayoutState> {
     read_state(&state_dir(project_dir))?.layout
+}
+
+/// Read licenses captured at install time without adding them to the main
+/// freshness state parsed by every warm install.
+pub fn read_state_package_licenses(project_dir: &Path) -> BTreeMap<String, String> {
+    let state_path = state_dir(project_dir);
+    read_package_licenses(&state_path)
+        .or_else(|| {
+            read_package_licenses(&project_dir.join(DEFAULT_STATE_DIR).join(state_dir_name()))
+        })
+        .unwrap_or_default()
 }
 
 /// Read layout state from the default `node_modules` location.
@@ -926,6 +935,15 @@ fn install_state_file(state_path: &Path) -> PathBuf {
     state_path.join(INSTALL_STATE_FILE_NAME)
 }
 
+fn license_state_file(state_path: &Path) -> PathBuf {
+    state_path.join(LICENSE_STATE_FILE_NAME)
+}
+
+fn read_package_licenses(state_path: &Path) -> Option<BTreeMap<String, String>> {
+    let content = std::fs::read(license_state_file(state_path)).ok()?;
+    serde_json::from_slice(&content).ok()
+}
+
 fn fresh_state_file(state_path: &Path) -> PathBuf {
     state_path.join(FRESH_STATE_FILE_NAME)
 }
@@ -961,7 +979,10 @@ fn remove_legacy_state_file(state_path: &Path) -> Result<(), std::io::Error> {
 }
 
 impl InstallLayoutState {
-    fn from_graph(project_dir: &Path, layout: &WriteStateLayout<'_>) -> Self {
+    fn from_graph(
+        project_dir: &Path,
+        layout: &WriteStateLayout<'_>,
+    ) -> (Self, BTreeMap<String, String>) {
         let linker = match layout.node_linker {
             aube_linker::NodeLinker::Isolated => InstallLayoutMode::Isolated,
             aube_linker::NodeLinker::Hoisted => InstallLayoutMode::Hoisted,
@@ -1038,15 +1059,17 @@ impl InstallLayoutState {
             );
         }
 
-        Self {
-            linker,
-            modules_dir_name: layout.modules_dir_name.to_string(),
-            hoisting_limits,
-            virtual_store_dir_max_length: Some(layout.virtual_store_dir_max_length),
+        (
+            Self {
+                linker,
+                modules_dir_name: layout.modules_dir_name.to_string(),
+                hoisting_limits,
+                virtual_store_dir_max_length: Some(layout.virtual_store_dir_max_length),
+                direct_entries,
+                packages,
+            },
             package_licenses,
-            direct_entries,
-            packages,
-        }
+        )
     }
 }
 
@@ -1430,7 +1453,6 @@ mod tests {
                 modules_dir_name: String::new(),
                 hoisting_limits: None,
                 virtual_store_dir_max_length: None,
-                package_licenses: BTreeMap::new(),
                 direct_entries: BTreeMap::new(),
                 packages: BTreeMap::from([(
                     "is-odd@3.0.1".to_string(),
@@ -1479,7 +1501,6 @@ mod tests {
             modules_dir_name: String::new(),
             hoisting_limits: None,
             virtual_store_dir_max_length: None,
-            package_licenses: BTreeMap::new(),
             direct_entries: BTreeMap::from([(
                 ".".to_string(),
                 vec!["node_modules/@scope/api".to_string()],
@@ -1512,7 +1533,6 @@ mod tests {
             modules_dir_name: String::new(),
             hoisting_limits: None,
             virtual_store_dir_max_length: None,
-            package_licenses: BTreeMap::new(),
             direct_entries: BTreeMap::from([(
                 ".".to_string(),
                 vec!["node_modules/@scope/api".to_string()],
@@ -1544,7 +1564,7 @@ mod tests {
             ..Default::default()
         };
 
-        let layout = InstallLayoutState::from_graph(
+        let (layout, _) = InstallLayoutState::from_graph(
             &project_dir,
             &WriteStateLayout {
                 graph: &graph,
@@ -1632,7 +1652,6 @@ mod tests {
                 modules_dir_name: String::new(),
                 hoisting_limits: None,
                 virtual_store_dir_max_length: None,
-                package_licenses: BTreeMap::new(),
                 direct_entries: BTreeMap::new(),
                 packages: BTreeMap::new(),
             }),

--- a/test/sbom.bats
+++ b/test/sbom.bats
@@ -57,12 +57,22 @@ JSON
   }
 }
 JSON
-	echo "virtualStoreDirMaxLength=40" >>.npmrc
-	run aube install
+	run env AUBE_VIRTUAL_STORE_DIR_MAX_LENGTH=40 aube install
 	assert_success
 
 	run bash -c 'aube sbom | jq -e "
 	  any(.components[]; .name == \"@pnpm.e2e/pre-and-postinstall-scripts-example\" and .licenses[0].license.id == \"MIT\")
+	"'
+	assert_success
+}
+
+@test "aube sbom falls back to lockfile license metadata" {
+	_setup_mixed_fixture
+	run find node_modules/.aube -path '*/node_modules/is-odd/package.json' -delete
+	assert_success
+
+	run bash -c 'aube sbom | jq -e "
+	  any(.components[]; .name == \"is-odd\" and .licenses[0].license.id == \"MIT\")
 	"'
 	assert_success
 }

--- a/test/sbom.bats
+++ b/test/sbom.bats
@@ -79,6 +79,26 @@ JSON
 	assert_success
 }
 
+@test "aube sbom reads current license metadata from linked packages" {
+	mkdir linked
+	cat >linked/package.json <<'JSON'
+{"name":"linked","version":"1.0.0","license":"MIT"}
+JSON
+	cat >package.json <<'JSON'
+{"name":"sbom-linked","version":"1.0.0","dependencies":{"linked":"link:./linked"}}
+JSON
+	run aube install
+	assert_success
+	cat >linked/package.json <<'JSON'
+{"name":"linked","version":"1.0.0","license":"Apache-2.0"}
+JSON
+
+	run bash -c 'aube sbom | jq -e "
+	  any(.components[]; .name == \"linked\" and .licenses[0].license.id == \"Apache-2.0\")
+	"'
+	assert_success
+}
+
 @test "aube sbom --format spdx emits SPDX 2.3 JSON" {
 	_setup_mixed_fixture
 	run aube sbom --format spdx

--- a/test/sbom.bats
+++ b/test/sbom.bats
@@ -66,11 +66,9 @@ JSON
 	assert_success
 }
 
-@test "aube sbom falls back to lockfile license metadata" {
+@test "aube sbom falls back to install-state license metadata" {
 	_setup_mixed_fixture
 	run find node_modules/.aube -path '*/node_modules/is-odd/package.json' -delete
-	assert_success
-	run rm -rf node_modules/.aube-state
 	assert_success
 
 	run bash -c 'aube sbom | jq -e "

--- a/test/sbom.bats
+++ b/test/sbom.bats
@@ -47,6 +47,26 @@ JSON
 	assert_success
 }
 
+@test "aube sbom finds licenses with a custom virtual store filename limit" {
+	cat >package.json <<'JSON'
+{
+  "name": "sbom-custom-limit",
+  "version": "1.0.0",
+  "dependencies": {
+    "@pnpm.e2e/pre-and-postinstall-scripts-example": "2.0.0"
+  }
+}
+JSON
+	echo "virtualStoreDirMaxLength=40" >>.npmrc
+	run aube install
+	assert_success
+
+	run bash -c 'aube sbom | jq -e "
+	  any(.components[]; .name == \"@pnpm.e2e/pre-and-postinstall-scripts-example\" and .licenses[0].license.id == \"MIT\")
+	"'
+	assert_success
+}
+
 @test "aube sbom --format spdx emits SPDX 2.3 JSON" {
 	_setup_mixed_fixture
 	run aube sbom --format spdx

--- a/test/sbom.bats
+++ b/test/sbom.bats
@@ -70,6 +70,8 @@ JSON
 	_setup_mixed_fixture
 	run find node_modules/.aube -path '*/node_modules/is-odd/package.json' -delete
 	assert_success
+	run rm -rf node_modules/.aube-state
+	assert_success
 
 	run bash -c 'aube sbom | jq -e "
 	  any(.components[]; .name == \"is-odd\" and .licenses[0].license.id == \"MIT\")

--- a/test/sbom.bats
+++ b/test/sbom.bats
@@ -14,6 +14,7 @@ _setup_mixed_fixture() {
 {
   "name": "sbom-test",
   "version": "1.2.3",
+  "license": "Apache-2.0",
   "dependencies": {
     "is-odd": "^3.0.1"
   },
@@ -36,6 +37,16 @@ JSON
 	assert_output --partial '"pkg:npm/is-number@7.0.0"'
 }
 
+@test "aube sbom emits CycloneDX licenses for root and dependency components" {
+	_setup_mixed_fixture
+	run bash -c 'aube sbom | jq -e "
+	  .metadata.component.licenses[0].license.id == \"Apache-2.0\"
+	  and
+	  any(.components[]; .name == \"is-odd\" and .licenses[0].license.id == \"MIT\")
+	"'
+	assert_success
+}
+
 @test "aube sbom --format spdx emits SPDX 2.3 JSON" {
 	_setup_mixed_fixture
 	run aube sbom --format spdx
@@ -48,6 +59,16 @@ JSON
 	# not just inter-package edges between closure entries.
 	assert_output --partial '"spdxElementId": "SPDXRef-Root"'
 	assert_output --partial 'aube.jdx.dev/spdx/'
+}
+
+@test "aube sbom --format spdx emits declared but not concluded licenses" {
+	_setup_mixed_fixture
+	run bash -c 'aube sbom --format spdx | jq -e "
+	  any(.packages[]; .SPDXID == \"SPDXRef-Root\" and .licenseDeclared == \"Apache-2.0\" and .licenseConcluded == \"NOASSERTION\")
+	  and
+	  any(.packages[]; .name == \"is-odd\" and .licenseDeclared == \"MIT\" and .licenseConcluded == \"NOASSERTION\")
+	"'
+	assert_success
 }
 
 @test "aube sbom --prod drops devDependencies" {


### PR DESCRIPTION
## Summary

- reuse `aube licenses` installed-package discovery for SBOM generation, including isolated, hoisted, linked, and custom virtual-store layouts
- emit root and dependency licenses in CycloneDX 1.5 as SPDX identifiers, SPDX expressions, or named licenses
- populate SPDX 2.3 `licenseDeclared` for valid expressions while leaving `licenseConcluded` as `NOASSERTION`
- snapshot installed license metadata in a fingerprinted sidecar, with live-manifest fallbacks for older installs and linked packages

## Root cause

`aube sbom` only consumed the lockfile, while `aube licenses` independently read installed package manifests. Canonical aube/pnpm lockfiles do not preserve package licenses, so SBOM output omitted CycloneDX licenses and hardcoded SPDX license fields.

## Performance

The initial implementation raised SBOM instructions by 53.32%. Selective parsing, cached SPDX classification, and a fingerprinted license sidecar reduced that to 6.31%. Warm install is +0.68%, startup +0.68%, and tree +0.23%, all below the 1% gate. The remaining SBOM-only delta covers reading the compact sidecar, validating SPDX values, and serializing the new license objects.

## Validation

- `cargo fmt --check`
- `cargo clippy -p aube --all-targets -- -D warnings`
- `cargo test -p aube commands::sbom::tests`
- `cargo test -p aube commands::licenses::tests`
- `mise run test:bats test/sbom.bats`

Closes discussion #1204.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SBOM output now includes validated license information for the project and its dependencies.
  * CycloneDX and SPDX reports identify license expressions, IDs, names, or `NOASSERTION` when unavailable.
  * License metadata is preserved across installations for more reliable reporting.

* **Bug Fixes**
  * Improved license discovery for custom layouts, hoisted and linked packages, and incomplete manifests.
  * Added support for multiple licenses and fallback metadata sources.
  * Improved handling of malformed or unavailable license declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->