### PR TITLE
fix(lockfile): reject unsupported named registry identities

### DIFF
--- a/crates/aube-codes/src/errors.rs
+++ b/crates/aube-codes/src/errors.rs
@@ -17,6 +17,7 @@ pub const ERR_AUBE_LOCKFILE_PARSE: &str = "ERR_AUBE_LOCKFILE_PARSE";
 pub const ERR_AUBE_LOCKFILE_UNSUPPORTED_FORMAT: &str = "ERR_AUBE_LOCKFILE_UNSUPPORTED_FORMAT";
 pub const ERR_AUBE_RESOLUTION_SHAPE_MISMATCH: &str = "ERR_AUBE_RESOLUTION_SHAPE_MISMATCH";
 pub const ERR_AUBE_LOCKFILE_CONFIG_MISMATCH: &str = "ERR_AUBE_LOCKFILE_CONFIG_MISMATCH";
+pub const ERR_AUBE_UNSUPPORTED_NAMED_REGISTRY: &str = "ERR_AUBE_UNSUPPORTED_NAMED_REGISTRY";
 
 // ── resolver ─────────────────────────────────────────────────────────
 pub const ERR_AUBE_NO_MATCHING_VERSION: &str = "ERR_AUBE_NO_MATCHING_VERSION";
@@ -176,6 +177,12 @@ pub const ALL: &[CodeMeta] = &[
         category: category::LOCKFILE,
         description: "A frozen install found configuration, such as patch-file content, that no longer matches the lockfile.",
         exit_code: Some(14),
+    },
+    CodeMeta {
+        name: ERR_AUBE_UNSUPPORTED_NAMED_REGISTRY,
+        category: category::LOCKFILE,
+        description: "A pnpm lockfile contains registry-qualified package identities that aube cannot safely resolve yet.",
+        exit_code: Some(15),
     },
     // Resolver
     CodeMeta {

--- a/crates/aube-lockfile/src/io.rs
+++ b/crates/aube-lockfile/src/io.rs
@@ -780,7 +780,7 @@ pub enum Error {
     #[diagnostic(
         code(ERR_AUBE_UNSUPPORTED_NAMED_REGISTRY),
         help(
-            "run `pnpm install` with pnpm 11.20 or newer for this project until aube supports named registries"
+            "aube cannot install this lockfile yet; use pnpm 11.20 or newer instead for this project"
         )
     )]
     UnsupportedNamedRegistry {

--- a/crates/aube-lockfile/src/io.rs
+++ b/crates/aube-lockfile/src/io.rs
@@ -779,7 +779,9 @@ pub enum Error {
     )]
     #[diagnostic(
         code(ERR_AUBE_UNSUPPORTED_NAMED_REGISTRY),
-        help("use pnpm 11.20 or newer to install this lockfile")
+        help(
+            "run `pnpm install` with pnpm 11.20 or newer for this project until aube supports named registries"
+        )
     )]
     UnsupportedNamedRegistry {
         path: std::path::PathBuf,

--- a/crates/aube-lockfile/src/io.rs
+++ b/crates/aube-lockfile/src/io.rs
@@ -774,6 +774,18 @@ pub enum Error {
     #[error("unsupported lockfile format: {0}")]
     #[diagnostic(code(ERR_AUBE_LOCKFILE_UNSUPPORTED_FORMAT))]
     UnsupportedFormat(String),
+    #[error(
+        "lockfile {path} contains named-registry package `{dep_path}` from `{registry_name}:`, which aube does not support yet"
+    )]
+    #[diagnostic(
+        code(ERR_AUBE_UNSUPPORTED_NAMED_REGISTRY),
+        help("use pnpm 11.20 or newer to install this lockfile")
+    )]
+    UnsupportedNamedRegistry {
+        path: std::path::PathBuf,
+        dep_path: String,
+        registry_name: String,
+    },
     #[error("failed to read lockfile {0}: {1}")]
     Io(std::path::PathBuf, std::io::Error),
     /// Structural/serialization lockfile errors that have no source

--- a/crates/aube-lockfile/src/pnpm/dep_path.rs
+++ b/crates/aube-lockfile/src/pnpm/dep_path.rs
@@ -176,6 +176,40 @@ pub(super) fn parse_dep_path(dep_path: &str) -> Option<(String, String)> {
     Some((name, version))
 }
 
