### PR TITLE
feat(lockfile): add configurable creation format

### DIFF
--- a/crates/aube-manifest/src/workspace/config.rs
+++ b/crates/aube-manifest/src/workspace/config.rs
@@ -200,6 +200,11 @@ pub struct WorkspaceConfig {
     #[serde(default)]
     pub lockfile: Option<bool>,
 
+    /// Format to create when no supported lockfile exists: "aube" or
+    /// "pnpm". Existing lockfiles still take precedence.
+    #[serde(default)]
+    pub default_lockfile_format: Option<String>,
+
     /// Directory the lockfile is written to and read from. When unset
     /// or equal to the project root, behaves as before. When set to a
     /// different directory, the project becomes an importer keyed by

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -1488,6 +1488,29 @@ examples = [
   "echo 'lockfile=false' >> .npmrc && aube install",
 ]
 
+[defaultLockfileFormat]
+description = "Lockfile format to create when a project has no supported lockfile."
+type = '"aube" | "pnpm"'
+default = '"aube"'
+docs = """
+Selects the lockfile format aube creates when none of the supported
+lockfiles already exists. The default, `aube`, writes `aube-lock.yaml`;
+`pnpm` writes `pnpm-lock.yaml` for projects that need pnpm-compatible
+tooling to recognize the generated lockfile.
+
+This is only a creation default. An existing supported lockfile still
+wins, so setting `defaultLockfileFormat=pnpm` does not convert or leave a
+second lockfile alongside an existing `aube-lock.yaml`, `package-lock.json`,
+`yarn.lock`, or `bun.lock`.
+"""
+sources.cli = []
+sources.env = ["AUBE_DEFAULT_LOCKFILE_FORMAT"]
+sources.npmrc = ["default-lockfile-format", "defaultLockfileFormat"]
+sources.workspaceYaml = ["defaultLockfileFormat"]
+examples = [
+  "echo 'default-lockfile-format=pnpm' >> .npmrc && aube install",
+]
+
 [lockfileDir]
 description = "Directory the lockfile is written to and read from."
 type = "path"

--- a/crates/aube/src/commands/add/mod.rs
+++ b/crates/aube/src/commands/add/mod.rs
@@ -508,13 +508,13 @@ pub async fn run(
     // project state stays exactly as they wrote it.
     //
     // The lockfile path matches whatever
-    // `write_lockfile_preserving_existing` will write to: detect the
-    // existing lockfile kind on disk (pnpm, npm, yarn, bun, …) so a
+    // the install pipeline will write to: detect the existing lockfile
+    // kind on disk (pnpm, npm, yarn, bun, …) so a
     // project using `pnpm-lock.yaml` doesn't end up with both a
     // restored aube-lock.yaml *and* a leftover modified pnpm-lock.yaml.
-    // When no lockfile exists yet the resolver falls back to aube's
-    // own format, so we target that path and the restore step deletes
-    // it (since `lockfile_bytes` is `None`).
+    // When no lockfile exists yet the resolver uses the configured
+    // creation default, so we target that path and the restore step
+    // deletes it (since `lockfile_bytes` is `None`).
     let lockfile_path = no_save::lockfile_path_for_project(&cwd);
     let no_save_snapshot = if no_save {
         Some(no_save::snapshot_manifest_and_lockfile(

--- a/crates/aube/src/commands/add/no_save.rs
+++ b/crates/aube/src/commands/add/no_save.rs
@@ -15,15 +15,14 @@ pub(super) struct Snapshot {
 /// Resolve the on-disk lockfile path that a normal `add` would write
 /// to in `project_dir`. Mirrors the `LockfileKind` -> filename mapping
 /// inside `aube_lockfile::write_lockfile_as` so the snapshot/restore
-/// path under `--no-save` lines up byte-for-byte with whatever
-/// `write_lockfile_preserving_existing` produces, including non-aube
+/// path under `--no-save` lines up byte-for-byte with the normal install
+/// write, including non-aube
 /// lockfiles (`pnpm-lock.yaml`, `package-lock.json`, `yarn.lock`,
 /// `bun.lock`, `npm-shrinkwrap.json`). When no lockfile exists yet the
-/// resolver falls back to aube's own format.
+/// resolver falls back to the configured default format.
 pub(super) fn lockfile_path_for_project(project_dir: &Path) -> PathBuf {
     use aube_lockfile::LockfileKind;
-    let kind =
-        aube_lockfile::detect_existing_lockfile_kind(project_dir).unwrap_or(LockfileKind::Aube);
+    let kind = crate::commands::lockfile_kind_for_write(project_dir);
     let filename = match kind {
         LockfileKind::Aube => aube_lockfile::aube_lock_filename(project_dir),
         LockfileKind::Pnpm => aube_lockfile::pnpm_lock_filename(project_dir),

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -814,6 +814,8 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     } else {
         None
     };
+    let write_kind =
+        source_kind_before.unwrap_or_else(|| super::default_lockfile_kind(&settings_ctx));
 
     // Hand any parseable lockfile to the resolver as `existing` so
     // unchanged specs reuse their already-pinned versions and only
@@ -918,7 +920,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
             lockfile_pre_parse: lockfile_pre_parse.as_ref(),
             lockfile_conflict_marker_warning_emitted,
             existing_for_resolver,
-            source_kind_before,
+            write_kind,
             lockfile_enabled,
             lockfile_include_tarball_url,
             shared_workspace_lockfile,
@@ -1360,8 +1362,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
                     // `None` only when no lockfile will be written, so
                     // widening to every common platform doesn't happen
                     // just to be discarded.
-                    target_lockfile_kind: lockfile_enabled
-                        .then(|| source_kind_before.unwrap_or(aube_lockfile::LockfileKind::Aube)),
+                    target_lockfile_kind: lockfile_enabled.then_some(write_kind),
                     dependency_policy: Some(dependency_policy.clone()),
                     cache_full_packuments: true,
                     ignore_scripts: opts.ignore_scripts,
@@ -1892,7 +1893,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
             // deleted patch from the stale lockfile is neither read during
             // materialization nor written back. This also prevents pnpm 11's
             // hash-only scalar entries from being mistaken for file paths.
-            if matches!(source_kind_before, Some(aube_lockfile::LockfileKind::Pnpm)) {
+            if matches!(write_kind, aube_lockfile::LockfileKind::Pnpm) {
                 graph.patched_dependencies = crate::patches::read_patched_dependencies(&cwd)?;
             }
             tracing::debug!("Resolved {} packages", graph.packages.len());
@@ -2050,11 +2051,9 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
             let mut indices = remap_indices_to_contextualized(&canonical_indices, &graph);
             apply_computed_integrities(&mut graph, &computed_integrities);
 
-            // Write the lockfile in whatever format the project was
-            // already using. If no lockfile existed, create aube's
-            // default `aube-lock.yaml`. Skipped entirely when
-            // `lockfile=false`.
-            let write_kind = source_kind_before.unwrap_or(aube_lockfile::LockfileKind::Aube);
+            // Write the lockfile in whatever format the project was already
+            // using, or the configured creation default when none existed.
+            // Skipped entirely when `lockfile=false`.
             if lockfile_enabled {
                 // When `lockfileIncludeTarballUrl=true`, record the
                 // registry tarball URL on every registry-sourced

--- a/crates/aube/src/commands/install/resolve.rs
+++ b/crates/aube/src/commands/install/resolve.rs
@@ -59,7 +59,7 @@ pub(super) struct LockfileOnlyInput<'a> {
     pub lockfile_pre_parse: Option<&'a (LockfileGraph, LockfileKind)>,
     pub lockfile_conflict_marker_warning_emitted: bool,
     pub existing_for_resolver: Option<&'a LockfileGraph>,
-    pub source_kind_before: Option<LockfileKind>,
+    pub write_kind: LockfileKind,
     pub lockfile_enabled: bool,
     pub lockfile_include_tarball_url: bool,
     pub shared_workspace_lockfile: bool,
@@ -93,7 +93,7 @@ pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::R
         lockfile_pre_parse,
         lockfile_conflict_marker_warning_emitted,
         existing_for_resolver,
-        source_kind_before,
+        write_kind,
         lockfile_enabled,
         lockfile_include_tarball_url,
         shared_workspace_lockfile,
@@ -249,11 +249,9 @@ pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::R
             // `lockfile=false` collapses to `None` so the resolver
             // doesn't waste a fetch widening a lockfile that will
             // never be written. With lockfiles enabled, a missing
-            // `source_kind_before` means "we'll create the default
-            // aube-lock.yaml", so the aube-native wide default
-            // applies.
-            target_lockfile_kind: lockfile_enabled
-                .then(|| source_kind_before.unwrap_or(LockfileKind::Aube)),
+            // With lockfiles enabled, `write_kind` is either the existing
+            // format or the configured creation default.
+            target_lockfile_kind: lockfile_enabled.then_some(write_kind),
             dependency_policy: Some(dependency_policy.clone()),
             cache_full_packuments: true,
             ignore_scripts,
@@ -298,7 +296,7 @@ pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::R
             }
         }
     }
-    let lo_write_kind = source_kind_before.unwrap_or(LockfileKind::Aube);
+    let lo_write_kind = write_kind;
     if matches!(lo_write_kind, LockfileKind::Pnpm) {
         graph.patched_dependencies = crate::patches::read_patched_dependencies(cwd)?;
     }

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -1338,6 +1338,7 @@ mod finalize_lockfile_graph_tests {
     async fn finalize_skips_checksums_on_aube_lock() {
         let dir = tempfile::tempdir().unwrap();
         let cwd = dir.path();
+        std::fs::write(cwd.join("aube-lock.yaml"), "lockfileVersion: '9.0'\n").unwrap();
         std::fs::write(
             cwd.join("package.json"),
             r#"{"name":"x","version":"1.0.0"}"#,

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -601,14 +601,13 @@ pub(crate) async fn finalize_lockfile_graph(
     ignore_pnpmfile: bool,
     cli_pnpmfile: Option<&std::path::Path>,
 ) -> miette::Result<()> {
-    let write_kind = aube_lockfile::detect_existing_lockfile_kind(cwd)
-        .unwrap_or(aube_lockfile::LockfileKind::Aube);
     let files = crate::commands::FileSources::load(cwd);
     let (ws_config, raw_workspace) = aube_manifest::workspace::load_both(cwd)
         .into_diagnostic()
         .wrap_err("failed to load workspace config for lockfile finalization")?;
     let env = aube_settings::values::process_env();
     let ctx = files.ctx(&raw_workspace, env, &[]);
+    let write_kind = crate::commands::lockfile_kind_for_write_with_ctx(cwd, &ctx);
     let local_pnpmfile = if ignore_pnpmfile {
         None
     } else {

--- a/crates/aube/src/commands/install/workspace.rs
+++ b/crates/aube/src/commands/install/workspace.rs
@@ -355,7 +355,7 @@ pub(super) fn order_lifecycle_manifests(
 /// already ships a `pnpm-lock.yaml` (or any other supported lockfile)
 /// keeps getting that file rewritten in place instead of gaining a
 /// surprise `aube-lock.yaml` next to it. This mirrors the single-project
-/// write path ([`aube_lockfile::write_lockfile_preserving_existing`]) and
+/// write path ([`aube_lockfile::write_lockfile_as`]) and
 /// pnpm's own `sharedWorkspaceLockfile=false` behavior, where each
 /// member keeps its own `pnpm-lock.yaml`. `fallback_kind` is only used
 /// for projects (root or member) that have no lockfile yet (the

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -136,11 +136,12 @@ pub(crate) use project_lock::take_install_project_lock;
 pub(crate) use project_lock::take_project_lock;
 pub(crate) use script_settings::{configure_script_settings, configure_script_settings_for_cwd};
 pub(crate) use settings_context::{
-    FileSources, GlobalOutputFlags, build_resolver, chained_frozen_mode,
+    FileSources, GlobalOutputFlags, build_resolver, chained_frozen_mode, default_lockfile_kind,
     ensure_registry_auth_for_package, expand_setting_path, global_frozen_override,
     global_output_flags, global_virtual_store_dir, global_virtual_store_dir_with_ctx,
-    global_virtual_store_flags, has_embedder_store_override, load_npm_config, make_client,
-    open_store, open_store_with_ctx, packument_cache_dir, packument_cache_dir_for_cwd,
+    global_virtual_store_flags, has_embedder_store_override, load_npm_config,
+    lockfile_kind_for_write, lockfile_kind_for_write_with_ctx, make_client, open_store,
+    open_store_with_ctx, packument_cache_dir, packument_cache_dir_for_cwd,
     packument_full_cache_dir, packument_full_cache_dir_for_cwd, project_modules_dir,
     resolve_fetch_policy, resolve_modules_dir_name_for_cwd, resolve_virtual_store_dir,
     resolve_virtual_store_dir_for_cwd, resolve_virtual_store_dir_max_length,

--- a/crates/aube/src/commands/settings_context.rs
+++ b/crates/aube/src/commands/settings_context.rs
@@ -348,6 +348,31 @@ pub(crate) fn with_settings_ctx_and_cli<T>(
     f(&ctx)
 }
 
+/// Resolve the format to create when a project has no supported lockfile.
+/// Existing lockfiles always win; this only replaces the historical Aube
+/// fallback for new or deliberately cleaned projects.
+pub(crate) fn default_lockfile_kind(
+    ctx: &aube_settings::ResolveCtx<'_>,
+) -> aube_lockfile::LockfileKind {
+    match aube_settings::resolved::default_lockfile_format(ctx) {
+        aube_settings::resolved::DefaultLockfileFormat::Aube => aube_lockfile::LockfileKind::Aube,
+        aube_settings::resolved::DefaultLockfileFormat::Pnpm => aube_lockfile::LockfileKind::Pnpm,
+    }
+}
+
+/// Pick the lockfile format a mutating command should write: preserve an
+/// existing supported file, otherwise honor `defaultLockfileFormat`.
+pub(crate) fn lockfile_kind_for_write_with_ctx(
+    cwd: &std::path::Path,
+    ctx: &aube_settings::ResolveCtx<'_>,
+) -> aube_lockfile::LockfileKind {
+    aube_lockfile::detect_existing_lockfile_kind(cwd).unwrap_or_else(|| default_lockfile_kind(ctx))
+}
+
+pub(crate) fn lockfile_kind_for_write(cwd: &std::path::Path) -> aube_lockfile::LockfileKind {
+    with_settings_ctx(cwd, |ctx| lockfile_kind_for_write_with_ctx(cwd, ctx))
+}
+
 /// Build a registry client configured from .npmrc files in the project directory.
 ///
 /// Also resolves the `fetch*` settings (timeout + retries + backoff)
@@ -445,10 +470,7 @@ pub(crate) fn build_resolver(
     // cross-platform widening rules — native package-manager lockfiles
     // that record per-package platform metadata keep optional natives for
     // every platform, while formats without that metadata stay host-only.
-    let target_lockfile_kind = Some(
-        aube_lockfile::detect_existing_lockfile_kind(cwd)
-            .unwrap_or(aube_lockfile::LockfileKind::Aube),
-    );
+    let target_lockfile_kind = Some(lockfile_kind_for_write_with_ctx(cwd, &ctx));
     install::configure_resolver(
         aube_resolver::Resolver::new(std::sync::Arc::new(make_client(cwd))),
         cwd,

--- a/crates/aube/src/commands/workspace_helpers.rs
+++ b/crates/aube/src/commands/workspace_helpers.rs
@@ -98,13 +98,15 @@ pub(crate) fn prepare_resolved_graph_for_lockfile_write(graph: &mut aube_lockfil
     aube_resolver::platform::mark_transitive_peer_dependencies(graph);
 }
 
-/// Write lockfile preserving existing format and log the file name.
+/// Write a lockfile preserving an existing format, or using the configured
+/// creation default, and log the file name.
 pub(crate) fn write_and_log_lockfile(
     cwd: &Path,
     graph: &aube_lockfile::LockfileGraph,
     manifest: &aube_manifest::PackageJson,
 ) -> miette::Result<PathBuf> {
-    let written_path = aube_lockfile::write_lockfile_preserving_existing(cwd, graph, manifest)
+    let kind = super::lockfile_kind_for_write(cwd);
+    let written_path = aube_lockfile::write_lockfile_as(cwd, graph, manifest, kind)
         .into_diagnostic()
         .wrap_err("failed to write lockfile")?;
     eprintln!(

--- a/docs/package-manager/lockfiles.md
+++ b/docs/package-manager/lockfiles.md
@@ -30,6 +30,17 @@ The practical upshot:
 - Only `aube import` (or manually removing the existing lockfile) switches a
   project onto `aube-lock.yaml`.
 
+To create `pnpm-lock.yaml` when a project has no lockfile yet, set the
+creation default in `.npmrc`:
+
+```ini
+default-lockfile-format=pnpm
+```
+
+This also preserves the pnpm filename after `aube clean --lockfile` followed
+by `aube install`. The setting does not convert an existing lockfile; the
+existing supported file still wins.
+
 Keep the original lockfile while its package manager is still part of the
 workflow — aube and the original package manager both read from and write to
 the same file without conflicting.

--- a/docs/package-manager/lockfiles.md
+++ b/docs/package-manager/lockfiles.md
@@ -21,14 +21,15 @@ On install (and on `add`, `remove`, `update`, `dedupe`), aube picks the
 lockfile to write from whichever supported file already exists in the project
 directory. Precedence is: `aube-lock.yaml` → `pnpm-lock.yaml` → `bun.lock` →
 `yarn.lock` → `npm-shrinkwrap.json` → `package-lock.json`. When none of those
-exist yet, aube writes `aube-lock.yaml`.
+exist yet, aube writes `aube-lock.yaml` by default;
+`default-lockfile-format` can select `pnpm-lock.yaml`.
 
 The practical upshot:
 
 - A pnpm project keeps getting `pnpm-lock.yaml` updates.
 - An npm project keeps getting `package-lock.json` updates.
-- Only `aube import` (or manually removing the existing lockfile) switches a
-  project onto `aube-lock.yaml`.
+- `aube import` switches a project onto `aube-lock.yaml`; removing the
+  existing lockfile makes the next install follow the configured default.
 
 To create `pnpm-lock.yaml` when a project has no lockfile yet, set the
 creation default in `.npmrc`:

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -72,6 +72,7 @@ Aube generates this page from [`settings.toml`](https://github.com/jdx/aube/blob
 | [`maxsockets`](#setting-maxsockets) | `int` | Maximum concurrent connections per origin. |
 | [`strictSsl`](#setting-strictssl) | `bool` | Validate SSL certificates for HTTPS requests. |
 | [`lockfile`](#setting-lockfile) | `bool` | Read and generate aube-lock.yaml. |
+| [`defaultLockfileFormat`](#setting-defaultlockfileformat) | `"aube" \| "pnpm"` | Lockfile format to create when a project has no supported lockfile. |
 | [`lockfileDir`](#setting-lockfiledir) | `path` | Directory the lockfile is written to and read from. |
 | [`preferFrozenLockfile`](#setting-preferfrozenlockfile) | `bool` | Perform a headless install if the lockfile already satisfies package.json. |
 | [`lockfileIncludeTarballUrl`](#setting-lockfileincludetarballurl) | `bool` | Add the full tarball URL to each lockfile entry. |
@@ -1513,6 +1514,30 @@ combined with `lockfile=false` is rejected as a contradiction.
 Examples:
 
 - `echo 'lockfile=false' >> .npmrc && aube install`
+
+### `defaultLockfileFormat` {#setting-defaultlockfileformat}
+
+Lockfile format to create when a project has no supported lockfile.
+
+- Type: `"aube" | "pnpm"`
+- Default: `"aube"`
+- Environment: `AUBE_DEFAULT_LOCKFILE_FORMAT`
+- .npmrc keys: `default-lockfile-format`, `defaultLockfileFormat`
+- Workspace YAML keys: `defaultLockfileFormat`
+
+Selects the lockfile format aube creates when none of the supported
+lockfiles already exists. The default, `aube`, writes `aube-lock.yaml`;
+`pnpm` writes `pnpm-lock.yaml` for projects that need pnpm-compatible
+tooling to recognize the generated lockfile.
+
+This is only a creation default. An existing supported lockfile still
+wins, so setting `defaultLockfileFormat=pnpm` does not convert or leave a
+second lockfile alongside an existing `aube-lock.yaml`, `package-lock.json`,
+`yarn.lock`, or `bun.lock`.
+
+Examples:
+
+- `echo 'default-lockfile-format=pnpm' >> .npmrc && aube install`
 
 ### `lockfileDir` {#setting-lockfiledir}
 

--- a/test/lockfile_settings.bats
+++ b/test/lockfile_settings.bats
@@ -124,6 +124,58 @@ teardown() {
 	refute_output --partial 'no lockfile found'
 }
 
+@test "defaultLockfileFormat=pnpm creates and recreates pnpm-lock.yaml" {
+	cat >package.json <<-'EOF'
+		{
+		  "name": "test-default-pnpm-lockfile",
+		  "version": "1.0.0",
+		  "dependencies": { "is-odd": "3.0.1" }
+		}
+	EOF
+	cat >>.npmrc <<-'EOF'
+
+		default-lockfile-format=pnpm
+	EOF
+
+	run aube install --no-frozen-lockfile
+	assert_success
+	assert_file_exists pnpm-lock.yaml
+	assert_file_not_exists aube-lock.yaml
+
+	run aube clean --lockfile
+	assert_success
+	assert_file_not_exists pnpm-lock.yaml
+
+	run aube install --no-frozen-lockfile
+	assert_success
+	assert_file_exists pnpm-lock.yaml
+	assert_file_not_exists aube-lock.yaml
+}
+
+@test "an existing lockfile wins over defaultLockfileFormat" {
+	cat >package.json <<-'EOF'
+		{
+		  "name": "test-existing-lockfile-wins",
+		  "version": "1.0.0",
+		  "dependencies": { "is-odd": "3.0.1" }
+		}
+	EOF
+	cat >>.npmrc <<-'EOF'
+
+		default-lockfile-format=pnpm
+	EOF
+
+	run env AUBE_DEFAULT_LOCKFILE_FORMAT=aube aube install --no-frozen-lockfile
+	assert_success
+	assert_file_exists aube-lock.yaml
+	assert_file_not_exists pnpm-lock.yaml
+
+	run aube install --no-frozen-lockfile
+	assert_success
+	assert_file_exists aube-lock.yaml
+	assert_file_not_exists pnpm-lock.yaml
+}
+
 # `lockfileIncludeTarballUrl=true` records each registry package's full
 # tarball URL in the lockfile's `resolution.tarball:` field.
 


### PR DESCRIPTION
## Summary

- add `defaultLockfileFormat = "aube" | "pnpm"` for selecting the format created when no supported lockfile exists
- preserve the existing-file-wins behavior so the setting never converts or creates a second lockfile alongside an existing one
- apply the configured fallback across install and the shared lockfile write paths used by add/remove/update/dedupe/audit
- document the setting and cover the `clean --lockfile` → install workflow reported in Discussion #1264

## Why

Aube determines the output format from an existing lockfile and historically falls back to `aube-lock.yaml` when none exists. Because `aube clean --lockfile` removes every recognized lockfile, projects that need pnpm compatibility had no persistent way to regenerate `pnpm-lock.yaml` after cleaning it.

The new setting changes only that missing-lockfile fallback. Existing lockfiles remain authoritative, avoiding implicit conversions and stale duplicate lockfiles.

## Validation

- `cargo test -p aube` (779 unit tests plus integration/doc tests)
- `cargo test -p aube-settings` (60 unit tests plus accessor/schema tests)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- focused BATS: `defaultLockfileFormat=pnpm creates and recreates pnpm-lock.yaml`
- focused BATS: `an existing lockfile wins over defaultLockfileFormat`

The full `test/lockfile_settings.bats` run passed both new cases; two unrelated existing tarball tests could not invoke this environment's stale `node` mise shim.

Addresses https://github.com/jdx/aube/discussions/1264.

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core install/resolve/lockfile write paths across many commands; behavior change is scoped to the no-lockfile case but incorrect wiring could pick the wrong format or resolver widening.
> 
> **Overview**
> Introduces **`defaultLockfileFormat`** (`"aube"` | `"pnpm"`, default `"aube"`) via workspace config, `settings.toml`, `.npmrc`, and env. It only applies when **no supported lockfile is on disk**; detection precedence for existing files is unchanged.
> 
> Central helpers **`default_lockfile_kind`** and **`lockfile_kind_for_write`** replace hardcoded `LockfileKind::Aube` fallbacks. Install now computes **`write_kind`** once and threads it through resolve (platform widening, pnpm patch metadata, runtime pins) and lockfile output. Shared writers use **`write_lockfile_as`** with that kind instead of **`write_lockfile_preserving_existing`**. **`add --no-save`** snapshots/restores the path that matches the same logic.
> 
> Docs cover the `aube clean --lockfile` → reinstall workflow; BATS assert pnpm default creation and that an existing `aube-lock.yaml` overrides the setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4f1c32de36da622857646d2206881cfdae60a83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `defaultLockfileFormat` configuration, supporting `aube` and `pnpm` formats.
  * Projects without an existing lockfile now create the configured format.
  * Existing supported lockfiles remain authoritative and are not converted or duplicated.
  * Lockfile format is preserved after cleaning and reinstalling.

* **Documentation**
  * Updated lockfile and settings documentation with configuration guidance.

* **Bug Fixes**
  * Consistent lockfile format selection across installation and dependency operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->