### PR TITLE
fix(linker): share hoisted deps across workspace importers

### DIFF
--- a/crates/aube-linker/src/builder.rs
+++ b/crates/aube-linker/src/builder.rs
@@ -235,8 +235,8 @@ impl Linker {
     /// copy via the root-level symlink, so consumer code is
     /// unaffected. Default false (pnpm parity). No-op under
     /// `virtualStoreOnly=true` (no per-importer symlink pass runs)
-    /// and under `NodeLinker::Hoisted` (each importer gets an
-    /// independent flat tree — no shared root to dedupe against).
+    /// and under `NodeLinker::Hoisted` (its workspace-wide placement
+    /// plan deduplicates compatible packages independently).
     pub fn with_dedupe_direct_deps(mut self, on: bool) -> Self {
         self.dedupe_direct_deps = on;
         self

--- a/crates/aube-linker/src/hoisted.rs
+++ b/crates/aube-linker/src/hoisted.rs
@@ -375,10 +375,24 @@ fn seed_importer(
     // order. BFS makes shallower deps win placement ties over
     // deeper ones, which matches npm's first-writer-wins policy.
     for dep in root_deps {
-        if !graph.packages.contains_key(&dep.dep_path) {
+        let Some(pkg) = graph.packages.get(&dep.dep_path) else {
             continue;
-        }
-        queue.push_back((importer_idx, floor, dep.name.clone(), dep.dep_path.clone()));
+        };
+        // A direct `link:` is a live importer-relative edge, including the
+        // locked representation of `workspace:` dependencies. Keep it in the
+        // consuming importer's node_modules instead of sharing it at the
+        // workspace root like an immutable registry package.
+        let dep_floor = if matches!(pkg.local_source.as_ref(), Some(LocalSource::Link(_))) {
+            importer_idx
+        } else {
+            floor
+        };
+        queue.push_back((
+            importer_idx,
+            dep_floor,
+            dep.name.clone(),
+            dep.dep_path.clone(),
+        ));
     }
 }
 
@@ -707,6 +721,29 @@ mod tests {
                 PathBuf::from("/project/packages/app/node_modules/shared"),
                 PathBuf::from("/project/packages/lib/node_modules/shared"),
             ]
+        );
+    }
+
+    #[test]
+    fn workspace_plan_keeps_direct_links_in_the_consuming_importer() {
+        let root_nm = PathBuf::from("/project/node_modules");
+        let importer_nm = PathBuf::from("/project/packages/app/node_modules");
+        let mut linked = pkg("linked", "0.0.0", &[]);
+        linked.local_source = Some(LocalSource::Link(PathBuf::from("packages/linked")));
+        let mut graph = LockfileGraph::default();
+        graph
+            .packages
+            .insert("linked@link:../linked".into(), linked);
+        let importers = vec![HoistedWorkspaceImporter {
+            modules_dir: importer_nm.clone(),
+            dependencies: vec![dep("linked", "linked@link:../linked")],
+        }];
+
+        let plan = plan_workspace(&root_nm, &importers, &graph, HoistingLimits::None).unwrap();
+
+        assert_eq!(
+            package_dir(&plan, "linked@link:../linked"),
+            importer_nm.join("linked")
         );
     }
 

--- a/crates/aube-linker/src/hoisted.rs
+++ b/crates/aube-linker/src/hoisted.rs
@@ -58,6 +58,13 @@ pub struct HoistedPlacements {
 }
 
 impl HoistedPlacements {
+    /// Restore an exact placement map recorded when the tree was linked.
+    /// This avoids replaying the planner against a graph whose filtering or
+    /// iteration order may differ from the materialized install.
+    pub fn from_package_dirs(by_dep_path: BTreeMap<String, Vec<PathBuf>>) -> Self {
+        Self { by_dep_path }
+    }
+
     /// Recompute hoisted placement paths for an already-linked graph
     /// without touching disk. Used by commands like `aube rebuild`
     /// that need to find package directories after install, but must
@@ -180,16 +187,15 @@ impl PlacementPlan {
         }
     }
 