+/// Return the registry alias from pnpm 11.20's registry-qualified
+/// `<alias>:<semver>` version slot. Reserved protocol prefixes retain
+/// their existing meaning and are not treated as registry aliases.
+pub(super) fn registry_name_from_qualified_version(version: &str) -> Option<&str> {
+    const RESERVED: &[&str] = &[
+        "bitbucket",
+        "catalog",
+        "custom",
+        "file",
+        "git",
+        "github",
+        "gitlab",
+        "http",
+        "https",
+        "jsr",
+        "link",
+        "npm",
+        "runtime",
+        "ssh",
+        "workspace",
+    ];
+
+    let (registry_name, qualified_version) = version.split_once(':')?;
+    let mut chars = registry_name.chars();
+    if !chars.next().is_some_and(|c| c.is_ascii_alphabetic())
+        || !chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '-'))
+        || RESERVED.contains(&registry_name)
+        || node_semver::Version::parse(qualified_version).is_err()
+    {
+        return None;
+    }
+    Some(registry_name)
+}
+
 /// Detect npm-aliased entries inside a snapshot's `dependencies` /
 /// `optionalDependencies` map and rewrite them to aube's internal shape.
 ///

--- a/crates/aube-lockfile/src/pnpm/read.rs
+++ b/crates/aube-lockfile/src/pnpm/read.rs
@@ -1,6 +1,6 @@
 use super::dep_path::{
-    parse_dep_path, peerless_alias_target, rewrite_peer_suffix, rewrite_snapshot_alias_deps,
-    version_to_dep_path,
+    parse_dep_path, peerless_alias_target, registry_name_from_qualified_version,
+    rewrite_peer_suffix, rewrite_snapshot_alias_deps, version_to_dep_path,
 };
 use super::raw::{
     RawBinSpec, RawDepSpec, RawRuntimeVariant, local_source_from_resolution, parse_raw_lockfile,
@@ -41,6 +41,18 @@ pub fn parse_with_options(path: &Path, options: ParseOptions) -> Result<Lockfile
     let content = crate::read_lockfile(path)?;
     let raw = parse_raw_lockfile(&content)
         .map_err(|e| Error::parse_yaml_err(path, content.clone(), &e))?;
+
+    for dep_path in raw.packages.keys().chain(raw.snapshots.keys()) {
+        if let Some((_, version)) = parse_dep_path(dep_path)
+            && let Some(registry_name) = registry_name_from_qualified_version(&version)
+        {
+            return Err(Error::UnsupportedNamedRegistry {
+                path: path.to_path_buf(),
+                dep_path: dep_path.clone(),
+                registry_name: registry_name.to_string(),
+            });
+        }
+    }
 
     // Parse importers (direct deps of each workspace package).
     // We track synthesized LockedPackages for local (`file:` / `link:`)

--- a/crates/aube-lockfile/src/pnpm/read.rs
+++ b/crates/aube-lockfile/src/pnpm/read.rs
@@ -42,18 +42,6 @@ pub fn parse_with_options(path: &Path, options: ParseOptions) -> Result<Lockfile
     let raw = parse_raw_lockfile(&content)
         .map_err(|e| Error::parse_yaml_err(path, content.clone(), &e))?;
 
-    for dep_path in raw.packages.keys().chain(raw.snapshots.keys()) {
-        if let Some((_, version)) = parse_dep_path(dep_path)
-            && let Some(registry_name) = registry_name_from_qualified_version(&version)
-        {
-            return Err(Error::UnsupportedNamedRegistry {
-                path: path.to_path_buf(),
-                dep_path: dep_path.clone(),
-                registry_name: registry_name.to_string(),
-            });
-        }
-    }
-
     // Parse importers (direct deps of each workspace package).
     // We track synthesized LockedPackages for local (`file:` / `link:`)
     // deps here so the main packages loop below doesn't try to process
@@ -498,6 +486,13 @@ pub fn parse_with_options(path: &Path, options: ParseOptions) -> Result<Lockfile
         }
         let (name, version) = parse_dep_path(&dep_path)
             .ok_or_else(|| Error::parse(path, format!("invalid dep path: {dep_path}")))?;
+        if let Some(registry_name) = registry_name_from_qualified_version(&version) {
+            return Err(Error::UnsupportedNamedRegistry {
+                path: path.to_path_buf(),
+                dep_path,
+                registry_name: registry_name.to_string(),
+            });
+        }
         // Runtime pin entries (`node@runtime:24.4.1`) are not packages
         // — they're absorbed into `graph.runtimes` below. Skipping them
         // here keeps them out of the package table so the fetch/link

