### PR TITLE
fix(runtime): enforce aube devEngines version errors

### DIFF
--- a/crates/aube/src/lib.rs
+++ b/crates/aube/src/lib.rs
@@ -833,7 +833,8 @@ async fn async_main(cli: Cli) -> miette::Result<Option<i32>> {
             .wrap_err_with(|| format!("failed to change directory to {}", dir.display()))?;
     }
 
-    if cli.workspace_root {
+    let print_top_level_version = should_print_top_level_version(&cli);
+    if cli.workspace_root && !print_top_level_version {
         let start = std::env::current_dir()
             .into_diagnostic()
             .wrap_err("failed to read current dir")?;
@@ -850,7 +851,24 @@ async fn async_main(cli: Cli) -> miette::Result<Option<i32>> {
     let effective_level = resolve_loglevel(&cli, settings.loglevel.as_deref());
     init_logging(&cli, effective_level);
 
-    if should_print_top_level_version(&cli) {
+    // `--silent` suppresses non-error stderr output from every command,
+    // including the ~230 direct `eprintln!` calls in command bodies. The
+    // guard restores fd 2 on drop (before main returns), so miette still
+    // prints error reports to the real stderr. We also register the
+    // saved fd with aube-scripts so child processes spawned via
+    // `aube_scripts::child_stderr()` (lifecycle scripts, `aube run`,
+    // `aube exec`, `aube dlx`) keep writing to the real terminal — only
+    // aube's own output is silenced, matching pnpm `--loglevel silent`.
+    // Install it before self-version handling, which can emit download
+    // progress even for a top-level version request.
+    let _silent_guard = matches!(effective_level, LogLevel::Silent)
+        .then(SilentStderrGuard::install)
+        .flatten();
+    if let Some(ref guard) = _silent_guard {
+        aube_scripts::set_saved_stderr_fd(guard.saved);
+    }
+
+    if print_top_level_version {
         self_version::maybe_switch(&settings).await?;
         println!("{}", crate::version::VERSION_LONG.as_str());
         let cwd =
@@ -868,21 +886,6 @@ async fn async_main(cli: Cli) -> miette::Result<Option<i32>> {
         }
     }
     raise_nofile_limit();
-
-    // `--silent` suppresses non-error stderr output from every command,
-    // including the ~230 direct `eprintln!` calls in command bodies. The
-    // guard restores fd 2 on drop (before main returns), so miette still
-    // prints error reports to the real stderr. We also register the
-    // saved fd with aube-scripts so child processes spawned via
-    // `aube_scripts::child_stderr()` (lifecycle scripts, `aube run`,
-    // `aube exec`, `aube dlx`) keep writing to the real terminal — only
-    // aube's own output is silenced, matching `pnpm --loglevel silent`.
-    let _silent_guard = matches!(effective_level, LogLevel::Silent)
-        .then(SilentStderrGuard::install)
-        .flatten();
-    if let Some(ref guard) = _silent_guard {
-        aube_scripts::set_saved_stderr_fd(guard.saved);
-    }
 
     commands::set_skip_auto_install_on_package_manager_mismatch(false);
     if command_needs_package_manager_guard(cli.command.as_ref()) {

--- a/crates/aube/src/lib.rs
+++ b/crates/aube/src/lib.rs
@@ -833,14 +833,6 @@ async fn async_main(cli: Cli) -> miette::Result<Option<i32>> {
             .wrap_err_with(|| format!("failed to change directory to {}", dir.display()))?;
     }
 
-    if should_print_top_level_version(&cli) {
-        println!("{}", crate::version::VERSION_LONG.as_str());
-        let cwd =
-            crate::dirs::project_root_or_cwd().unwrap_or_else(|_| std::path::PathBuf::from("."));
-        update_check::check_and_notify(&cwd).await;
-        return Ok(None);
-    }
-
     if cli.workspace_root {
         let start = std::env::current_dir()
             .into_diagnostic()
@@ -857,6 +849,16 @@ async fn async_main(cli: Cli) -> miette::Result<Option<i32>> {
     let settings = load_startup_settings()?;
     let effective_level = resolve_loglevel(&cli, settings.loglevel.as_deref());
     init_logging(&cli, effective_level);
+
+    if should_print_top_level_version(&cli) {
+        self_version::maybe_switch(&settings).await?;
+        println!("{}", crate::version::VERSION_LONG.as_str());
+        let cwd =
+            crate::dirs::project_root_or_cwd().unwrap_or_else(|_| std::path::PathBuf::from("."));
+        update_check::check_and_notify(&cwd).await;
+        return Ok(None);
+    }
+
     // Skip diag init for the `diag` subcommand itself — the analyzer
     // would otherwise truncate the JSONL file it's about to read.
     if !matches!(cli.command, Some(Commands::Diag(_))) {

--- a/crates/aube/src/self_version.rs
+++ b/crates/aube/src/self_version.rs
@@ -63,6 +63,14 @@ pub(crate) async fn maybe_switch(settings: &crate::startup::StartupSettings) -> 
         return Ok(());
     }
 
+    // An explicit error policy validates the invoking aube itself. Do
+    // not silently satisfy it by switching to another installed binary:
+    // callers use this policy when they want a version mismatch to stop
+    // every aube command.
+    if pin.on_fail == aube_manifest::OnFail::Error {
+        return self_pin_unsatisfied(&pin, "onFail is \"error\"".to_string());
+    }
+
     // Resolve the pin to an exact version: exact pins directly, ranges
     // against installed versions first, then the published list. A
     // range that can't be resolved (offline, or nothing satisfies)
@@ -192,11 +200,19 @@ fn self_pin_unsatisfied(pin: &SelfPin, detail: String) -> miette::Result<()> {
     // Product name in the spec syntax shown to the user (standalone aube →
     // "aube"): the pin reads `packageManager: "<name>@<version>"`.
     let name = aube_util::embedder().name;
+    let help = if pin.on_fail == aube_manifest::OnFail::Error {
+        format!(
+            "run the project with a {name} version satisfying {}, or set devEngines.packageManager.onFail to \"warn\", \"ignore\", or \"download\"",
+            pin.raw
+        )
+    } else {
+        format!(
+            "pin an exact released version (e.g. `packageManager: \"{name}@<version>\"`), or set managePackageManagerVersions=false to skip switching"
+        )
+    };
     Err(miette!(
         code = aube_codes::errors::ERR_AUBE_RUNTIME_VERSION_UNSATISFIED,
-        help = format!(
-            "pin an exact released version (e.g. `packageManager: \"{name}@<version>\"`), or set managePackageManagerVersions=false to skip switching"
-        ),
+        help = help,
         "the project pins {name}@{} via {}, but this is {name}@{} and {detail}",
         pin.raw,
         pin.source,

--- a/test/self_version.bats
+++ b/test/self_version.bats
@@ -4,6 +4,8 @@
 # pinned aube. Hermetic — pinned "versions" are fabricated shell
 # scripts in the mise installs dir, so no downloads happen.
 
+bats_require_minimum_version 1.5.0
+
 setup() {
 	load 'test_helper/common_setup'
 	_common_setup
@@ -151,6 +153,38 @@ _running_version() {
 	run aube --version
 	assert_success
 	assert_output --partial "$(_running_version)"
+}
+
+@test "version flag skips workspace-root discovery outside a workspace" {
+	run aube --version --workspace-root
+	assert_success
+	assert_output --partial "$(_running_version)"
+}
+
+@test "silent version switch suppresses progress output" {
+	cat >package.json <<-'JSON'
+		{
+		  "name": "t",
+		  "version": "0.0.0",
+		  "devEngines": { "packageManager": { "name": "aube", "version": "9.8.7", "onFail": "download" } }
+		}
+	JSON
+	echo "runtime-installer=mise" >.npmrc
+	mkdir -p "$TEST_TEMP_DIR/stubbin"
+	cat >"$TEST_TEMP_DIR/stubbin/mise" <<-STUB
+		#!/bin/sh
+		dir="$XDG_DATA_HOME/mise/installs/aube/9.8.7"
+		mkdir -p "\$dir"
+		for bin in aube aubr aubx; do
+			printf '#!/bin/sh\necho "FAKE-AUBE 9.8.7 args: \$*"\n' >"\$dir/\$bin"
+			chmod +x "\$dir/\$bin"
+		done
+	STUB
+	chmod +x "$TEST_TEMP_DIR/stubbin/mise"
+	PATH="$TEST_TEMP_DIR/stubbin:$PATH" run --separate-stderr aube --version --silent
+	assert_success
+	assert_output --partial "FAKE-AUBE 9.8.7"
+	[ -z "$stderr" ]
 }
 
 @test "onFail=warn keeps the running aube" {

--- a/test/self_version.bats
+++ b/test/self_version.bats
@@ -112,7 +112,8 @@ _running_version() {
 	refute_output --partial "FAKE-AUBE"
 }
 
-@test "onFail=error fails when the pinned version is not installed" {
+@test "onFail=error rejects a mismatch even when the pinned version is installed" {
+	_fab_aube "$(_mise_aube_dir)" "9.8.7"
 	cat >package.json <<-'JSON'
 		{
 		  "name": "t",
@@ -122,7 +123,34 @@ _running_version() {
 	JSON
 	run aube install
 	assert_failure
-	assert_output --partial "aube@9.8.7 is not installed"
+	assert_output --partial 'onFail is "error"'
+	refute_output --partial "FAKE-AUBE"
+}
+
+@test "onFail=error rejects a mismatch for the version flag" {
+	cat >package.json <<-'JSON'
+		{
+		  "name": "t",
+		  "version": "0.0.0",
+		  "devEngines": { "packageManager": { "name": "aube", "version": "9.8.7", "onFail": "error" } }
+		}
+	JSON
+	run aube --version
+	assert_failure
+	assert_output --partial 'onFail is "error"'
+}
+
+@test "non-aube devEngines package manager does not guard the version flag" {
+	cat >package.json <<-'JSON'
+		{
+		  "name": "t",
+		  "version": "0.0.0",
+		  "devEngines": { "packageManager": { "name": "pnpm", "version": "999.0.0", "onFail": "error" } }
+		}
+	JSON
+	run aube --version
+	assert_success
+	assert_output --partial "$(_running_version)"
 }
 
 @test "onFail=warn keeps the running aube" {


### PR DESCRIPTION
## Summary

- reject an explicit `devEngines.packageManager.onFail: "error"` when the running aube version does not satisfy the declared aube version
- enforce the same self-version policy for `aube --version`
- preserve compatibility behavior for `devEngines.packageManager` entries naming pnpm or another package manager

## Root cause

Self-version handling treated `onFail` as a download policy. If the requested aube version was already installed, aube re-executed it before consulting `onFail`, so an explicit `error` policy did not reject the invoking version mismatch. The top-level version flag also returned before self-version handling.

Fixes the behavior reported in https://github.com/jdx/aube/discussions/1263.

## Validation

- `cargo test -p aube self_version`
- `mise run test:bats test/self_version.bats`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CLI startup ordering and self-version re-exec policy for every guarded command and `aube --version`; behavior change is intentional but could surprise projects that relied on silent re-exec under `onFail: "error"`.
> 
> **Overview**
> **`devEngines.packageManager.onFail: "error"`** now fails when the **invoking** aube does not satisfy the pinned aube version, instead of re-execing to an already-installed match. Error help text distinguishes the explicit error policy from other pin failures.
> 
> **Startup for top-level `--version`** loads settings and logging, installs the silent stderr guard before self-version handling (so download/switch progress respects `--silent`), runs `self_version::maybe_switch`, then prints version and update check. **`--workspace-root`** is skipped on the version path so `aube --version --workspace-root` works outside a workspace. Diag init and `raise_nofile_limit` run only after the version early return.
> 
> Bats coverage adds cases for error policy on install and `--version`, non-aube `devEngines` not blocking version, workspace-root + version, and silent version switches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1f6fa623bd4492163456f81e1b35c67be2f7cbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Version commands now consistently honor configured version pins after startup settings are loaded.
  - When a pinned version cannot be satisfied and the failure policy is set to `error`, the command stops immediately instead of switching to or downloading another version.
  - Error messages now explain how to change the pinned version or failure policy.
  - Unrelated package-manager settings no longer interfere with version checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->