### PR TITLE
fix(store): fail closed on incomplete index scans

### DIFF
--- a/crates/aube-codes/src/errors.rs
+++ b/crates/aube-codes/src/errors.rs
@@ -60,6 +60,7 @@ pub const ERR_AUBE_PKG_CONTENT_MISMATCH: &str = "ERR_AUBE_PKG_CONTENT_MISMATCH";
 pub const ERR_AUBE_TARBALL_URL_MISMATCH: &str = "ERR_AUBE_TARBALL_URL_MISMATCH";
 pub const ERR_AUBE_NO_HOME: &str = "ERR_AUBE_NO_HOME";
 pub const ERR_AUBE_GIT_ERROR: &str = "ERR_AUBE_GIT_ERROR";
+pub const ERR_AUBE_STORE_INDEX_SCAN_FAILED: &str = "ERR_AUBE_STORE_INDEX_SCAN_FAILED";
 
 // ── linker ──────────────────────────────────────────────────────────
 pub const ERR_AUBE_LINK_FAILED: &str = "ERR_AUBE_LINK_FAILED";
@@ -286,6 +287,12 @@ pub const ALL: &[CodeMeta] = &[
         name: ERR_AUBE_NO_HOME,
         category: category::TARBALL_STORE,
         description: "`HOME` (or platform equivalent) is unset, so aube can't locate its store.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: ERR_AUBE_STORE_INDEX_SCAN_FAILED,
+        category: category::TARBALL_STORE,
+        description: "A store maintenance command couldn't completely read or parse the cached package indexes.",
         exit_code: None,
     },
     // Registry / network

--- a/crates/aube/src/commands/store.rs
+++ b/crates/aube/src/commands/store.rs
@@ -174,49 +174,94 @@ async fn add(specs: Vec<String>) -> miette::Result<()> {
     Ok(())
 }
 
