### PR TITLE
fix(deps): re-pin decmpfs to 0.1.0 so musl targets build

### DIFF
--- a/.github/workflows/ffi.yml
+++ b/.github/workflows/ffi.yml
@@ -14,6 +14,8 @@ on:
       - "crates/aube/src/commands/install/frozen.rs"
       - "crates/aube-util/src/identity.rs"
       - "crates/aube-util/src/lib.rs"
+      - "Cargo.toml"
+      - "Cargo.lock"
       - ".github/workflows/ffi.yml"
   push:
     branches: [main]
@@ -29,6 +31,8 @@ on:
       - "crates/aube/src/commands/install/frozen.rs"
       - "crates/aube-util/src/identity.rs"
       - "crates/aube-util/src/lib.rs"
+      - "Cargo.toml"
+      - "Cargo.lock"
       - ".github/workflows/ffi.yml"
   release:
     types: [published]

--- a/.github/workflows/node-addon.yml
+++ b/.github/workflows/node-addon.yml
@@ -16,6 +16,8 @@ on:
       - "crates/aube/src/commands/install/frozen.rs"
       - "crates/aube-util/src/identity.rs"
       - "crates/aube-util/src/lib.rs"
+      - "Cargo.toml"
+      - "Cargo.lock"
       - ".github/workflows/node-addon.yml"
   push:
     branches: [main]
@@ -33,6 +35,8 @@ on:
       - "crates/aube/src/commands/install/frozen.rs"
       - "crates/aube-util/src/identity.rs"
       - "crates/aube-util/src/lib.rs"
+      - "Cargo.toml"
+      - "Cargo.lock"
       - ".github/workflows/node-addon.yml"
   release:
     types: [published]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1393,9 +1393,9 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "decmpfs"
-version = "0.1.2"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a32fcc951ae53a24a3138b63f54bbb7a9b27e1da6d1578144e397732dd2c530c"
+checksum = "651715809b4119e14ba1ba88650756d8a7012686473a32ec14c0e602e90fc47f"
 dependencies = [
  "libc",
  "sha2 0.10.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ reflink-copy = "0.1"
 # `libc::c_ulong`, which is `libc::Ioctl` on glibc but `c_int` on musl, so it
 # fails to compile for *-unknown-linux-musl. Unpin once
 # https://github.com/SocketDev/decmpfs releases a fix.
-decmpfs = { version = "=0.1.2", features = ["addon"] }
+decmpfs = { version = "=0.1.0", features = ["addon"] }
 glob = "0.3"
 # BurntSushi's gitignore matcher (from ripgrep). Used by `aube pack` /
 # `aube publish` to honor `.npmignore` / `.gitignore` with full


### PR DESCRIPTION
`main`'s musl builds are broken. #1226 bumped `decmpfs` to `=0.1.2` — the exact version the comment directly above the pin warns about:

```toml
# Pinned to 0.1.0: 0.1.2's FICLONE reflink path types the ioctl request as
# `libc::c_ulong`, which is `libc::Ioctl` on glibc but `c_int` on musl, so it
# fails to compile for *-unknown-linux-musl. Unpin once
# https://github.com/SocketDev/decmpfs releases a fix.
decmpfs = { version = "=0.1.2", features = ["addon"] }   # ← contradicts the comment
```

The compile failure, from the `linux-x64-musl` job:

```
error[E0308]: mismatched types
  --> decmpfs-0.1.2/src/linux.rs:296:60
   | libc::ioctl(dest_file.as_raw_fd(), FICLONE, src_file.as_raw_fd())
   |                                    ^^^^^^^ expected `i32`, found `u64`
```

This takes out `linux-x64-musl` and `linux-arm64-musl` in **both** the ffi and node-addon workflows — the jobs that build the musl npm packages — so the next release would publish without them.

## Why it landed green

Neither workflow watched `Cargo.toml` or `Cargo.lock`. Their path filters list crate sources only, so a dependency-only change can't trigger the musl matrix. #1226 touched nothing but the manifest and lockfile and was therefore never built for musl.

I hit this on #1231, which happens to touch `crates/aube-codes/**` and so does trigger both workflows — that PR's musl failures are inherited from `main`, not caused by it.

## Changes

- Re-pin `decmpfs` to `=0.1.0` and downgrade the lockfile, restoring the state the comment describes. Still waiting on an upstream fix in https://github.com/SocketDev/decmpfs before it can move.
- Add `Cargo.toml` and `Cargo.lock` to the `pull_request` and `push` path filters of both workflows, so dependency bumps run the musl matrix instead of skipping it. That's also what makes this PR's own musl jobs run — they're the proof the pin fixes it.

## Testing

`cargo build`, `cargo clippy --all-targets -- -D warnings`, and `cargo test -p aube-store` (110 tests) pass locally with the downgrade. I could not reproduce the musl compile locally — `cargo check --target x86_64-unknown-linux-musl` stops earlier on `zstd-sys` needing `musl-gcc`, which the CI runners install via `musl-tools`. The musl jobs on this PR are the real verification; worth confirming they're green before merging.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency downgrade to a known-good pin plus CI path-filter tweaks; no runtime logic changes.
> 
> **Overview**
> Restores **musl builds** by downgrading the workspace `decmpfs` pin from `=0.1.2` back to `=0.1.0` (with matching `Cargo.lock`), aligning with the existing comment about `0.1.2` failing on `*-unknown-linux-musl` due to an FICLONE ioctl type mismatch.
> 
> Updates **ffi** and **node-addon** GitHub Actions path filters so `pull_request` and `push` runs also trigger when only `Cargo.toml` or `Cargo.lock` change, so future dependency bumps exercise the musl matrix instead of skipping CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92fab10965237ffcff41854c24df61bee010a4e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->