### PR TITLE
fix(deploy): preserve workspace dependency patches

### DIFF
--- a/crates/aube/src/commands/deploy/mod.rs
+++ b/crates/aube/src/commands/deploy/mod.rs
@@ -407,8 +407,16 @@ fn patches_for_importer<'a>(
     let Some(subset) = graph.subset_to_importer(&importer_path, keep_dep) else {
         return Ok(all());
     };
-    let relevant: std::collections::HashSet<String> =
-        subset.packages.values().map(|pkg| pkg.spec_key()).collect();
+    let relevant: std::collections::HashSet<String> = subset
+        .packages
+        .values()
+        .flat_map(|pkg| {
+            [
+                pkg.spec_key(),
+                format!("{}@{}", pkg.registry_name(), pkg.version),
+            ]
+        })
+        .collect();
     Ok(patches
         .values()
         .filter(|patch| relevant.contains(&patch.key))

--- a/crates/aube/src/commands/deploy/mod.rs
+++ b/crates/aube/src/commands/deploy/mod.rs
@@ -407,7 +407,15 @@ fn patches_for_importer<'a>(
     let Some(subset) = graph.subset_to_importer(&importer_path, keep_dep) else {
         return Ok(all());
     };
-    let relevant: std::collections::HashSet<String> = subset
+    let relevant = package_patch_keys(&subset);
+    Ok(patches
+        .values()
+        .filter(|patch| relevant.contains(&patch.key))
+        .collect())
+}
+
+fn package_patch_keys(graph: &aube_lockfile::LockfileGraph) -> std::collections::HashSet<String> {
+    graph
         .packages
         .values()
         .flat_map(|pkg| {
@@ -416,11 +424,7 @@ fn patches_for_importer<'a>(
                 format!("{}@{}", pkg.registry_name(), pkg.version),
             ]
         })
-        .collect();
-    Ok(patches
-        .values()
-        .filter(|patch| relevant.contains(&patch.key))
-        .collect())
+        .collect()
 }
 
 /// Attempt to seed `target` with a subset of the source workspace's
