### PR TITLE
fix(install): filter cold per-project materialization

### DIFF
--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1165,8 +1165,16 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
             let (lock_patches, lock_patch_hashes) =
                 crate::patches::load_patches_for_linker(&cwd, &graph.patched_dependencies)?;
             let (lock_materialize_tx, lock_materialize_rx) = materialize_channel();
+            let lock_materialize_graph = filter_graph_for_install(
+                &cwd,
+                &workspace_packages,
+                &graph,
+                &opts,
+                has_workspace && !link_all_workspace_importers,
+                false,
+            )?;
             let lock_prewarm_inputs = GvsPrewarmInputs {
-                graph: std::sync::Arc::new(graph.clone()),
+                graph: std::sync::Arc::new(lock_materialize_graph),
                 store: store.clone(),
                 cwd: cwd.clone(),
                 virtual_store_dir_max_length,
@@ -1952,7 +1960,14 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
             // below hits pkg_nm_dir.exists() fast path and only writes
             // the per-project .aube/<dep_path> symlink.
             let materialize_phase_start = std::time::Instant::now();
-            let materialize_graph_arc = std::sync::Arc::new(graph.clone());
+            let materialize_graph_arc = std::sync::Arc::new(filter_graph_for_install(
+                &cwd,
+                &workspace_packages,
+                &graph,
+                &opts,
+                has_workspace && !link_all_workspace_importers,
+                false,
+            )?);
             let materialize_strategy = resolve_link_strategy(&cwd, &settings_ctx, planned_gvs)?;
             let (materialize_patches, materialize_patch_hashes) =
                 crate::patches::load_patches_for_linker(&cwd, &graph.patched_dependencies)?;
@@ -2355,39 +2370,14 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     //     only reachable through them. The filtered graph is what gets passed
     //     to the linker, so node_modules won't contain the excluded deps.
     //     The lockfile on disk is untouched.
-    let mut graph_for_link = if opts.dep_selection.is_filtered() {
-        let before = graph.packages.len();
-        let sel = opts.dep_selection;
-        let filtered = graph.filter_deps(|d| {
-            if sel.prod_only() && d.dep_type == aube_lockfile::DepType::Dev {
-                return false;
-            }
-            if sel.dev_only() && d.dep_type != aube_lockfile::DepType::Dev {
-                return false;
-            }
-            if sel.skip_optional() && d.dep_type == aube_lockfile::DepType::Optional {
-                return false;
-            }
-            true
-        });
-        let dropped = before - filtered.packages.len();
-        if dropped > 0 {
-            tracing::debug!("{}: skipping {dropped} packages", sel.label());
-        }
-        filtered
-    } else {
-        graph.clone()
-    };
-    if !opts.workspace_filter.is_empty() {
-        graph_for_link = filter_graph_to_workspace_selection(
-            &cwd,
-            &workspace_packages,
-            &graph_for_link,
-            &opts.workspace_filter,
-        )?;
-    } else if has_workspace && !link_all_workspace_importers {
-        graph_for_link = filter_graph_to_importers(&graph_for_link, ["."]);
-    }
+    let graph_for_link = filter_graph_for_install(
+        &cwd,
+        &workspace_packages,
+        &graph,
+        &opts,
+        has_workspace && !link_all_workspace_importers,
+        true,
+    )?;
 
     // 5c. Validate root + dependency `engines.node` constraints against
     //     the current Node version. Runs against `graph_for_link` so
@@ -2534,6 +2524,51 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
         );
     }
     Ok(())