-    /// Add a workspace importer below the shared workspace root. The
-    /// synthetic node has no package directory of its own; it only
-    /// models the importer's `node_modules/` and its parent-directory
-    /// visibility into the workspace root.
-    fn add_importer(&mut self, importer_nm: PathBuf) -> usize {
+    /// Add a workspace importer to the plan. The synthetic node has no
+    /// package directory of its own; `parent` models whether Node's
+    /// ancestor lookup can reach the workspace root.
+    fn add_importer(&mut self, importer_nm: PathBuf, parent: Option<usize>) -> usize {
         let idx = self.nodes.len();
         self.nodes.push(TreeNode {
             pkg_dir: None,
             nm_dir: importer_nm,
-            parent: Some(self.root_idx),
+            parent,
             children: BTreeMap::new(),
             dep_path: None,
         });
@@ -325,15 +331,24 @@ fn plan_workspace(
 ) -> Result<PlacementPlan, Error> {
     let mut plan = PlacementPlan::new(root_nm.to_path_buf());
     let mut queue: VecDeque<(usize, usize, String, String)> = VecDeque::new();
+    let workspace_root = root_nm.parent().unwrap_or(root_nm);
 
     for importer in importers {
+        let root_reachable = importer
+            .modules_dir
+            .parent()
+            .is_some_and(|importer_dir| importer_dir.starts_with(workspace_root));
         let importer_idx = if importer.modules_dir == root_nm {
             plan.root_idx
         } else {
-            plan.add_importer(importer.modules_dir.clone())
+            plan.add_importer(
+                importer.modules_dir.clone(),
+                root_reachable.then_some(plan.root_idx),
+            )
         };
         let floor = match hoisting_limits {
-            HoistingLimits::None => plan.root_idx,
+            HoistingLimits::None if root_reachable => plan.root_idx,
+            HoistingLimits::None => importer_idx,
             HoistingLimits::Workspaces | HoistingLimits::Dependencies => importer_idx,
         };
         seed_importer(
@@ -853,5 +868,37 @@ mod tests {
             Some(shared_dir.as_path())
         );
         assert_eq!(placements.all_package_dirs("shared@1.0.0").len(), 1);
+    }
+
+    #[test]
+    fn parent_relative_importer_cannot_reuse_workspace_root_placement() {
+        let root_nm = PathBuf::from("/workspace/node_modules");
+        let mut graph = LockfileGraph::default();
+        graph
+            .packages
+            .insert("shared@1.0.0".into(), pkg("shared", "1.0.0", &[]));
+        let deps = vec![dep("shared", "shared@1.0.0")];
+        let importers = vec![
+            HoistedWorkspaceImporter {
+                modules_dir: root_nm.clone(),
+                dependencies: deps.clone(),
+            },
+            HoistedWorkspaceImporter {
+                modules_dir: PathBuf::from("/sibling/node_modules"),
+                dependencies: deps,
+            },
+        ];
+
+        let plan = plan_workspace(&root_nm, &importers, &graph, HoistingLimits::None).unwrap();
+        let dirs: Vec<_> = plan
+            .nodes
+            .iter()
+            .filter(|node| node.dep_path.as_deref() == Some("shared@1.0.0"))
+            .filter_map(|node| node.pkg_dir.as_ref())
+            .collect();
+
+        assert_eq!(dirs.len(), 2);
+        assert!(dirs.contains(&&root_nm.join("shared")));
+        assert!(dirs.contains(&&PathBuf::from("/sibling/node_modules/shared")));
     }
 }

--- a/crates/aube-linker/src/hoisted.rs
+++ b/crates/aube-linker/src/hoisted.rs
@@ -8,10 +8,10 @@
 //! matches npm / yarn-classic's flat tree and is what certain legacy
 //! toolchains (React Native's Metro, some Jest plugins) require.
 //!
-//! Placement algorithm (npm-style, per importer):
+//! Placement algorithm (npm-style, workspace-aware):
 //!
-//! 1. Start with a `TreeNode` for the importer — its `node_modules`
-//!    directory and an empty child map.
+//! 1. Start with a `TreeNode` for the workspace-root `node_modules`
+//!    directory, with physical importers modeled as synthetic children.
 //! 2. BFS from the importer's direct deps. For each `(requester, name,
 //!    dep_path)` pair, walk up from the requester looking for the
 //!    shallowest ancestor whose `children[name]` is either absent or
@@ -36,7 +36,7 @@
 //! fallback.
 //!
 //! The planner output (`PlacementPlan`) is consumed by the
-//! materializer in `link_hoisted_importer` and also surfaced to the
+//! materializer and also surfaced to the
 //! install driver via `HoistedPlacements` so bin linking and
 //! dependency lifecycle scripts can locate a package's on-disk
 //! directory without recomputing the tree.
@@ -71,6 +71,7 @@ impl HoistedPlacements {
         hoisting_limits: HoistingLimits,
     ) -> Result<Self, Error> {
         let mut placements = Self::default();
+        let mut importers = Vec::with_capacity(graph.importers.len());
         for (importer_path, deps) in &graph.importers {
             if !crate::is_physical_importer(importer_path) {
                 continue;
@@ -78,17 +79,21 @@ impl HoistedPlacements {
             let importer_dir = if importer_path == "." {
                 root_dir.to_path_buf()
             } else {
-                root_dir.join(importer_path)
+                aube_util::path::normalize_lexical(&root_dir.join(importer_path))
             };
-            let nm = importer_dir.join(modules_dir_name);
-            let plan = plan_importer(&nm, deps, graph, hoisting_limits)?;
-            for node in &plan.nodes {
-                let (Some(dep_path), Some(pkg_dir)) = (&node.dep_path, &node.pkg_dir) else {
-                    continue;
-                };
-                if pkg_dir.exists() {
-                    placements.record(dep_path, pkg_dir.clone());
-                }
+            importers.push(HoistedWorkspaceImporter {
+                modules_dir: importer_dir.join(modules_dir_name),
+                dependencies: deps.clone(),
+            });
+        }
+        let root_nm = root_dir.join(modules_dir_name);
+        let plan = plan_workspace(&root_nm, &importers, graph, hoisting_limits)?;
+        for node in &plan.nodes {
+            let (Some(dep_path), Some(pkg_dir)) = (&node.dep_path, &node.pkg_dir) else {
+                continue;
+            };
+            if pkg_dir.exists() {
+                placements.record(dep_path, pkg_dir.clone());
             }
         }
         Ok(placements)
@@ -151,6 +156,7 @@ struct TreeNode {
 pub(crate) struct PlacementPlan {
     nodes: Vec<TreeNode>,
     root_idx: usize,
+    importer_indices: Vec<usize>,
 }
 
 struct PlaceOutcome {
@@ -170,7 +176,25 @@ impl PlacementPlan {
         Self {
             nodes: vec![root],
             root_idx: 0,
+            importer_indices: vec![0],
         }
+    }
+
+    /// Add a workspace importer below the shared workspace root. The
+    /// synthetic node has no package directory of its own; it only
+    /// models the importer's `node_modules/` and its parent-directory
+    /// visibility into the workspace root.
+    fn add_importer(&mut self, importer_nm: PathBuf) -> usize {
+        let idx = self.nodes.len();
+        self.nodes.push(TreeNode {
+            pkg_dir: None,
+            nm_dir: importer_nm,
+            parent: Some(self.root_idx),
+            children: BTreeMap::new(),
+            dep_path: None,
+        });
+        self.importer_indices.push(idx);
+        idx
     }
 
     /// Place `(name, dep_path)` under the ancestor chain rooted at
@@ -248,13 +272,10 @@ impl PlacementPlan {
         })
     }
 
-    /// Names placed directly in the importer root's `node_modules/`.
-    /// Drives the stale-entry sweep in `link_hoisted_importer`.
-    pub(crate) fn root_names(&self) -> impl Iterator<Item = &str> {
-        self.nodes[self.root_idx]
-            .children
-            .keys()
-            .map(|s| s.as_str())
+    /// Names placed directly in an importer's `node_modules/`. Drives
+    /// the stale-entry sweep before the plan is materialized.
+    fn importer_root_names(&self, importer_idx: usize) -> impl Iterator<Item = &str> {
+        self.nodes[importer_idx].children.keys().map(String::as_str)
     }
 }
 
@@ -280,6 +301,61 @@ pub(crate) fn plan_importer(
     let mut plan = PlacementPlan::new(importer_nm.to_path_buf());
     let mut queue: VecDeque<(usize, usize, String, String)> = VecDeque::new();
 
+    seed_importer(&mut queue, plan.root_idx, plan.root_idx, root_deps, graph);
+    complete_plan(&mut plan, queue, graph, hoisting_limits)?;
+
+    Ok(plan)
+}
+
+/// One physical importer in a hoisted workspace plan.
+pub(crate) struct HoistedWorkspaceImporter {
+    pub(crate) modules_dir: PathBuf,
+    pub(crate) dependencies: Vec<DirectDep>,
+}
+
+/// Build one placement plan for an entire workspace. Importers are
+/// represented as synthetic children of the workspace root, which lets
+/// `hoistingLimits=none` promote compatible packages to the shared root
+/// while the other limits keep their importer-local boundaries.
+fn plan_workspace(
+    root_nm: &Path,
+    importers: &[HoistedWorkspaceImporter],
+    graph: &LockfileGraph,
+    hoisting_limits: HoistingLimits,
+) -> Result<PlacementPlan, Error> {
+    let mut plan = PlacementPlan::new(root_nm.to_path_buf());
+    let mut queue: VecDeque<(usize, usize, String, String)> = VecDeque::new();
+
+    for importer in importers {
+        let importer_idx = if importer.modules_dir == root_nm {
+            plan.root_idx
+        } else {
+            plan.add_importer(importer.modules_dir.clone())
+        };
+        let floor = match hoisting_limits {
+            HoistingLimits::None => plan.root_idx,
+            HoistingLimits::Workspaces | HoistingLimits::Dependencies => importer_idx,
+        };
+        seed_importer(
+            &mut queue,
+            importer_idx,
+            floor,
+            &importer.dependencies,
+            graph,
+        );
+    }
+
+    complete_plan(&mut plan, queue, graph, hoisting_limits)?;
+    Ok(plan)
+}
+
+fn seed_importer(
+    queue: &mut VecDeque<(usize, usize, String, String)>,
+    importer_idx: usize,
+    floor: usize,
+    root_deps: &[DirectDep],
+    graph: &LockfileGraph,
+) {
     // Seed the queue with the importer's direct deps in declaration
     // order. BFS makes shallower deps win placement ties over
     // deeper ones, which matches npm's first-writer-wins policy.
@@ -287,14 +363,16 @@ pub(crate) fn plan_importer(
         if !graph.packages.contains_key(&dep.dep_path) {
             continue;
         }
-        queue.push_back((
-            plan.root_idx,
-            plan.root_idx,
-            dep.name.clone(),
-            dep.dep_path.clone(),
-        ));
+        queue.push_back((importer_idx, floor, dep.name.clone(), dep.dep_path.clone()));
     }
+}
 
+fn complete_plan(
+    plan: &mut PlacementPlan,
+    mut queue: VecDeque<(usize, usize, String, String)>,
+    graph: &LockfileGraph,
+    hoisting_limits: HoistingLimits,
+) -> Result<(), Error> {
     while let Some((requester, floor, name, dep_path)) = queue.pop_front() {
         let outcome = plan.place(requester, floor, &name, &dep_path)?;
         if !outcome.created {
@@ -311,7 +389,8 @@ pub(crate) fn plan_importer(
             continue;
         }
         let child_floor = match hoisting_limits {
-            HoistingLimits::None | HoistingLimits::Workspaces => plan.root_idx,
+            HoistingLimits::None => plan.root_idx,
+            HoistingLimits::Workspaces => floor,
             HoistingLimits::Dependencies => outcome.node_idx,
         };
         for (dep_name, dep_tail) in &pkg.dependencies {
@@ -332,8 +411,7 @@ pub(crate) fn plan_importer(
             ));
         }
     }
-
-    Ok(plan)
+    Ok(())
 }
 
 /// Materialize a planned tree onto disk for a single importer.
@@ -366,36 +444,71 @@ pub(crate) fn link_hoisted_importer(
     let root_dir = dirs.root;
     let importer_dir = dirs.importer;
     let nm = importer_dir.join(linker.modules_dir_name());
-    crate::mkdirp(&nm)?;
-
     let plan = plan_importer(&nm, root_deps, graph, linker.hoisting_limits)?;
+    materialize_hoisted_plan(
+        linker,
+        root_dir,
+        &plan,
+        graph,
+        package_indices,
+        stats,
+        placements,
+    )
+}
 
-    // Sweep any top-level entries that are no longer claimed by the
-    // plan. Dotfiles (`.aube`, `.bin`, …) are preserved — .aube in
-    // particular may hold a previous isolated tree that the user
-    // hasn't switched off; we leave it alone rather than wiping
-    // bytes the other layout owns.
-    let keep_root: std::collections::HashSet<&str> = plan.root_names().collect();
-    crate::sweep_stale_top_level_entries(&nm, &keep_root, None);
+pub(crate) fn link_hoisted_workspace(
+    linker: &Linker,
+    root_dir: &Path,
+    importers: &[HoistedWorkspaceImporter],
+    graph: &LockfileGraph,
+    package_indices: &BTreeMap<String, PackageIndex>,
+    stats: &mut LinkStats,
+    placements: &mut HoistedPlacements,
+) -> Result<(), Error> {
+    let root_nm = root_dir.join(linker.modules_dir_name());
+    let plan = plan_workspace(&root_nm, importers, graph, linker.hoisting_limits)?;
+    materialize_hoisted_plan(
+        linker,
+        root_dir,
+        &plan,
+        graph,
+        package_indices,
+        stats,
+        placements,
+    )
+}
 
-    // Materialize every non-root node. Order doesn't matter for
+fn materialize_hoisted_plan(
+    linker: &Linker,
+    root_dir: &Path,
+    plan: &PlacementPlan,
+    graph: &LockfileGraph,
+    package_indices: &BTreeMap<String, PackageIndex>,
+    stats: &mut LinkStats,
+    placements: &mut HoistedPlacements,
+) -> Result<(), Error> {
+    for &importer_idx in &plan.importer_indices {
+        let nm = &plan.nodes[importer_idx].nm_dir;
+        crate::mkdirp(nm)?;
+        let keep_root: std::collections::HashSet<&str> =
+            plan.importer_root_names(importer_idx).collect();
+        crate::sweep_stale_top_level_entries(nm, &keep_root, None);
+    }
+
+    // Materialize every package node. Order doesn't matter for
     // correctness (each package's files are written into its own
     // directory) but we iterate by index so the BFS order surfaces
     // in progress/debug logs.
     for idx in 0..plan.nodes.len() {
-        if idx == plan.root_idx {
-            continue;
-        }
         // Borrow scoping: take a clone of the fields we need out of
         // the node before calling methods that re-borrow `linker`
         // with `&mut stats`. The arena is read-only from here on.
-        let (dep_path, pkg_dir) = {
-            let node = &plan.nodes[idx];
-            (
-                node.dep_path.clone().expect("non-root node has dep_path"),
-                node.pkg_dir.clone().expect("non-root node has pkg_dir"),
-            )
+        let node = &plan.nodes[idx];
+        let (Some(dep_path), Some(pkg_dir)) = (&node.dep_path, &node.pkg_dir) else {
+            continue;
         };
+        let dep_path = dep_path.clone();
+        let pkg_dir = pkg_dir.clone();
         let Some(pkg) = graph.packages.get(&dep_path) else {
             continue;
         };
@@ -413,7 +526,7 @@ pub(crate) fn link_hoisted_importer(
             }
             crate::try_remove_entry(&pkg_dir);
             let abs_target = root_dir.join(rel);
-            let link_parent = pkg_dir.parent().unwrap_or(&nm);
+            let link_parent = pkg_dir.parent().unwrap_or(root_dir);
             let rel_target = pathdiff::diff_paths(&abs_target, link_parent).unwrap_or(abs_target);
             crate::sys::create_dir_link(&rel_target, &pkg_dir)
                 .map_err(|e| Error::Io(pkg_dir.clone(), e))?;
@@ -496,7 +609,11 @@ pub(crate) fn link_hoisted_importer(
         placements.record(&dep_path, pkg_dir);
     }
 
-    stats.top_level_linked += plan.nodes[plan.root_idx].children.len();
+    stats.top_level_linked += plan
+        .importer_indices
+        .iter()
+        .map(|&idx| plan.nodes[idx].children.len())
+        .sum::<usize>();
     Ok(())
 }
 
@@ -533,6 +650,49 @@ mod tests {
             .find(|node| node.dep_path.as_deref() == Some(dep_path))
             .and_then(|node| node.pkg_dir.clone())
             .unwrap_or_else(|| panic!("{dep_path} was not placed"))
+    }
+
+    fn package_dirs(plan: &PlacementPlan, dep_path: &str) -> Vec<PathBuf> {
+        plan.nodes
+            .iter()
+            .filter(|node| node.dep_path.as_deref() == Some(dep_path))
+            .filter_map(|node| node.pkg_dir.clone())
+            .collect()
+    }
+
+    #[test]
+    fn workspace_limit_controls_cross_importer_hoisting() {
+        let root_nm = PathBuf::from("/project/node_modules");
+        let mut graph = LockfileGraph::default();
+        graph
+            .packages
+            .insert("shared@1.0.0".into(), pkg("shared", "1.0.0", &[]));
+        let importers = vec![
+            HoistedWorkspaceImporter {
+                modules_dir: PathBuf::from("/project/packages/app/node_modules"),
+                dependencies: vec![dep("shared", "shared@1.0.0")],
+            },
+            HoistedWorkspaceImporter {
+                modules_dir: PathBuf::from("/project/packages/lib/node_modules"),
+                dependencies: vec![dep("shared", "shared@1.0.0")],
+            },
+        ];
+
+        let unlimited = plan_workspace(&root_nm, &importers, &graph, HoistingLimits::None).unwrap();
+        assert_eq!(
+            package_dirs(&unlimited, "shared@1.0.0"),
+            vec![root_nm.join("shared")]
+        );
+
+        let workspace_limited =
+            plan_workspace(&root_nm, &importers, &graph, HoistingLimits::Workspaces).unwrap();
+        assert_eq!(
+            package_dirs(&workspace_limited, "shared@1.0.0"),
+            vec![
+                PathBuf::from("/project/packages/app/node_modules/shared"),
+                PathBuf::from("/project/packages/lib/node_modules/shared"),
+            ]
+        );
     }
 
     #[test]
@@ -661,5 +821,37 @@ mod tests {
             placements.package_dir("left-pad@1.0.0"),
             Some(left_pad_dir.as_path())
         );
+    }
+
+    #[test]
+    fn from_graph_reconstructs_shared_workspace_root_placement() {
+        let root = tempfile::tempdir().unwrap();
+        let shared_dir = root.path().join("node_modules/shared");
+        std::fs::create_dir_all(&shared_dir).unwrap();
+
+        let mut graph = LockfileGraph::default();
+        graph
+            .importers
+            .insert("packages/app".into(), vec![dep("shared", "shared@1.0.0")]);
+        graph
+            .importers
+            .insert("packages/lib".into(), vec![dep("shared", "shared@1.0.0")]);
+        graph
+            .packages
+            .insert("shared@1.0.0".into(), pkg("shared", "1.0.0", &[]));
+
+        let placements = HoistedPlacements::from_graph(
+            root.path(),
+            &graph,
+            "node_modules",
+            HoistingLimits::None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            placements.package_dir("shared@1.0.0"),
+            Some(shared_dir.as_path())
+        );
+        assert_eq!(placements.all_package_dirs("shared@1.0.0").len(), 1);
     }
 }

--- a/crates/aube-linker/src/lib.rs
+++ b/crates/aube-linker/src/lib.rs
@@ -68,8 +68,7 @@ pub enum HoistingLimits {
     /// Hoist as far as possible.
     #[default]
     None,
-    /// Aube plans hoisted installs per physical importer, so this is
-    /// currently equivalent to `None`.
+    /// Do not hoist dependencies above their workspace package.
     Workspaces,
     /// Do not hoist transitives above the direct dependency that
     /// introduced them.

--- a/crates/aube-linker/src/link.rs
+++ b/crates/aube-linker/src/link.rs
@@ -598,13 +598,10 @@ impl Linker {
         Ok(stats)
     }
 
-    /// Hoisted-mode workspace linker. Runs the per-importer
-    /// hoisted planner once per importer in the graph, accumulating
-    /// stats + placements into a single `LinkStats`. Each importer
-    /// gets its own independent flat tree (no shared root
-    /// virtual-store like the isolated layout), matching npm
-    /// workspaces and what hoisted-mode toolchains expect: a
-    /// self-contained `node_modules/` under every importer.
+    /// Hoisted-mode workspace linker. Plans every physical importer as
+    /// one tree rooted at the workspace's `node_modules/`, allowing the
+    /// default unlimited mode to share compatible placements across
+    /// importers while stricter hoisting limits retain local trees.
     fn link_workspace_hoisted(
         &self,
         root_dir: &Path,
@@ -614,6 +611,7 @@ impl Linker {
     ) -> Result<LinkStats, Error> {
         let mut stats = LinkStats::default();
         let mut placements = HoistedPlacements::default();
+        let mut importers = Vec::with_capacity(graph.importers.len());
         for (importer_path, deps) in &graph.importers {
             if !is_physical_importer(importer_path) {
                 continue;
@@ -650,20 +648,31 @@ impl Linker {
                 })
                 .cloned()
                 .collect();
-            hoisted::link_hoisted_importer(
-                self,
-                hoisted::HoistedImporterDirs {
-                    root: root_dir,
-                    importer: &importer_dir,
-                },
-                &planner_deps,
-                graph,
-                package_indices,
-                &mut stats,
-                &mut placements,
-            )?;
+            importers.push(hoisted::HoistedWorkspaceImporter {
+                modules_dir: importer_dir.join(&self.modules_dir_name),
+                dependencies: planner_deps,
+            });
+        }
+        hoisted::link_hoisted_workspace(
+            self,
+            root_dir,
+            &importers,
+            graph,
+            package_indices,
+            &mut stats,
+            &mut placements,
+        )?;
 
-            // Drop workspace deps in as symlinks, same as isolated mode.
+        // Drop workspace deps in as symlinks, same as isolated mode.
+        for (importer_path, deps) in &graph.importers {
+            if !is_physical_importer(importer_path) {
+                continue;
+            }
+            let importer_dir = if importer_path == "." {
+                root_dir.to_path_buf()
+            } else {
+                aube_util::path::normalize_lexical(&root_dir.join(importer_path))
+            };
             let nm = importer_dir.join(&self.modules_dir_name);
             if !self.hoist_workspace_packages {
                 continue;

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -795,9 +795,7 @@ active, mirroring Yarn's `nmHoistingLimits` and pnpm's
 `hoistingLimits` setting:
 
 - `none`: hoist as far as possible (default).
-- `workspaces`: hoist only as far as each workspace package. Aube plans
-  hoisted installs per physical importer, so this currently matches
-  `none`.
+- `workspaces`: hoist only as far as each workspace package.
 - `dependencies`: hoist only up to each workspace package's direct
   dependencies. Transitive packages stay under the direct dependency
   that introduced them instead of being promoted to the importer root.

--- a/crates/aube/src/commands/install/link.rs
+++ b/crates/aube/src/commands/install/link.rs
@@ -305,6 +305,16 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
     );
     phase_timings.record("link", phase_start.elapsed());
 
+    // Keep the exact hoisted placement map in a sidecar even for filtered
+    // installs, which intentionally do not replace the main freshness state.
+    // Replanning the full graph later can associate a root-level package with
+    // the wrong conflicting version.
+    if !virtual_store_only {
+        state::write_hoisted_placements(cwd, stats.hoisted_placements.as_ref())
+            .into_diagnostic()
+            .wrap_err("failed to record hoisted package placements")?;
+    }
+
     // Apply `dependenciesMeta.<name>.injected` overrides. Only runs in
     // workspace + isolated mode: hoisted layouts don't have a
     // `.aube/<dep_path>/` virtual store for `apply_injected` to

--- a/crates/aube/src/commands/licenses.rs
+++ b/crates/aube/src/commands/licenses.rs
@@ -175,13 +175,20 @@ pub(super) fn collect_installed_metadata<'a>(
                     aube_linker::HoistingLimits::Dependencies
                 }
             });
-        // Reconstruct from the full installed graph. Filtering first could
-        // change which conflicting version won a hoisted placement.
-        Some(match recorded_hoisting_limits {
-            Some(limits) => {
-                aube_linker::HoistedPlacements::from_graph(cwd, graph, &modules_dir_name, limits)?
-            }
-            None => legacy_hoisted_placements(cwd, graph, &modules_dir_name)?,
+        // Prefer the exact linker-produced map. Replanning the full graph can
+        // change which conflicting version owns a root placement after a
+        // filtered install.
+        Some(match crate::state::read_hoisted_placements(cwd) {
+            Some(placements) => placements,
+            None => match recorded_hoisting_limits {
+                Some(limits) => aube_linker::HoistedPlacements::from_graph(
+                    cwd,
+                    graph,
+                    &modules_dir_name,
+                    limits,
+                )?,
+                None => legacy_hoisted_placements(cwd, graph, &modules_dir_name)?,
+            },
         })
     } else {
         None

--- a/crates/aube/src/commands/rebuild.rs
+++ b/crates/aube/src/commands/rebuild.rs
@@ -134,12 +134,15 @@ pub async fn run(
                     ));
                 }
                 aube_settings::resolved::NodeLinker::Hoisted => {
-                    Some(aube_linker::HoistedPlacements::from_graph(
-                        &cwd,
-                        &graph,
-                        &modules_dir_name,
-                        hoisting_limits,
-                    )?)
+                    Some(match crate::state::read_hoisted_placements(&cwd) {
+                        Some(placements) => placements,
+                        None => aube_linker::HoistedPlacements::from_graph(
+                            &cwd,
+                            &graph,
+                            &modules_dir_name,
+                            hoisting_limits,
+                        )?,
+                    })
                 }
                 aube_settings::resolved::NodeLinker::Isolated => None,
             };

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -7,6 +7,7 @@ const DEFAULT_STATE_DIR: &str = "node_modules";
 const INSTALL_STATE_FILE_NAME: &str = "state.json";
 const FRESH_STATE_FILE_NAME: &str = "fresh.json";
 const LICENSE_STATE_FILE_NAME: &str = "licenses.json";
+const HOISTED_PLACEMENTS_FILE_NAME: &str = "hoisted-placements.json";
 
 /// The install-state directory name, `.<name>-state`. Standalone aube:
 /// `.aube-state`.
@@ -862,6 +863,62 @@ pub fn read_state_layout(project_dir: &Path) -> Option<InstallLayoutState> {
     read_state(&state_dir(project_dir))?.layout
 }
 
+/// Persist the exact hoisted tree produced by the linker. This is a separate
+/// sidecar because filtered installs deliberately do not replace the main
+/// freshness state, while commands such as `rebuild` still need to inspect
+/// the tree that is actually on disk.
+pub fn write_hoisted_placements(
+    project_dir: &Path,
+    placements: Option<&aube_linker::HoistedPlacements>,
+) -> Result<(), std::io::Error> {
+    let state_path = state_dir(project_dir);
+    let Some(placements) = placements else {
+        if state_path.is_file() {
+            return Ok(());
+        }
+        let path = state_path.join(HOISTED_PLACEMENTS_FILE_NAME);
+        return match std::fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(err),
+        };
+    };
+    remove_legacy_state_file(&state_path)?;
+    let path = state_path.join(HOISTED_PLACEMENTS_FILE_NAME);
+    let mut recorded: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for (dep_path, package_dir) in placements.iter() {
+        recorded
+            .entry(dep_path.to_string())
+            .or_default()
+            .push(relative_path_or_original(package_dir, project_dir));
+    }
+    let json = serde_json::to_vec(&recorded)?;
+    aube_util::fs_atomic::atomic_write(&path, &json)
+}
+
+/// Read the exact linker-produced hoisted placement map. `None` means the
+/// install predates the sidecar (or it is unreadable), so callers may use the
+/// legacy planner-based reconstruction as a compatibility fallback.
+pub fn read_hoisted_placements(project_dir: &Path) -> Option<aube_linker::HoistedPlacements> {
+    let path = state_dir(project_dir).join(HOISTED_PLACEMENTS_FILE_NAME);
+    let recorded: BTreeMap<String, Vec<String>> =
+        serde_json::from_slice(&std::fs::read(path).ok()?).ok()?;
+    let by_dep_path = recorded
+        .into_iter()
+        .map(|(dep_path, paths)| {
+            let paths = paths
+                .into_iter()
+                .map(|path| project_dir.join(path))
+                .filter(|path| path.exists())
+                .collect();
+            (dep_path, paths)
+        })
+        .collect();
+    Some(aube_linker::HoistedPlacements::from_package_dirs(
+        by_dep_path,
+    ))
+}
+
 /// Read licenses captured at install time without adding them to the main
 /// freshness state parsed by every warm install.
 pub fn read_state_package_licenses(project_dir: &Path) -> InstallLicenseState {
@@ -1469,8 +1526,8 @@ mod tests {
         InstallLayoutMode, InstallLayoutState, InstallState, InstalledPackageState,
         WriteStateLayout, collect_package_json_hashes_from_manifests, empty_blake3_hash,
         fresh_state_file, hash_file, hash_settings, install_state_file, member_lockfiles_stale,
-        read_or_migrate_fresh_state, relative_path_or_original, remove_state,
-        verify_install_layout,
+        read_hoisted_placements, read_or_migrate_fresh_state, relative_path_or_original,
+        remove_state, verify_install_layout, write_hoisted_placements,
     };
     use std::collections::BTreeMap;
     use std::path::{Path, PathBuf};
@@ -1484,6 +1541,28 @@ mod tests {
             relative_path_or_original(original, base),
             original.to_string_lossy()
         );
+    }
+
+    #[test]
+    fn hoisted_placement_sidecar_preserves_exact_conflicting_version_paths() {
+        let project_dir = temp_project_dir("exact-hoisted-placements");
+        let root_v2 = project_dir.join("node_modules/foo");
+        let nested_v1 = project_dir.join("node_modules/bar/node_modules/foo");
+        std::fs::create_dir_all(&root_v2).expect("root placement should write");
+        std::fs::create_dir_all(&nested_v1).expect("nested placement should write");
+        let placements = aube_linker::HoistedPlacements::from_package_dirs(BTreeMap::from([
+            ("foo@1.0.0".to_string(), vec![nested_v1.clone()]),
+            ("foo@2.0.0".to_string(), vec![root_v2.clone()]),
+        ]));
+
+        write_hoisted_placements(&project_dir, Some(&placements))
+            .expect("placement sidecar should write");
+        let restored =
+            read_hoisted_placements(&project_dir).expect("placement sidecar should read");
+
+        assert_eq!(restored.package_dir("foo@1.0.0"), Some(nested_v1.as_path()));
+        assert_eq!(restored.package_dir("foo@2.0.0"), Some(root_v2.as_path()));
+        remove_state(&project_dir).expect("state directory should remove");
     }
 
     #[test]

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -3141,3 +3141,4 @@ Examples:
 
 - `AUBE_NO_AUTO_INSTALL=1 aube run dev`
 - `echo 'aubeNoAutoInstall=true' >> .npmrc`
+

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -862,9 +862,7 @@ active, mirroring Yarn's `nmHoistingLimits` and pnpm's
 `hoistingLimits` setting:
 
 - `none`: hoist as far as possible (default).
-- `workspaces`: hoist only as far as each workspace package. Aube plans
-  hoisted installs per physical importer, so this currently matches
-  `none`.
+- `workspaces`: hoist only as far as each workspace package.
 - `dependencies`: hoist only up to each workspace package's direct
   dependencies. Transitive packages stay under the direct dependency
   that introduced them instead of being promoted to the importer root.
@@ -3143,4 +3141,3 @@ Examples:
 
 - `AUBE_NO_AUTO_INSTALL=1 aube run dev`
 - `echo 'aubeNoAutoInstall=true' >> .npmrc`
-

--- a/test/hoisted.bats
+++ b/test/hoisted.bats
@@ -104,9 +104,9 @@ JSON
 	assert_not_exists packages/app/node_modules/is-number
 	assert_not_exists packages/lib/node_modules/is-number
 	run bash -c '
-app=$(realpath packages/app/../../node_modules/is-number)
-lib=$(realpath packages/lib/../../node_modules/is-number)
-test "$app" = "$lib"
+app=$(cd packages/app && node -p '\''require.resolve("is-number/package.json")'\'')
+lib=$(cd packages/lib && node -p '\''require.resolve("is-number/package.json")'\'')
+test "$(realpath "$app")" = "$(realpath "$lib")"
 '
 	assert_success
 }

--- a/test/hoisted.bats
+++ b/test/hoisted.bats
@@ -81,6 +81,61 @@ YAML
 	assert_failure
 }
 
+@test "hoisted workspaces share compatible dependencies at the workspace root" {
+	mkdir -p packages/app packages/lib
+	cat >package.json <<'JSON'
+{"name":"root","private":true}
+JSON
+	cat >pnpm-workspace.yaml <<'YAML'
+packages:
+  - packages/*
+nodeLinker: hoisted
+YAML
+	cat >packages/app/package.json <<'JSON'
+{"name":"app","private":true,"dependencies":{"is-number":"7.0.0"}}
+JSON
+	cat >packages/lib/package.json <<'JSON'
+{"name":"lib","private":true,"dependencies":{"is-number":"7.0.0"}}
+JSON
+
+	run aube install
+	assert_success
+	assert_dir_exists node_modules/is-number
+	assert_not_exists packages/app/node_modules/is-number
+	assert_not_exists packages/lib/node_modules/is-number
+	run bash -c '
+app=$(realpath packages/app/../../node_modules/is-number)
+lib=$(realpath packages/lib/../../node_modules/is-number)
+test "$app" = "$lib"
+'
+	assert_success
+}
+
+@test "hoistingLimits=workspaces keeps dependencies under each workspace" {
+	mkdir -p packages/app packages/lib
+	cat >package.json <<'JSON'
+{"name":"root","private":true}
+JSON
+	cat >pnpm-workspace.yaml <<'YAML'
+packages:
+  - packages/*
+nodeLinker: hoisted
+hoistingLimits: workspaces
+YAML
+	cat >packages/app/package.json <<'JSON'
+{"name":"app","private":true,"dependencies":{"is-number":"7.0.0"}}
+JSON
+	cat >packages/lib/package.json <<'JSON'
+{"name":"lib","private":true,"dependencies":{"is-number":"7.0.0"}}
+JSON
+
+	run aube install
+	assert_success
+	assert_not_exists node_modules/is-number
+	assert_dir_exists packages/app/node_modules/is-number
+	assert_dir_exists packages/lib/node_modules/is-number
+}
+
 @test "--node-linker=pnp is rejected" {
 	_setup_basic_fixture
 	run aube install --node-linker=pnp


### PR DESCRIPTION
## Summary

- plan hoisted workspace installs as one tree rooted at the workspace `node_modules`
- share compatible dependency placements across importers when `hoistingLimits=none`
- keep `workspaces` and `dependencies` as distinct placement boundaries
- reconstruct the same workspace-wide placements for rebuild and license commands
- add unit and BATS coverage for shared package identity and workspace-limited hoisting

## Root cause

The hoisted linker planned every workspace importer independently. That made cross-importer deduplication impossible and also made `hoistingLimits=none` behave identically to `workspaces`.

This change models workspace importers as children of a shared root placement node. Compatible dependencies can now hoist to one physical workspace-root package, while version and peer-context conflicts remain nested below the appropriate importer.

Fixes the behavior reported in [discussion 1242](https://github.com/jdx/aube/discussions/1242).

## Validation

- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `mise run test:bats test/hoisted.bats --filter 'hoisted workspaces|hoistingLimits=workspaces'`
- verified the public reproduction resolves both workspace importers to the same `node_modules/is-number` realpath

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core `node_modules` layout for hoisted workspaces and downstream commands that resolve package paths; mitigated by sidecar persistence and new tests, but regressions could affect Metro/Jest-style tooling expectations.
> 
> **Overview**
> Fixes hoisted monorepos where each workspace package was planned in isolation, so identical deps could not share a root `node_modules` copy and **`hoistingLimits=workspaces`** behaved like **`none`**.
> 
> The hoisted linker now builds a **single workspace-wide placement plan** rooted at the repo’s `node_modules`, with physical importers as synthetic nodes. With **`hoistingLimits=none`**, compatible versions can hoist once at the workspace root; **`workspaces`** and **`dependencies`** keep importer-local or nested boundaries. Direct **`link:`** / workspace links stay in the consuming package instead of being promoted to the root.
> 
> Install persists the linker’s exact map in **`hoisted-placements.json`** (including filtered installs) so **`rebuild`** and **`licenses`** prefer recorded paths over replanning—which could pick the wrong conflicting version at the root. Docs and BATS cover shared resolution and workspace-limited hoisting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11dea23fc1ba3e8a2b618316ae82a3ed7fc44f44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Hoisted dependency linking now creates a shared workspace-wide placement plan.
  - Compatible dependencies can be shared at the repository root across workspaces.
  - Installations preserve hoisted package placements for consistent rebuilds and license reporting.

- **Bug Fixes**
  - `hoistingLimits: workspaces` now keeps dependencies within workspace boundaries.
  - Rebuilds and license reporting more reliably reflect hoisted dependency locations.

- **Documentation**
  - Updated hoisting guidance to describe workspace boundaries and shared placement behavior.

- **Tests**
  - Added coverage for shared dependencies and workspace-isolated installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->