### PR TITLE
fix(update): keep no-save resolutions within range

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -4151,11 +4151,11 @@ Interactive update picker.
 Parsed for pnpm compatibility.
 """#
     }
-    flag "-L --latest" help="Update past the manifest range" {
+    flag "-L --latest" help="Update past the manifest range unless paired with `--no-save`" {
         long_help #"""
-Update past the manifest range.
+Update past the manifest range unless paired with `--no-save`.
 
-Rewrites `package.json` specifiers to match the newly resolved versions (the registry's `latest` dist-tag, clamped by `minimumReleaseAge` / `resolution-mode` as usual).
+Rewrites `package.json` specifiers to match the newly resolved versions (the registry's `latest` dist-tag, clamped by `minimumReleaseAge` / `resolution-mode` as usual). With `--no-save`, leaves the manifest range unchanged and resolves only to the newest version that range allows.
 """#
     }
     flag "-P --prod --production" help="Update only production dependencies"

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -4196,7 +4196,7 @@ Re-resolves the full graph (direct + transitive) and writes `aube-lock.yaml`, th
         long_help #"""
 Refresh the lockfile without rewriting `package.json` ranges.
 
-Pair with `--latest` to pull a newer resolved version into the lockfile while leaving the manifest's caret/tilde ranges untouched. Without `--latest` this flag is a no-op (plain `update` already doesn't touch the manifest). Mirrors `pnpm update --no-save`.
+Pair with `--latest` to refresh the lockfile to the newest version allowed by the unchanged manifest range. Without `--latest`, it still suppresses manifest range rewrites enabled by `updateRewritesSpecifier`. Mirrors `pnpm update --no-save`.
 """#
     }
     flag --pnpmfile help="Override the local pnpmfile location" {

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -104,8 +104,8 @@ pub struct UpdateArgs {
     ///
     /// Pair with `--latest` to refresh the lockfile to the newest
     /// version allowed by the unchanged manifest range. Without
-    /// `--latest` this flag is a no-op (plain `update` already doesn't
-    /// touch the manifest). Mirrors `pnpm update --no-save`.
+    /// `--latest`, it still suppresses manifest range rewrites enabled
+    /// by `updateRewritesSpecifier`. Mirrors `pnpm update --no-save`.
     #[arg(long)]
     pub no_save: bool,
     /// Override the local pnpmfile location.

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -102,11 +102,10 @@ pub struct UpdateArgs {
     pub no_optional: bool,
     /// Refresh the lockfile without rewriting `package.json` ranges.
     ///
-    /// Pair with `--latest` to pull a newer resolved version into the
-    /// lockfile while leaving the manifest's caret/tilde ranges
-    /// untouched. Without `--latest` this flag is a no-op (plain
-    /// `update` already doesn't touch the manifest). Mirrors
-    /// `pnpm update --no-save`.
+    /// Pair with `--latest` to refresh the lockfile to the newest
+    /// version allowed by the unchanged manifest range. Without
+    /// `--latest` this flag is a no-op (plain `update` already doesn't
+    /// touch the manifest). Mirrors `pnpm update --no-save`.
     #[arg(long)]
     pub no_save: bool,
     /// Override the local pnpmfile location.
@@ -537,7 +536,7 @@ async fn run_inner(
 
     let mut workspace_catalogs = super::load_workspace_catalogs(&cwd)?;
     let mut catalog_targets = Vec::new();
-    if effective_latest {
+    if effective_latest && !no_save {
         for key in &manifest_keys_to_update {
             if !should_rewrite_key(key) || preserve_pin.contains(key) {
                 continue;
@@ -583,7 +582,7 @@ async fn run_inner(
     // pin alone. Both `--latest` (every direct dep) and `<pkg>@latest`
     // (only the named entries — see `should_rewrite_key`) flow
     // through this loop.
-    let resolver_manifest = if effective_latest {
+    let resolver_manifest = if effective_latest && !no_save {
         let mut m = manifest.clone();
         for key in &manifest_keys_to_update {
             if !should_rewrite_key(key) {
@@ -828,9 +827,9 @@ async fn run_inner(
     // they already had, so an idempotent rewrite doesn't churn the
     // manifest for no reason.
     //
-    // `--no-save` short-circuits the manifest rewrite: the resolver
-    // already pulled in the new versions for the lockfile above, so we
-    // just skip persisting any range bumps to `package.json`.
+    // `--no-save` short-circuits the manifest rewrite. The resolver kept
+    // the original range authoritative, so the refreshed lockfile cannot
+    // contradict the unchanged `package.json` specifier.
     if no_save && (effective_latest || rewrites_specifier_setting) {
         eprintln!("Skipping package.json update (--no-save)");
     } else if effective_latest || cosmetic_rewrite_eligible {

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -45,11 +45,13 @@ pub struct UpdateArgs {
     /// Parsed for pnpm compatibility.
     #[arg(short = 'i', long)]
     pub interactive: bool,
-    /// Update past the manifest range.
+    /// Update past the manifest range unless paired with `--no-save`.
     ///
     /// Rewrites `package.json` specifiers to match the newly resolved
     /// versions (the registry's `latest` dist-tag, clamped by
-    /// `minimumReleaseAge` / `resolution-mode` as usual).
+    /// `minimumReleaseAge` / `resolution-mode` as usual). With
+    /// `--no-save`, leaves the manifest range unchanged and resolves
+    /// only to the newest version that range allows.
     #[arg(short = 'L', long)]
     pub latest: bool,
     /// Update only production dependencies.

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -12485,7 +12485,7 @@
             "name": "no-save",
             "usage": "--no-save",
             "help": "Refresh the lockfile without rewriting `package.json` ranges",
-            "help_long": "Refresh the lockfile without rewriting `package.json` ranges.\n\nPair with `--latest` to pull a newer resolved version into the lockfile while leaving the manifest's caret/tilde ranges untouched. Without `--latest` this flag is a no-op (plain `update` already doesn't touch the manifest). Mirrors `pnpm update --no-save`.",
+            "help_long": "Refresh the lockfile without rewriting `package.json` ranges.\n\nPair with `--latest` to refresh the lockfile to the newest version allowed by the unchanged manifest range. Without `--latest`, it still suppresses manifest range rewrites enabled by `updateRewritesSpecifier`. Mirrors `pnpm update --no-save`.",
             "help_first_line": "Refresh the lockfile without rewriting `package.json` ranges",
             "short": [],
             "long": [

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -12350,9 +12350,9 @@
           {
             "name": "latest",
             "usage": "-L --latest",
-            "help": "Update past the manifest range",
-            "help_long": "Update past the manifest range.\n\nRewrites `package.json` specifiers to match the newly resolved versions (the registry's `latest` dist-tag, clamped by `minimumReleaseAge` / `resolution-mode` as usual).",
-            "help_first_line": "Update past the manifest range",
+            "help": "Update past the manifest range unless paired with `--no-save`",
+            "help_long": "Update past the manifest range unless paired with `--no-save`.\n\nRewrites `package.json` specifiers to match the newly resolved versions (the registry's `latest` dist-tag, clamped by `minimumReleaseAge` / `resolution-mode` as usual). With `--no-save`, leaves the manifest range unchanged and resolves only to the newest version that range allows.",
+            "help_first_line": "Update past the manifest range unless paired with `--no-save`",
             "short": [
               "L"
             ],

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -38,9 +38,9 @@ Parsed for pnpm compatibility.
 
 ### `-L --latest`
 
-Update past the manifest range.
+Update past the manifest range unless paired with `--no-save`.
 
-Rewrites `package.json` specifiers to match the newly resolved versions (the registry's `latest` dist-tag, clamped by `minimumReleaseAge` / `resolution-mode` as usual).
+Rewrites `package.json` specifiers to match the newly resolved versions (the registry's `latest` dist-tag, clamped by `minimumReleaseAge` / `resolution-mode` as usual). With `--no-save`, leaves the manifest range unchanged and resolves only to the newest version that range allows.
 
 ### `-P --prod`
 

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -80,7 +80,7 @@ Skip optionalDependencies
 
 Refresh the lockfile without rewriting `package.json` ranges.
 
-Pair with `--latest` to pull a newer resolved version into the lockfile while leaving the manifest's caret/tilde ranges untouched. Without `--latest` this flag is a no-op (plain `update` already doesn't touch the manifest). Mirrors `pnpm update --no-save`.
+Pair with `--latest` to refresh the lockfile to the newest version allowed by the unchanged manifest range. Without `--latest`, it still suppresses manifest range rewrites enabled by `updateRewritesSpecifier`. Mirrors `pnpm update --no-save`.
 
 ### `--pnpmfile <PATH>`
 

--- a/mise.toml
+++ b/mise.toml
@@ -126,7 +126,9 @@ run = [
 # measurement on purpose — nothing tak times ever touches the registry.
 [tasks.perf]
 dir = "{{config_root}}"
-env = { npm_config_enable_global_virtual_store = "true" }
+# Cachegrind aggregates instructions from every worker. Pin the pools so idle
+# work-stealing races do not move the install count by 10%+ between runs.
+env = { npm_config_enable_global_virtual_store = "true", TOKIO_WORKER_THREADS = "1", RAYON_NUM_THREADS = "1", AUBE_LINK_CONCURRENCY = "1" }
 run = [
   "cargo build --release",
   "./target/release/aube -C fixtures/medium install --frozen-lockfile",
@@ -138,7 +140,7 @@ run = [
 # Safe to run locally — nothing leaves the machine until `tak push`.
 [tasks."perf:record"]
 dir = "{{config_root}}"
-env = { npm_config_enable_global_virtual_store = "true" }
+env = { npm_config_enable_global_virtual_store = "true", TOKIO_WORKER_THREADS = "1", RAYON_NUM_THREADS = "1", AUBE_LINK_CONCURRENCY = "1" }
 run = [
   "cargo build --release",
   "./target/release/aube -C fixtures/medium install --frozen-lockfile",

--- a/test/update.bats
+++ b/test/update.bats
@@ -528,8 +528,8 @@ EOF
 
 @test "aube update --latest --no-save: does not resolve past the kept range" {
 	_setup_outdated_project
-	sed -i.bak 's/>=0.1.0/^0.1.0/g' package.json aube-lock.yaml
-	rm package.json.bak aube-lock.yaml.bak
+	sed -i.bak 's/>=0.1.0/^0.1.0/g' package.json
+	rm package.json.bak
 
 	run aube update --latest --no-save is-odd --lockfile-only
 	assert_success

--- a/test/update.bats
+++ b/test/update.bats
@@ -332,7 +332,7 @@ EOF
 	assert_success
 	run grep -A4 '^catalogs:' aube-lock.yaml
 	assert_output --partial 'specifier: 0.1.2'
-	assert_output --partial 'version: 3.0.1'
+	assert_output --partial 'version: 0.1.2'
 }
 
 @test "aube update -r --latest updates a named catalog and preserves its prefix" {
@@ -524,6 +524,23 @@ EOF
 	# The lockfile picked up a newer version than 0.1.2 (the seed pin).
 	run grep -c 'is-odd@3' aube-lock.yaml
 	assert_success
+}
+
+@test "aube update --latest --no-save: does not resolve past the kept range" {
+	_setup_outdated_project
+	sed -i.bak 's/>=0.1.0/^0.1.0/g' package.json aube-lock.yaml
+	rm package.json.bak aube-lock.yaml.bak
+
+	run aube update --latest --no-save is-odd --lockfile-only
+	assert_success
+
+	run grep '"is-odd": "^0.1.0"' package.json
+	assert_success
+	run grep -A3 'is-odd:' aube-lock.yaml
+	assert_output --partial 'specifier: ^0.1.0'
+	assert_output --partial 'version: 0.1.2'
+	run grep -c 'is-odd@3' aube-lock.yaml
+	assert_failure
 }
 
 @test "aube update --lockfile-only: refreshes lockfile without populating node_modules" {


### PR DESCRIPTION
## Summary

- keep the unchanged manifest range authoritative during `update --no-save`
- apply the same behavior to shared catalog entries
- cover direct and catalog ranges that exclude the registry's latest version

## Why

The update resolver previously replaced targeted ranges with `latest` even when `--no-save` kept the original manifest or catalog specifier. That could record a resolved version excluded by its own specifier, making a subsequent frozen install reject the lockfile.

The command still drops the targeted locked package, so it refreshes to the newest version allowed by the retained range.

## Validation

- `test/bats/bin/bats --filter 'aube update --latest --no-save|aube update -r --latest --no-save' test/update.bats`
- `cargo clippy -p aube --all-targets -- -D warnings`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes resolver/manifest rewrite behavior for `update`, which can affect lockfile contents and downstream frozen installs; scope is limited to the update command path.
> 
> **Overview**
> **`aube update --no-save`** no longer treats **`--latest`** as permission to bump manifest/catalog specifiers or resolve beyond the unchanged range. Catalog rewrites and the temporary “latest” resolver manifest now run only when **`effective_latest && !no_save`**, so the lockfile refresh stays compatible with frozen installs.
> 
> CLI and generated docs are updated to describe **`--latest --no-save`** as “newest version allowed by the existing range” rather than registry latest. Bats coverage is adjusted (catalog case expects in-range **0.1.2**) and a new test asserts **`^0.1.0`** does not pick **is-odd@3**.
> 
> **`mise` `perf` / `perf:record`** pin Tokio, Rayon, and link concurrency to **1** to stabilize Cachegrind instruction counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c60731568d385a98635d71abbaf740ec86e1dd8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `--no-save` now preserves existing manifest and catalog entries while refreshing the lockfile.
  * `--latest --no-save` respects declared version ranges and avoids selecting incompatible releases.

* **Documentation**
  * Clarified that `--no-save` prevents manifest range rewrites while still allowing lockfile updates within the existing range.
  * Documented how `--latest` and `--no-save` work together.

* **Tests**
  * Added coverage confirming version specifiers remain unchanged and compatible versions are resolved correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->