### PR TITLE
fix(unlink): keep GVS-backed deps out of bare unlink

### DIFF
--- a/crates/aube/src/commands/unlink.rs
+++ b/crates/aube/src/commands/unlink.rs
@@ -49,11 +49,17 @@ pub async fn run(args: UnlinkArgs) -> miette::Result<()> {
                 ));
             }
 
-            // Skip symlinks pointing into .aube — those are regular install symlinks,
-            // not user-created links. Remove via the shared guard so scope cleanup still runs.
+            // Skip symlinks pointing into the virtual store — those are regular
+            // install symlinks, not user-created links. Remove via the shared
+            // guard so scope cleanup still runs.
+            //
+            // The message stays neutral about the store's name: it defaults to
+            // `.aube`, but `virtualStoreDir` can move it (the classification
+            // resolves the leaf dynamically for that reason), so naming `.aube`
+            // outright would be wrong for anyone who overrode it.
             if !remove_if_external_symlink(&cwd, &link_path)? {
                 return Err(miette!(
-                    "{name} is not a linked package (points into .aube — run `{}` to restore)",
+                    "{name} is not a linked package (points into the virtual store — run `{}` to restore)",
                     aube_util::cmd("install")
                 ));
             }

--- a/crates/aube/src/commands/unlink.rs
+++ b/crates/aube/src/commands/unlink.rs
@@ -162,6 +162,18 @@ fn unlink_global(cwd: &std::path::Path, explicit_name: Option<&str>) -> miette::
 /// If `path` is a symlink whose target is outside `project_dir/node_modules/.aube`,
 /// remove it and return `true`. Symlinks pointing into `.aube/` (regular install symlinks)
 /// are left alone and return `false`.
