### PR TITLE
fix(install): route deprecation warnings through embedder output

### DIFF
--- a/crates/aube-codes/src/warnings.rs
+++ b/crates/aube-codes/src/warnings.rs
@@ -18,6 +18,8 @@ pub const WARN_AUBE_HOOK_PACKAGE_ADDED: &str = "WARN_AUBE_HOOK_PACKAGE_ADDED";
 
 // ── install lifecycle ───────────────────────────────────────────────
 pub const WARN_AUBE_IGNORED_BUILD_SCRIPTS: &str = "WARN_AUBE_IGNORED_BUILD_SCRIPTS";
+pub const WARN_AUBE_DEPRECATED_PACKAGE: &str = "WARN_AUBE_DEPRECATED_PACKAGE";
+pub const WARN_AUBE_DEPRECATED_PACKAGE_SUMMARY: &str = "WARN_AUBE_DEPRECATED_PACKAGE_SUMMARY";
 #[rustfmt::skip] pub const WARN_AUBE_SUSPICIOUS_LIFECYCLE_SCRIPT: &str = "WARN_AUBE_SUSPICIOUS_LIFECYCLE_SCRIPT";
 #[rustfmt::skip] pub const WARN_AUBE_WINDOWS_JOB_OBJECT_UNAVAILABLE: &str = "WARN_AUBE_WINDOWS_JOB_OBJECT_UNAVAILABLE";
 pub const WARN_AUBE_MISSING_INTEGRITY: &str = "WARN_AUBE_MISSING_INTEGRITY";
