### PR TITLE
fix(linker): protect project root from modules cleanup

### DIFF
--- a/crates/aube-codes/src/errors.rs
+++ b/crates/aube-codes/src/errors.rs
@@ -69,6 +69,7 @@ pub const ERR_AUBE_MISSING_PACKAGE_INDEX: &str = "ERR_AUBE_MISSING_PACKAGE_INDEX
 pub const ERR_AUBE_UNSAFE_INDEX_KEY: &str = "ERR_AUBE_UNSAFE_INDEX_KEY";
 pub const ERR_AUBE_UNSAFE_PACKAGE_NAME: &str = "ERR_AUBE_UNSAFE_PACKAGE_NAME";
 pub const ERR_AUBE_MISSING_STORE_FILE: &str = "ERR_AUBE_MISSING_STORE_FILE";
+pub const ERR_AUBE_UNSAFE_MODULES_DIR: &str = "ERR_AUBE_UNSAFE_MODULES_DIR";
 
 // ── scripts ─────────────────────────────────────────────────────────
 pub const ERR_AUBE_SCRIPT_SPAWN: &str = "ERR_AUBE_SCRIPT_SPAWN";
@@ -447,6 +448,12 @@ pub const ALL: &[CodeMeta] = &[
         category: category::LINKER,
         description: "A package index references a CAS shard that doesn't exist on disk. Re-run install to re-fetch.",
         exit_code: Some(63),
+    },
+    CodeMeta {
+        name: ERR_AUBE_UNSAFE_MODULES_DIR,
+        category: category::LINKER,
+        description: "The configured modules directory resolves to the project root, where linker cleanup could remove project files.",
+        exit_code: Some(64),
     },
     // Manifest / workspace
     CodeMeta {

--- a/crates/aube-codes/src/errors.rs
+++ b/crates/aube-codes/src/errors.rs
@@ -452,7 +452,7 @@ pub const ALL: &[CodeMeta] = &[
     CodeMeta {
         name: ERR_AUBE_UNSAFE_MODULES_DIR,
         category: category::LINKER,
-        description: "The configured modules directory resolves to the project root, where linker cleanup could remove project files.",
+        description: "The configured modules directory resolves to the project root or outside it, where linker cleanup could remove unrelated files.",
         exit_code: Some(64),
     },
     // Manifest / workspace

--- a/crates/aube-linker/src/error.rs
+++ b/crates/aube-linker/src/error.rs
@@ -23,7 +23,7 @@ pub enum Error {
     #[error("refusing to create node_modules entry for unsafe package name: {0:?}")]
     #[diagnostic(code(ERR_AUBE_UNSAFE_PACKAGE_NAME))]
     UnsafePackageName(String),
-    #[error("refusing to use the project root as the modules directory: {0}")]
+    #[error("refusing to use a modules directory that is not inside the project: {0}")]
     #[diagnostic(code(ERR_AUBE_UNSAFE_MODULES_DIR))]
     UnsafeModulesDir(PathBuf),
     #[error(

--- a/crates/aube-linker/src/error.rs
+++ b/crates/aube-linker/src/error.rs
@@ -23,6 +23,9 @@ pub enum Error {
     #[error("refusing to create node_modules entry for unsafe package name: {0:?}")]
     #[diagnostic(code(ERR_AUBE_UNSAFE_PACKAGE_NAME))]
     UnsafePackageName(String),
+    #[error("refusing to use the project root as the modules directory: {0}")]
+    #[diagnostic(code(ERR_AUBE_UNSAFE_MODULES_DIR))]
+    UnsafeModulesDir(PathBuf),
     #[error(
         "cached package index references a missing CAS shard at {store_path} (file: {rel_path:?}). The store and its index cache are out of sync — rerun the install to re-fetch the tarball."
     )]

--- a/crates/aube-linker/src/link.rs
+++ b/crates/aube-linker/src/link.rs
@@ -21,13 +21,24 @@ impl Linker {
         let project_dir = aube_util::path::normalize_lexical(project_dir);
         let modules_dir =
             aube_util::path::normalize_lexical(&project_dir.join(&self.modules_dir_name));
-        let aliases_project_root = modules_dir == project_dir
-            || (project_dir
-                .canonicalize()
-                .ok()
-                .zip(modules_dir.canonicalize().ok())
-                .is_some_and(|(project, modules)| project == modules));
-        if aliases_project_root {
+        let lexical_is_safe = modules_dir != project_dir && modules_dir.starts_with(&project_dir);
+        let canonical_is_safe = project_dir.canonicalize().map_or(true, |project| {
+            modules_dir
+                .ancestors()
+                .find_map(|ancestor| {
+                    ancestor.canonicalize().ok().map(|canonical_ancestor| {
+                        if ancestor == modules_dir {
+                            canonical_ancestor != project
+                                && canonical_ancestor.starts_with(&project)
+                        } else {
+                            canonical_ancestor == project
+                                || canonical_ancestor.starts_with(&project)
+                        }
+                    })
+                })
+                .unwrap_or(false)
+        });
+        if !lexical_is_safe || !canonical_is_safe {
             return Err(Error::UnsafeModulesDir(modules_dir));
         }
         Ok(modules_dir)

--- a/crates/aube-linker/src/link.rs
+++ b/crates/aube-linker/src/link.rs
@@ -17,13 +17,7 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 impl Linker {
-    /// Link all packages into node_modules for the given project.
-    pub fn link_all(
-        &self,
-        project_dir: &Path,
-        graph: &LockfileGraph,
-        package_indices: &BTreeMap<String, PackageIndex>,
-    ) -> Result<LinkStats, Error> {
+    fn checked_modules_dir(&self, project_dir: &Path) -> Result<PathBuf, Error> {
         let project_dir = aube_util::path::normalize_lexical(project_dir);
         let modules_dir =
             aube_util::path::normalize_lexical(&project_dir.join(&self.modules_dir_name));
@@ -36,6 +30,18 @@ impl Linker {
         if aliases_project_root {
             return Err(Error::UnsafeModulesDir(modules_dir));
         }
+        Ok(modules_dir)
+    }
+
+    /// Link all packages into node_modules for the given project.
+    pub fn link_all(
+        &self,
+        project_dir: &Path,
+        graph: &LockfileGraph,
+        package_indices: &BTreeMap<String, PackageIndex>,
+    ) -> Result<LinkStats, Error> {
+        let project_dir = aube_util::path::normalize_lexical(project_dir);
+        let modules_dir = self.checked_modules_dir(&project_dir)?;
         if matches!(self.node_linker, NodeLinker::Hoisted) {
             let mut stats = LinkStats::default();
             let mut placements = HoistedPlacements::default();
@@ -661,7 +667,7 @@ impl Linker {
                 .cloned()
                 .collect();
             importers.push(hoisted::HoistedWorkspaceImporter {
-                modules_dir: importer_dir.join(&self.modules_dir_name),
+                modules_dir: self.checked_modules_dir(&importer_dir)?,
                 dependencies: planner_deps,
             });
         }
@@ -685,7 +691,7 @@ impl Linker {
             } else {
                 aube_util::path::normalize_lexical(&root_dir.join(importer_path))
             };
-            let nm = importer_dir.join(&self.modules_dir_name);
+            let nm = self.checked_modules_dir(&importer_dir)?;
             if !self.hoist_workspace_packages {
                 continue;
             }
@@ -732,12 +738,22 @@ impl Linker {
         package_indices: &BTreeMap<String, PackageIndex>,
         workspace_dirs: &BTreeMap<String, PathBuf>,
     ) -> Result<LinkStats, Error> {
-        if matches!(self.node_linker, NodeLinker::Hoisted) {
-            return self.link_workspace_hoisted(root_dir, graph, package_indices, workspace_dirs);
+        let root_dir = aube_util::path::normalize_lexical(root_dir);
+        self.checked_modules_dir(&root_dir)?;
+        for importer_path in graph.importers.keys() {
+            if !is_physical_importer(importer_path) || importer_path == "." {
+                continue;
+            }
+            let importer_dir = aube_util::path::normalize_lexical(&root_dir.join(importer_path));
+            self.checked_modules_dir(&importer_dir)?;
         }
 
-        let root_nm = root_dir.join(&self.modules_dir_name);
-        let aube_dir = self.aube_dir_for(root_dir);
+        if matches!(self.node_linker, NodeLinker::Hoisted) {
+            return self.link_workspace_hoisted(&root_dir, graph, package_indices, workspace_dirs);
+        }
+
+        let root_nm = self.checked_modules_dir(&root_dir)?;
+        let aube_dir = self.aube_dir_for(&root_dir);
 
         mkdirp(&aube_dir)?;
         mkdirp(&root_nm)?;
@@ -762,7 +778,7 @@ impl Linker {
             );
         }
 
-        let nested_link_targets = build_nested_link_targets(root_dir, graph);
+        let nested_link_targets = build_nested_link_targets(&root_dir, graph);
 
         // Step 1a: Materialize local (`file:` dir/tarball, `portal:`,
         // `exec:`) packages straight into the shared per-project

--- a/crates/aube-linker/src/link.rs
+++ b/crates/aube-linker/src/link.rs
@@ -24,14 +24,26 @@ impl Linker {
         graph: &LockfileGraph,
         package_indices: &BTreeMap<String, PackageIndex>,
     ) -> Result<LinkStats, Error> {
+        let project_dir = aube_util::path::normalize_lexical(project_dir);
+        let modules_dir =
+            aube_util::path::normalize_lexical(&project_dir.join(&self.modules_dir_name));
+        let aliases_project_root = modules_dir == project_dir
+            || (project_dir
+                .canonicalize()
+                .ok()
+                .zip(modules_dir.canonicalize().ok())
+                .is_some_and(|(project, modules)| project == modules));
+        if aliases_project_root {
+            return Err(Error::UnsafeModulesDir(modules_dir));
+        }
         if matches!(self.node_linker, NodeLinker::Hoisted) {
             let mut stats = LinkStats::default();
             let mut placements = HoistedPlacements::default();
             hoisted::link_hoisted_importer(
                 self,
                 hoisted::HoistedImporterDirs {
-                    root: project_dir,
-                    importer: project_dir,
+                    root: &project_dir,
+                    importer: &project_dir,
                 },
                 graph.root_deps(),
                 graph,
@@ -48,14 +60,14 @@ impl Linker {
             // leftover `.aube/<dep_path>/` directories until their
             // eventual cleanup. Honors `virtualStoreDir`.
             let _ = crate::remove_dir_all_with_retry(
-                &self.aube_dir_for(project_dir).join("node_modules"),
+                &self.aube_dir_for(&project_dir).join("node_modules"),
             );
             stats.hoisted_placements = Some(placements);
             return Ok(stats);
         }
 
-        let nm = project_dir.join(&self.modules_dir_name);
-        let aube_dir = self.aube_dir_for(project_dir);
+        let nm = modules_dir;
+        let aube_dir = self.aube_dir_for(&project_dir);
 
         mkdirp(&aube_dir)?;
 
@@ -123,7 +135,7 @@ impl Linker {
             );
         }
 
-        let nested_link_targets = build_nested_link_targets(project_dir, graph);
+        let nested_link_targets = build_nested_link_targets(&project_dir, graph);
 
         // Step 1: Populate .aube virtual store
         //

--- a/crates/aube-linker/src/tests.rs
+++ b/crates/aube-linker/src/tests.rs
@@ -36,8 +36,8 @@ fn setup_store_with_files(dir: &Path) -> (Store, BTreeMap<String, aube_store::Pa
 }
 
 #[test]
-fn refuses_modules_dir_that_resolves_to_project_root() {
-    for modules_dir in [".", "nested/.."] {
+fn refuses_modules_dir_at_or_outside_project() {
+    for modules_dir in [".", "nested/..", "..", "../.."] {
         let dir = tempfile::tempdir().unwrap();
         let project_dir = dir.path().join("project");
         std::fs::create_dir_all(project_dir.join("nested")).unwrap();
@@ -75,10 +75,33 @@ fn refuses_modules_dir_symlink_to_project_root() {
     assert_eq!(std::fs::read(&marker).unwrap(), b"{}");
 }
 
+#[cfg(unix)]
 #[test]
-fn workspace_modes_refuse_modules_dir_that_resolves_to_root() {
+fn refuses_modules_dir_through_symlink_outside_project() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = dir.path().join("project");
+    let outside_dir = dir.path().join("outside");
+    std::fs::create_dir_all(&project_dir).unwrap();
+    std::fs::create_dir_all(&outside_dir).unwrap();
+    std::os::unix::fs::symlink(&outside_dir, project_dir.join("modules")).unwrap();
+    let marker = outside_dir.join("marker");
+    std::fs::write(&marker, b"keep").unwrap();
+    let store = Store::at(dir.path().join("store/files"));
+    let linker =
+        Linker::new(&store, LinkStrategy::Copy).with_modules_dir_name("modules/not-created");
+
+    let err = linker
+        .link_all(&project_dir, &LockfileGraph::default(), &BTreeMap::new())
+        .unwrap_err();
+
+    assert!(matches!(err, Error::UnsafeModulesDir(_)));
+    assert_eq!(std::fs::read(&marker).unwrap(), b"keep");
+}
+
+#[test]
+fn workspace_modes_refuse_modules_dir_at_or_outside_root() {
     for node_linker in [NodeLinker::Isolated, NodeLinker::Hoisted] {
-        for modules_dir in [".", "nested/.."] {
+        for modules_dir in [".", "nested/..", "..", "../.."] {
             let dir = tempfile::tempdir().unwrap();
             let project_dir = dir.path().join("project");
             std::fs::create_dir_all(project_dir.join("nested")).unwrap();

--- a/crates/aube-linker/src/tests.rs
+++ b/crates/aube-linker/src/tests.rs
@@ -35,6 +35,46 @@ fn setup_store_with_files(dir: &Path) -> (Store, BTreeMap<String, aube_store::Pa
     (store, indices)
 }
 
+#[test]
+fn refuses_modules_dir_that_resolves_to_project_root() {
+    for modules_dir in [".", "nested/.."] {
+        let dir = tempfile::tempdir().unwrap();
+        let project_dir = dir.path().join("project");
+        std::fs::create_dir_all(project_dir.join("nested")).unwrap();
+        let marker = project_dir.join("package.json");
+        std::fs::write(&marker, b"{}").unwrap();
+        let store = Store::at(dir.path().join("store/files"));
+        let linker = Linker::new(&store, LinkStrategy::Copy).with_modules_dir_name(modules_dir);
+
+        let err = linker
+            .link_all(&project_dir, &LockfileGraph::default(), &BTreeMap::new())
+            .unwrap_err();
+
+        assert!(matches!(err, Error::UnsafeModulesDir(_)));
+        assert_eq!(std::fs::read(&marker).unwrap(), b"{}");
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn refuses_modules_dir_symlink_to_project_root() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = dir.path().join("project");
+    std::fs::create_dir_all(&project_dir).unwrap();
+    std::os::unix::fs::symlink(&project_dir, project_dir.join("modules")).unwrap();
+    let marker = project_dir.join("package.json");
+    std::fs::write(&marker, b"{}").unwrap();
+    let store = Store::at(dir.path().join("store/files"));
+    let linker = Linker::new(&store, LinkStrategy::Copy).with_modules_dir_name("modules");
+
+    let err = linker
+        .link_all(&project_dir, &LockfileGraph::default(), &BTreeMap::new())
+        .unwrap_err();
+
+    assert!(matches!(err, Error::UnsafeModulesDir(_)));
+    assert_eq!(std::fs::read(&marker).unwrap(), b"{}");
+}
+
 fn make_graph() -> LockfileGraph {
     let mut packages = BTreeMap::new();
 

--- a/crates/aube-linker/src/tests.rs
+++ b/crates/aube-linker/src/tests.rs
@@ -75,6 +75,61 @@ fn refuses_modules_dir_symlink_to_project_root() {
     assert_eq!(std::fs::read(&marker).unwrap(), b"{}");
 }
 
+#[test]
+fn workspace_modes_refuse_modules_dir_that_resolves_to_root() {
+    for node_linker in [NodeLinker::Isolated, NodeLinker::Hoisted] {
+        for modules_dir in [".", "nested/.."] {
+            let dir = tempfile::tempdir().unwrap();
+            let project_dir = dir.path().join("project");
+            std::fs::create_dir_all(project_dir.join("nested")).unwrap();
+            let marker = project_dir.join("package.json");
+            std::fs::write(&marker, b"{}").unwrap();
+            let store = Store::at(dir.path().join("store/files"));
+            let linker = Linker::new(&store, LinkStrategy::Copy)
+                .with_node_linker(node_linker)
+                .with_modules_dir_name(modules_dir);
+            let mut graph = LockfileGraph::default();
+            graph.importers.insert(".".to_string(), Vec::new());
+
+            let err = linker
+                .link_workspace(&project_dir, &graph, &BTreeMap::new(), &BTreeMap::new())
+                .unwrap_err();
+
+            assert!(matches!(err, Error::UnsafeModulesDir(_)));
+            assert_eq!(std::fs::read(&marker).unwrap(), b"{}");
+        }
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn workspace_modes_refuse_importer_modules_dir_symlink_to_importer() {
+    for node_linker in [NodeLinker::Isolated, NodeLinker::Hoisted] {
+        let dir = tempfile::tempdir().unwrap();
+        let project_dir = dir.path().join("project");
+        let importer_dir = project_dir.join("packages/app");
+        std::fs::create_dir_all(&importer_dir).unwrap();
+        std::os::unix::fs::symlink(&importer_dir, importer_dir.join("modules")).unwrap();
+        let marker = importer_dir.join("package.json");
+        std::fs::write(&marker, b"{}").unwrap();
+        let store = Store::at(dir.path().join("store/files"));
+        let linker = Linker::new(&store, LinkStrategy::Copy)
+            .with_node_linker(node_linker)
+            .with_modules_dir_name("modules");
+        let mut graph = LockfileGraph::default();
+        graph
+            .importers
+            .insert("packages/app".to_string(), Vec::new());
+
+        let err = linker
+            .link_workspace(&project_dir, &graph, &BTreeMap::new(), &BTreeMap::new())
+            .unwrap_err();
+
+        assert!(matches!(err, Error::UnsafeModulesDir(_)));
+        assert_eq!(std::fs::read(&marker).unwrap(), b"{}");
+    }
+}
+
 fn make_graph() -> LockfileGraph {
     let mut packages = BTreeMap::new();
 

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -297,7 +297,7 @@
     {
       "name": "ERR_AUBE_UNSAFE_MODULES_DIR",
       "category": "Linker",
-      "description": "The configured modules directory resolves to the project root, where linker cleanup could remove project files.",
+      "description": "The configured modules directory resolves to the project root or outside it, where linker cleanup could remove unrelated files.",
       "exit_code": 64
     },
     {

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -295,6 +295,12 @@
       "exit_code": 63
     },
     {
+      "name": "ERR_AUBE_UNSAFE_MODULES_DIR",
+      "category": "Linker",
+      "description": "The configured modules directory resolves to the project root, where linker cleanup could remove project files.",
+      "exit_code": 64
+    },
+    {
       "name": "ERR_AUBE_MANIFEST_PARSE",
       "category": "Manifest / workspace",
       "description": "A `package.json` had a syntax error. miette renders a pointer at the offending byte.",

--- a/mise.toml
+++ b/mise.toml
@@ -126,7 +126,9 @@ run = [
 # measurement on purpose — nothing tak times ever touches the registry.
 [tasks.perf]
 dir = "{{config_root}}"
-env = { npm_config_enable_global_virtual_store = "true" }
+# Cachegrind aggregates instructions from every worker. Pin the pools so idle
+# work-stealing races do not move the install count by 10%+ between runs.
+env = { npm_config_enable_global_virtual_store = "true", TOKIO_WORKER_THREADS = "1", RAYON_NUM_THREADS = "1", AUBE_LINK_CONCURRENCY = "1" }
 run = [
   "cargo build --release",
   "./target/release/aube -C fixtures/medium install --frozen-lockfile",
@@ -138,7 +140,7 @@ run = [
 # Safe to run locally — nothing leaves the machine until `tak push`.
 [tasks."perf:record"]
 dir = "{{config_root}}"
-env = { npm_config_enable_global_virtual_store = "true" }
+env = { npm_config_enable_global_virtual_store = "true", TOKIO_WORKER_THREADS = "1", RAYON_NUM_THREADS = "1", AUBE_LINK_CONCURRENCY = "1" }
 run = [
   "cargo build --release",
   "./target/release/aube -C fixtures/medium install --frozen-lockfile",


### PR DESCRIPTION
## Summary

- reject `modulesDir` values that lexically resolve to the project root
- reject existing modules-directory symlinks that resolve to the project root
- add `ERR_AUBE_UNSAFE_MODULES_DIR` with linker exit code 64

## Why

Linker cleanup treats the configured modules directory as disposable. Values such as `.`, `nested/..`, an absolute project-root path, or a symlink back to the project could therefore make cleanup operate on project files.

The guard runs before both isolated and hoisted linking perform any filesystem mutation.

## Validation

- `cargo test -p aube-linker refuses_modules_dir`
- `cargo clippy -p aube-linker --tests -- -D warnings`
- `cargo test -p aube-codes`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Safety-critical linker path validation that changes behavior for edge-case `modulesDir` configs and symlinks; core install flows are unchanged for normal `node_modules` layouts.
> 
> **Overview**
> **Prevents linker cleanup from targeting the project root or paths outside the repo** when `modulesDir` is misconfigured (e.g. `.`, `nested/..`, `..`) or when an existing modules-directory symlink points at the project root or an external directory.
> 
> Adds `checked_modules_dir` in the linker: lexical normalization plus canonical path checks run **before** isolated or hoisted `link_all` / `link_workspace` mutate disk. Failures surface as `Error::UnsafeModulesDir` / **`ERR_AUBE_UNSAFE_MODULES_DIR`** (linker exit **64**), registered in `aube-codes` and the error-code docs.
> 
> New linker tests cover single-project and workspace (isolated + hoisted) cases, including Unix symlink scenarios, and assert project files are untouched on refusal.
> 
> Separately, **`perf` / `perf:record`** in `mise.toml` pin Tokio, Rayon, and link concurrency to **1** so Cachegrind instruction counts are less noisy between runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e36b6fc9fc73ca27248d2d4b4589e72f62411fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented linking when the configured modules directory resolves to the project or workspace root.
  * Added path normalization to safely handle traversal paths and symlinks.
  * Protects existing project files from accidental cleanup or modification.

* **Documentation**
  * Added the new unsafe modules directory error code to the error catalog.

* **Chores**
  * Standardized performance test environments for more consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->