### PR TITLE
ci: build perf binaries on bamboo

### DIFF
--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -73,6 +73,7 @@ jobs:
     needs: check
     if: needs.check.outputs.drift == 'true'
     runs-on: bamboo-perf
+    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -83,7 +83,8 @@ jobs:
           token: ${{ secrets.AUBE_GH_TOKEN }}
           submodules: recursive
           persist-credentials: false
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      # Compile inside this disposable VM. Restoring target/ can relabel a
+      # binary built on a different runner class as a Bamboo measurement.
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         env:
           MISE_LOCKED: "1"

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -61,8 +61,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-
+      # Compile inside this disposable VM. Restoring target/ can relabel a
+      # binary built on a different runner class as a Bamboo measurement.
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           cache_save: false

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -44,8 +44,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-
+      # Compile inside this disposable VM. Restoring target/ can relabel a
+      # binary built on a different runner class as a Bamboo measurement.
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         env:
           MISE_LOCKED: "1"


### PR DESCRIPTION
## Summary

- compile benchmark binaries from scratch inside each disposable Bamboo VM
- prevent a cached `target/` built on Namespace from being measured and labeled as Bamboo
- document the runner-class integrity requirement beside the build setup

## Validation

- `actionlint` on the affected performance workflows
- `git diff --check`

Generated with AI assistance and manually validated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change; trades faster CI for correct runner-class labeling of benchmark binaries, with longer Bamboo compile times as the main operational impact.
> 
> **Overview**
> **Bamboo perf workflows now compile Rust from scratch** instead of restoring `Swatinem/rust-cache` `target/` artifacts. Comments next to `mise-action` explain that a cache built on another runner class could be measured and recorded as Bamboo, which would corrupt instruction-count baselines and PR comparisons.
> 
> The change applies to **`perf.yml`**, **`perf-pr.yml`**, and the **`bench-refresh` refresh job**. **`bench-refresh`** also gets a **60-minute job timeout** on the refresh step. Hermetic bench registry caching and `perf-pr`’s `cache_save: false` on mise are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fb096a2a65922b23ca02f6fa45c078b644f377f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated performance and benchmark automation to compile within disposable build environments.
  * Prevented reuse of compiled artifacts across different runner types, improving build consistency.
  * Added a 60-minute timeout for benchmark refresh jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->