### PR TITLE
fix(global): unlink global bins when the shared virtual store is on

### DIFF
--- a/crates/aube/src/commands/global.rs
+++ b/crates/aube/src/commands/global.rs
@@ -334,20 +334,37 @@ pub fn unlink_bins(install_dir: &Path, bin_dir: &Path, bin_names: &[String]) {
             let link = bin_dir.join(name);
             match std::fs::read_link(&link) {
                 Ok(target) => {
-                    // Symlink bin: fully resolve and check against
-                    // `install_canon`. Matches the pre-settings behavior.
+                    // Symlink bin: `link_bins` wrote the target as
+                    // `<install_dir>/node_modules/<alias>/<rel>`, so the
+                    // ownership check is textual for the same reason the
+                    // shim branch below is. Canonicalizing first resolves
+                    // through `node_modules/<alias>` and `.aube/<dep_path>`
+                    // into `<cacheDir>/virtual-store/...` whenever the
+                    // global virtual store is on (the default outside CI) —
+                    // that lands outside `install_dir`, the ownership check
+                    // reads the bin as belonging to another install, and
+                    // every global bin leaks as a dangling symlink after
+                    // `remove -g` deletes the install dir.
                     let absolute = if target.is_absolute() {
                         target
                     } else {
                         bin_dir.join(target)
                     };
-                    let Some(install_canon) = install_canon.as_ref() else {
-                        continue;
-                    };
-                    let Some(resolved) = std::fs::canonicalize(&absolute).ok() else {
-                        continue;
-                    };
-                    if resolved.starts_with(install_canon) {
+                    let resolved = aube_linker::normalize_path(&absolute);
+                    // Full canonicalization stays as a fallback: a bin
+                    // linked by an older aube (or a target reached through
+                    // a symlinked `install_dir` ancestor) only matches
+                    // once both sides are resolved.
+                    if resolved.starts_with(&install_lex)
+                        || install_canon
+                            .as_ref()
+                            .is_some_and(|canon| resolved.starts_with(canon))
+                        || std::fs::canonicalize(&absolute).is_ok_and(|resolved| {
+                            install_canon
+                                .as_ref()
+                                .is_some_and(|canon| resolved.starts_with(canon))
+                        })
+                    {
                         let _ = std::fs::remove_file(&link);
                     }
                 }

--- a/test/global_install.bats
+++ b/test/global_install.bats
@@ -213,6 +213,12 @@ teardown() {
 	run aube remove -g semver
 	assert_success
 	assert_file_not_exists "$AUBE_HOME/semver"
+	# `assert_file_not_exists` is `[ -f ]`, which follows symlinks — a
+	# *dangling* symlink passes it. With the global virtual store on, the
+	# bin's canonical target lives in the shared store rather than under
+	# the install dir, so the ownership check has to stay textual or the
+	# symlink survives as a dangle (Discussion #1219).
+	[ ! -L "$AUBE_HOME/semver" ]
 
 	run aube list -g
 	assert_success


### PR DESCRIPTION
`aube remove -g <pkg>` deleted the install directory but left the package's bin behind in the global bin dir as a **dangling symlink**. Reported in https://github.com/jdx/aube/discussions/1219 against macOS, but it reproduces on Linux and affects every global package — not one platform or one package.

## Root cause

`unlink_bins` decided whether a bin belonged to the install being removed by canonicalizing the symlink's target and requiring the result to sit under `install_dir`. With the global virtual store enabled — the default outside CI — `node_modules/<alias>` resolves through `.aube/<dep_path>` into the shared store:

```
bin target:  <install_dir>/node_modules/aube-test-bin-uses-dep/./index.js
canonical:   ~/.cache/aube/virtual-store/aube-test-bin-uses-dep@1.0.0-41cb57db…/node_modules/…/index.js
```

That is never under `install_dir`, so the ownership check read every global bin as belonging to some *other* install and skipped it. Once `remove -g` deleted the install dir, the bin dangled: `which <cmd>` finds nothing, but the symlink is still sitting in the bin dir.

The sibling branch in the same function — the regular-file shim path used when `preferSymlinkedExecutables=false` — already avoided this, and its comment even names the shared virtual store as the reason it has to stay textual. The symlink branch never got the same treatment.

## Fix

Check the lexically-normalized target first. `link_bins` writes the target as `<install_dir>/node_modules/<alias>/<rel>`, so the textual comparison is exact, and full canonicalization stays as a fallback for bins linked by older versions or reached through a symlinked `install_dir` ancestor.

The check strictly widens: everything the previous code removed still matches via the retained canonicalize arm. Ownership semantics are unchanged —

- a bin overwritten by a later `add -g` points under *that* install's directory, so it isn't collected (covered by the existing `add -g twice replaces the prior install` test);
- `Path::starts_with` compares whole components, so `global-aube/abc` and `global-aube/abc-def` can't be mistaken for one another;
- in the prior-install replacement path `link_bins` runs before the prior's `unlink_bins`, and the new bin points at the new install dir.

Not retroactive: cleanup is driven by `bin_names_for`, which reads the install dir's `package.json` to learn bin names, so symlinks already orphaned by a previous version have to be removed by hand. This stops new ones from accumulating.

## Why CI never caught it

The test asserted with `assert_file_not_exists`, which is `[ -f ]`. That follows symlinks, so a *dangling* symlink passes it and the leak looked like a pass. It now also asserts `[ ! -L ]`; verified failing on the parent commit and passing with the fix.

## Testing

- `test/global_install.bats`: 24/24.
- `cargo test --workspace`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`: clean.

This commit was originally the first half of #1231. Split out here so it can land on its own — #1231 is breaking and waiting on a v2, and this doesn't need to wait for it. #1231 still carries the identical commit; whichever merges first, the other rebases cleanly.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global uninstall ownership logic on Unix; behavior is intentionally widened but still scoped with `starts_with` and retained canonicalize fallbacks.
> 
> **Overview**
> **`aube remove -g`** could leave **dangling bin symlinks** in the global bin dir because **`unlink_bins`** treated symlink ownership using **canonicalized** targets. With the **global virtual store** (default outside CI), those targets resolve into the shared cache, **outside** the install dir, so bins were skipped and only removed when the install directory was deleted.
> 
> The **symlink branch** now aligns with the existing **shell-shim** path: compare the **lexically normalized** path `link_bins` wrote under `<install_dir>/node_modules/...`, and keep **full canonicalization** as a fallback for older layouts or symlinked install ancestors.
> 
> The **`global_install.bats`** remove test also asserts **`[ ! -L ]`**, since **`[ -f ]`** follows symlinks and would not catch a leftover dangling symlink.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf39aef83575ce08f88cae0c8e24e514805b826c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->