-/// Collect the set of hex hashes referenced by any cached package index
-/// under `<store>/v1/index/`. Integrity-keyed entries live under
-/// `<16 hex>/<name>@<version>.json` subdirs; integrity-less entries
-/// live at the root as `<name>@<version>.json`. Walk both. Used as
-/// the "known-referenced" set for `store prune` and `store status`.
-fn referenced_hashes(store: &aube_store::Store) -> std::collections::HashSet<String> {
+/// Collect the set of hex hashes referenced by every cached package index.
+/// Pruning must fail closed if this scan is incomplete: a skipped index would
+/// otherwise make its live CAS files look unreferenced.
+fn referenced_hashes(
+    store: &aube_store::Store,
+) -> miette::Result<std::collections::HashSet<String>> {
     let mut seen = std::collections::HashSet::new();
-    let index_dir = store.index_dir();
-    collect_hashes_from_dir(&index_dir, &mut seen);
-    let Ok(entries) = std::fs::read_dir(&index_dir) else {
-        return seen;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            collect_hashes_from_dir(&path, &mut seen);
-        }
-    }
-    seen
-}
-
-fn collect_hashes_from_dir(dir: &std::path::Path, seen: &mut std::collections::HashSet<String>) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if !path.is_file() {
-            continue;
-        }
-        if path.extension().and_then(|s| s.to_str()) != Some("json") {
-            continue;
-        }
-        let Ok(content) = std::fs::read_to_string(&path) else {
-            continue;
-        };
-        let Ok(index): Result<aube_store::PackageIndex, _> = serde_json::from_str(&content) else {
-            continue;
-        };
+    visit_cached_indices(store, |_, index| {
         for stored in index.values() {
             seen.insert(stored.hex_hash.clone());
         }
+    })?;
+    Ok(seen)
+}
+
+/// Visit every JSON index at the root and in integrity-keyed subdirectories.
+/// A missing index root is an empty cache; every other scan failure is fatal.
+fn visit_cached_indices(
+    store: &aube_store::Store,
+    mut visit: impl FnMut(&Path, aube_store::PackageIndex),
+) -> miette::Result<()> {
+    let index_dir = store.index_dir();
+    if !index_dir.try_exists().map_err(|e| {
+        miette!(
+            code = aube_codes::errors::ERR_AUBE_STORE_INDEX_SCAN_FAILED,
+            "failed to inspect store index directory {}: {e}",
+            index_dir.display()
+        )
+    })? {
+        return Ok(());
     }
+    visit_indices_in_dir(&index_dir, true, &mut visit)
+}
+
+fn visit_indices_in_dir(
+    dir: &Path,
+    visit_subdirs: bool,
+    visit: &mut impl FnMut(&Path, aube_store::PackageIndex),
+) -> miette::Result<()> {
+    let entries = std::fs::read_dir(dir).map_err(|e| {
+        miette!(
+            code = aube_codes::errors::ERR_AUBE_STORE_INDEX_SCAN_FAILED,
+            "failed to list store index directory {}: {e}",
+            dir.display()
+        )
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|e| {
+            miette!(
+                code = aube_codes::errors::ERR_AUBE_STORE_INDEX_SCAN_FAILED,
+                "failed to read an entry in store index directory {}: {e}",
+                dir.display()
+            )
+        })?;
+        let path = entry.path();
+        let metadata = entry.metadata().map_err(|e| {
+            miette!(
+                code = aube_codes::errors::ERR_AUBE_STORE_INDEX_SCAN_FAILED,
+                "failed to inspect store index path {}: {e}",
+                path.display()
+            )
+        })?;
+        if metadata.is_dir() {
+            if visit_subdirs {
+                visit_indices_in_dir(&path, false, visit)?;
+            }
+            continue;
+        }
+        if !metadata.is_file() || path.extension() != Some(std::ffi::OsStr::new("json")) {
+            continue;
+        }
+        let content = std::fs::read(&path).map_err(|e| {
+            miette!(
+                code = aube_codes::errors::ERR_AUBE_STORE_INDEX_SCAN_FAILED,
+                "failed to read store index {}: {e}",
+                path.display()
+            )
+        })?;
+        let index = serde_json::from_slice(&content).map_err(|e| {
+            miette!(
+                code = aube_codes::errors::ERR_AUBE_STORE_INDEX_SCAN_FAILED,
+                "failed to parse store index {}: {e}",
+                path.display()
+            )
+        })?;
+        visit(&path, index);
+    }
+    Ok(())
 }
 
 fn prune(args: PruneArgs) -> miette::Result<()> {
@@ -227,7 +272,7 @@ fn prune(args: PruneArgs) -> miette::Result<()> {
         return Ok(());
     }
 
-    let referenced = referenced_hashes(&store);
+    let referenced = referenced_hashes(&store)?;
     let mut removed_files = 0u64;
     let mut removed_bytes = 0u64;
 
@@ -311,25 +356,29 @@ fn prune(args: PruneArgs) -> miette::Result<()> {
 
 fn status() -> miette::Result<()> {
     let store = open_store()?;
-    let index_dir = store.index_dir();
-    if !index_dir.exists() {
-        eprintln!("Store is consistent (no cached indices found)");
-        return Ok(());
-    }
-
     let mut checked = 0usize;
     let mut broken: Vec<String> = Vec::new();
-
-    // Walk the index root (integrity-less entries) and every
-    // `<16 hex>/` subdir (integrity-keyed entries). Flat filenames at
-    // the root are the integrity-less variants; files one level
-    // deep are the integrity-keyed variants — both need verifying.
-    verify_indices_in_dir(&index_dir, &mut checked, &mut broken).into_diagnostic()?;
-    for entry in std::fs::read_dir(&index_dir).into_diagnostic()?.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            verify_indices_in_dir(&path, &mut checked, &mut broken).into_diagnostic()?;
+    visit_cached_indices(&store, |path, index| {
+        checked += 1;
+        let pkg_label = path
+            .file_stem()
+            .map(|stem| stem.to_string_lossy().replace("__", "/"))
+            .unwrap_or_else(|| path.display().to_string());
+        let mut pkg_ok = true;
+        for (rel, stored) in &index {
+            if !verify_stored_file(&stored.store_path, &stored.hex_hash) {
+                broken.push(format!("{pkg_label}: {rel}"));
+                pkg_ok = false;
+            }
         }
+        if pkg_ok {
+            tracing::debug!("store ok: {pkg_label}");
+        }
+    })?;
+
+    if checked == 0 {
+        eprintln!("Store is consistent (no cached indices found)");
+        return Ok(());
     }
 
     if broken.is_empty() {
@@ -351,51 +400,6 @@ fn status() -> miette::Result<()> {
             pluralizer::pluralize("file", broken.len() as isize, false)
         ))
     }
-}
-
-/// Verify every `*.json` cached index directly inside `dir` (no
-/// recursion). Callers walk the layout hierarchy and call this on
-/// each directory that can hold index files. Keeps the BLAKE3 hot
-/// loop in one place.
-fn verify_indices_in_dir(
-    dir: &Path,
-    checked: &mut usize,
-    broken: &mut Vec<String>,
-) -> std::io::Result<()> {
-    for entry in std::fs::read_dir(dir)?.flatten() {
-        let path = entry.path();
-        if !path.is_file() {
-            continue;
-        }
-        if path.extension().and_then(|s| s.to_str()) != Some("json") {
-            continue;
-        }
-        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
-            continue;
-        };
-        // `@scope/name@version.json` gets stored as `@scope__name@version.json`.
-        let pkg_label = stem.replace("__", "/");
-
-        let Ok(content) = std::fs::read_to_string(&path) else {
-            continue;
-        };
-        let Ok(index): Result<aube_store::PackageIndex, _> = serde_json::from_str(&content) else {
-            continue;
-        };
-
-        *checked += 1;
-        let mut pkg_ok = true;
-        for (rel, stored) in &index {
-            if !verify_stored_file(&stored.store_path, &stored.hex_hash) {
-                broken.push(format!("{pkg_label}: {rel}"));
-                pkg_ok = false;
-            }
-        }
-        if pkg_ok {
-            tracing::debug!("store ok: {pkg_label}");
-        }
-    }
-    Ok(())
 }
 
 /// Stream the file at `path` through BLAKE3 and compare to the expected

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -139,6 +139,12 @@
       "exit_code": null
     },
     {
+      "name": "ERR_AUBE_STORE_INDEX_SCAN_FAILED",
+      "category": "Tarball / store",
+      "description": "A store maintenance command couldn't completely read or parse the cached package indexes.",
+      "exit_code": null
+    },
+    {
       "name": "ERR_AUBE_PACKAGE_NOT_FOUND",
       "category": "Registry / network",
       "description": "Registry returned 404 for the package name.",

--- a/test/store.bats
+++ b/test/store.bats
@@ -103,6 +103,74 @@ EOF
 	assert_output --partial "corrupt"
 }
 
