### PR TITLE
fix(store): disable Git terminal credential prompts

### DIFF
--- a/crates/aube-store/src/git.rs
+++ b/crates/aube-store/src/git.rs
@@ -6,9 +6,9 @@ use aube_util::url::redact_url;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-/// Construct a Git subprocess that cannot stop an unattended install
-/// waiting for credentials on stdin. Credential helpers and configured
-/// tokens still work; Git only suppresses its terminal fallback.
+/// Construct a Git subprocess that disables Git's own terminal credential
+/// prompts. Credential helpers and configured tokens still work. SSH
+/// transports may still prompt independently through the user's SSH client.
 pub(crate) fn git_command() -> Command {
     let mut command = Command::new("git");
     command.env("GIT_TERMINAL_PROMPT", "0");

--- a/crates/aube-store/src/git.rs
+++ b/crates/aube-store/src/git.rs
@@ -4,6 +4,16 @@ use crate::{
 };
 use aube_util::url::redact_url;
 use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Construct a Git subprocess that cannot stop an unattended install
+/// waiting for credentials on stdin. Credential helpers and configured
+/// tokens still work; Git only suppresses its terminal fallback.
+pub(crate) fn git_command() -> Command {
+    let mut command = Command::new("git");
+    command.env("GIT_TERMINAL_PROMPT", "0");
+    command
+}
 
 /// Render a git argv tail for error messages with any embedded
 /// userinfo stripped. A raw `{args:?}` would otherwise dump the
@@ -78,7 +88,7 @@ pub fn git_resolve_ref(url: &str, committish: Option<&str>) -> Result<String, Er
     // `--` terminates git's own option parsing so an attacker-supplied
     // url that slips a leading `-` past `validate_git_positional` (we
     // don't expect this, but defense in depth) can't land as an option.
-    let out = std::process::Command::new("git")
+    let out = git_command()
         .args(["ls-remote", "--", url])
         .output()
         .map_err(|e| Error::Git(format!("spawn git ls-remote {}: {e}", redact_url(url))))?;
@@ -255,7 +265,6 @@ pub fn git_shallow_clone(
     commit: &str,
     shallow: bool,
 ) -> Result<(PathBuf, String), Error> {
-    use std::process::Command;
     validate_git_positional(url, "git url")?;
     validate_git_positional(commit, "git commit")?;
     // Deterministic path keyed by url+commit so two callers in the
@@ -328,7 +337,7 @@ pub fn git_shallow_clone(
     // an older aube version — it'll get replaced by the atomic
     // rename below.
     if target.join(".git").is_dir()
-        && let Ok(out) = Command::new("git")
+        && let Ok(out) = git_command()
             .args(["rev-parse", "HEAD"])
             .current_dir(&target)
             .output()
@@ -361,7 +370,7 @@ pub fn git_shallow_clone(
         .keep();
 
     let run_in = |dir: &Path, args: &[&str]| -> Result<(), Error> {
-        let out = Command::new("git")
+        let out = git_command()
             .args(args)
             .current_dir(dir)
             .output()
@@ -407,7 +416,7 @@ pub fn git_shallow_clone(
         // stale reflog) could still leave HEAD on something else —
         // mirrors the defensive check the reuse path at line 1260
         // already performs.
-        let out = Command::new("git")
+        let out = git_command()
             .args(["rev-parse", "HEAD"])
             .current_dir(&scratch)
             .output()
@@ -447,7 +456,7 @@ pub fn git_shallow_clone(
         )),
         Err(_) => {
             if target.join(".git").is_dir()
-                && let Ok(out) = Command::new("git")
+                && let Ok(out) = git_command()
                     .args(["rev-parse", "HEAD"])
                     .current_dir(&target)
                     .output()

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -22,7 +22,8 @@ use cas::copy_dir_recursive;
 pub(crate) use cas::parse_compress_store_gate;
 #[cfg(test)]
 use git::{
-    codeload_cache_paths, extract_codeload_tarball_at, git_commit_matches, validate_git_positional,
+    codeload_cache_paths, extract_codeload_tarball_at, git_command, git_commit_matches,
+    validate_git_positional,
 };
 pub use index::{PackageIndex, StoredFile, index_content_fingerprint};
 pub use integrity::{
@@ -1569,6 +1570,16 @@ mod tests {
         // the validation runs at the public entry point.
         let err = git_resolve_ref("--upload-pack=/tmp/evil", None).unwrap_err();
         assert!(matches!(err, Error::Git(_)));
+    }
+
+    #[test]
+    fn test_git_commands_disable_terminal_prompts() {
+        let command = git_command();
+        let prompt = command
+            .get_envs()
+            .find(|(name, _)| *name == "GIT_TERMINAL_PROMPT")
+            .and_then(|(_, value)| value);
+        assert_eq!(prompt, Some(std::ffi::OsStr::new("0")));
     }
 
     #[test]

--- a/mise.toml
+++ b/mise.toml
@@ -126,7 +126,9 @@ run = [
 # measurement on purpose — nothing tak times ever touches the registry.
 [tasks.perf]
 dir = "{{config_root}}"
-env = { npm_config_enable_global_virtual_store = "true" }
+# Cachegrind aggregates instructions from every worker. Pin the pools so idle
+# work-stealing races do not move the install count by 10%+ between runs.
+env = { npm_config_enable_global_virtual_store = "true", TOKIO_WORKER_THREADS = "1", RAYON_NUM_THREADS = "1", AUBE_LINK_CONCURRENCY = "1" }
 run = [
   "cargo build --release",
   "./target/release/aube -C fixtures/medium install --frozen-lockfile",
@@ -138,7 +140,7 @@ run = [
 # Safe to run locally — nothing leaves the machine until `tak push`.
 [tasks."perf:record"]
 dir = "{{config_root}}"
-env = { npm_config_enable_global_virtual_store = "true" }
+env = { npm_config_enable_global_virtual_store = "true", TOKIO_WORKER_THREADS = "1", RAYON_NUM_THREADS = "1", AUBE_LINK_CONCURRENCY = "1" }
 run = [
   "cargo build --release",
   "./target/release/aube -C fixtures/medium install --frozen-lockfile",


### PR DESCRIPTION
## Summary

- set `GIT_TERMINAL_PROMPT=0` on every Git subprocess spawned by the store
- retain configured credential helpers and non-interactive tokens
- test the shared Git command configuration

## Why

Resolving or fetching a private Git dependency without available credentials could block an unattended install waiting for an interactive prompt. CI and other non-interactive callers should instead receive Git's authentication failure immediately.

Using a shared command constructor also keeps `ls-remote`, fetch, checkout, and cache verification behavior consistent.

## Validation

- `cargo test -p aube-store test_git_commands_disable_terminal_prompts`
- `cargo clippy -p aube-store --tests -- -D warnings`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> The Git change is a small, well-scoped non-interactive behavior fix with a test; perf env pinning only affects local/CI benchmark tasks, not production installs.
> 
> **Overview**
> **Git store operations** no longer hang in CI or unattended installs waiting for an interactive credential prompt. A shared `git_command()` helper sets `GIT_TERMINAL_PROMPT=0` on every spawned `git` invocation (`ls-remote`, clone/fetch/checkout, and cache `rev-parse` checks). Configured credential helpers and embedded tokens still apply; SSH may still prompt via the user's SSH client.
> 
> A unit test asserts the shared command sets that environment variable.
> 
> **Perf measurement** (`mise` `perf` and `perf:record`) pins `TOKIO_WORKER_THREADS`, `RAYON_NUM_THREADS`, and `AUBE_LINK_CONCURRENCY` to `1` so Cachegrind instruction totals do not swing from work-stealing between runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c47039ac13744e4fa2e2f888caf7c23449487e24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented Git operations from hanging while waiting for interactive credential prompts.
  * Preserved support for configured Git credential helpers during cloning and reference resolution.

* **Performance**
  * Made performance profiling runs more consistent by limiting worker and link concurrency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->