### PR TITLE
chore(deps): simplify cargo version requirements

### DIFF
--- a/.rules
+++ b/.rules
@@ -233,6 +233,9 @@ security[5]:
 
 deps:
   policy: minimize, prefer std over external, every added dep must justify >=20 LOC saved
+  version_requirements: use the lowest compatibility-significant specificity (for example, "1" for stable 1.x dependencies)
+  routine_updates: update Cargo.lock only when the existing Cargo.toml requirement already accepts the new version
+  lockfile_scope: keep dependency lockfile updates focused; avoid unrelated transitive churn
   tls: rustls (no OpenSSL / native-tls)
   reqwest_features: minimal (rustls-tls + http2 + json + stream + charset + system-proxy)
   supply_chain[2]:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,28 +47,28 @@ tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 
 # Node-API bindings
-napi = { version = "3.10.5", default-features = false, features = ["napi8", "tokio_rt", "dyn-symbols"] }
-napi-derive = "3.5.10"
-napi-build = "2.3.2"
+napi = { version = "3", default-features = false, features = ["napi8", "tokio_rt", "dyn-symbols"] }
+napi-derive = "3"
+napi-build = "2"
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order", "raw_value"] }
 spdx = "0.13"
-yaml_serde = "0.10.4"
+yaml_serde = "0.10"
 # Comment- and format-preserving YAML edits. Used by aube-manifest /
 # aube to surgically rewrite user-authored workspace YAML files
 # (catalogs, allowBuilds, patchedDependencies) without stripping
 # comments — yaml_serde's round-trip would otherwise destroy them.
 # yamlpatch uses yaml_serde for patch payloads; serde_yaml remains only
 # for the manual block injector that works around nested Add formatting.
-yamlpatch = "1.25"
+yamlpatch = "1"
 # yamlpath 1.28 does not declare the Rust 1.97 requirement it inherits
 # from tree-sitter-iter 1.28, so resolver 3 cannot avoid it.
 yamlpath = ">=1.25, <1.28"
 serde_yaml = "0.9"
 sonic-rs = "0.5"
-toml = "1.1"
+toml = "1"
 rkyv = "0.8"
 
 # CLI
@@ -192,19 +192,19 @@ diffy = "0.5"
 # Internal crates — `version` is required so `cargo publish` can resolve
 # transitive crate dependencies via crates.io. release-plz keeps these
 # versions in sync with [workspace.package].version during release PRs.
-aube = { path = "crates/aube", version = "1.38.1", default-features = false }
-aube-codes = { path = "crates/aube-codes", version = "1.38.1" }
-aube-settings = { path = "crates/aube-settings", version = "1.38.1" }
-aube-resolver = { path = "crates/aube-resolver", version = "1.38.1" }
-aube-registry = { path = "crates/aube-registry", version = "1.38.1" }
-aube-store = { path = "crates/aube-store", version = "1.38.1" }
-aube-linker = { path = "crates/aube-linker", version = "1.38.1" }
-aube-lockfile = { path = "crates/aube-lockfile", version = "1.38.1" }
-aube-manifest = { path = "crates/aube-manifest", version = "1.38.1" }
-aube-runtime = { path = "crates/aube-runtime", version = "1.38.1" }
-aube-scripts = { path = "crates/aube-scripts", version = "1.38.1" }
-aube-workspace = { path = "crates/aube-workspace", version = "1.38.1" }
-aube-util = { path = "crates/aube-util", version = "1.38.1" }
+aube = { path = "crates/aube", version = "1", default-features = false }
+aube-codes = { path = "crates/aube-codes", version = "1" }
+aube-settings = { path = "crates/aube-settings", version = "1" }
+aube-resolver = { path = "crates/aube-resolver", version = "1" }
+aube-registry = { path = "crates/aube-registry", version = "1" }
+aube-store = { path = "crates/aube-store", version = "1" }
+aube-linker = { path = "crates/aube-linker", version = "1" }
+aube-lockfile = { path = "crates/aube-lockfile", version = "1" }
+aube-manifest = { path = "crates/aube-manifest", version = "1" }
+aube-runtime = { path = "crates/aube-runtime", version = "1" }
+aube-scripts = { path = "crates/aube-scripts", version = "1" }
+aube-workspace = { path = "crates/aube-workspace", version = "1" }
+aube-util = { path = "crates/aube-util", version = "1" }
 
 [profile.dev]
 debug = 1

--- a/crates/aube-registry/Cargo.toml
+++ b/crates/aube-registry/Cargo.toml
@@ -53,5 +53,5 @@ tar = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 wiremock = "0.6"
 proptest = "1"
-rcgen = { version = "0.14.8", default-features = false, features = ["crypto", "aws_lc_rs"] }
+rcgen = { version = "0.14", default-features = false, features = ["crypto", "aws_lc_rs"] }
 tokio-rustls = "0.26"

--- a/crates/aube/Cargo.toml
+++ b/crates/aube/Cargo.toml
@@ -101,11 +101,11 @@ libc = { workspace = true }
 pathdiff = "0.2"
 is_ci = "1"
 ci_info = "0.14"
-pluralizer = "0.5.0"
+pluralizer = "0.5"
 toml = { workspace = true }
 mimalloc = { version = "0.1", default-features = false, optional = true }
-ratatui = { version = "0.30.0", default-features = false, features = ["crossterm", "std"], optional = true }
-crossterm = { version = "0.29.0", optional = true }
+ratatui = { version = "0.30", default-features = false, features = ["crossterm", "std"], optional = true }
+crossterm = { version = "0.29", optional = true }
 
 [features]
 default = ["mimalloc", "config-tui", "publish", "rustls", "hickory-dns"]


### PR DESCRIPTION
## Summary
- normalize stable Cargo requirements to their lowest compatibility-significant specificity
- normalize internal aube workspace crate requirements to `1`
- document that routine compatible updates should only change `Cargo.lock`
- preserve deliberate exact and pre-1 compatibility requirements

`Cargo.lock` is unchanged.

## Validation
- `cargo check --locked`
- `cargo fmt --check`
- `cargo test --locked`
- `cargo clippy --locked --all-targets -- -D warnings`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only Cargo.toml and documentation changes with no lockfile or runtime code changes; resolved versions remain those already locked in CI.
> 
> **Overview**
> **Dependency policy** in `.rules` now states that requirements should use the lowest compatibility-significant specificity, routine compatible bumps should touch `Cargo.lock` only when `Cargo.toml` already allows the version, and lockfile updates should stay focused without unrelated transitive churn.
> 
> **Version strings** are relaxed across the workspace: third-party deps drop patch-level pins where `1` / `0.10` / `3` etc. suffice (e.g. `napi`, `yaml_serde`, `toml`, `yamlpatch`, optional TUI crates in `crates/aube`, `rcgen` in `aube-registry`). Internal `aube-*` workspace path deps change from `version = "1.38.1"` to `version = "1"` so published crate metadata stays semver-broad while `release-plz` still syncs real versions via `[workspace.package]`.
> 
> Deliberate pins (e.g. `decmpfs = "=0.1.0"`, `yamlpath` upper bound, `ambient-id`) are unchanged. **`Cargo.lock` is not modified** in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b893b210c09ec4b8e3ecd926bd02166e3e90a45a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version requirements to allow compatible minor and patch updates.
  * Broadened compatibility ranges for core N-API, YAML, TOML, registry, terminal UI, and text-processing dependencies.
  * Kept dependency configuration focused without unrelated lockfile changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->