### PR TITLE
fix(install): make explicit release age strict

### DIFF
--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -283,10 +283,11 @@ type = "int"
 default = "1440"
 docs = """
 Supply-chain attack mitigation: versions published within the last N
-minutes are skipped by the resolver. By default the resolver falls back
-to the next-oldest version that satisfies the range; set
-`minimumReleaseAgeStrict=true` to fail the install instead. Defaults to
-24 hours, matching pnpm v11. Set to `0` to disable.
+minutes are skipped by the resolver. Existing lockfile pins remain
+authoritative and are not revalidated against publish times. The built-in
+24-hour policy uses loose mode; explicitly configuring `minimumReleaseAge`
+enables strict mode unless
+`minimumReleaseAgeStrict=false` is also set. Set to `0` to disable.
 """
 sources.cli = []
 sources.env = ["npm_config_minimum_release_age", "NPM_CONFIG_MINIMUM_RELEASE_AGE", "AUBE_MINIMUM_RELEASE_AGE"]
@@ -347,9 +348,10 @@ description = "Fail the install when no version satisfies the minimumReleaseAge 
 type = "bool"
 default = "false"
 docs = """
-By default the resolver falls back to the lowest satisfying version when
-every candidate is younger than `minimumReleaseAge`. With this set, the
-resolver fails the install instead.
+Fail when every matching candidate is younger than `minimumReleaseAge`.
+This is implicitly enabled when `minimumReleaseAge` is explicitly configured.
+Set it to `false` explicitly to retain loose mode, which records any immature
+selection in the lockfile. Existing lockfile pins are always respected.
 """
 sources.cli = []
 sources.env = ["npm_config_minimum_release_age_strict", "NPM_CONFIG_MINIMUM_RELEASE_AGE_STRICT", "AUBE_MINIMUM_RELEASE_AGE_STRICT"]

--- a/crates/aube-settings/src/lib.rs
+++ b/crates/aube-settings/src/lib.rs
@@ -24,6 +24,6 @@ pub mod values;
 
 pub use meta::{SettingMeta, all, find};
 pub use values::{
-    ResolveCtx, embedder_defaults, parse_bool, resolved, set_embedder_defaults,
+    ResolveCtx, embedder_defaults, has_explicit_value, parse_bool, resolved, set_embedder_defaults,
     set_global_cli_overrides, workspace_yaml_value,
 };

--- a/crates/aube-settings/src/values.rs
+++ b/crates/aube-settings/src/values.rs
@@ -134,6 +134,45 @@ impl<'a> ResolveCtx<'a> {
     }
 }
 
+/// Return whether a setting was supplied by a user-controlled configuration
+/// source, excluding managed policy, built-in defaults, and embedder defaults.
+pub fn has_explicit_value(setting: &str, ctx: &ResolveCtx<'_>) -> bool {
+    let Some(meta) = meta::find(setting) else {
+        return false;
+    };
+    let file_key_matches = |key: &str| {
+        key == meta.name
+            || meta.npmrc_keys.contains(&key)
+            || meta.workspace_yaml_keys.contains(&key)
+    };
+    let file_sources = [
+        ctx.project_aube_config,
+        ctx.project_npmrc,
+        ctx.user_aube_config,
+        ctx.user_npmrc,
+    ];
+    if file_sources
+        .into_iter()
+        .any(|entries| entries.iter().any(|(key, _)| file_key_matches(key)))
+    {
+        return true;
+    }
+    if meta
+        .workspace_yaml_keys
+        .iter()
+        .any(|key| workspace_yaml_value(ctx.workspace_yaml, key).is_some())
+    {
+        return true;
+    }
+    if raw_from_env(meta, ctx.env).is_some() {
+        return true;
+    }
+    ctx.cli
+        .iter()
+        .chain(global_cli_overrides())
+        .any(|(key, _)| cli_key_matches(key, meta))
+}
+
 /// Embedder-supplied setting defaults, registered once at startup by an
 /// embedding host. Standalone aube never registers any, so this stays empty
 /// and the per-setting built-in defaults from `settings.toml` apply. Each
