### PR TITLE
ci: run perf jobs on bamboo

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,6 @@
 self-hosted-runner:
   labels:
+    - bamboo-perf
     - namespace-profile-endev-linux-amd64
     - namespace-profile-endev-linux-amd64-large
     - namespace-profile-endev-linux-arm64

--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -72,7 +72,7 @@ jobs:
     name: Refresh benchmarks
     needs: check
     if: needs.check.outputs.drift == 'true'
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
+    runs-on: bamboo-perf
     permissions:
       contents: write
       pull-requests: write
@@ -83,9 +83,7 @@ jobs:
           token: ${{ secrets.AUBE_GH_TOKEN }}
           submodules: recursive
           persist-credentials: false
-      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
-        with:
-          cache: rust
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         env:
           MISE_LOCKED: "1"

--- a/.github/workflows/perf-backfill.yml
+++ b/.github/workflows/perf-backfill.yml
@@ -38,8 +38,10 @@ jobs:
     # Same runner class as perf.yml. Absolute instruction counts shift between
     # machine types by more than a real regression does, so the backfilled
     # series and the ongoing one have to come from the same kind of machine.
-    runs-on: namespace-profile-endev-linux-amd64
+    runs-on: bamboo-perf
     timeout-minutes: 60
+    env:
+      TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.97.1
     permissions:
       contents: read # listing releases and downloading assets; no write here
     steps:

--- a/.github/workflows/perf-backfill.yml
+++ b/.github/workflows/perf-backfill.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: bamboo-perf
     timeout-minutes: 60
     env:
-      TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.97.1
+      TAK_RUNNER: bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1
     permissions:
       contents: read # listing releases and downloading assets; no write here
     steps:

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -28,7 +28,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.97.1
+  TAK_RUNNER: bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1
 
 jobs:
   compare:

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -37,7 +37,7 @@ jobs:
     # Measuring them repeats the same binary already measured on main. Restrict
     # the exemption to release-plz branches in this repository so a fork cannot
     # bypass the comparison by choosing the same branch prefix.
-    if: github.event_name == 'pull_request' && !(startsWith(github.head_ref, 'release-plz-') && github.event.pull_request.head.repo.full_name == github.repository)
+    if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'jdx' && !(startsWith(github.head_ref, 'release-plz-') && github.event.pull_request.head.repo.full_name == github.repository)
     # Same runner class as perf.yml and perf-backfill.yml. Absolute counts shift
     # between machine types by more than a real regression does, so a comparison
     # across runner classes is not a comparison — tak refuses to make one, and

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -28,6 +28,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
+  TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.97.1
 
 jobs:
   compare:
@@ -41,7 +42,7 @@ jobs:
     # between machine types by more than a real regression does, so a comparison
     # across runner classes is not a comparison — tak refuses to make one, and
     # the report would say "nothing was compared" instead of anything useful.
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
+    runs-on: bamboo-perf
     timeout-minutes: 40
     permissions:
       contents: read
@@ -60,9 +61,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
-        with:
-          cache: rust
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -27,7 +27,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.97.1
+  TAK_RUNNER: bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1
 
 jobs:
   measure:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -27,6 +27,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
+  TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.97.1
 
 jobs:
   measure:
@@ -34,7 +35,7 @@ jobs:
     # Pinned to one runner class on purpose. Absolute instruction counts shift
     # between machine types by more than a real regression does, so a series
     # that wanders between runners is unreadable.
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
+    runs-on: bamboo-perf
     timeout-minutes: 30
     permissions:
       contents: write # pushing refs/notes/tak is a write to this repository
@@ -43,9 +44,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
-        with:
-          cache: rust
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         env:


### PR DESCRIPTION
## Summary

- run Tak measurement jobs on the isolated `bamboo-perf` runner
- run the separate `bench-refresh` benchmark job on Bamboo while leaving its drift check hosted
- identify the 30-vCPU/24-GiB Bamboo image and stable Rust toolchain as a distinct Tak runner class
- leave Tak publish jobs on hosted runners

## Validation

- `actionlint` (with `bamboo-perf` registered as the expected custom label)
- `git diff --check`
- trusted `main` baseline queued on the disposable runner

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where instruction-count baselines are recorded and how PR perf gates run, which can break comparability or skip checks for most contributors until the `jdx`-only condition is removed.
> 
> **Overview**
> **Moves Tak instruction-count and benchmark refresh work onto the `bamboo-perf` self-hosted label**, replacing Namespace `endev-linux-amd64` (and its shared rust cache-tag override) on `perf.yml`, `perf-pr.yml`, `perf-backfill`’s measure job, and `bench-refresh`’s refresh job. **`actionlint` is updated** so `bamboo-perf` is a recognized runner label.
> 
> **Rust caching on those jobs switches** from `namespacelabs/nscloud-cache-action` to **`Swatinem/rust-cache`**. **`TAK_RUNNER`** is set to `bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1` on the main perf workflows so Tak can treat measurements as one comparable runner class across the series and PR compares.
> 
> **`perf-pr` is narrowed temporarily**: the compare job only runs for pull requests opened by `jdx`, in addition to the existing `release-plz-` exemption. Hosted Namespace runners remain for drift check (`bench-refresh`) and notes publish (`perf-backfill`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a118ed467e3c290a15bf1a35f5c6389ccae3157c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized performance testing workflows across pull requests, scheduled runs, benchmark refreshes, and backfills.
  * Improved Rust build caching for more consistent and efficient performance checks.
  * Updated performance execution environments to improve reliability and consistency.
  * No product functionality or user-facing behavior has changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->