### PR TITLE
chore(ci): qualify mise rust cache

### DIFF
--- a/.github/mise-cache-qualification.toml
+++ b/.github/mise-cache-qualification.toml
@@ -1,0 +1,7 @@
+[settings]
+experimental = true
+
+[tasks."cache:qualify"]
+dir = "{{ env.GITHUB_WORKSPACE }}"
+run = "cargo build --workspace"
+rust_cache = { verify = true }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,107 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+  # Qualify mise's experimental Rust action cache against the production
+  # service without replacing Namespace's cache yet. Pull requests can read
+  # jdx/aube but must not write; main uses the same job to seed verified
+  # entries for subsequent qualification runs.
+  cache-qualification:
+    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'
+    runs-on: namespace-profile-endev-linux-amd64
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target/cache-qualification
+      MISE_CACHE_DIR: /tmp/aube-cache-qualification-${{ github.run_id }}-${{ github.run_attempt }}/mise
+      MISE_CONFIG_FILE: ${{ github.workspace }}/.github/mise-cache-qualification.toml
+      MISE_TASK_CACHE_REMOTE_MODE: ${{ github.ref == 'refs/heads/main' && 'read-write' || 'read-only' }}
+      MISE_TASK_CACHE_REMOTE_NAMESPACE: jdx/aube
+      MISE_TASK_CACHE_REMOTE_OIDC_AUDIENCE: https://cache.mise.jdx.dev
+      MISE_TASK_CACHE_REMOTE_URL: https://cache.mise.jdx.dev
+      RUSTFLAGS: "-D warnings"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        with:
+          version: 2026.8.4
+          install: false
+          cache: false
+      - name: Qualify production cache authorization
+        env:
+          CACHE_URL: https://cache.mise.jdx.dev
+        run: |
+          response=$(curl --fail --silent --show-error \
+            --get \
+            --data-urlencode "audience=$CACHE_URL" \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL")
+          token=$(jq -er '.value | strings | select(length > 0)' <<<"$response")
+          echo "::add-mask::$token"
+
+          empty_blake3=af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+          blob_url="$CACHE_URL/v1/blobs/blake3/$empty_blake3/0"
+          headers=(
+            -H "Authorization: Bearer $token"
+            -H "Mise-Cache-Namespace: jdx/aube"
+            -H "Mise-Cache-Protocol: 1"
+          )
+          read_status=$(curl --silent --show-error \
+            --output /dev/null \
+            --write-out '%{http_code}' \
+            "${headers[@]}" \
+            "$blob_url")
+          case "$read_status" in
+            200|404) ;;
+            *)
+              echo "::error::production cache read authorization returned HTTP $read_status"
+              exit 1
+              ;;
+          esac
+
+          if [ "$GITHUB_EVENT_NAME" = pull_request ]; then
+            write_status=$(curl --silent --show-error \
+              --output /dev/null \
+              --write-out '%{http_code}' \
+              --request PUT \
+              --data-binary '' \
+              -H "If-None-Match: *" \
+              "${headers[@]}" \
+              "$blob_url")
+            if [ "$write_status" != 403 ]; then
+              echo "::error::pull request cache write returned HTTP $write_status instead of 403"
+              exit 1
+            fi
+          fi
+      - name: Qualify Rust action cache
+        run: |
+          set -o pipefail
+          log="$RUNNER_TEMP/mise-cache-qualification.log"
+          mise run cache:qualify 2>&1 | tee "$log"
+          cargo clean --target-dir "$CARGO_TARGET_DIR"
+          mise run cache:qualify 2>&1 | tee -a "$log"
+          summary=$(grep -Eo \
+            'Action cache qualification: [0-9]+ verified, [0-9]+ diverged' \
+            "$log" | tail -n 1 || true)
+          if [[ ! "$summary" =~ ^Action\ cache\ qualification:\ ([0-9]+)\ verified,\ ([0-9]+)\ diverged$ ]]; then
+            echo "::error::mise did not report Rust action-cache qualification results"
+            exit 1
+          fi
+          verified=${BASH_REMATCH[1]}
+          diverged=${BASH_REMATCH[2]}
+          if (( verified == 0 || diverged != 0 )); then
+            echo "::error::Rust action-cache qualification reported $verified verified and $diverged diverged actions"
+            exit 1
+          fi
+          if grep -Eiq 'remote cache .* failed|mise rustc cache warning' \
+            "$log"; then
+            echo "::error::mise reported a Rust action-cache warning"
+            exit 1
+          fi
+
   # Linux-only test + lint + render + docs:build. Matches the
   # `linux / test` step in .buildkite/pipeline.sh. Split from `build` so
   # lint failures don't block the BATS jobs from starting against a