+///
+/// The "internal" test is textual first. With the global virtual store
+/// enabled, `.aube/<dep_path>` is itself a symlink into
+/// `<cacheDir>/virtual-store/<dep>-<hash>`, so canonicalizing the
+/// target escapes the project's virtual store and every ordinary
+/// registry dep would look like a user `aube link`. Comparing the
+/// lex-normalized raw target against the resolved virtual-store dir
+/// keeps a `.aube/<dep>` target internal regardless of where that
+/// entry points; the GVS root is checked too, for entries recorded as
+/// absolute paths into the shared store. Canonicalization stays as the
+/// fallback so a symlinked project path (macOS `/tmp` →
+/// `/private/tmp`) still compares correctly without GVS.
 fn remove_if_external_symlink(
     project_dir: &std::path::Path,
     path: &std::path::Path,
@@ -184,11 +196,29 @@ fn remove_if_external_symlink(
         target.clone()
     };
 
-    // Canonicalize both sides so symlinked project paths (e.g. macOS /tmp → /private/tmp)
-    // compare correctly. Honors `virtualStoreDir` so a custom-path
-    // `.aube/` still classifies as internal.
+    // Honors `virtualStoreDir` so a custom-path `.aube/` still
+    // classifies as internal.
     let pnpm_raw = super::resolve_virtual_store_dir_for_cwd(project_dir);
-    let pnpm_dir = std::fs::canonicalize(&pnpm_raw).unwrap_or_else(|_| pnpm_raw.clone());
+    let pnpm_lex = aube_linker::normalize_path(&pnpm_raw);
+    // Shared virtual store (`enableGlobalVirtualStore`). Targets under
+    // it belong to an install, not to `aube link`.
+    let gvs_raw = super::global_virtual_store_dir(project_dir);
+    let gvs_lex = aube_linker::normalize_path(&gvs_raw);
+
+    // An empty anchor would make `starts_with` true for every target and
+    // turn genuine user links into "internal", so never match on one.
+    let contains = |target: &std::path::Path, anchor: &std::path::Path| {
+        !anchor.as_os_str().is_empty() && target.starts_with(anchor)
+    };
+
+    // Textual pass: collapse `.`/`..` without following symlinks, so a
+    // relative `.aube/<dep>/node_modules/<name>` target stays anchored
+    // inside the project's virtual store.
+    let target_lex = aube_linker::normalize_path(&abs_target);
+    if contains(&target_lex, &pnpm_lex) || contains(&target_lex, &gvs_lex) {
+        return Ok(false);
+    }
+
     // Derive the virtual-store dir's leaf name from the resolved path
     // so the dangling-symlink fallback below matches regardless of
     // whether the user overrode `virtualStoreDir` to `.custom-vs`,
@@ -200,7 +230,11 @@ fn remove_if_external_symlink(
 
     match std::fs::canonicalize(&abs_target) {
         Ok(canonical) => {
-            if canonical.starts_with(&pnpm_dir) {
+            // Canonicalize the anchors too, so symlinked project paths
+            // (e.g. macOS `/tmp` → `/private/tmp`) compare correctly.
+            let pnpm_dir = std::fs::canonicalize(&pnpm_raw).unwrap_or(pnpm_raw);
+            let gvs_dir = std::fs::canonicalize(&gvs_raw).unwrap_or(gvs_raw);
+            if contains(&canonical, &pnpm_dir) || contains(&canonical, &gvs_dir) {
                 return Ok(false);
             }
         }

--- a/crates/aube/src/commands/unlink.rs
+++ b/crates/aube/src/commands/unlink.rs
@@ -170,10 +170,17 @@ fn unlink_global(cwd: &std::path::Path, explicit_name: Option<&str>) -> miette::
 /// registry dep would look like a user `aube link`. Comparing the
 /// lex-normalized raw target against the resolved virtual-store dir
 /// keeps a `.aube/<dep>` target internal regardless of where that
-/// entry points; the GVS root is checked too, for entries recorded as
-/// absolute paths into the shared store. Canonicalization stays as the
-/// fallback so a symlinked project path (macOS `/tmp` →
-/// `/private/tmp`) still compares correctly without GVS.
+/// entry points. Canonicalization stays as the fallback so a symlinked
+/// project path (macOS `/tmp` → `/private/tmp`) still compares
+/// correctly.
+///
+/// Deliberately no global-virtual-store anchor here: every writer of a
+/// visible `node_modules/<name>` symlink (`link.rs` steps 2/2b, both
+/// hoist passes) targets `.aube/<entry>/node_modules/<name>`, a
+/// workspace sibling, or a `link:` path — never the shared store
+/// directly. A GVS-root check would be dead weight that could only
+/// misfire, hiding a genuine link whose target happens to sit under a
+/// user-configured `globalVirtualStoreDir`.
 fn remove_if_external_symlink(
     project_dir: &std::path::Path,
     path: &std::path::Path,
@@ -199,11 +206,6 @@ fn remove_if_external_symlink(
     // Honors `virtualStoreDir` so a custom-path `.aube/` still
     // classifies as internal.
     let pnpm_raw = super::resolve_virtual_store_dir_for_cwd(project_dir);
-    let pnpm_lex = aube_linker::normalize_path(&pnpm_raw);
-    // Shared virtual store (`enableGlobalVirtualStore`). Targets under
-    // it belong to an install, not to `aube link`.
-    let gvs_raw = super::global_virtual_store_dir(project_dir);
-    let gvs_lex = aube_linker::normalize_path(&gvs_raw);
 
     // An empty anchor would make `starts_with` true for every target and
     // turn genuine user links into "internal", so never match on one.
@@ -215,7 +217,7 @@ fn remove_if_external_symlink(
     // relative `.aube/<dep>/node_modules/<name>` target stays anchored
     // inside the project's virtual store.
     let target_lex = aube_linker::normalize_path(&abs_target);
-    if contains(&target_lex, &pnpm_lex) || contains(&target_lex, &gvs_lex) {
+    if contains(&target_lex, &aube_linker::normalize_path(&pnpm_raw)) {
         return Ok(false);
     }
 
@@ -230,11 +232,10 @@ fn remove_if_external_symlink(
 
     match std::fs::canonicalize(&abs_target) {
         Ok(canonical) => {
-            // Canonicalize the anchors too, so symlinked project paths
+            // Canonicalize the anchor too, so symlinked project paths
             // (e.g. macOS `/tmp` → `/private/tmp`) compare correctly.
             let pnpm_dir = std::fs::canonicalize(&pnpm_raw).unwrap_or(pnpm_raw);
-            let gvs_dir = std::fs::canonicalize(&gvs_raw).unwrap_or(gvs_raw);
-            if contains(&canonical, &pnpm_dir) || contains(&canonical, &gvs_dir) {
+            if contains(&canonical, &pnpm_dir) {
                 return Ok(false);
             }
         }

--- a/test/unlink.bats
+++ b/test/unlink.bats
@@ -175,6 +175,50 @@ EOF
 	assert_failure
 }
 
+@test "aube unlink (no args) keeps registry deps installed through the global virtual store" {
+	# Regression: with GVS on (the default here — _common_setup unsets CI),
+	# `node_modules/.aube/<dep>` is itself a symlink into
+	# <cacheDir>/virtual-store/. Canonicalizing a dep's target escaped the
+	# project's virtual store, so every ordinary dep looked like an
+	# `aube link` and bare `aube unlink` emptied node_modules/.
+	cat >package.json <<'EOF'
+{"name": "consumer", "version": "1.0.0", "dependencies": {"semver": "7.7.4"}}
+EOF
+
+	run aube install
+	assert_success
+	run test -L node_modules/semver
+	assert_success
+	# Confirm GVS is actually in play, otherwise this asserts nothing.
+	run test -L "node_modules/.aube/semver@7.7.4"
+	assert_success
+
+	run aube unlink
+	assert_success
+	assert_output --partial "No linked packages found"
+	refute_output --partial "Unlinked semver"
+
+	run test -L node_modules/semver
+	assert_success
+	assert_file_exists node_modules/semver/package.json
+}
+
+@test "aube unlink <pkg> refuses to remove a GVS-backed registry dep" {
+	cat >package.json <<'EOF'
+{"name": "consumer", "version": "1.0.0", "dependencies": {"semver": "7.7.4"}}
+EOF
+
+	run aube install
+	assert_success
+
+	run aube unlink semver
+	assert_failure
+	assert_output --partial "not a linked package"
+
+	run test -L node_modules/semver
+	assert_success
+}
+
 @test "aube unlink <pkg> refuses to remove non-symlink entries" {
 	cat >package.json <<'EOF'
 {"name": "consumer", "version": "1.0.0"}

--- a/test/unlink.bats
+++ b/test/unlink.bats
@@ -219,6 +219,35 @@ EOF
 	assert_success
 }
 
+@test "aube unlink removes a real link whose target sits under globalVirtualStoreDir" {
+	# The GVS root must not be an "internal" anchor: no visible
+	# node_modules/<name> symlink ever points into the shared store
+	# directly, so anchoring on it could only misfire — hiding a genuine
+	# `aube link` whose target happens to live under a user-configured
+	# globalVirtualStoreDir.
+	cat >package.json <<'EOF'
+{"name": "consumer", "version": "1.0.0"}
+EOF
+
+	mkdir -p shared-store/my-lib
+	cat >shared-store/my-lib/package.json <<'EOF'
+{"name": "my-lib", "version": "1.0.0"}
+EOF
+	echo "globalVirtualStoreDir=$PWD/shared-store" >>.npmrc
+
+	run aube link ./shared-store/my-lib
+	assert_success
+	run test -L node_modules/my-lib
+	assert_success
+
+	run aube unlink
+	assert_success
+	assert_output --partial "Unlinked my-lib"
+
+	run test -e node_modules/my-lib
+	assert_failure
+}
+
 @test "aube unlink <pkg> refuses to remove non-symlink entries" {
 	cat >package.json <<'EOF'
 {"name": "consumer", "version": "1.0.0"}


### PR DESCRIPTION
## Problem

With the global virtual store enabled (the default outside CI), bare `aube unlink` deleted every regular dependency symlink from `node_modules/`, reporting each as an "Unlinked \<name\>" linked package.

`remove_if_external_symlink` classified a `node_modules/<name>` symlink as external (a real `aube link` target worth removing) by canonicalizing its target and checking `starts_with(<project>/node_modules/.aube)`. Under GVS, `.aube/<dep_path>` is itself a symlink into `<cacheDir>/virtual-store/<dep>-<hash>`, so canonicalization escaped the project's virtual store and every ordinary registry dep looked external.

Sibling of the `unlink_bins` GVS-canonicalization bug from https://github.com/jdx/aube/discussions/1219.

## Fix

The "internal" test is now textual first, mirroring `unlink_bins` in `global.rs`:

1. **Textual pass (new, runs first)** — lex-normalize the raw target via `aube_linker::normalize_path` and compare against the lex-normalized `resolve_virtual_store_dir_for_cwd`. A relative `.aube/<dep>/node_modules/<name>` target stays anchored inside the project's virtual store, so it counts as internal regardless of where that entry symlinks to.
2. **Canonicalization becomes the fallback**, behavior unchanged for the non-GVS case (macOS `/tmp` → `/private/tmp`).
3. Both passes go through a `contains` closure that refuses to match on an empty anchor. `Path::starts_with("")` is true for everything, which would flip this bug's polarity and make every genuine user link look internal.

**Deliberately no GVS-root anchor.** An earlier revision added one; review prompted me to verify whether it was reachable, and it isn't. Every writer of a visible `node_modules/<name>` symlink — `link.rs` step 2 and step 2b, plus `hoist_remaining_into` and `link_hidden_hoist` — targets `.aube/<entry>/node_modules/<name>`, a workspace sibling dir, or a `link:` path. None point into the shared store directly; under GVS it's the `.aube/<dep_path>` entry that symlinks one level down into `<gvs>/<dep>-<hash>`. So the lexical `.aube/` check already covers GVS installs, and a GVS anchor could only misfire — hiding a genuine link whose target happens to sit under a user-configured `globalVirtualStoreDir`, making it impossible to unlink. The reasoning is recorded on the function so it doesn't get re-added.

Also made the named-unlink diagnostic store-name-neutral ("points into the virtual store"): `virtualStoreDir` can move the store off `.aube` and the classification already resolves the leaf dynamically, so hardcoding `.aube` contradicted its own logic.

The dangling-symlink `vstore_leaf` component check is untouched.

## Tests

Three cases in `test/unlink.bats`. The first two install `semver@7.7.4` from the offline registry with GVS on by default (`_common_setup` unsets `CI`):

- bare `aube unlink` reports "No linked packages found" and leaves `node_modules/semver` intact — with an intermediate assertion that `node_modules/.aube/semver@7.7.4` really is a symlink, so the test can't silently pass by GVS being off
- `aube unlink semver` fails with "not a linked package"
- `globalVirtualStoreDir` pointed at a directory holding a genuine `aube link` target — `aube unlink` must still remove it

Each was verified to actually catch its bug. The first two fail before the fix, the first with exactly the reported output (`Unlinked semver` / `Unlinked 1 package.`) and the second by wrongly succeeding. The third fails with the GVS anchor restored ("No linked packages found" instead of "Unlinked my-lib"). Both GVS tests still pass with the anchor removed, which is what establishes it was dead code.

- `test/unlink.bats` — 13/13 pass
- `test/unlink.bats test/link.bats test/global_install.bats test/modules_dir_settings.bats` — 64 pass, 0 failures (guarding the `aube link`-removal path the textual check could have over-broadened)
- `cargo test` — 0 failed
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` — clean

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.220.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes symlink classification in `unlink`, which directly affects what gets deleted from `node_modules`; logic is nuanced but covered by new regression tests and mirrors an existing GVS pattern in `unlink_bins`.
> 
> **Overview**
> Fixes a regression where **bare `aube unlink`** treated normal registry install symlinks as user links and removed them when the **global virtual store** is on. Under GVS, `node_modules/<pkg>` targets resolve through `.aube/...` into the shared cache; **canonicalize-only** “internal vs external” checks escaped the project virtual store and misclassified every dep.
> 
> **`remove_if_external_symlink`** now mirrors the **`unlink_bins`** approach: a **lex-normalized** pass (`aube_linker::normalize_path` vs `resolve_virtual_store_dir_for_cwd`) runs first so `.aube/...` targets stay internal without following GVS symlinks; **canonicalization** remains the fallback (e.g. macOS `/tmp` vs `/private/tmp`). A **`contains`** helper skips empty anchors so `starts_with("")` cannot mark real links as internal. Docs note that a **GVS-root anchor** is intentionally omitted so links under a custom `globalVirtualStoreDir` can still be unlinked.
> 
> Named unlink errors now say **“virtual store”** instead of hardcoding `.aube`. **Three bats tests** cover GVS bare unlink, refusing to unlink a GVS-backed dep, and unlinking a real link whose target lives under `globalVirtualStoreDir`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 149dfe40ae281123423f9045d0331b3398503ef5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->