### PR TITLE
fix(resolver): preserve dependency type for auto-installed peers

### DIFF
--- a/crates/aube-resolver/src/peer_context.rs
+++ b/crates/aube-resolver/src/peer_context.rs
@@ -19,7 +19,7 @@
 
 use crate::version_satisfies;
 use crate::{FxHashMap, FxHashSet};
-use aube_lockfile::{DirectDep, LocalSource, LockedPackage, LockfileGraph};
+use aube_lockfile::{DepType, DirectDep, LocalSource, LockedPackage, LockfileGraph};
 use std::collections::{BTreeMap, BTreeSet};
 
 /// A peer dependency whose declared range doesn't match the version the
@@ -120,8 +120,9 @@ pub fn detect_unmet_peers(graph: &LockfileGraph) -> Vec<UnmetPeer> {
 ///   2. Visit only those direct dependency packages and examine their
 ///      `peer_dependencies` declarations. For each declared peer not
 ///      already satisfied by the importer, find a resolved version somewhere
-///      in the graph and synthesize a `DirectDep` entry. Mark it as
-///      satisfied so a second direct dep doesn't add a duplicate.
+///      in the graph and synthesize one `DirectDep` entry. If another direct
+///      dependency needs the same peer, promote the synthetic entry to the
+///      strongest section classification required by either package.
 ///   3. Stable: we walk in-order and take the first declared peer range
 ///      encountered per name as the specifier. Conflicting ranges across
 ///      the tree are not reconciled — first one wins. This matches pnpm
@@ -135,11 +136,13 @@ pub fn hoist_auto_installed_peers(mut graph: LockfileGraph) -> LockfileGraph {
         let Some(direct_deps) = graph.importers.get(&importer_path) else {
             continue;
         };
-        let mut satisfied: FxHashSet<String> = direct_deps.iter().map(|d| d.name.clone()).collect();
+        let satisfied: FxHashSet<String> = direct_deps.iter().map(|d| d.name.clone()).collect();
 
         // Additions are gathered into a separate vec so we don't mutate
         // the importer's direct-dep list while still borrowing from it.
         let mut additions: Vec<DirectDep> = Vec::new();
+        let mut additions_by_name: FxHashMap<String, usize> =
+            FxHashMap::with_capacity_and_hasher(direct_deps.len(), Default::default());
 
         for direct_dep in direct_deps {
             let Some(pkg) = graph.packages.get(&direct_dep.dep_path) else {
@@ -149,6 +152,18 @@ pub fn hoist_auto_installed_peers(mut graph: LockfileGraph) -> LockfileGraph {
             // Collect unmet peer declarations from this package.
             for (peer_name, peer_range) in &pkg.peer_dependencies {
                 if satisfied.contains(peer_name) {
+                    continue;
+                }
+                if let Some(&idx) = additions_by_name.get(peer_name) {
+                    let current = additions[idx].dep_type;
+                    // Production must survive every production-mode filter.
+                    // Optional wins over dev because --production retains
+                    // optional roots unless --no-optional is also present.
+                    additions[idx].dep_type = match (current, direct_dep.dep_type) {
+                        (DepType::Production, _) | (_, DepType::Production) => DepType::Production,
+                        (DepType::Optional, _) | (_, DepType::Optional) => DepType::Optional,
+                        _ => DepType::Dev,
+                    };
                     continue;
                 }
                 // Find any resolved version in the graph for this peer.
@@ -194,7 +209,7 @@ pub fn hoist_auto_installed_peers(mut graph: LockfileGraph) -> LockfileGraph {
                     // rather than writing a dangling DirectDep.
                     continue;
                 }
-                satisfied.insert(peer_name.clone());
+                additions_by_name.insert(peer_name.clone(), additions.len());
                 additions.push(DirectDep {
                     name: peer_name.clone(),
                     dep_path: synth_dep_path,

--- a/crates/aube-resolver/src/peer_context.rs
+++ b/crates/aube-resolver/src/peer_context.rs
@@ -19,7 +19,7 @@
 
 use crate::version_satisfies;
 use crate::{FxHashMap, FxHashSet};
-use aube_lockfile::{DepType, DirectDep, LocalSource, LockedPackage, LockfileGraph};
+use aube_lockfile::{DirectDep, LocalSource, LockedPackage, LockfileGraph};
 use std::collections::{BTreeMap, BTreeSet};
 
 /// A peer dependency whose declared range doesn't match the version the
@@ -98,12 +98,14 @@ pub fn detect_unmet_peers(graph: &LockfileGraph) -> Vec<UnmetPeer> {
 /// Promote direct dependencies' unmet peers to importer direct deps.
 ///
 /// Walks each importer's direct dependencies and hoists any peer they
-/// declare that isn't already a direct dep of the importer up to the
-/// importer's `dependencies` list — what pnpm's
-/// `auto-install-peers=true` produces in its v9 lockfile. Peers declared by
-/// transitive dependencies stay in the resolved graph for peer-context
-/// sibling wiring, but they are not surfaced as top-level
-/// `node_modules/<peer>` entries.
+/// declare that isn't already a direct dep of the importer into a synthetic
+/// importer entry. Aube uses that entry to create the top-level
+/// `node_modules/<peer>` symlink required by its isolated linker. The
+/// synthetic entry inherits the requiring package's dependency kind so
+/// section-filtered installs retain it only when they retain the package
+/// that needs it. Peers declared by transitive dependencies stay in the
+/// resolved graph for peer-context sibling wiring, but they are not surfaced
+/// as top-level entries.
 ///
 /// Public so lockfile-driven installs that need to re-derive peer
 /// wiring (npm/yarn/bun formats, which don't record peer contexts)
@@ -139,8 +141,8 @@ pub fn hoist_auto_installed_peers(mut graph: LockfileGraph) -> LockfileGraph {
         // the importer's direct-dep list while still borrowing from it.
         let mut additions: Vec<DirectDep> = Vec::new();
 
-        for dep_path in direct_deps.iter().map(|d| &d.dep_path) {
-            let Some(pkg) = graph.packages.get(dep_path) else {
+        for direct_dep in direct_deps {
+            let Some(pkg) = graph.packages.get(&direct_dep.dep_path) else {
                 continue;
             };
 
@@ -196,9 +198,7 @@ pub fn hoist_auto_installed_peers(mut graph: LockfileGraph) -> LockfileGraph {
                 additions.push(DirectDep {
                     name: peer_name.clone(),
                     dep_path: synth_dep_path,
-                    // Peers auto-hoisted to the root are in the prod
-                    // graph by convention — matches what pnpm writes.
-                    dep_type: DepType::Production,
+                    dep_type: direct_dep.dep_type,
                     specifier: Some(peer_range.clone()),
                 });
             }

--- a/crates/aube-resolver/src/peer_context.rs
+++ b/crates/aube-resolver/src/peer_context.rs
@@ -156,13 +156,15 @@ pub fn hoist_auto_installed_peers(mut graph: LockfileGraph) -> LockfileGraph {
                 }
                 if let Some(&idx) = additions_by_name.get(peer_name) {
                     let current = additions[idx].dep_type;
-                    // Production must survive every production-mode filter.
-                    // Optional wins over dev because --production retains
-                    // optional roots unless --no-optional is also present.
+                    // A peer needed by roots from different sections cannot
+                    // safely inherit either narrower classification: the
+                    // other section's filter could then drop it while keeping
+                    // a requirer. Normalize mixed classifications to
+                    // Production, which survives both --production and
+                    // --no-optional. Matching classifications stay unchanged.
                     additions[idx].dep_type = match (current, direct_dep.dep_type) {
-                        (DepType::Production, _) | (_, DepType::Production) => DepType::Production,
-                        (DepType::Optional, _) | (_, DepType::Optional) => DepType::Optional,
-                        _ => DepType::Dev,
+                        (left, right) if left == right => left,
+                        _ => DepType::Production,
                     };
                     continue;
                 }

--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -152,10 +152,10 @@ impl Resolver {
             pnpmfile_checksum: None,
         };
 
-        // Second pass: hoist every auto-installed peer to its importer's
-        // direct deps so pnpm-style `node_modules/<peer>` top-level
-        // symlinks get created and the lockfile's `importers.` section
-        // lists them the way pnpm does with `auto-install-peers=true`.
+        // Second pass: hoist every auto-installed peer to a synthetic
+        // importer direct dep so the isolated linker creates the required
+        // `node_modules/<peer>` top-level symlink. The synthetic root keeps
+        // the requiring direct dependency's section classification.
         // Skipped entirely when the setting is off — matches pnpm, which
         // leaves the importer's `dependencies` untouched in that mode.
         let hoisted = if self.auto_install_peers {

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -2589,9 +2589,9 @@ fn contains_canonical_back_ref_respects_boundaries() {
 }
 
 // A package whose only dep is another package that declares a peer
-// should hoist that peer to the importer — matching pnpm's
-// `auto-install-peers=true` default. The hoisted DirectDep carries
-// the declared peer range as its specifier.
+// should hoist that peer to the importer. The hoisted DirectDep carries
+// the declared peer range as its specifier and inherits the requiring
+// direct dependency's section classification.
 #[test]
 fn hoist_auto_installed_peers_hoists_unmet_peers_to_importer() {
     // consumer declares `peer react: ^17 || ^18` and already has
@@ -2637,6 +2637,47 @@ fn hoist_auto_installed_peers_hoists_unmet_peers_to_importer() {
     assert_eq!(root[1].dep_type, DepType::Production);
     // Specifier carries the declared peer range verbatim.
     assert_eq!(root[1].specifier.as_deref(), Some("^17 || ^18"));
+}
+
+#[test]
+fn hoist_auto_installed_peers_preserves_requirer_dep_type() {
+    for dep_type in [DepType::Production, DepType::Dev, DepType::Optional] {
+        let mut consumer = mk_locked(
+            "consumer",
+            "1.0.0",
+            &[("react", "18.2.0")],
+            &[("react", "^18")],
+        );
+        consumer.dep_path = "consumer@1.0.0".to_string();
+
+        let mut packages = BTreeMap::new();
+        packages.insert("consumer@1.0.0".to_string(), consumer);
+        packages.insert(
+            "react@18.2.0".to_string(),
+            mk_locked("react", "18.2.0", &[], &[]),
+        );
+
+        let mut importers = BTreeMap::new();
+        importers.insert(
+            ".".to_string(),
+            vec![DirectDep {
+                name: "consumer".to_string(),
+                dep_path: "consumer@1.0.0".to_string(),
+                dep_type,
+                specifier: Some("^1".to_string()),
+            }],
+        );
+
+        let graph = LockfileGraph {
+            importers,
+            packages,
+            ..Default::default()
+        };
+        let hoisted = hoist_auto_installed_peers(graph);
+        let root = hoisted.importers.get(".").unwrap();
+        let react = root.iter().find(|dep| dep.name == "react").unwrap();
+        assert_eq!(react.dep_type, dep_type);
+    }
 }
 
 // Peers declared by transitive dependencies are still resolved and

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -2680,6 +2680,65 @@ fn hoist_auto_installed_peers_preserves_requirer_dep_type() {
     }
 }
 
+#[test]
+fn hoist_auto_installed_peers_promotes_shared_peer_dep_type() {
+    for (first_type, second_type, expected) in [
+        (DepType::Dev, DepType::Optional, DepType::Optional),
+        (DepType::Dev, DepType::Production, DepType::Production),
+        (DepType::Optional, DepType::Production, DepType::Production),
+    ] {
+        let first = mk_locked(
+            "first",
+            "1.0.0",
+            &[("react", "18.2.0")],
+            &[("react", "^18")],
+        );
+        let second = mk_locked(
+            "second",
+            "1.0.0",
+            &[("react", "18.2.0")],
+            &[("react", "^18")],
+        );
+
+        let mut packages = BTreeMap::new();
+        packages.insert("first@1.0.0".to_string(), first);
+        packages.insert("second@1.0.0".to_string(), second);
+        packages.insert(
+            "react@18.2.0".to_string(),
+            mk_locked("react", "18.2.0", &[], &[]),
+        );
+
+        let mut importers = BTreeMap::new();
+        importers.insert(
+            ".".to_string(),
+            vec![
+                DirectDep {
+                    name: "first".to_string(),
+                    dep_path: "first@1.0.0".to_string(),
+                    dep_type: first_type,
+                    specifier: Some("^1".to_string()),
+                },
+                DirectDep {
+                    name: "second".to_string(),
+                    dep_path: "second@1.0.0".to_string(),
+                    dep_type: second_type,
+                    specifier: Some("^1".to_string()),
+                },
+            ],
+        );
+
+        let graph = LockfileGraph {
+            importers,
+            packages,
+            ..Default::default()
+        };
+        let hoisted = hoist_auto_installed_peers(graph);
+        let root = hoisted.importers.get(".").unwrap();
+        let react = root.iter().find(|dep| dep.name == "react").unwrap();
+        assert_eq!(react.dep_type, expected);
+    }
+}
+
 // Peers declared by transitive dependencies are still resolved and
 // sibling-linked by the peer-context pass, but pnpm does not expose
 // them as root importer deps or top-level node_modules entries.

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -2683,7 +2683,7 @@ fn hoist_auto_installed_peers_preserves_requirer_dep_type() {
 #[test]
 fn hoist_auto_installed_peers_promotes_shared_peer_dep_type() {
     for (first_type, second_type, expected) in [
-        (DepType::Dev, DepType::Optional, DepType::Optional),
+        (DepType::Dev, DepType::Optional, DepType::Production),
         (DepType::Dev, DepType::Production, DepType::Production),
         (DepType::Optional, DepType::Production, DepType::Production),
     ] {

--- a/test/peer_deps.bats
+++ b/test/peer_deps.bats
@@ -18,6 +18,25 @@ teardown() {
 	_common_teardown
 }
 
+@test "auto-installed peer of a dev dependency is excluded from production installs" {
+	cat >package.json <<'JSON'
+{
+  "name": "dev-peer-production-filter",
+  "version": "1.0.0",
+  "devDependencies": {
+    "react-dom": "18.3.1"
+  }
+}
+JSON
+	run aube install --lockfile-only
+	assert_success
+
+	run aube install --frozen-lockfile --production --disable-global-virtual-store
+	assert_success
+	assert_not_exists node_modules/react-dom
+	assert_not_exists node_modules/react
+}
+
 @test "required peer is auto-installed and sibling-linked with peer-suffix dep_path" {
 	# use-sync-external-store@1.2.0 declares peerDep react ^16.8 || ^17 || ^18.
 	# Intentionally do NOT list react in package.json — auto-install-peers


### PR DESCRIPTION
## Summary

- preserve the dependency type of a direct dependency when synthesizing its auto-installed peer root
- keep dev-only auto-installed peers out of `--production` installs
- cover production, development, and optional classifications plus the reported end-to-end reproduction

## Root cause

`hoist_auto_installed_peers` discarded the requiring direct dependency and hardcoded every synthesized `DirectDep` as production. The lockfile writer therefore recorded a peer required only by a dev dependency under `dependencies`, and production filtering retained it.

Fixes the behavior reported in https://github.com/jdx/aube/discussions/1251.

## Validation

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `./test/bats/bin/bats --filter "auto-installed peer of a dev dependency" test/peer_deps.bats`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes lockfile importer rows and install filtering for auto-installed peers; behavior is well-tested but affects production installs and mixed dev/prod peer hoists.
> 
> **Overview**
> **`hoist_auto_installed_peers`** no longer marks every synthesized importer `DirectDep` as production. Auto-installed peers **inherit the `dep_type` of the direct dependency** that declared them, so section filters (`--production`, `--no-optional`) treat hoisted peers like the package that pulled them in.
> 
> When **two direct deps share the same unmet peer** but sit in different sections (e.g. dev + optional), the single hoisted entry is **upgraded to `Production`** so neither filter can drop the peer while still keeping a requirer.
> 
> Unit tests cover per-section inheritance and mixed-section promotion; a **bats** case checks that a dev-only `react-dom` install does not leave `react`/`react-dom` on disk under `--production`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e395d3246156528b0f161dce9fcf4a043dfed50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->