@@ -519,6 +523,10 @@ fn seed_target_lockfile(
     subset.overrides.clear();
     subset.ignored_optional_dependencies.clear();
     subset.catalogs.clear();
+    let relevant_patch_keys = package_patch_keys(&subset);
+    subset
+        .patched_dependencies
+        .retain(|key, _| relevant_patch_keys.contains(key));
 
     // Prune `times` to match the subset's `packages`. `times` isn't
     // part of drift detection, so keeping the source workspace's

--- a/crates/aube/src/commands/deploy/mod.rs
+++ b/crates/aube/src/commands/deploy/mod.rs
@@ -137,10 +137,10 @@ pub async fn run(
     let source_root = crate::dirs::cwd().wrap_err("failed to read current directory")?;
     // A deploy install runs from the standalone target, so workspace-root
     // patch declarations and files would otherwise disappear when staging
-    // copies only the selected package. Resolve them before creating any
-    // targets, both to fail atomically on a missing patch and to reuse the
-    // loaded content across multi-package fanout.
-    let patches = crate::patches::load_declared_patches(&source_root)?;
+    // copies only the selected package. Read declaration metadata now, but
+    // defer path validation and content loading until after importer filtering:
+    // an unrelated broken patch must not block this deployment.
+    let patch_paths = crate::patches::load_declared_patch_paths(&source_root)?;
 
     // Resolve `deployAllFiles` from the source workspace root, before
     // we chdir into any per-match target. `.npmrc` and
@@ -255,18 +255,29 @@ pub async fn run(
         v
     };
 
+    // Filter and resolve every target's patches before creating any target.
+    // This preserves atomic failure for missing relevant patches across a
+    // multi-package fanout without validating unrelated workspace entries.
+    let resolved_patches: Vec<BTreeMap<String, crate::patches::ResolvedPatch>> = plan
+        .iter()
+        .map(|(_, source_pkg_dir, _)| {
+            let selected = patch_paths_for_importer(
+                &source_root,
+                source_pkg_dir,
+                &patch_paths,
+                keep_dep_for_args(&args),
+            )?;
+            crate::patches::resolve_declared_patches(&source_root, selected)
+        })
+        .collect::<miette::Result<_>>()?;
+
     // Stage every target (copy + manifest rewrite) up front. Running
     // staging for all matches before any install means a multi-package
     // fanout can't half-install one package and then fail on a copy
     // error in the next.
     let mut staged: Vec<StagedDeploy> = Vec::with_capacity(plan.len());
-    for (_name, source_pkg_dir, target) in &plan {
-        let target_patches = patches_for_importer(
-            &source_root,
-            source_pkg_dir,
-            &patches,
-            keep_dep_for_args(&args),
-        )?;
+    for ((_name, source_pkg_dir, target), patches) in plan.iter().zip(&resolved_patches) {
+        let target_patches: Vec<&crate::patches::ResolvedPatch> = patches.values().collect();
         staged.push(stage_one(
             source_pkg_dir,
             target,
@@ -389,13 +400,13 @@ pub(super) fn canonicalize(p: &Path) -> PathBuf {
 /// A missing, stale, or foreign lockfile still needs the conservative fallback:
 /// fresh resolution may discover a patched transitive dependency that cannot be
 /// inferred from manifests alone.
-fn patches_for_importer<'a>(
+fn patch_paths_for_importer(
     source_root: &Path,
     source_pkg_dir: &Path,
-    patches: &'a BTreeMap<String, crate::patches::ResolvedPatch>,
+    patches: &BTreeMap<String, String>,
     keep_dep: impl Fn(&aube_lockfile::DirectDep) -> bool,
-) -> miette::Result<Vec<&'a crate::patches::ResolvedPatch>> {
-    let all = || patches.values().collect();
+) -> miette::Result<BTreeMap<String, String>> {
+    let all = || patches.clone();
     let Ok(source_manifest) = PackageJson::from_path(&source_root.join("package.json")) else {
         return Ok(all());
     };
@@ -409,8 +420,9 @@ fn patches_for_importer<'a>(
     };
     let relevant = package_patch_keys(&subset);
     Ok(patches
-        .values()
-        .filter(|patch| relevant.contains(&patch.key))
+        .iter()
+        .filter(|(key, _)| relevant.contains(*key))
+        .map(|(key, path)| (key.clone(), path.clone()))
         .collect())
 }
 

--- a/crates/aube/src/commands/deploy/mod.rs
+++ b/crates/aube/src/commands/deploy/mod.rs
@@ -135,6 +135,12 @@ pub async fn run(
         ));
     }
     let source_root = crate::dirs::cwd().wrap_err("failed to read current directory")?;
+    // A deploy install runs from the standalone target, so workspace-root
+    // patch declarations and files would otherwise disappear when staging
+    // copies only the selected package. Resolve them before creating any
+    // targets, both to fail atomically on a missing patch and to reuse the
+    // loaded content across multi-package fanout.
+    let patches = crate::patches::load_declared_patches(&source_root)?;
 
     // Resolve `deployAllFiles` from the source workspace root, before
     // we chdir into any per-match target. `.npmrc` and
@@ -260,6 +266,7 @@ pub async fn run(
             target,
             &ws_index,
             &catalogs,
+            &patches,
             &args,
             deploy_all_files,
         )?);

--- a/crates/aube/src/commands/deploy/mod.rs
+++ b/crates/aube/src/commands/deploy/mod.rs
@@ -261,12 +261,18 @@ pub async fn run(
     // error in the next.
     let mut staged: Vec<StagedDeploy> = Vec::with_capacity(plan.len());
     for (_name, source_pkg_dir, target) in &plan {
+        let target_patches = patches_for_importer(
+            &source_root,
+            source_pkg_dir,
+            &patches,
+            keep_dep_for_args(&args),
+        )?;
         staged.push(stage_one(
             source_pkg_dir,
             target,
             &ws_index,
             &catalogs,
-            &patches,
+            &target_patches,
             &args,
             deploy_all_files,
         )?);
@@ -374,6 +380,39 @@ pub async fn run(
 /// reach the same target via different relative specs.
 pub(super) fn canonicalize(p: &Path) -> PathBuf {
     std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf())
+}
+
+/// Select patches whose package occurs in the deployed importer's retained
+/// lockfile closure. This prevents a patch for an unrelated workspace package
+/// from colliding with a publishable file in the selected package.
+///
+/// A missing, stale, or foreign lockfile still needs the conservative fallback:
+/// fresh resolution may discover a patched transitive dependency that cannot be
+/// inferred from manifests alone.
+fn patches_for_importer<'a>(
+    source_root: &Path,
+    source_pkg_dir: &Path,
+    patches: &'a BTreeMap<String, crate::patches::ResolvedPatch>,
+    keep_dep: impl Fn(&aube_lockfile::DirectDep) -> bool,
+) -> miette::Result<Vec<&'a crate::patches::ResolvedPatch>> {
+    let all = || patches.values().collect();
+    let Ok(source_manifest) = PackageJson::from_path(&source_root.join("package.json")) else {
+        return Ok(all());
+    };
+    let Ok((graph, _)) = aube_lockfile::parse_lockfile_with_kind(source_root, &source_manifest)
+    else {
+        return Ok(all());
+    };
+    let importer_path = super::workspace_importer_path(source_root, source_pkg_dir)?;
+    let Some(subset) = graph.subset_to_importer(&importer_path, keep_dep) else {
+        return Ok(all());
+    };
+    let relevant: std::collections::HashSet<String> =
+        subset.packages.values().map(|pkg| pkg.spec_key()).collect();
+    Ok(patches
+        .values()
+        .filter(|patch| relevant.contains(&patch.key))
+        .collect())
 }
 
 /// Attempt to seed `target` with a subset of the source workspace's

--- a/crates/aube/src/commands/deploy/staging.rs
+++ b/crates/aube/src/commands/deploy/staging.rs
@@ -9,6 +9,7 @@ use super::injection::{materialize_injections, plan_injections};
 use super::rewrite::{DeployRoot, rewrite_local_refs};
 use crate::commands::CatalogMap;
 use crate::commands::pack::collect_package_files;
+use crate::patches::ResolvedPatch;
 use miette::{Context, IntoDiagnostic, miette};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -39,6 +40,7 @@ pub(super) fn stage_one(
     target: &Path,
     ws_index: &BTreeMap<String, (PathBuf, Option<String>)>,
     catalogs: &CatalogMap,
+    patches: &BTreeMap<String, ResolvedPatch>,
     args: &DeployArgs,
     deploy_all_files: bool,
 ) -> miette::Result<StagedDeploy> {
@@ -127,6 +129,7 @@ pub(super) fn stage_one(
             root,
         )?;
     }
+    stage_patches(patches, target)?;
 
     Ok(StagedDeploy {
         name,
@@ -134,6 +137,44 @@ pub(super) fn stage_one(
         target: target.to_path_buf(),
         bundled_local_refs: !plan.is_empty(),
     })
+}
+
+/// Carry workspace-root patches into the standalone deploy target.
+///
+/// Preserve each declared relative path so the copied declaration has the
+/// same shape as the source workspace. A selected package may publish a file
+/// at that path already; identical content is harmless, while differing
+/// content is an ambiguous deploy artifact and must fail instead of silently
+/// overwriting a package file.
+fn stage_patches(patches: &BTreeMap<String, ResolvedPatch>, target: &Path) -> miette::Result<()> {
+    for (key, patch) in patches {
+        let rel = Path::new(&patch.rel_path);
+        let dst = target.join(rel);
+        if dst.exists() {
+            let existing = std::fs::read_to_string(&dst)
+                .into_diagnostic()
+                .wrap_err_with(|| format!("deploy: failed to read {}", dst.display()))?;
+            if existing != patch.content {
+                return Err(miette!(
+                    code = aube_codes::errors::ERR_AUBE_PATCH_FAILED,
+                    "deploy: patch for {key} conflicts with staged file {}",
+                    dst.display()
+                ));
+            }
+        } else {
+            if let Some(parent) = dst.parent() {
+                std::fs::create_dir_all(parent)
+                    .into_diagnostic()
+                    .wrap_err_with(|| format!("failed to create {}", parent.display()))?;
+            }
+            std::fs::write(&dst, &patch.content)
+                .into_diagnostic()
+                .wrap_err_with(|| format!("deploy: failed to write {}", dst.display()))?;
+        }
+        let rel = patch.rel_path.replace('\\', "/");
+        crate::patches::upsert_patched_dependency(target, key, &rel)?;
+    }
+    Ok(())
 }
 
 /// Walk `source` recursively and collect every file path. Skips only

--- a/crates/aube/src/commands/deploy/staging.rs
+++ b/crates/aube/src/commands/deploy/staging.rs
@@ -40,7 +40,7 @@ pub(super) fn stage_one(
     target: &Path,
     ws_index: &BTreeMap<String, (PathBuf, Option<String>)>,
     catalogs: &CatalogMap,
-    patches: &BTreeMap<String, ResolvedPatch>,
+    patches: &[&ResolvedPatch],
     args: &DeployArgs,
     deploy_all_files: bool,
 ) -> miette::Result<StagedDeploy> {
@@ -141,15 +141,15 @@ pub(super) fn stage_one(
 
 /// Carry workspace-root patches into the standalone deploy target.
 ///
-/// Preserve each declared relative path so the copied declaration has the
-/// same shape as the source workspace. A selected package may publish a file
-/// at that path already; identical content is harmless, while differing
-/// content is an ambiguous deploy artifact and must fail instead of silently
-/// overwriting a package file.
-fn stage_patches(patches: &BTreeMap<String, ResolvedPatch>, target: &Path) -> miette::Result<()> {
-    for (key, patch) in patches {
-        let rel = Path::new(&patch.rel_path);
-        let dst = target.join(rel);
+/// Patch files use a content-addressed path in aube's reserved deploy metadata
+/// directory. This avoids colliding with a selected package that publishes a
+/// file at the source workspace's declared patch path.
+fn stage_patches(patches: &[&ResolvedPatch], target: &Path) -> miette::Result<()> {
+    for patch in patches {
+        let key = &patch.key;
+        let rel = PathBuf::from(format!(".{}-deploy-patches", aube_util::embedder().name))
+            .join(format!("{}.patch", patch.content_hash()));
+        let dst = target.join(&rel);
         if dst.exists() {
             let existing = std::fs::read_to_string(&dst)
                 .into_diagnostic()
@@ -171,7 +171,7 @@ fn stage_patches(patches: &BTreeMap<String, ResolvedPatch>, target: &Path) -> mi
                 .into_diagnostic()
                 .wrap_err_with(|| format!("deploy: failed to write {}", dst.display()))?;
         }
-        let rel = patch.rel_path.replace('\\', "/");
+        let rel = rel.to_string_lossy().replace('\\', "/");
         crate::patches::upsert_patched_dependency(target, key, &rel)?;
     }
     Ok(())

--- a/crates/aube/src/commands/deploy/staging.rs
+++ b/crates/aube/src/commands/deploy/staging.rs
@@ -71,13 +71,18 @@ pub(super) fn stage_one(
     } else {
         collect_package_files(source_pkg_dir, &manifest)?
     };
-    let deploy_patch_dir = PathBuf::from(format!(".{}-deploy-patches", aube_util::embedder().name));
+    let deploy_patch_paths: std::collections::HashSet<PathBuf> = patches
+        .iter()
+        .map(|patch| {
+            PathBuf::from(format!(".{}-deploy-patches", aube_util::embedder().name))
+                .join(format!("{}.patch", patch.content_hash()))
+        })
+        .collect();
 
     for (src, rel) in &files {
-        // Patch metadata owns this directory whenever the deployed closure
-        // contains patches. A package file at the generated content-addressed
-        // path must not prevent an otherwise valid standalone deployment.
-        if !patches.is_empty() && Path::new(rel).starts_with(&deploy_patch_dir) {
+        // Patch metadata owns its exact generated paths. Other package assets
+        // in the same directory remain part of the deploy payload.
+        if deploy_patch_paths.contains(Path::new(rel)) {
             continue;
         }
         let dst = target.join(rel);

--- a/crates/aube/src/commands/deploy/staging.rs
+++ b/crates/aube/src/commands/deploy/staging.rs
@@ -71,8 +71,15 @@ pub(super) fn stage_one(
     } else {
         collect_package_files(source_pkg_dir, &manifest)?
     };
+    let deploy_patch_dir = PathBuf::from(format!(".{}-deploy-patches", aube_util::embedder().name));
 
     for (src, rel) in &files {
+        // Patch metadata owns this directory whenever the deployed closure
+        // contains patches. A package file at the generated content-addressed
+        // path must not prevent an otherwise valid standalone deployment.
+        if !patches.is_empty() && Path::new(rel).starts_with(&deploy_patch_dir) {
+            continue;
+        }
         let dst = target.join(rel);
         if let Some(parent) = dst.parent() {
             std::fs::create_dir_all(parent)

--- a/crates/aube/src/patches.rs
+++ b/crates/aube/src/patches.rs
@@ -148,25 +148,11 @@ pub fn load_patches_for_linker(
     Ok((patches, hashes))
 }
 
-/// Resolve patch declarations from the project manifest and workspace config.
-/// Deploy uses the validated content to make each patch self-contained in its
-/// staged target.
-pub(crate) fn load_declared_patches(cwd: &Path) -> Result<BTreeMap<String, ResolvedPatch>> {
-    load_patches_with_lockfile_entries(cwd, &BTreeMap::new())
-}
-
-#[cfg(test)]
-fn load_patches(cwd: &Path) -> Result<BTreeMap<String, ResolvedPatch>> {
-    load_declared_patches(cwd)
-}
-
-fn load_patches_with_lockfile_entries(
-    cwd: &Path,
-    lockfile_patched_dependencies: &BTreeMap<String, String>,
-) -> Result<BTreeMap<String, ResolvedPatch>> {
-    let mut entries: BTreeMap<String, String> = BTreeMap::new();
-    entries.extend(lockfile_patched_dependencies.clone());
-
+/// Read patch declarations from the project manifest and workspace config
+/// without touching their files. Deploy filters this map to each selected
+/// importer's closure before validating paths and loading content.
+pub(crate) fn load_declared_patch_paths(cwd: &Path) -> Result<BTreeMap<String, String>> {
+    let mut entries = BTreeMap::new();
     let manifest_path = cwd.join("package.json");
     if manifest_path.exists() {
         let manifest = aube_manifest::PackageJson::from_path(&manifest_path)
@@ -180,7 +166,35 @@ fn load_patches_with_lockfile_entries(
         .map_err(miette::Report::new)
         .wrap_err("failed to read pnpm-workspace.yaml")?;
     entries.extend(ws_config.patched_dependencies);
+    Ok(entries)
+}
 
+pub(crate) fn resolve_declared_patches(
+    cwd: &Path,
+    entries: BTreeMap<String, String>,
+) -> Result<BTreeMap<String, ResolvedPatch>> {
+    resolve_patch_entries(cwd, entries)
+}
+
+#[cfg(test)]
+fn load_patches(cwd: &Path) -> Result<BTreeMap<String, ResolvedPatch>> {
+    load_patches_with_lockfile_entries(cwd, &BTreeMap::new())
+}
+
+fn load_patches_with_lockfile_entries(
+    cwd: &Path,
+    lockfile_patched_dependencies: &BTreeMap<String, String>,
+) -> Result<BTreeMap<String, ResolvedPatch>> {
+    let mut entries = BTreeMap::new();
+    entries.extend(lockfile_patched_dependencies.clone());
+    entries.extend(load_declared_patch_paths(cwd)?);
+    resolve_patch_entries(cwd, entries)
+}
+
+fn resolve_patch_entries(
+    cwd: &Path,
+    entries: BTreeMap<String, String>,
+) -> Result<BTreeMap<String, ResolvedPatch>> {
     let mut out = BTreeMap::new();
     for (key, rel) in entries {
         let (name, version) = split_patch_key(&key)?;

--- a/crates/aube/src/patches.rs
+++ b/crates/aube/src/patches.rs
@@ -25,8 +25,6 @@ pub struct ResolvedPatch {
     pub version: String,
     #[allow(dead_code)]
     pub path: PathBuf,
-    /// Safe project-relative path from the declaring workspace root.
-    pub rel_path: String,
     pub content: String,
 }
 
@@ -151,8 +149,8 @@ pub fn load_patches_for_linker(
 }
 
 /// Resolve patch declarations from the project manifest and workspace config.
-/// Deploy uses the original relative path to make each patch self-contained in
-/// its staged target.
+/// Deploy uses the validated content to make each patch self-contained in its
+/// staged target.
 pub(crate) fn load_declared_patches(cwd: &Path) -> Result<BTreeMap<String, ResolvedPatch>> {
     load_patches_with_lockfile_entries(cwd, &BTreeMap::new())
 }
@@ -213,7 +211,6 @@ fn load_patches_with_lockfile_entries(
                 name,
                 version,
                 path,
-                rel_path: rel,
                 content,
             },
         );

--- a/crates/aube/src/patches.rs
+++ b/crates/aube/src/patches.rs
@@ -25,6 +25,8 @@ pub struct ResolvedPatch {
     pub version: String,
     #[allow(dead_code)]
     pub path: PathBuf,
+    /// Safe project-relative path from the declaring workspace root.
+    pub rel_path: String,
     pub content: String,
 }
 
@@ -148,9 +150,16 @@ pub fn load_patches_for_linker(
     Ok((patches, hashes))
 }
 
+/// Resolve patch declarations from the project manifest and workspace config.
+/// Deploy uses the original relative path to make each patch self-contained in
+/// its staged target.
+pub(crate) fn load_declared_patches(cwd: &Path) -> Result<BTreeMap<String, ResolvedPatch>> {
+    load_patches_with_lockfile_entries(cwd, &BTreeMap::new())
+}
+
 #[cfg(test)]
 fn load_patches(cwd: &Path) -> Result<BTreeMap<String, ResolvedPatch>> {
-    load_patches_with_lockfile_entries(cwd, &BTreeMap::new())
+    load_declared_patches(cwd)
 }
 
 fn load_patches_with_lockfile_entries(
@@ -204,6 +213,7 @@ fn load_patches_with_lockfile_entries(
                 name,
                 version,
                 path,
+                rel_path: rel,
                 content,
             },
         );

--- a/test/deploy.bats
+++ b/test/deploy.bats
@@ -31,6 +31,29 @@ _setup_workspace_fixture() {
 	[ ! -f out/pnpm-workspace.yaml ]
 }
 
+@test "aube deploy: preserves workspace-root dependency patches" {
+	_setup_workspace_fixture
+	mkdir -p patches
+	printf '\npatchedDependencies:\n  is-odd@3.0.1: patches/is-odd@3.0.1.patch\n' >>pnpm-workspace.yaml
+	cat >patches/is-odd@3.0.1.patch <<'EOF'
+diff --git a/index.js b/index.js
+--- a/index.js
++++ b/index.js
+@@ -8,1 +8,2 @@
+ 'use strict';
++// deployed-patch-marker
+EOF
+
+	run aube deploy --filter @test/lib ./out
+	assert_success
+	assert_file_exists out/patches/is-odd@3.0.1.patch
+
+	run grep -q "deployed-patch-marker" out/node_modules/is-odd/index.js
+	assert_success
+	run grep -Fq '"is-odd@3.0.1": "patches/is-odd@3.0.1.patch"' out/package.json
+	assert_success
+}
+
 @test "aube deploy: subsets the source lockfile into the target" {
 	_setup_workspace_fixture
 

--- a/test/deploy.bats
+++ b/test/deploy.bats
@@ -106,6 +106,7 @@ EOF
 	metadata_rel="${metadata_file#seed/}"
 	mkdir -p packages/lib/.aube-deploy-patches
 	printf 'selected package conflict\n' >"packages/lib/$metadata_rel"
+	printf 'selected package asset\n' >packages/lib/.aube-deploy-patches/asset.txt
 
 	run aube deploy --filter @test/lib ./out
 	assert_success
@@ -113,6 +114,8 @@ EOF
 	assert_success
 	run grep -q "selected package conflict" "out/$metadata_rel"
 	assert_failure
+	run grep -q "selected package asset" out/.aube-deploy-patches/asset.txt
+	assert_success
 }
 
 @test "aube deploy: excludes patches outside the selected package closure" {
@@ -141,6 +144,8 @@ EOF
 	run grep -q "selected package file" out/patches/is-even@1.0.0.patch
 	assert_success
 	run grep -q 'is-even@1.0.0' out/package.json
+	assert_failure
+	run grep -q 'is-even@1.0.0' out/aube-lock.yaml
 	assert_failure
 }
 

--- a/test/deploy.bats
+++ b/test/deploy.bats
@@ -58,6 +58,33 @@ EOF
 	assert_success
 }
 
+@test "aube deploy: preserves registry-name patches for npm aliases" {
+	_setup_workspace_fixture
+	sed -i 's/"is-odd": "\^3\.0\.1"/"odd-alias": "npm:is-odd@3.0.1"/' packages/lib/package.json
+	mkdir -p patches
+	printf '\npatchedDependencies:\n  is-odd@3.0.1: patches/is-odd@3.0.1.patch\n' >>pnpm-workspace.yaml
+	cat >patches/is-odd@3.0.1.patch <<'EOF'
+diff --git a/index.js b/index.js
+--- a/index.js
++++ b/index.js
+@@ -8,1 +8,2 @@
+ 'use strict';
++// deployed-alias-patch-marker
+EOF
+
+	# Exercise importer filtering against an existing lockfile, where the
+	# package key uses the alias but patchedDependencies uses the real name.
+	run aube install
+	assert_success
+	run aube deploy --filter @test/lib ./out
+	assert_success
+
+	run grep -q "deployed-alias-patch-marker" out/node_modules/odd-alias/index.js
+	assert_success
+	run grep -Fq '"is-odd@3.0.1": ".aube-deploy-patches/' out/package.json
+	assert_success
+}
+
 @test "aube deploy: excludes patches outside the selected package closure" {
 	_setup_workspace_fixture
 	mkdir -p patches packages/lib/patches

--- a/test/deploy.bats
+++ b/test/deploy.bats
@@ -136,6 +136,7 @@ EOF
 	# not from the selected @test/lib importer.
 	run aube install
 	assert_success
+	rm patches/is-even@1.0.0.patch
 	run aube deploy --filter @test/lib ./out
 	assert_success
 

--- a/test/deploy.bats
+++ b/test/deploy.bats
@@ -33,7 +33,7 @@ _setup_workspace_fixture() {
 
 @test "aube deploy: preserves workspace-root dependency patches" {
 	_setup_workspace_fixture
-	mkdir -p patches
+	mkdir -p patches packages/lib/patches
 	printf '\npatchedDependencies:\n  is-odd@3.0.1: patches/is-odd@3.0.1.patch\n' >>pnpm-workspace.yaml
 	cat >patches/is-odd@3.0.1.patch <<'EOF'
 diff --git a/index.js b/index.js
@@ -43,15 +43,48 @@ diff --git a/index.js b/index.js
  'use strict';
 +// deployed-patch-marker
 EOF
+	printf 'selected package file\n' >packages/lib/patches/is-odd@3.0.1.patch
 
 	run aube deploy --filter @test/lib ./out
 	assert_success
-	assert_file_exists out/patches/is-odd@3.0.1.patch
+	run find out/.aube-deploy-patches -type f -name '*.patch'
+	assert_success
 
 	run grep -q "deployed-patch-marker" out/node_modules/is-odd/index.js
 	assert_success
-	run grep -Fq '"is-odd@3.0.1": "patches/is-odd@3.0.1.patch"' out/package.json
+	run grep -q "selected package file" out/patches/is-odd@3.0.1.patch
 	assert_success
+	run grep -Fq '"is-odd@3.0.1": ".aube-deploy-patches/' out/package.json
+	assert_success
+}
+
+@test "aube deploy: excludes patches outside the selected package closure" {
+	_setup_workspace_fixture
+	mkdir -p patches packages/lib/patches
+	printf '\npatchedDependencies:\n  is-even@1.0.0: patches/is-even@1.0.0.patch\n' >>pnpm-workspace.yaml
+	cat >patches/is-even@1.0.0.patch <<'EOF'
+diff --git a/index.js b/index.js
+--- a/index.js
++++ b/index.js
+@@ -2,1 +2,2 @@
+ 'use strict';
++// unrelated-workspace-patch
+EOF
+	printf 'selected package file\n' >packages/lib/patches/is-even@1.0.0.patch
+
+	# Populate a lockfile where is-even is reachable only from @test/app,
+	# not from the selected @test/lib importer.
+	run aube install
+	assert_success
+	run aube deploy --filter @test/lib ./out
+	assert_success
+
+	# The unrelated workspace patch neither collides with nor replaces the
+	# selected package's publishable file at the same relative path.
+	run grep -q "selected package file" out/patches/is-even@1.0.0.patch
+	assert_success
+	run grep -q 'is-even@1.0.0' out/package.json
+	assert_failure
 }
 
 @test "aube deploy: subsets the source lockfile into the target" {

--- a/test/deploy.bats
+++ b/test/deploy.bats
@@ -85,6 +85,36 @@ EOF
 	assert_success
 }
 
+@test "aube deploy: reserves generated patch metadata paths" {
+	_setup_workspace_fixture
+	mkdir -p patches
+	printf '\npatchedDependencies:\n  is-odd@3.0.1: patches/is-odd@3.0.1.patch\n' >>pnpm-workspace.yaml
+	cat >patches/is-odd@3.0.1.patch <<'EOF'
+diff --git a/index.js b/index.js
+--- a/index.js
++++ b/index.js
+@@ -8,1 +8,2 @@
+ 'use strict';
++// deployed-metadata-collision-marker
+EOF
+
+	# Discover the generated content-addressed name, then make the selected
+	# package publish conflicting bytes at that exact reserved path.
+	run aube deploy --filter @test/lib ./seed
+	assert_success
+	metadata_file="$(find seed/.aube-deploy-patches -type f -name '*.patch' | head -n 1)"
+	metadata_rel="${metadata_file#seed/}"
+	mkdir -p packages/lib/.aube-deploy-patches
+	printf 'selected package conflict\n' >"packages/lib/$metadata_rel"
+
+	run aube deploy --filter @test/lib ./out
+	assert_success
+	run grep -q "deployed-metadata-collision-marker" out/node_modules/is-odd/index.js
+	assert_success
+	run grep -q "selected package conflict" "out/$metadata_rel"
+	assert_failure
+}
+
 @test "aube deploy: excludes patches outside the selected package closure" {
 	_setup_workspace_fixture
 	mkdir -p patches packages/lib/patches

--- a/test/deploy.bats
+++ b/test/deploy.bats
@@ -60,7 +60,7 @@ EOF
 
 @test "aube deploy: preserves registry-name patches for npm aliases" {
 	_setup_workspace_fixture
-	sed -i 's/"is-odd": "\^3\.0\.1"/"odd-alias": "npm:is-odd@3.0.1"/' packages/lib/package.json
+	perl -0pi -e 's/"is-odd": "\^3\.0\.1"/"odd-alias": "npm:is-odd\@3.0.1"/' packages/lib/package.json
 	mkdir -p patches
 	printf '\npatchedDependencies:\n  is-odd@3.0.1: patches/is-odd@3.0.1.patch\n' >>pnpm-workspace.yaml
 	cat >patches/is-odd@3.0.1.patch <<'EOF'


### PR DESCRIPTION
## Summary

- resolve workspace-root dependency patch declarations before deploy staging
- filter patches to each selected importer's retained lockfile closure
- copy patch files into a content-addressed deploy metadata directory
- write equivalent patch metadata into the deployed manifest so the target install applies and retains the patches
- avoid collisions with publishable package files at the source patch paths

## Root cause

`aube deploy` copied only the selected package's publishable files, then ran install from the standalone target. Workspace-root `patchedDependencies` metadata and patch files were therefore unavailable to that install, so dependencies were silently materialized without their patches.

Fixes the behavior reported in [Discussion #1212](https://github.com/jdx/aube/discussions/1212).

## Validation

- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p aube patches --lib`
- focused `test/deploy.bats` regression tests for patch application, publish-path collisions, and per-importer filtering
- verified the original `hilja/aube-update-repro` now deploys `is-even@1.0.0` with its `// PATCHED` marker

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deploy staging, lockfile subsetting, and install-time patch application; mistakes could mis-apply patches or skip them silently, but behavior is scoped to deploy with regression tests.
> 
> **Overview**
> **`aube deploy`** no longer drops workspace-root **`patchedDependencies`** when only the selected package is staged. Declarations are read early, but patch files are validated and loaded only for patches relevant to each deploy target.
> 
> For each match, patches are **filtered to the deployed importer’s lockfile closure** (with a conservative “include all” fallback when the lockfile is missing or unusable). Only those entries are resolved and staged. **Unrelated** workspace patches are ignored so they cannot block deploy or collide with publishable files at the same relative path in the selected package.
> 
> Patch bodies are written under **`.{embedder}-deploy-patches/<content-hash>.patch`**, **`patchedDependencies`** in the target manifest point at those paths, and the file copy step **skips** those reserved paths so generated metadata wins over package assets. Subset lockfiles written into the target **retain only** patched-dependency keys that appear in the pruned graph (including npm-alias registry names).
> 
> The **`patches`** module splits **declaration loading** (`load_declared_patch_paths`) from **resolution** (`resolve_declared_patches` / `resolve_patch_entries`). New **`deploy.bats`** cases cover patch application, alias keys, metadata collisions, and closure filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e71532be1973bc6e3562b3020602c7347b3942e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployments now preserve and apply declared dependency patches for each selected package.
  * Workspace and npm alias patches are resolved during deployment.
  * Patch metadata is stored separately and registered in the target manifest.
* **Bug Fixes**
  * Prevented unrelated patches from being included in deployments.
  * Added safeguards against patch metadata conflicts and accidental overwrites.
  * Pruned lockfiles now retain only relevant patched dependencies.
  * Deployments remain reliable when lockfile information is unavailable or invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->