@@ -1132,6 +1171,25 @@ mod tests {
 
         let screaming = vec![("STRICT_DEP_BUILDS".to_string(), "false".to_string())];
         assert_eq!(bool_from_cli("strictDepBuilds", &screaming), Some(false));
+    }
+
+    #[test]
+    fn explicit_value_matches_kebab_case_generic_cli_key() {
+        let cli = entries(&[("minimum-release-age-strict", "false")]);
+        let workspace = BTreeMap::new();
+        let ctx = ResolveCtx {
+            managed_aube_config: &[],
+            project_aube_config: &[],
+            project_npmrc: &[],
+            user_aube_config: &[],
+            user_npmrc: &[],
+            workspace_yaml: &workspace,
+            env: &[],
+            cli: &cli,
+            embedder_defaults: &[],
+        };
+
+        assert!(has_explicit_value("minimumReleaseAgeStrict", &ctx));
     }
 
     #[test]

--- a/crates/aube-settings/tests/explicit_env_brand_gate.rs
+++ b/crates/aube-settings/tests/explicit_env_brand_gate.rs
@@ -1,0 +1,57 @@
+//! Integration test for explicit setting detection under an embedder that
+//! disables tool-branded environment aliases.
+
+use aube_settings::{ResolveCtx, has_explicit_value};
+use aube_util::Embedder;
+use std::collections::BTreeMap;
+
+static NUBLIKE: Embedder = Embedder {
+    name: "nublike",
+    display_name: "nublike",
+    vendor: None,
+    version: "1.0.0",
+    user_agent: "nublike/1.0.0",
+    self_names: &["nublike"],
+    compatible_names: &["pnpm"],
+    lockfile_basename: "lock.yaml",
+    workspace_yaml: None,
+    manifest_namespace: "",
+    env_prefix: None,
+    config_env_prefix: Some("NUB"),
+    cache_namespace: "nublike",
+    data_namespace: "nublike",
+    canonical_lockfile_always_wins: false,
+    runtime_switching: false,
+    self_engines_check: false,
+    self_update_enabled: false,
+};
+
+#[test]
+fn disabled_branded_env_alias_is_not_explicit() {
+    aube_util::set_embedder(&NUBLIKE);
+    let workspace = BTreeMap::new();
+    let branded = vec![("AUBE_MINIMUM_RELEASE_AGE".to_string(), "999".to_string())];
+    let ctx = ResolveCtx {
+        managed_aube_config: &[],
+        project_aube_config: &[],
+        project_npmrc: &[],
+        user_aube_config: &[],
+        user_npmrc: &[],
+        workspace_yaml: &workspace,
+        env: &branded,
+        cli: &[],
+        embedder_defaults: &[],
+    };
+
+    assert!(!has_explicit_value("minimumReleaseAge", &ctx));
+
+    let neutral = vec![(
+        "NPM_CONFIG_MINIMUM_RELEASE_AGE".to_string(),
+        "999".to_string(),
+    )];
+    let ctx = ResolveCtx {
+        env: &neutral,
+        ..ctx
+    };
+    assert!(has_explicit_value("minimumReleaseAge", &ctx));
+}

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -96,13 +96,107 @@ pub(crate) fn resolve_minimum_release_age(
         );
     }
     // `paranoid=true` forces the gate to be hard, not advisory.
-    let strict = aube_settings::resolved::minimum_release_age_strict(ctx)
-        || aube_settings::resolved::paranoid(ctx);
+    let strict_was_set = aube_settings::has_explicit_value("minimumReleaseAgeStrict", ctx);
+    let unmanaged_ctx = aube_settings::ResolveCtx {
+        managed_aube_config: &[],
+        embedder_defaults: &[],
+        project_aube_config: ctx.project_aube_config,
+        project_npmrc: ctx.project_npmrc,
+        user_aube_config: ctx.user_aube_config,
+        user_npmrc: ctx.user_npmrc,
+        workspace_yaml: ctx.workspace_yaml,
+        env: ctx.env,
+        cli: ctx.cli,
+    };
+    let age_was_set = cli_minutes.is_some()
+        || (aube_settings::has_explicit_value("minimumReleaseAge", ctx)
+            && aube_settings::resolved::minimum_release_age(&unmanaged_ctx) > 0);
+    let strict = aube_settings::resolved::paranoid(ctx)
+        || aube_settings::resolved::minimum_release_age_strict(ctx)
+        || (age_was_set && !strict_was_set);
     Some(aube_resolver::MinimumReleaseAge {
         minutes,
         exclude,
         strict,
     })
