### PR TITLE
fix(linker): resolve symlinks in POSIX shims

### DIFF
--- a/crates/aube-linker/src/sys.rs
+++ b/crates/aube-linker/src/sys.rs
@@ -831,10 +831,25 @@ fn generate_sh_shim(
 /// Marker the POSIX shim writer stamps into every generated file so
 /// [`parse_posix_shim_target`] can unambiguously identify our shims and
 /// recover the `$basedir`-relative target path on uninstall. Any format
-/// change here must bump the `v1` suffix so older shims stop being
+/// change here must bump the version suffix so older shims stop being
 /// recognized (forcing a reinstall) rather than being silently
 /// misparsed.
-pub const POSIX_SHIM_MARKER_PREFIX: &str = "# aube-bin-shim v1 target=";
+pub const POSIX_SHIM_MARKER_PREFIX: &str = "# aube-bin-shim v2 target=";
+
+/// Resolve the invoked shim through absolute and relative symlink hops before
+/// deriving `$basedir`. The 40-hop cap matches the Linux kernel's `ELOOP`
+/// limit and prevents a user-created symlink cycle from hanging execution.
+const POSIX_SHIM_BASEDIR: &str = "link=\"$0\"\n\
+hops=0\n\
+while [ -L \"$link\" ] && [ \"$hops\" -lt 40 ]; do\n\
+  hops=$((hops+1))\n\
+  target=$(readlink \"$link\")\n\
+  case \"$target\" in\n\
+    /*) link=\"$target\" ;;\n\
+    *)  link=\"$(dirname \"$link\")/$target\" ;;\n\
+  esac\n\
+done\n\
+basedir=$(dirname \"$link\")\n";
 
 /// POSIX shell-script shim used when `prefer_symlinked_executables=false`
 /// (so `extend_node_path` can actually inject `NODE_PATH`). Mirrors the
@@ -854,7 +869,7 @@ fn generate_posix_shim(
         return format!(
             "#!/bin/sh\n\
              {POSIX_SHIM_MARKER_PREFIX}{rel_target_fwdslash}\n\
-             basedir=$(dirname \"$0\")\n\
+             {POSIX_SHIM_BASEDIR}\
              {node_path}\
              exec \"$basedir/{rel_target_fwdslash}\" \"$@\"\n"
         );
@@ -866,7 +881,7 @@ fn generate_posix_shim(
     format!(
         "#!/bin/sh\n\
          {POSIX_SHIM_MARKER_PREFIX}{rel_target_fwdslash}\n\
-         basedir=$(dirname \"$0\")\n\
+         {POSIX_SHIM_BASEDIR}\
          {node_path}\
          if [ -x \"$basedir/{prog}\" ]; then\n\
          \x20 exec \"$basedir/{prog}\" \"$basedir/{rel_target_fwdslash}\" \"$@\"\n\
@@ -1572,6 +1587,47 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
         let mode = std::fs::metadata(&path).unwrap().permissions().mode();
         assert_eq!(mode & 0o111, 0o111);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn posix_shim_executes_target_through_external_symlink_chain() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let bin_dir = dir.path().join("node_modules/.bin");
+        let pkg_dir = dir.path().join("node_modules/pkg/bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        std::fs::create_dir_all(&pkg_dir).unwrap();
+        let target = pkg_dir.join("tool");
+        std::fs::write(&target, "#!/bin/sh\necho shim-target\n").unwrap();
+
+        create_bin_shim(
+            &bin_dir,
+            "tool",
+            &target,
+            BinShimOptions {
+                extend_node_path: false,
+                prefer_symlinked_executables: Some(false),
+                hidden_modules_dir: None,
+            },
+        )
+        .unwrap();
+
+        let absolute_hop = dir.path().join("absolute-hop");
+        symlink(bin_dir.join("tool"), &absolute_hop).unwrap();
+        let path_dir = dir.path().join("local/bin");
+        std::fs::create_dir_all(&path_dir).unwrap();
+        let relative_hop = path_dir.join("tool");
+        symlink("../../absolute-hop", &relative_hop).unwrap();
+
+        let output = std::process::Command::new(&relative_hop).output().unwrap();
+        assert!(
+            output.status.success(),
+            "shim failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "shim-target\n");
     }
 
     #[cfg(unix)]

--- a/crates/aube/src/commands/exec.rs
+++ b/crates/aube/src/commands/exec.rs
@@ -779,7 +779,7 @@ mod tests {
         std::fs::write(
             &shim,
             "#!/bin/sh\n\
-             # aube-bin-shim v1 target=pkg/bin.js\n\
+             # aube-bin-shim v2 target=pkg/bin.js\n\
              basedir=$(dirname \"$0\")\n\
              export NODE_PATH=\"$basedir/node_modules\"\n\
              exec node \"$basedir/pkg/bin.js\" \"$@\"\n",

--- a/mise.toml
+++ b/mise.toml
@@ -126,7 +126,9 @@ run = [
 # measurement on purpose — nothing tak times ever touches the registry.
 [tasks.perf]
 dir = "{{config_root}}"
-env = { npm_config_enable_global_virtual_store = "true" }
+# Cachegrind aggregates instructions from every worker. Pin the pools so idle
+# work-stealing races do not move the install count by 10%+ between runs.
+env = { npm_config_enable_global_virtual_store = "true", TOKIO_WORKER_THREADS = "1", RAYON_NUM_THREADS = "1", AUBE_LINK_CONCURRENCY = "1" }
 run = [
   "cargo build --release",
   "./target/release/aube -C fixtures/medium install --frozen-lockfile",
@@ -138,7 +140,7 @@ run = [
 # Safe to run locally — nothing leaves the machine until `tak push`.
 [tasks."perf:record"]
 dir = "{{config_root}}"
-env = { npm_config_enable_global_virtual_store = "true" }
+env = { npm_config_enable_global_virtual_store = "true", TOKIO_WORKER_THREADS = "1", RAYON_NUM_THREADS = "1", AUBE_LINK_CONCURRENCY = "1" }
 run = [
   "cargo build --release",
   "./target/release/aube -C fixtures/medium install --frozen-lockfile",

--- a/test/workspace.bats
+++ b/test/workspace.bats
@@ -576,7 +576,7 @@ _setup_shared_direct_dep_workspace() {
 	# the isolated linker are POSIX shims (so `extendNodePath` can
 	# set NODE_PATH), which means `readlink -f` returns the shim's
 	# own canonical path. Check the recorded target inside the shim
-	# instead: the v1 marker comment carries the resolved relative
+	# instead: the v2 marker comment carries the resolved relative
 	# path for the prune / unlink pass to recover.
 	for app in app1 app2; do
 		bin="packages/$app/node_modules/.bin/my-tool"
@@ -585,9 +585,9 @@ _setup_shared_direct_dep_workspace() {
 		if [ -L "$bin" ]; then
 			target="$(readlink -f "$bin")"
 		else
-			# `aube-bin-shim v1 target=...` line embeds the
+			# `aube-bin-shim v2 target=...` line embeds the
 			# $basedir-relative path to the workspace file.
-			target="$(grep -m1 'aube-bin-shim v1 target=' "$bin")"
+			target="$(grep -m1 'aube-bin-shim v2 target=' "$bin")"
 		fi
 		[[ "$target" == *"tools/dev/bin/my-tool.mjs" ]]
 	done


### PR DESCRIPTION
## Summary

- resolve POSIX shim invocation paths through absolute and relative symlink chains
- cap traversal at 40 hops to avoid hanging on symlink cycles
- bump the generated shim marker version and add an execution regression test

## Why

POSIX shells preserve the invoked symlink in `$0`. Computing `basedir` directly from `$0` therefore points at the external symlink directory instead of the real `node_modules/.bin` directory, breaking the shim's relative target path.

The generated shim now follows the chain before deriving `basedir`, including mixed absolute and relative targets.

## Validation

- `cargo test -p aube-linker posix_shim`
- `cargo clippy -p aube-linker --tests -- -D warnings`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes generated shell for every POSIX shim install path; wrong resolution would break CLI binaries, though scope is linker-only with targeted tests.
> 
> **Overview**
> **POSIX `.bin` shims** now walk up to 40 symlink hops (absolute and relative) before computing `$basedir`, so launching a tool through a PATH symlink still resolves the real `node_modules/.bin` location and the embedded relative target. The stamped shim marker is bumped to **`aube-bin-shim v2`** so older shims are not mis-parsed on uninstall.
> 
> Adds a Unix regression test for mixed symlink chains, updates workspace bats and exec fixture comments for **v2**, and pins **`TOKIO_WORKER_THREADS`**, **`RAYON_NUM_THREADS`**, and **`AUBE_LINK_CONCURRENCY`** to **1** on **`perf`** / **`perf:record`** so instruction-count benchmarks are less noisy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20ba1b2bc4d761b670ce98942486575cf6d32a08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Unix command shims when launched through one or more symbolic links.
  * Improved path resolution for direct and interpreter-based shims, including relative and absolute links.
  * Added support for resolving longer chains of linked paths, improving command reliability across more installation setups.

* **Performance**
  * Improved performance task consistency by limiting background worker concurrency during benchmarking and profiling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->