### PR TITLE
fix(deps): prevent incompatible yamlpatch updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,12 @@
       "matchManagers": ["cargo"],
       "matchPackageNames": ["decmpfs"],
       "allowedVersions": "<=0.1.0"
+    },
+    {
+      "description": "yamlpatch and yamlpath 1.28+ require Rust 1.97 transitively, above the project MSRV.",
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["yamlpatch", "yamlpath"],
+      "allowedVersions": "<1.28.0"
     }
   ]
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,10 +62,10 @@ yaml_serde = "0.10"
 # comments — yaml_serde's round-trip would otherwise destroy them.
 # yamlpatch uses yaml_serde for patch payloads; serde_yaml remains only
 # for the manual block injector that works around nested Add formatting.
-yamlpatch = "1"
+yamlpatch = ">=1.25, <1.28"
 # yamlpath 1.28 does not declare the Rust 1.97 requirement it inherits
 # from tree-sitter-iter 1.28, so resolver 3 cannot avoid it.
-yamlpath = ">=1.25, <1.30"
+yamlpath = ">=1.25, <1.28"
 serde_yaml = "0.9"
 sonic-rs = "0.5"
 toml = "1"


### PR DESCRIPTION
## Summary

- cap `yamlpatch` and `yamlpath` below 1.28 in the workspace dependency constraints
- add a matching Renovate `allowedVersions` rule

## Why

`yamlpatch` and `yamlpath` 1.28+ pull in `tree-sitter-iter` releases that require Rust 1.97. Because the intermediate crates do not declare that effective Rust requirement, Renovate can generate a valid lockfile with a newer toolchain even though the result exceeds aube's MSRV and fails CI.

This keeps automated and manual dependency resolution on the latest compatible releases until the project MSRV or upstream dependency requirements change.

## Validation

- `jq empty .github/renovate.json`
- `cargo metadata --locked --no-deps --format-version 1`
- `cargo check --locked -p aube-manifest`
- `git diff --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version ceiling changes only; no application logic or security-sensitive code paths are modified.
> 
> **Overview**
> **Dependency bounds** for `yamlpatch` and `yamlpath` are tightened so resolution stays below **1.28**, matching the workspace **Rust 1.91** MSRV instead of pulling **Rust 1.97** via `tree-sitter-iter` without upstream declaring that requirement.
> 
> In `Cargo.toml`, `yamlpatch` moves from an open `1` range to `>=1.25, <1.28`, and `yamlpath`’s upper bound drops from `<1.30` to `<1.28`. **Renovate** gets a parallel `allowedVersions: "<1.28.0"` rule so automated bumps cannot reintroduce incompatible releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e62569469bf807a683962030d33729849042dae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Constrained YAML-related package versions to maintain compatibility.
  * Updated automated dependency management rules to prevent unsupported upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->