+@test "aube store maintenance fails closed on a malformed package index" {
+	run aube store add is-odd@3.0.1
+	assert_success
+
+	store_v1="$(aube store path)"
+	index="$(find "$store_v1/index" -mindepth 2 -maxdepth 2 -name 'is-odd@3.0.1.json' -print -quit)"
+	assert_file_exists "$index"
+	before="$(find "$store_v1/files" -type f | wc -l)"
+	echo '{not valid JSON' >"$index"
+
+	run aube store prune --dry-run
+	assert_failure
+	assert_output --partial "ERR_AUBE_STORE_INDEX_SCAN_FAILED"
+	assert_output --partial "is-odd@3.0.1.json"
+	assert_equal "$before" "$(find "$store_v1/files" -type f | wc -l)"
+
+	run aube store prune
+	assert_failure
+	assert_output --partial "ERR_AUBE_STORE_INDEX_SCAN_FAILED"
+	assert_output --partial "is-odd@3.0.1.json"
+	assert_equal "$before" "$(find "$store_v1/files" -type f | wc -l)"
+
+	run aube store status
+	assert_failure
+	assert_output --partial "ERR_AUBE_STORE_INDEX_SCAN_FAILED"
+	assert_output --partial "is-odd@3.0.1.json"
+}
+
+@test "aube store prune preserves files when an index path is unreadable" {
+	run aube store add is-odd@3.0.1
+	assert_success
+
+	store_v1="$(aube store path)"
+	index="$(find "$store_v1/index" -mindepth 2 -maxdepth 2 -name 'is-odd@3.0.1.json' -print -quit)"
+	assert_file_exists "$index"
+	index_dir="$(dirname "$index")"
+	before="$(find "$store_v1/files" -type f | wc -l)"
+	chmod 000 "$index"
+
+	# Root can bypass mode bits, so skip rather than asserting a false
+	# negative in privileged containers.
+	if test -r "$index"; then
+		chmod 600 "$index"
+		skip "running as a user that can bypass file permissions"
+	fi
+
+	run aube store prune --dry-run
+	chmod 600 "$index"
+	assert_failure
+	assert_output --partial "ERR_AUBE_STORE_INDEX_SCAN_FAILED"
+	assert_output --partial "is-odd@3.0.1.json"
+	assert_equal "$before" "$(find "$store_v1/files" -type f | wc -l)"
+
+	chmod 000 "$index_dir"
+
+	if test -r "$index"; then
+		chmod 700 "$index_dir"
+		skip "running as a user that can bypass directory permissions"
+	fi
+
+	run aube store prune
+	chmod 700 "$index_dir"
+	assert_failure
+	assert_output --partial "ERR_AUBE_STORE_INDEX_SCAN_FAILED"
+	assert_output --partial "$(basename "$index_dir")"
+	assert_equal "$before" "$(find "$store_v1/files" -type f | wc -l)"
+}
+
 @test "aube store prune runs cleanly on an empty store" {
 	run aube store prune
 	assert_success


### PR DESCRIPTION
## Summary

- make `store prune` and `--dry-run` abort before examining CAS files when a cached package index cannot be completely scanned
- make `store status` report the same malformed or unreadable indexes instead of claiming consistency
- add `ERR_AUBE_STORE_INDEX_SCAN_FAILED` with path-specific diagnostics
- cover malformed JSON and unreadable index files/directories while asserting store files remain untouched

## Root cause

The JSON index walker flattened directory-entry errors and skipped directory, file-read, and parse failures. Pruning then treated the resulting partial hash set as complete, making files referenced only by a skipped index eligible for deletion.

This replaces the best-effort walkers with one strict scanner shared by prune, dry-run, and status. A missing index root still represents an empty cache, but any failure within an existing index tree aborts the command.

Discussion: https://github.com/jdx/aube/discussions/1234

## Validation

- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `mise run test:bats test/store.bats`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes store prune behavior on index I/O/parse errors (fail-closed vs silent skip), which prevents data loss but may surface new failures on damaged stores; scope is limited to store maintenance commands.
> 
> **Overview**
> **Store maintenance no longer treats a partial index walk as success.** Previously, `store prune` (including `--dry-run`) and `store status` could skip unreadable or invalid cached package indexes; prune then built an incomplete “referenced” hash set and could delete CAS files that were still live.
> 
> This PR replaces the separate best-effort walkers with one strict scanner, `visit_cached_indices`, shared by prune and status. A missing index root still means an empty cache; any list/read/parse failure under an existing index tree aborts with **`ERR_AUBE_STORE_INDEX_SCAN_FAILED`** and path-specific diagnostics. **`store status`** surfaces those scan failures instead of reporting consistency when indexes were never fully read.
> 
> Bats coverage asserts malformed JSON and permission-denied index paths leave **`files/`** untouched on failed prune/status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39a9c8321b0e9d7fc589369cc68e2ec7dd71324b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Store maintenance now detects malformed, unreadable, or incomplete package indexes instead of silently skipping them.
  * Pruning stops safely when index scanning fails, preserving store contents.
  * Store status reports consistent errors and identifies the affected index.
  * Added a dedicated error code for store index scan failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->