+}
+
+#[cfg(test)]
+mod minimum_release_age_tests {
+    use super::*;
+
+    #[test]
+    fn managed_age_raise_does_not_implicitly_enable_strict_mode() {
+        let managed = vec![("minimumReleaseAge".to_string(), "1440".to_string())];
+        let project = vec![("minimumReleaseAge".to_string(), "0".to_string())];
+        let workspace = BTreeMap::new();
+        let ctx = aube_settings::ResolveCtx {
+            managed_aube_config: &managed,
+            project_aube_config: &project,
+            project_npmrc: &[],
+            user_aube_config: &[],
+            user_npmrc: &[],
+            workspace_yaml: &workspace,
+            env: &[],
+            cli: &[],
+            embedder_defaults: &[],
+        };
+
+        let policy = resolve_minimum_release_age(&ctx, None).unwrap();
+        assert_eq!(policy.minutes, 1440);
+        assert!(!policy.strict);
+    }
+
+    #[test]
+    fn winning_workspace_age_implicitly_enables_strict_mode() {
+        let project_npmrc = vec![("minimumReleaseAge".to_string(), "0".to_string())];
+        let workspace = BTreeMap::from([(
+            "minimumReleaseAge".to_string(),
+            yaml_serde::Value::Number(1440_u64.into()),
+        )]);
+        let ctx = aube_settings::ResolveCtx {
+            managed_aube_config: &[],
+            project_aube_config: &[],
+            project_npmrc: &project_npmrc,
+            user_aube_config: &[],
+            user_npmrc: &[],
+            workspace_yaml: &workspace,
+            env: &[],
+            cli: &[],
+            embedder_defaults: &[],
+        };
+
+        let policy = resolve_minimum_release_age(&ctx, None).unwrap();
+        assert_eq!(policy.minutes, 1440);
+        assert!(policy.strict);
+    }
+
+    #[test]
+    fn kebab_case_generic_cli_can_explicitly_disable_strict_mode() {
+        let workspace = BTreeMap::new();
+        let cli = vec![
+            ("minimum-release-age".to_string(), "999".to_string()),
+            (
+                "minimum-release-age-strict".to_string(),
+                "false".to_string(),
+            ),
+        ];
+        let ctx = aube_settings::ResolveCtx {
+            managed_aube_config: &[],
+            project_aube_config: &[],
+            project_npmrc: &[],
+            user_aube_config: &[],
+            user_npmrc: &[],
+            workspace_yaml: &workspace,
+            env: &[],
+            cli: &cli,
+            embedder_defaults: &[],
+        };
+
+        let policy = resolve_minimum_release_age(&ctx, None).unwrap();
+        assert_eq!(policy.minutes, 999);
+        assert!(!policy.strict);
+    }
 }
 
 /// Resolve the effective `autoInstallPeers` setting from a

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -381,10 +381,11 @@ Delay installation of newly published versions (minutes).
 - Managed policy: `max`
 
 Supply-chain attack mitigation: versions published within the last N
-minutes are skipped by the resolver. By default the resolver falls back
-to the next-oldest version that satisfies the range; set
-`minimumReleaseAgeStrict=true` to fail the install instead. Defaults to
-24 hours, matching pnpm v11. Set to `0` to disable.
+minutes are skipped by the resolver. Existing lockfile pins remain
+authoritative and are not revalidated against publish times. The built-in
+24-hour policy uses loose mode; explicitly configuring `minimumReleaseAge`
+enables strict mode unless
+`minimumReleaseAgeStrict=false` is also set. Set to `0` to disable.
 
 ### `minimumPackageAge` {#setting-minimumpackageage}
 
@@ -437,9 +438,10 @@ Fail the install when no version satisfies the minimumReleaseAge cutoff.
 - Workspace YAML keys: `minimumReleaseAgeStrict`
 - Managed policy: `trueWins`
 