--- a/crates/aube-lockfile/src/pnpm/tests.rs
+++ b/crates/aube-lockfile/src/pnpm/tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    dep_path::{parse_dep_path, version_to_dep_path},
+    dep_path::{parse_dep_path, registry_name_from_qualified_version, version_to_dep_path},
     parse, parse_with_options, write,
 };
 use crate::{
@@ -62,6 +62,55 @@ fn test_parse_dep_path_prerelease() {
 #[test]
 fn test_parse_dep_path_no_at() {
     assert!(parse_dep_path("invalid").is_none());
+}
+
+#[test]
+fn registry_qualified_version_requires_non_reserved_alias_and_semver() {
+    assert_eq!(
+        registry_name_from_qualified_version("work:1.0.0"),
+        Some("work")
+    );
+    assert_eq!(
+        registry_name_from_qualified_version("gh:2.1.0-beta.1"),
+        Some("gh")
+    );
+    for version in [
+        "file:1.0.0",
+        "runtime:24.0.0",
+        "work:^1.0.0",
+        "9work:1.0.0",
+        "1.0.0",
+    ] {
+        assert_eq!(registry_name_from_qualified_version(version), None);
+    }
+}
+
+#[test]
+fn parser_rejects_registry_qualified_package_keys() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("pnpm-lock.yaml");
+    std::fs::write(
+        &path,
+        r#"lockfileVersion: '9.0'
+importers: {}
+packages:
+  foo@work:1.0.0:
+    resolution: {integrity: sha512-test}
+snapshots:
+  foo@work:1.0.0: {}
+"#,
+    )
+    .unwrap();
+
+    let err = parse(&path).unwrap_err();
+    assert!(matches!(
+        err,
+        crate::Error::UnsupportedNamedRegistry {
+            ref dep_path,
+            ref registry_name,
+            ..
+        } if dep_path == "foo@work:1.0.0" && registry_name == "work"
+    ));
 }
 
 #[test]

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -31,6 +31,12 @@
       "exit_code": 14
     },
     {
+      "name": "ERR_AUBE_UNSUPPORTED_NAMED_REGISTRY",
+      "category": "Lockfile",
+      "description": "A pnpm lockfile contains registry-qualified package identities that aube cannot safely resolve yet.",
+      "exit_code": 15
+    },
+    {
       "name": "ERR_AUBE_NO_MATCHING_VERSION",
       "category": "Resolver",
       "description": "No published version of the named package satisfies the requested range.",


### PR DESCRIPTION
## Summary

- recognize pnpm 11.20 registry-qualified package keys
- fail closed before resolving them through aube's default registry
- add `ERR_AUBE_UNSUPPORTED_NAMED_REGISTRY` with lockfile exit code 15

## Why

pnpm 11.20 records named-registry packages as `<name>@<registry>:<version>` so registry provenance remains part of package identity. Aube does not support `namedRegistries` yet; treating the qualified version as an ordinary version could lose that provenance. This change rejects those lockfiles explicitly until aube can resolve them safely.

## Validation

- `cargo fmt --check`
- `cargo test -p aube-lockfile registry_qualified`
- `cargo test -p aube-codes`
- `cargo clippy -p aube-lockfile -p aube-codes --all-targets -- -D warnings`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow lockfile parse guard with explicit errors; no resolver or install behavior change for supported lockfiles.
> 
> **Overview**
> pnpm 11.20 can encode packages as `name@<registry>:<semver>` so registry provenance stays in the lockfile identity. **This PR fails closed** on those entries instead of treating the version as a normal semver and resolving from the default registry.
> 
> Detection lives in `registry_name_from_qualified_version`, which only treats `alias:semver` as a named registry when the alias is not a reserved protocol (`file:`, `git:`, `runtime:`, etc.) and the suffix parses as semver. The pnpm lockfile reader checks each snapshot key after `parse_dep_path` and returns **`ERR_AUBE_UNSUPPORTED_NAMED_REGISTRY`** (lockfile exit **15**) with a diagnostic that names the dep path and registry alias.
> 
> The new `UnsupportedNamedRegistry` error variant is wired through `aube-codes` and `docs/error-codes.data.json`. Unit tests cover the detector and an end-to-end parse rejection for keys like `foo@work:1.0.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62f7de05456cd36e37a6e8a6927cec6b00b13d0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clear diagnostic for pnpm lockfiles using unsupported named registries.
  * Error messages identify the affected dependency and registry and recommend pnpm 11.20 or later.

* **Bug Fixes**
  * Improved validation of registry-qualified package versions, including invalid aliases, reserved protocols, ranges, and malformed versions.

* **Documentation**
  * Added the new lockfile error code and exit status to the documented error reference.

* **Tests**
  * Added coverage for valid and invalid registry-qualified versions and corresponding lockfile parsing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->