+}
+
+fn filter_graph_for_install(
+    cwd: &std::path::Path,
+    workspace_packages: &[std::path::PathBuf],
+    graph: &aube_lockfile::LockfileGraph,
+    opts: &InstallOptions,
+    filter_to_root_importer: bool,
+    log_dropped_packages: bool,
+) -> miette::Result<aube_lockfile::LockfileGraph> {
+    let mut filtered = if opts.dep_selection.is_filtered() {
+        let sel = opts.dep_selection;
+        let selected = graph.filter_deps(|d| {
+            if sel.prod_only() && d.dep_type == aube_lockfile::DepType::Dev {
+                return false;
+            }
+            if sel.dev_only() && d.dep_type != aube_lockfile::DepType::Dev {
+                return false;
+            }
+            if sel.skip_optional() && d.dep_type == aube_lockfile::DepType::Optional {
+                return false;
+            }
+            true
+        });
+        let dropped = graph.packages.len() - selected.packages.len();
+        if log_dropped_packages && dropped > 0 {
+            tracing::debug!("{}: skipping {dropped} packages", sel.label());
+        }
+        selected
+    } else {
+        graph.clone()
+    };
+
+    if !opts.workspace_filter.is_empty() {
+        filtered = filter_graph_to_workspace_selection(
+            cwd,
+            workspace_packages,
+            &filtered,
+            &opts.workspace_filter,
+        )?;
+    } else if filter_to_root_importer {
+        filtered = filter_graph_to_importers(&filtered, ["."]);
+    }
+
+    Ok(filtered)
 }
 
 fn has_explicit_store_dir_override(cli_flags: &[(String, String)]) -> bool {

--- a/test/filter.bats
+++ b/test/filter.bats
@@ -189,6 +189,65 @@ _setup_filter_workspace() {
 	assert_output --partial "node_modules/is-odd"
 }
 
+@test "filtered production install materializes only selected packages on a cold store" {
+	cat >pnpm-workspace.yaml <<-'EOF'
+		packages:
+		  - packages/*
+	EOF
+	cat >package.json <<-'EOF'
+		{"name":"filter-materialize-root","version":"0.0.0","private":true}
+	EOF
+	mkdir -p packages/backend packages/backend-two packages/frontend
+	cat >packages/backend/package.json <<-'EOF'
+		{
+		  "name": "backend",
+		  "version": "1.0.0",
+		  "dependencies": { "is-number": "7.0.0" },
+		  "devDependencies": { "kind-of": "6.0.3" }
+		}
+	EOF
+	cat >packages/backend-two/package.json <<-'EOF'
+		{
+		  "name": "backend-two",
+		  "version": "1.0.0",
+		  "dependencies": { "picocolors": "1.1.1" }
+		}
+	EOF
+	cat >packages/frontend/package.json <<-'EOF'
+		{
+		  "name": "frontend",
+		  "version": "1.0.0",
+		  "dependencies": { "is-odd": "3.0.1" }
+		}
+	EOF
+
+	# Resolve the complete workspace without warming the package store.
+	run aube install --lockfile-only --recursive
+	assert_success
+
+	run aube install --frozen-lockfile --production \
+		--disable-global-virtual-store \
+		--filter ./packages/backend \
+		--filter ./packages/backend-two
+	assert_success
+
+	run bash -c 'find node_modules/.aube -mindepth 1 -maxdepth 1 ! -name node_modules -exec basename {} \; | sort'
+	assert_success
+	assert_output $'is-number@7.0.0\npicocolors@1.1.1'
+
+	# A warm-store reinstall must produce the identical project-local tree.
+	run aube clean
+	assert_success
+	run aube install --frozen-lockfile --production \
+		--disable-global-virtual-store \
+		--filter ./packages/backend \
+		--filter ./packages/backend-two
+	assert_success
+	run bash -c 'find node_modules/.aube -mindepth 1 -maxdepth 1 ! -name node_modules -exec basename {} \; | sort'
+	assert_success
+	assert_output $'is-number@7.0.0\npicocolors@1.1.1'
+}
+
 @test "aube install --filter <member>... scopes to the member and its workspace deps (sharedWorkspaceLockfile=false)" {
 	# Mirrors a per-project-lockfile monorepo. A plain `aube install` from
 	# anywhere installs every importer (recursiveInstall defaults to true,


### PR DESCRIPTION
## Summary

- apply dependency-section and workspace selection before pipelined materialization
- reuse the same selection helper for the final linker graph
- cover cold and warm filtered production installs with GVS disabled

## Root cause

Cold-store fetches streamed every newly imported package from the complete lockfile graph into the per-project materializer. Workspace and production filtering happened only later, before final linking, so importer links were correct while unrelated package cells remained under `node_modules/.aube`. Cached packages are not streamed, which caused warm installs to produce the expected smaller tree.

The materializer now receives the selected graph in both frozen-lockfile and fresh-resolution paths. The complete graph remains available for lockfile preservation and full-graph validation.

## Validation

- `cargo fmt --check`
- `cargo test -p aube --lib` — 779 passed
- `cargo clippy --all-targets -- -D warnings`
- focused BATS regression for the cold/warm filtered no-GVS install

The complete `test/filter.bats` file also ran: the new regression and 26 other tests passed; one existing test failed afterward because the local mise `node` shim is invalid.

Fixes the behavior reported in discussion #1250.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install materialization inputs on hot paths (frozen and streaming fetch); behavior is scoped to filtered installs but incorrect filtering could skip needed packages or over-materialize.
> 
> **Overview**
> **Filtered installs** (`--production`, `--filter`, workspace scoping) used to run only at link time, while cold-store pipelined materialization still streamed the **full lockfile graph** into `node_modules/.aube`. That left extra package cells on disk even though symlinks looked correct; warm installs often looked fine because cached packages were not re-streamed.
> 
> This PR introduces **`filter_graph_for_install`** and feeds its output to **GVS prewarm/materialization** on both frozen-lockfile and fresh-resolve paths, while the linker keeps using the same helper (with optional debug logging when packages are dropped). The on-disk lockfile and full-graph validation still use the unfiltered graph.
> 
> A **BATS regression** asserts that a filtered production install with GVS disabled materializes only the selected deps on a **cold** store and matches after **clean + reinstall**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ad1081945a7e42d5ee638c5a11da7ac9528a0d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->