@@ -344,6 +445,7 @@ jobs:
   final:
     needs:
       - build
+      - cache-qualification
       - test-linux
       - bats
       - bats-serial
@@ -358,16 +460,20 @@ jobs:
     steps:
       - name: Gate on upstream job results
         env:
+          EVENT_NAME: ${{ github.event_name }}
           NEEDS_JSON: ${{ toJSON(needs) }}
+          REF: ${{ github.ref }}
         run: |
           python3 - <<'PY'
           import json
           import os
           import sys
 
-          # Jobs whose `if:` legitimately skips them on non-PR runs. A skip
+          # Jobs whose `if:` legitimately skips them in this event. A skip
           # here is a pass; every other job must actually succeed.
           SKIP_OK = {"api-stability"}
+          if os.environ["EVENT_NAME"] == "workflow_dispatch" and os.environ["REF"] != "refs/heads/main":
+              SKIP_OK.add("cache-qualification")
 
           needs = json.loads(os.environ["NEEDS_JSON"])
           failed = False


### PR DESCRIPTION
## Summary

- add a dedicated Linux job that qualifies mise 2026.8.4 against the production cache
- use GitHub OIDC to verify `jdx/aube` read access and enforce 403 responses for pull-request writes
- run the Rust adapter from a clean target and fail on remote-cache or rustc-cache warnings
- keep the existing Namespace cache in place while qualification data is collected

## Rollout

This pull-request run is intentionally read-only. After merge, the identical main-branch job can seed verified entries; a subsequent pull-request run will then exercise remote prefetch, restore, and shadow verification before the existing Rust cache is removed.

The experimental task lives in a CI-only config so aube's normal `mise.toml` remains compatible with mise versions older than 2026.8.4.

## Validation

- `actionlint .github/workflows/ci.yml`
- parsed the CI-only task with the merged mise implementation
- `cargo fmt --all --check`
- cold local build: 953.4 MiB of cacheable outputs stored
- clean-target replay: 382 compiler actions verified, 0 divergent

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive CI validation and gating; they do not alter application code or swap the primary Rust cache used by build/test.
> 
> **Overview**
> Adds a **CI-only** path to validate mise **2026.8.4**’s experimental Rust action cache against production (`cache.mise.jdx.dev`) while **Namespace Rust cache stays on** the main `build` / `test-linux` jobs.
> 
> A new `cache-qualification` job uses `.github/mise-cache-qualification.toml` to run `cache:qualify` (`cargo build --workspace` with `rust_cache = { verify = true }`) in an isolated `CARGO_TARGET_DIR`, with remote mode **read-only on PRs** and **read-write on `main`**. It checks OIDC-backed read access to namespace `jdx/aube`, asserts PR blob writes return **403**, then runs a cold build plus a post-`cargo clean` replay and fails unless mise reports verified actions with zero divergence and no remote/rustc-cache warnings.
> 
> The `final` aggregator now depends on `cache-qualification`, and treats that job as skippable only for **non-`main` `workflow_dispatch`** runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd50a8a8bbb20c762700cc54d1084790c35b7fc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added automated validation for build-cache permissions and behavior.
  - Confirmed pull requests cannot write to the production cache.
  - Added Rust cache qualification checks with warning detection.
  - Integrated cache validation into the CI completion checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->