### PR TITLE
fix(registry): normalize disabled proxy settings

### DIFF
--- a/crates/aube-registry/src/config/apply.rs
+++ b/crates/aube-registry/src/config/apply.rs
@@ -9,7 +9,7 @@ use super::url::{
     is_public_npmjs_url, lookup_by_uri_prefix, normalize_npmrc_uri_key, normalize_registry_url,
     package_scope, registry_uri_key,
 };
-use super::util::{non_empty, pem_value};
+use super::util::{non_empty, pem_value, proxy_url};
 
 impl NpmConfig {
     /// Register default scope→registry mappings that aube ships with
@@ -45,17 +45,18 @@ impl NpmConfig {
     /// single `https-proxy=...` line in `.npmrc` configures both.
     pub fn apply_proxy_env(&mut self) {
         if self.https_proxy.is_none() {
-            self.https_proxy = self
-                .npmrc_proxy
-                .clone()
-                .or_else(|| env_any(&["HTTPS_PROXY", "https_proxy"]));
+            self.https_proxy = match self.npmrc_proxy.as_deref() {
+                Some("false") => None,
+                Some(_) => self.npmrc_proxy.clone(),
+                None => env_any(&["HTTPS_PROXY", "https_proxy"]),
+            };
         }
         if self.http_proxy.is_none() {
-            self.http_proxy = self
-                .https_proxy
-                .clone()
-                .or_else(|| env_any(&["HTTP_PROXY", "http_proxy"]))
-                .or_else(|| env_any(&["PROXY", "proxy"]));
+            self.http_proxy = self.https_proxy.clone();
+            if self.http_proxy.is_none() && self.npmrc_proxy.as_deref() != Some("false") {
+                self.http_proxy =
+                    env_any(&["HTTP_PROXY", "http_proxy"]).or_else(|| env_any(&["PROXY", "proxy"]));
+            }
         }
         if self.no_proxy.is_none() {
             self.no_proxy = env_any(&["NO_PROXY", "no_proxy"]);
@@ -398,10 +399,10 @@ impl NpmConfig {
                 } else {
                     match key.as_str() {
                         "https-proxy" | "httpsProxy" => {
-                            self.https_proxy = non_empty(value);
+                            self.https_proxy = proxy_url(value);
                         }
                         "http-proxy" | "httpProxy" => {
-                            self.http_proxy = non_empty(value);
+                            self.http_proxy = proxy_url(value);
                         }
                         "proxy" => {
                             // pnpm treats `.npmrc proxy=` as the
@@ -412,7 +413,7 @@ impl NpmConfig {
                             self.npmrc_proxy = non_empty(value);
                         }
                         _ => {
-                            self.no_proxy = non_empty(value);
+                            self.no_proxy = proxy_url(value);
                         }
                     }
                 }

--- a/crates/aube-registry/src/config/tests.rs
+++ b/crates/aube-registry/src/config/tests.rs
@@ -1124,6 +1124,47 @@ fn test_explicit_https_proxy_wins_over_npmrc_proxy() {
 }
 
 #[test]
+fn test_legacy_proxy_false_disables_environment_fallback() {
+    let mut config = NpmConfig::default();
+    config.apply(vec![("proxy".to_string(), "false".to_string())]);
+    config.apply_proxy_env();
+
+    assert_eq!(config.npmrc_proxy.as_deref(), Some("false"));
+    assert!(config.https_proxy.is_none());
+    assert!(config.http_proxy.is_none());
+}
+
+#[test]
+fn test_scheme_specific_proxy_overrides_legacy_false() {
+    let mut config = NpmConfig::default();
+    config.apply(vec![
+        ("proxy".to_string(), "false".to_string()),
+        (
+            "https-proxy".to_string(),
+            "http://explicit:8080".to_string(),
+        ),
+    ]);
+    config.apply_proxy_env();
+
+    assert_eq!(config.https_proxy.as_deref(), Some("http://explicit:8080"));
+    assert_eq!(config.http_proxy.as_deref(), Some("http://explicit:8080"));
+}
+
+#[test]
+fn test_false_and_null_scheme_proxy_values_are_unset() {
+    let mut config = NpmConfig::default();
+    config.apply(vec![
+        ("https-proxy".to_string(), "false".to_string()),
+        ("http-proxy".to_string(), "null".to_string()),
+        ("no-proxy".to_string(), "false".to_string()),
+    ]);
+
+    assert!(config.https_proxy.is_none());
+    assert!(config.http_proxy.is_none());
+    assert!(config.no_proxy.is_none());
+}
+
+#[test]
 fn test_default_strict_ssl_is_true() {
     // Regression: `NpmConfig::default()` must not leave
     // `strict_ssl = false` (bool::default), because

--- a/crates/aube-registry/src/config/util.rs
+++ b/crates/aube-registry/src/config/util.rs
@@ -11,6 +11,13 @@ pub(super) fn non_empty(s: String) -> Option<String> {
     }
 }
 
+/// Normalize the scheme-specific proxy settings. pnpm treats the
+/// config-parser boolean/null spellings as unset instead of attempting
+/// to parse them as proxy hostnames.
+pub(super) fn proxy_url(s: String) -> Option<String> {
+    non_empty(s).filter(|value| !matches!(value.as_str(), "false" | "null"))
+}
+
 pub(super) fn pem_value(s: String) -> String {
     s.replace("\\n", "\n")
 }


### PR DESCRIPTION
## Summary

- treat scheme-specific `false` and `null` proxy values as unset
- make legacy `proxy=false` disable environment proxy fallback
- preserve explicit `https-proxy` and `http-proxy` precedence over the legacy setting

## Why

Proxy values were previously kept as literal strings, so `proxy=false` could be passed to reqwest as a hostname and scheme-specific boolean/null values could suppress or distort the normal fallback chain. pnpm 11.20 defines explicit normalization for these values.

## Validation

- `cargo fmt --check`
- `cargo test -p aube-registry config::tests`
- `cargo clippy -p aube-registry --all-targets -- -D warnings`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how registry HTTP clients resolve proxies for all installs; behavior now matches pnpm but differs from the previous literal-string handling.
> 
> **Overview**
> Aligns **aube-registry** proxy handling with **pnpm 11.20** so disabled proxy values are not passed through as literal hostnames.
> 
> Adds **`proxy_url`**, which treats scheme-specific **`https-proxy`**, **`http-proxy`**, and **`no-proxy`** values of **`false`** or **`null`** as unset when parsing `.npmrc`. **`apply_proxy_env`** now treats legacy **`proxy=false`** as “no proxy”: it does not use that value as a URL and blocks **`HTTPS_PROXY`** / **`HTTP_PROXY`** fallback for both schemes. Explicit **`https-proxy`** / **`http-proxy`** still win over **`proxy=false`**, and **`http_proxy`** continues to inherit resolved **`https_proxy`** before env.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c540cfc0525e66c1d6904a49ce0ee5c45c1d5579. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy configuration handling for npm settings.
  * Correctly recognizes `false`, `null`, and empty proxy values as disabled.
  * Ensures explicit HTTPS proxy settings take precedence and prevents unintended proxy inheritance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->