-By default the resolver falls back to the lowest satisfying version when
-every candidate is younger than `minimumReleaseAge`. With this set, the
-resolver fails the install instead.
+Fail when every matching candidate is younger than `minimumReleaseAge`.
+This is implicitly enabled when `minimumReleaseAge` is explicitly configured.
+Set it to `false` explicitly to retain loose mode, which records any immature
+selection in the lockfile. Existing lockfile pins are always respected.
 
 ### `securityScanner` {#setting-securityscanner}
 

--- a/test/minimum_release_age.bats
+++ b/test/minimum_release_age.bats
@@ -47,10 +47,33 @@ EOF
 	# (~1900 years) excludes every candidate and forces the fallback.
 	_setup_basic_fixture
 	rm aube-lock.yaml
-	echo "minimumReleaseAge=999999999" >.npmrc
+	cat >.npmrc <<EOF
+minimumReleaseAge=999999999
+minimumReleaseAgeStrict=false
+EOF
 	run aube install
 	assert_success
 	assert_file_exists aube-lock.yaml
+}
+
+@test "explicit minimumReleaseAge defaults to strict mode" {
+	_setup_basic_fixture
+	rm aube-lock.yaml
+	echo "minimumReleaseAge=999999999" >.npmrc
+	run aube install
+	assert_failure
+	assert_output --partial "ERR_AUBE_NO_MATURE_MATCHING_VERSION"
+}
+
+@test "loaded lockfile entries remain authoritative under minimumReleaseAge" {
+	_setup_basic_fixture
+	cat >pnpm-workspace.yaml <<EOF
+minimumReleaseAge: 999999999
+minimumReleaseAgeStrict: true
+trustPolicy: off
+EOF
+	run aube install
+	assert_success
 }
 
 @test "aube install with minimumReleaseAgeStrict=true and impossible cutoff fails" {


### PR DESCRIPTION
## Summary

- make an explicitly configured `minimumReleaseAge` enable strict fresh-resolution behavior unless `minimumReleaseAgeStrict=false` is also explicit
- distinguish user-controlled configuration from managed, embedder, and built-in defaults
- keep existing lockfile pins authoritative, including under strict release-age settings
- document the intentional lockfile behavior and add regression coverage

## Root cause

The typed settings accessor returned only the final value, so install code could not distinguish the built-in 24-hour default from an explicitly configured age. The first source-presence implementation was too broad because it also counted managed policy and losing local values.

This addresses the cold-resolution behavior reported in [discussion #1240](https://github.com/jdx/aube/discussions/1240) while preserving aube's intentional difference from pnpm: existing lockfile pins are respected rather than revalidated against publish times.

## Tests

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `mise run test:bats test/minimum_release_age.bats test/config.bats`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes supply-chain age-gate behavior on fresh resolution (stricter by default when age is explicitly configured), though lockfile pins and explicit `minimumReleaseAgeStrict=false` limit blast radius.
> 
> **Overview**
> **Explicit `minimumReleaseAge` now turns on strict fresh-resolution behavior** unless the user also sets `minimumReleaseAgeStrict=false`. The built-in 24-hour default stays **loose** (fallback to oldest satisfying version); only user-controlled configuration counts as “explicit,” not managed policy or embedder defaults.
> 
> Adds **`has_explicit_value`** in `aube-settings` so install code can tell real user config from resolved defaults. **`resolve_minimum_release_age`** uses it so managed `minimumReleaseAge` raises do not implicitly enable strict, while a winning workspace/npmrc/cli age does.
> 
> Docs and bats cover the new semantics: impossible age without `minimumReleaseAgeStrict=false` fails cold resolve; existing lockfile pins still install under strict age settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4edeebcb96980ad1e7fda29f686d24bc6a2d0a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuring a minimum release age now enables strict mode by default.
  * Explicit loose mode remains available when desired.
  * Existing lockfile selections remain authoritative, even under strict age restrictions.
  * Release-age settings now consistently recognize workspace, environment, and command-line configuration.

* **Documentation**
  * Clarified strict-mode behavior, fallback handling, and lockfile recording of immature selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->