@@ -190,6 +192,18 @@ pub const ALL: &[CodeMeta] = &[
         name: WARN_AUBE_IGNORED_BUILD_SCRIPTS,
         category: category::INSTALL_LIFECYCLE,
         description: "Dep had `preinstall`/`install`/`postinstall` scripts but isn't on the `allowBuilds` allowlist. Run `aube approve-builds`.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: WARN_AUBE_DEPRECATED_PACKAGE,
+        category: category::INSTALL_LIFECYCLE,
+        description: "An installed package version is deprecated.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: WARN_AUBE_DEPRECATED_PACKAGE_SUMMARY,
+        category: category::INSTALL_LIFECYCLE,
+        description: "One or more installed package versions have deprecation warnings.",
         exit_code: None,
     },
     CodeMeta {

--- a/crates/aube/src/deprecations.rs
+++ b/crates/aube/src/deprecations.rs
@@ -12,10 +12,10 @@
 
 use aube_lockfile::LockfileGraph;
 use aube_settings::resolved::DeprecationWarnings;
-use clx::style;
 use std::collections::{BTreeMap, BTreeSet};
-use std::io::Write;
 use std::sync::Arc;
+
+use crate::commands::install::InstallOutputLevel;
 
 #[derive(Debug, Clone)]
 pub struct DeprecationRecord {
@@ -85,8 +85,9 @@ pub fn dedupe(records: Vec<DeprecationRecord>) -> Vec<DeprecationRecord> {
 }
 
 /// Render install-time warnings according to the user's `deprecationWarnings`
-/// setting. Writes to stderr. Must be called after the progress UI has been
-/// finished (see `InstallProgress::finish`).
+/// setting. Output is routed through the active install control so embedded
+/// hosts receive events instead of writes that can collide with their own
+/// progress UI.
 pub fn render_install_warnings(
     records: &[DeprecationRecord],
     graph: &LockfileGraph,
@@ -116,39 +117,111 @@ pub fn render_install_warnings(
 }
 
 fn write_warn_line(r: &DeprecationRecord) {
-    let line = format!(
-        "{} {}@{}: {}",
-        style::eyellow("WARN deprecated").bold(),
-        r.name,
-        r.version,
-        r.message
+    crate::commands::install::control::output(
+        InstallOutputLevel::Warning,
+        Some(aube_codes::warnings::WARN_AUBE_DEPRECATED_PACKAGE),
+        format!("deprecated {}@{}: {}", r.name, r.version, r.message),
     );
-    let _ = writeln!(std::io::stderr(), "{line}");
 }
 
 fn write_transitive_count_line(count: usize) {
     let pkgs = pluralizer::pluralize("transitive package", count as isize, true);
     let verb = if count == 1 { "has" } else { "have" };
-    // Product name from the active embedder (standalone aube → "aube"), not a
-    // literal: this hint streams to stderr mid-install, so it must be branded at
-    // the emit site — a host embedder's later output-capture rewrite never sees it.
-    let product = aube_util::embedder().name;
-    let msg = format!(
-        "{pkgs} {verb} deprecation warnings. Run `{product} deprecations --transitive` to see them."
+    let msg = append_command_hint(
+        format!("{pkgs} {verb} deprecation warnings."),
+        "aube deprecations --transitive",
+        is_standalone_aube(),
     );
-    let _ = writeln!(std::io::stderr(), "{}", style::edim(msg));
+    write_summary_line(msg);
 }
 
 fn write_count_line(count: usize, has_transitive: bool) {
     let pkgs = pluralizer::pluralize("package", count as isize, true);
     let verb = if count == 1 { "has" } else { "have" };
-    // See `write_transitive_count_line`: streamed line, brand at emit.
-    let product = aube_util::embedder().name;
     let cmd = if has_transitive {
-        format!("{product} deprecations --transitive")
+        "aube deprecations --transitive"
     } else {
-        format!("{product} deprecations")
+        "aube deprecations"
     };
-    let msg = format!("{pkgs} {verb} deprecation warnings. Run `{cmd}` to see them.");
-    let _ = writeln!(std::io::stderr(), "{}", style::edim(msg));
+    let msg = append_command_hint(
+        format!("{pkgs} {verb} deprecation warnings."),
+        cmd,
+        is_standalone_aube(),
+    );
+    write_summary_line(msg);
+}
+
+fn is_standalone_aube() -> bool {
+    aube_util::embedder().name == aube_util::AUBE.name
+}
+
+fn append_command_hint(message: String, command: &str, show_hint: bool) -> String {
+    if show_hint {
+        format!("{message} Run `{command}` to see them.")
+    } else {
+        message
+    }
+}
+
+fn write_summary_line(message: String) {
+    crate::commands::install::control::output(
+        InstallOutputLevel::Warning,
+        Some(aube_codes::warnings::WARN_AUBE_DEPRECATED_PACKAGE_SUMMARY),
+        message,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use crate::commands::install::{
+        InstallControl, InstallEvent, InstallOutputLevel, InstallReporter,
+    };
+
+    use super::*;
+
+    #[derive(Default)]
+    struct RecordingReporter(Mutex<Vec<InstallEvent>>);
+
+    impl InstallReporter for RecordingReporter {
+        fn report(&self, event: InstallEvent) {
+            self.0.lock().unwrap().push(event);
+        }
+    }
+
+    #[test]
+    fn command_hint_is_only_added_for_standalone_aube() {
+        let message = "1 transitive package has deprecation warnings.".to_string();
+        assert_eq!(
+            append_command_hint(message.clone(), "aube deprecations --transitive", true,),
+            "1 transitive package has deprecation warnings. Run `aube deprecations --transitive` to see them."
+        );
+        assert_eq!(
+            append_command_hint(message.clone(), "aube deprecations --transitive", false),
+            message
+        );
+    }
+
+    #[tokio::test]
+    async fn summary_is_reported_as_a_structured_warning_event() {
+        let reporter = Arc::new(RecordingReporter::default());
+        let control = InstallControl::events(reporter.clone());
+
+        crate::commands::install::control::scope(control, async {
+            write_summary_line("1 package has deprecation warnings.".to_string());
+        })
+        .await;
+
+        let events = reporter.0.lock().unwrap();
+        assert!(matches!(
+            events.as_slice(),
+            [InstallEvent::Output {
+                level: InstallOutputLevel::Warning,
+                code: Some(code),
+                message,
+            }] if code == aube_codes::warnings::WARN_AUBE_DEPRECATED_PACKAGE_SUMMARY
+                && message == "1 package has deprecation warnings."
+        ));
+    }
 }

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -579,6 +579,18 @@
       "exit_code": null
     },
     {
+      "name": "WARN_AUBE_DEPRECATED_PACKAGE",
+      "category": "Install lifecycle",
+      "description": "An installed package version is deprecated.",
+      "exit_code": null
+    },
+    {
+      "name": "WARN_AUBE_DEPRECATED_PACKAGE_SUMMARY",
+      "category": "Install lifecycle",
+      "description": "One or more installed package versions have deprecation warnings.",
+      "exit_code": null
+    },
+    {
       "name": "WARN_AUBE_SUSPICIOUS_LIFECYCLE_SCRIPT",
       "category": "Install lifecycle",
       "description": "A dependency's lifecycle script matched a dangerous-shape heuristic (curl|sh, eval+atob, credential-file read, secret-env exfil, exfil endpoint, bare-IP HTTP). Advisory only; the `allowBuilds` allowlist still gates execution. Inspect the script before approving the build.",


### PR DESCRIPTION
## Summary
- route install-time package deprecation warnings through the active `InstallControl`
- deliver warnings as structured events to embedded hosts instead of writing directly to stderr
- omit the standalone `aube deprecations` hint when aube is running under another host
- add stable warning codes for individual and summary deprecation messages

## Root cause
The deprecation renderer wrote directly to stderr even when an embedder selected `InstallOutputMode::Events`. In mise, that write raced with mise's active progress renderer and corrupted the terminal row on Windows.

The hint also derived its command name from the active embedder. That produced `mise deprecations --transitive`, although mise does not expose that command.

## User impact
Embedded hosts can now render deprecation warnings safely through their own output pipeline. Standalone aube keeps the existing `aube deprecations` hint, while embedded hosts receive the warning without an invalid host-branded command.

Fixes the aube side of https://github.com/jdx/mise/discussions/11742.

## Validation
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `mise run render`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Install output plumbing and UX only; no resolver, lockfile, or auth changes. Behavior change is intentional for embedded hosts.
> 
> **Overview**
> Install-time deprecation warnings no longer write directly to **stderr**; they go through **`InstallControl`** as structured **`InstallEvent::Output`** warnings so embedders using **`InstallOutputMode::Events`** can render them without racing the host progress UI (e.g. mise on Windows).
> 
> Per-package lines use **`WARN_AUBE_DEPRECATED_PACKAGE`**; count/summary lines use **`WARN_AUBE_DEPRECATED_PACKAGE_SUMMARY`**, with matching entries in **`aube-codes`** and **`docs/error-codes.data.json`**. The **`Run \`aube deprecations …\``** hint is shown only when the active embedder is standalone aube, not when embedded under another host.
> 
> Tests cover hint gating and that summary output is emitted as a coded warning event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0eff033c636ba9a34dbbcc58428978ffff07022. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clear warnings when installed packages are deprecated.
  - Added an aggregated summary for multiple deprecated packages.
  - Standalone Aube runs now include guidance for reviewing deprecations with the `aube deprecations` command.
- **Bug Fixes**
  - Deprecation notices now appear consistently through the installation warning system instead of directly in terminal output.
  - Embedded integrations receive concise warnings without standalone command hints.
- **Documentation**
  - Added the new deprecation warning codes to the documented error-code reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->