### PR TITLE
fix(install): canonicalize isolated dependency build paths

### DIFF
--- a/crates/aube/src/commands/install/finalize.rs
+++ b/crates/aube/src/commands/install/finalize.rs
@@ -185,7 +185,7 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
             graph_for_link,
             build_policy,
             virtual_store_dir_max_length,
-            node_linker == aube_linker::NodeLinker::Isolated,
+            cfg!(windows) && planned_gvs && node_linker == aube_linker::NodeLinker::Isolated,
             child_concurrency,
             placements_ref,
             side_effects_cache,

--- a/crates/aube/src/commands/install/finalize.rs
+++ b/crates/aube/src/commands/install/finalize.rs
@@ -185,6 +185,7 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
             graph_for_link,
             build_policy,
             virtual_store_dir_max_length,
+            node_linker == aube_linker::NodeLinker::Isolated,
             child_concurrency,
             placements_ref,
             side_effects_cache,

--- a/crates/aube/src/commands/install/gvs.rs
+++ b/crates/aube/src/commands/install/gvs.rs
@@ -240,7 +240,7 @@ pub(super) fn modules_metadata_is_current<'a>(
         })
 }
 
-pub(super) fn detect_existing_global_virtual_store(
+pub(crate) fn detect_existing_global_virtual_store(
     workspace_root: &Path,
     aube_dir: &Path,
     modules_dir_name: &str,

--- a/crates/aube/src/commands/install/lifecycle.rs
+++ b/crates/aube/src/commands/install/lifecycle.rs
@@ -408,6 +408,7 @@ pub(crate) async fn run_dep_lifecycle_scripts(
     graph: &aube_lockfile::LockfileGraph,
     policy: &aube_scripts::BuildPolicy,
     virtual_store_dir_max_length: usize,
+    canonicalize_package_dir: bool,
     child_concurrency: usize,
     placements: Option<&aube_linker::HoistedPlacements>,
     side_effects_cache: SideEffectsCacheConfig<'_>,
@@ -489,6 +490,23 @@ pub(crate) async fn run_dep_lifecycle_scripts(
             );
             continue;
         }
+        // On Windows, changing directory through an NTFS junction preserves
+        // the logical `.aube/<dep_path>` path. Native build tools such as
+        // node-gyp can then resolve a dependency to its graph-hashed GVS path
+        // but interpret that path relative to the unhashed local `.aube/`
+        // namespace, leaving an apparently missing `node_api.gyp`. POSIX
+        // `getcwd` resolves the outer symlink and masks the same mismatch.
+        // Enter the physical shared-store directory explicitly so the script
+        // cwd and every nested dependency use the same namespace.
+        let package_dir = lifecycle_package_dir(&package_dir, canonicalize_package_dir)
+            .into_diagnostic()
+            .wrap_err_with(|| {
+                format!(
+                    "failed to resolve isolated package directory for {} at {}",
+                    pkg.name,
+                    package_dir.display()
+                )
+            })?;
         // Read the dep's `package.json` directly from its materialized
         // location. Previously we looked it up via `package_indices`,
         // but the fetch phase now skips `load_index` for packages
@@ -708,6 +726,17 @@ pub(crate) async fn run_dep_lifecycle_scripts(
         ran += res.into_diagnostic()??;
     }
     Ok(ran)
+}
+
+fn lifecycle_package_dir(
+    package_dir: &std::path::Path,
+    canonicalize: bool,
+) -> std::io::Result<std::path::PathBuf> {
+    if canonicalize {
+        crate::dirs::canonicalize(package_dir)
+    } else {
+        Ok(package_dir.to_path_buf())
+    }
 }
 
 /// Verify + import + validate + save-index for a freshly fetched
@@ -1223,6 +1252,43 @@ pub(super) fn unreviewed_dep_builds(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn global_virtual_store_lifecycle_uses_physical_package_dir() {
+        let temp = tempfile::tempdir().unwrap();
+        let physical = temp.path().join("shared-store/pkg@1.0.0/node_modules/pkg");
+        std::fs::create_dir_all(&physical).unwrap();
+        let logical = temp.path().join("project/node_modules/.aube/pkg@1.0.0");
+        std::fs::create_dir_all(logical.parent().unwrap()).unwrap();
+
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(
+            physical.parent().and_then(std::path::Path::parent).unwrap(),
+            &logical,
+        )
+        .unwrap();
+        #[cfg(windows)]
+        {
+            let target = physical.parent().and_then(std::path::Path::parent).unwrap();
+            let status = std::process::Command::new("cmd")
+                .args(["/C", "mklink", "/J"])
+                .arg(&logical)
+                .arg(target)
+                .status()
+                .unwrap();
+            assert!(status.success());
+        }
+
+        let logical_package = logical.join("node_modules/pkg");
+        assert_eq!(
+            lifecycle_package_dir(&logical_package, true).unwrap(),
+            crate::dirs::canonicalize(&physical).unwrap()
+        );
+        assert_eq!(
+            lifecycle_package_dir(&logical_package, false).unwrap(),
+            logical_package
+        );
+    }
 
     #[test]
     fn pnpm_trusted_dependencies_are_allowed_by_default() {

--- a/crates/aube/src/commands/install/lifecycle.rs
+++ b/crates/aube/src/commands/install/lifecycle.rs
@@ -490,24 +490,29 @@ pub(crate) async fn run_dep_lifecycle_scripts(
             );
             continue;
         }
-        // On Windows, changing directory through an NTFS junction preserves
-        // the logical `.aube/<dep_path>` path. Native build tools such as
+        // With the global virtual store on Windows, changing directory through
+        // an NTFS junction preserves the logical `.aube/<dep_path>` path.
+        // Native build tools such as
         // node-gyp can then resolve a dependency to its graph-hashed GVS path
         // but interpret that path relative to the unhashed local `.aube/`
         // namespace, leaving an apparently missing `node_api.gyp`. POSIX
         // `getcwd` resolves the outer symlink and masks the same mismatch.
         // Enter the physical shared-store directory explicitly so the script
         // cwd and every nested dependency use the same namespace.
-        let package_dir = lifecycle_package_dir(&package_dir, canonicalize_package_dir)
-            .await
-            .into_diagnostic()
-            .wrap_err_with(|| {
-                format!(
-                    "failed to resolve isolated package directory for {} at {}",
-                    pkg.name,
-                    package_dir.display()
-                )
-            })?;
+        let package_dir = if canonicalize_package_dir {
+            lifecycle_package_dir(&package_dir, true)
+                .await
+                .into_diagnostic()
+                .wrap_err_with(|| {
+                    format!(
+                        "failed to resolve isolated package directory for {} at {}",
+                        pkg.name,
+                        package_dir.display()
+                    )
+                })?
+        } else {
+            package_dir
+        };
         // Read the dep's `package.json` directly from its materialized
         // location. Previously we looked it up via `package_indices`,
         // but the fetch phase now skips `load_index` for packages
@@ -1260,9 +1265,19 @@ mod tests {
     #[tokio::test]
     async fn global_virtual_store_lifecycle_uses_physical_package_dir() {
         let temp = tempfile::tempdir().unwrap();
-        let physical = temp.path().join("shared-store/pkg@1.0.0/node_modules/pkg");
+        let physical = temp
+            .path()
+            .join("shared-store")
+            .join("pkg@1.0.0")
+            .join("node_modules")
+            .join("pkg");
         std::fs::create_dir_all(&physical).unwrap();
-        let logical = temp.path().join("project/node_modules/.aube/pkg@1.0.0");
+        let logical = temp
+            .path()
+            .join("project")
+            .join("node_modules")
+            .join(".aube")
+            .join("pkg@1.0.0");
         std::fs::create_dir_all(logical.parent().unwrap()).unwrap();
 
         #[cfg(unix)]
@@ -1274,10 +1289,13 @@ mod tests {
         #[cfg(windows)]
         {
             let target = physical.parent().and_then(std::path::Path::parent).unwrap();
+            let command = format!(
+                "mklink /J \"{}\" \"{}\"",
+                logical.display(),
+                target.display()
+            );
             let status = std::process::Command::new("cmd")
-                .args(["/C", "mklink", "/J"])
-                .arg(&logical)
-                .arg(target)
+                .args(["/C", &command])
                 .status()
                 .unwrap();
             assert!(status.success());

--- a/crates/aube/src/commands/install/lifecycle.rs
+++ b/crates/aube/src/commands/install/lifecycle.rs
@@ -1289,13 +1289,10 @@ mod tests {
         #[cfg(windows)]
         {
             let target = physical.parent().and_then(std::path::Path::parent).unwrap();
-            let command = format!(
-                "mklink /J \"{}\" \"{}\"",
-                logical.display(),
-                target.display()
-            );
             let status = std::process::Command::new("cmd")
-                .args(["/C", &command])
+                .args(["/C", "mklink", "/J"])
+                .arg(&logical)
+                .arg(target)
                 .status()
                 .unwrap();
             assert!(status.success());

--- a/crates/aube/src/commands/install/lifecycle.rs
+++ b/crates/aube/src/commands/install/lifecycle.rs
@@ -499,6 +499,7 @@ pub(crate) async fn run_dep_lifecycle_scripts(
         // Enter the physical shared-store directory explicitly so the script
         // cwd and every nested dependency use the same namespace.
         let package_dir = lifecycle_package_dir(&package_dir, canonicalize_package_dir)
+            .await
             .into_diagnostic()
             .wrap_err_with(|| {
                 format!(
@@ -728,12 +729,15 @@ pub(crate) async fn run_dep_lifecycle_scripts(
     Ok(ran)
 }
 
-fn lifecycle_package_dir(
+async fn lifecycle_package_dir(
     package_dir: &std::path::Path,
     canonicalize: bool,
 ) -> std::io::Result<std::path::PathBuf> {
     if canonicalize {
-        crate::dirs::canonicalize(package_dir)
+        let package_dir = package_dir.to_path_buf();
+        tokio::task::spawn_blocking(move || crate::dirs::canonicalize(&package_dir))
+            .await
+            .map_err(std::io::Error::other)?
     } else {
         Ok(package_dir.to_path_buf())
     }
@@ -1253,8 +1257,8 @@ pub(super) fn unreviewed_dep_builds(
 mod tests {
     use super::*;
 
-    #[test]
-    fn global_virtual_store_lifecycle_uses_physical_package_dir() {
+    #[tokio::test]
+    async fn global_virtual_store_lifecycle_uses_physical_package_dir() {
         let temp = tempfile::tempdir().unwrap();
         let physical = temp.path().join("shared-store/pkg@1.0.0/node_modules/pkg");
         std::fs::create_dir_all(&physical).unwrap();
@@ -1281,11 +1285,13 @@ mod tests {
 
         let logical_package = logical.join("node_modules/pkg");
         assert_eq!(
-            lifecycle_package_dir(&logical_package, true).unwrap(),
+            lifecycle_package_dir(&logical_package, true).await.unwrap(),
             crate::dirs::canonicalize(&physical).unwrap()
         );
         assert_eq!(
-            lifecycle_package_dir(&logical_package, false).unwrap(),
+            lifecycle_package_dir(&logical_package, false)
+                .await
+                .unwrap(),
             logical_package
         );
     }

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -47,6 +47,7 @@ use fetch::{
     strip_peer_context_suffix, version_from_dep_path,
 };
 pub use frozen::{FrozenMode, FrozenOverride, GlobalVirtualStoreFlags};
+pub(crate) use gvs::detect_existing_global_virtual_store;
 pub(crate) use lifecycle::{
     JailBuildPolicy, build_policy_from_manifest_sources, build_policy_from_sources,
     run_dep_lifecycle_scripts,

--- a/crates/aube/src/commands/rebuild.rs
+++ b/crates/aube/src/commands/rebuild.rs
@@ -184,6 +184,7 @@ pub async fn run(
                 &graph,
                 &policy,
                 super::resolve_virtual_store_dir_max_length(&settings_ctx),
+                isolated,
                 child_concurrency,
                 hoisted_placements.as_ref(),
                 side_effects_cache_root

--- a/crates/aube/src/commands/rebuild.rs
+++ b/crates/aube/src/commands/rebuild.rs
@@ -159,6 +159,15 @@ pub async fn run(
                 node_linker_setting,
                 aube_settings::resolved::NodeLinker::Hoisted
             );
+            let canonicalize_package_dir = cfg!(windows)
+                && isolated
+                && super::install::detect_existing_global_virtual_store(
+                    &cwd,
+                    &aube_dir,
+                    &modules_dir_name,
+                    &super::global_virtual_store_dir(&cwd),
+                )
+                .unwrap_or(false);
             let prefer_symlinked_executables =
                 aube_settings::resolved::prefer_symlinked_executables(&settings_ctx)
                     .or(isolated.then_some(false));
@@ -184,7 +193,7 @@ pub async fn run(
                 &graph,
                 &policy,
                 super::resolve_virtual_store_dir_max_length(&settings_ctx),
-                isolated,
+                canonicalize_package_dir,
                 child_concurrency,
                 hoisted_placements.as_ref(),
                 side_effects_cache_root


### PR DESCRIPTION
## Summary

- canonicalize isolated dependency package directories before lifecycle scripts run
- derive dependency-local bin paths from the same physical virtual-store namespace
- apply the behavior consistently to both install and rebuild
- add a cross-platform symlink/junction regression test

## Root cause

On Windows, entering an NTFS junction preserves the logical `.aube/<dep_path>` working directory. Native build tools such as node-gyp could resolve a dependency to its graph-hashed global virtual-store path, then interpret that path relative to the unhashed local `.aube` namespace. This made existing files such as `node-addon-api/node_api.gyp` appear missing.

Canonicalizing the lifecycle working directory ensures the package cwd and its nested dependencies use the same physical namespace. Per-project isolated directories are already physical, so canonicalization is a no-op there; hoisted installs keep their existing paths.

Addresses [Discussion #1235](https://github.com/jdx/aube/discussions/1235).

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p aube` (792 tests passed)

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only the cwd for dependency lifecycle scripts in a narrow Windows+GVS+isolated case; mis-resolution would break native builds but auth, data, and default install paths are untouched.
> 
> **Overview**
> Fixes **Windows** installs where **global virtual store** + **isolated** linking left lifecycle scripts (e.g. **node-gyp**) using the logical `node_modules/.aube/<dep>` cwd while dependency paths pointed at the hashed GVS tree, so files like `node_api.gyp` looked missing.
> 
> `run_dep_lifecycle_scripts` gains a **`canonicalize_package_dir`** flag: when set, each dep’s working directory is resolved to the **physical** package path via blocking `canonicalize` before scripts run. **Install** enables this only for `cfg!(windows) && planned_gvs && NodeLinker::Isolated`; **rebuild** uses the same rule by calling the newly **`pub(crate)`** `detect_existing_global_virtual_store`. Other platforms and hoisted/non-GVS paths are unchanged (canonicalization is a no-op where paths are already physical).
> 
> Adds a **cross-platform** test (`symlink` on Unix, **junction** on Windows) for `lifecycle_package_dir`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78e3d4744d5271a5651dad4166a4357a00be4b04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency installation and rebuild behavior when isolated linking is enabled on Windows.
  * Lifecycle scripts now correctly resolve package locations when packages are accessed through symlinks or junctions.
  * Added clearer, package-specific errors when physical package paths cannot be resolved.
  * Preserved existing package paths when path resolution is not required, maintaining compatibility with prior behavior.
  * Improved consistency when running dependency setup scripts across different package linking modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->