### PR TITLE
fix(store): prune unused global virtual store entries

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -3780,7 +3780,7 @@ Remove unreferenced packages from the global store.
 
 Operates on the store printed by `aube store path`; it does not touch project node_modules directories, manifests, or lockfiles.
 
-It removes global virtual-store graph entries not referenced by any registered project, then prunes content-store files.
+It removes global virtual-store graph entries not referenced by any registered project, except legacy entries preserved for older checkouts. It then prunes content-store files.
 
 On reflink filesystems such as APFS or btrfs, link counts cannot prove project reachability, so content-store pruning relies on cached package indexes. Global virtual-store reachability comes from project links.
 """#

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -3780,7 +3780,7 @@ Remove unreferenced packages from the global store.
 
 Operates on the store printed by `aube store path`; it does not touch project node_modules directories, manifests, or lockfiles.
 
-It removes global virtual-store graph entries not referenced by any registered project, except legacy entries preserved for older checkouts. It then prunes content-store files.
+It removes global virtual-store graph entries not referenced by any registered project. Entries from older aube releases live outside the registry-managed versioned namespace and are not touched. It then prunes content-store files.
 
 On reflink filesystems such as APFS or btrfs, link counts cannot prove project reachability, so content-store pruning relies on cached package indexes. Global virtual-store reachability comes from project links.
 """#

--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -3780,9 +3780,9 @@ Remove unreferenced packages from the global store.
 
 Operates on the store printed by `aube store path`; it does not touch project node_modules directories, manifests, or lockfiles.
 
-It keeps files referenced by cached package indexes and, on hardlink filesystems, files that still have project hardlink references.
+It removes global virtual-store graph entries not referenced by any registered project, then prunes content-store files.
 
-On reflink filesystems such as APFS or btrfs, link counts cannot prove project reachability, so pruning relies on cached package indexes.
+On reflink filesystems such as APFS or btrfs, link counts cannot prove project reachability, so content-store pruning relies on cached package indexes. Global virtual-store reachability comes from project links.
 """#
         flag --dry-run help="Do not actually delete anything; report what would be pruned"
     }

--- a/crates/aube-codes/src/errors.rs
+++ b/crates/aube-codes/src/errors.rs
@@ -61,6 +61,7 @@ pub const ERR_AUBE_TARBALL_URL_MISMATCH: &str = "ERR_AUBE_TARBALL_URL_MISMATCH";
 pub const ERR_AUBE_NO_HOME: &str = "ERR_AUBE_NO_HOME";
 pub const ERR_AUBE_GIT_ERROR: &str = "ERR_AUBE_GIT_ERROR";
 pub const ERR_AUBE_STORE_INDEX_SCAN_FAILED: &str = "ERR_AUBE_STORE_INDEX_SCAN_FAILED";
+pub const ERR_AUBE_GVS_PRUNE_FAILED: &str = "ERR_AUBE_GVS_PRUNE_FAILED";
 
 // ── linker ──────────────────────────────────────────────────────────
 pub const ERR_AUBE_LINK_FAILED: &str = "ERR_AUBE_LINK_FAILED";
@@ -294,6 +295,12 @@ pub const ALL: &[CodeMeta] = &[
         name: ERR_AUBE_STORE_INDEX_SCAN_FAILED,
         category: category::TARBALL_STORE,
         description: "A store maintenance command couldn't completely read or parse the cached package indexes.",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: ERR_AUBE_GVS_PRUNE_FAILED,
+        category: category::TARBALL_STORE,
+        description: "The global virtual store project registry or prune walk failed.",
         exit_code: None,
     },
     // Registry / network

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -1151,7 +1151,9 @@ docs = """
 Relocates the global virtual store — the shared tree of materialized
 package directories that `node_modules/.aube/<dep>` symlinks into when
 `enableGlobalVirtualStore` is on. Unset, it lives at
-`<cacheDir>/virtual-store/`.
+`<cacheDir>/virtual-store/`. Aube stores registry-managed entries in a
+versioned child directory below this root so older releases cannot share
+entries that a current `aube store prune` may remove.
 
 Set this when the global virtual store belongs somewhere other than
 the rest of the cache — typically to put it on the same volume as

--- a/crates/aube/src/commands/gvs_registry.rs
+++ b/crates/aube/src/commands/gvs_registry.rs
@@ -52,6 +52,25 @@ fn open_lock(global_virtual_store: &Path) -> miette::Result<std::fs::File> {
 
 pub(crate) fn lock_for_install(global_virtual_store: &Path) -> miette::Result<GvsLock> {
     let file = open_lock(global_virtual_store)?;
+    if !global_virtual_store.join(LEGACY_ENTRIES_FILE).exists() {
+        file.lock().map_err(|e| {
+            miette!(
+                code = aube_codes::errors::ERR_AUBE_GVS_PRUNE_FAILED,
+                "failed to lock global virtual store {} for initialization: {e}",
+                global_virtual_store.display()
+            )
+        })?;
+        // Re-check under the exclusive lock: another installer may have
+        // initialized the snapshot while this process was waiting.
+        preserve_legacy_entries(global_virtual_store, false)?;
+        file.unlock().map_err(|e| {
+            miette!(
+                code = aube_codes::errors::ERR_AUBE_GVS_PRUNE_FAILED,
+                "failed to unlock global virtual store {} after initialization: {e}",
+                global_virtual_store.display()
+            )
+        })?;
+    }
     file.lock_shared().map_err(|e| {
         miette!(
             code = aube_codes::errors::ERR_AUBE_GVS_PRUNE_FAILED,
@@ -74,10 +93,6 @@ fn lock_for_prune(global_virtual_store: &Path) -> miette::Result<GvsLock> {
     Ok(GvsLock(file))
 }
 
-pub(crate) fn initialize_for_install(global_virtual_store: &Path) -> miette::Result<()> {
-    preserve_legacy_entries(global_virtual_store, false).map(|_| ())
-}
-
 pub(crate) fn register_project(
     global_virtual_store: &Path,
     project_dir: &Path,
@@ -85,7 +100,6 @@ pub(crate) fn register_project(
 ) -> miette::Result<()> {
     std::fs::create_dir_all(global_virtual_store)
         .map_err(|e| registry_error(global_virtual_store, e))?;
-    preserve_legacy_entries(global_virtual_store, false)?;
     let projects_dir = global_virtual_store.join(PROJECTS_DIR);
     std::fs::create_dir_all(&projects_dir).map_err(|e| registry_error(&projects_dir, e))?;
     let project_dir = std::fs::canonicalize(project_dir).unwrap_or_else(|_| project_dir.into());
@@ -94,7 +108,6 @@ pub(crate) fn register_project(
     } else {
         project_dir.join(aube_dir)
     };
-    let key = blake3::hash(project_dir.as_os_str().as_encoded_bytes()).to_hex();
     let record = RegisteredProject {
         project_dir,
         aube_dir,
@@ -105,8 +118,33 @@ pub(crate) fn register_project(
             "failed to encode global virtual store project registry entry: {e}"
         )
     })?;
-    aube_util::fs_atomic::atomic_write(&projects_dir.join(format!("{key}.json")), &bytes)
-        .map_err(|e| registry_error(&projects_dir, e))
+    aube_util::fs_atomic::atomic_write(
+        &project_record_path(&projects_dir, &record.project_dir),
+        &bytes,
+    )
+    .map_err(|e| registry_error(&projects_dir, e))
+}
+
+pub(crate) fn unregister_if_unreferenced(
+    global_virtual_store: &Path,
+    project_dir: &Path,
+    aube_dir: &Path,
+) -> miette::Result<()> {
+    if project_links_into(aube_dir, global_virtual_store)? {
+        return Ok(());
+    }
+    let project_dir = std::fs::canonicalize(project_dir).unwrap_or_else(|_| project_dir.into());
+    let path = project_record_path(&global_virtual_store.join(PROJECTS_DIR), &project_dir);
+    match std::fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(registry_error(&path, e)),
+    }
+}
+
+fn project_record_path(projects_dir: &Path, project_dir: &Path) -> PathBuf {
+    let key = blake3::hash(project_dir.as_os_str().as_encoded_bytes()).to_hex();
+    projects_dir.join(format!("{key}.json"))
 }
 
 pub(crate) fn register_fast_path_project(project_dir: &Path) -> miette::Result<()> {
@@ -325,7 +363,7 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir should be created");
         let gvs = tmp.path().join("virtual-store");
         std::fs::create_dir_all(&gvs).expect("global virtual store should be created");
-        initialize_for_install(&gvs).expect("legacy snapshot should initialize");
+        drop(lock_for_install(&gvs).expect("legacy snapshot should initialize"));
         let project = tmp.path().join("project");
         let aube_dir = project.join("node_modules/.aube");
         let live = gvs.join("live@1.0.0-deadbeefdeadbeef");
@@ -351,6 +389,7 @@ mod tests {
         let gvs = tmp.path().join("virtual-store");
         let legacy = gvs.join("legacy@1.0.0-deadbeefdeadbeef");
         std::fs::create_dir_all(&legacy).expect("legacy entry should be created");
+        drop(lock_for_install(&gvs).expect("legacy snapshot should initialize"));
 
         let project = tmp.path().join("project");
         let aube_dir = project.join("node_modules/.aube");
@@ -365,11 +404,45 @@ mod tests {
     }
 
     #[test]
+    fn failed_link_cleanup_removes_only_unreferenced_records() {
+        let tmp = tempfile::tempdir().expect("tempdir should be created");
+        let gvs = tmp.path().join("virtual-store");
+        drop(lock_for_install(&gvs).expect("legacy snapshot should initialize"));
+        let project = tmp.path().join("project");
+        let aube_dir = project.join("node_modules/.aube");
+        std::fs::create_dir_all(&aube_dir).expect("project virtual store should be created");
+        register_project(&gvs, &project, &aube_dir).expect("project should register");
+
+        unregister_if_unreferenced(&gvs, &project, &aube_dir)
+            .expect("empty project record should be removed");
+        assert_eq!(
+            std::fs::read_dir(gvs.join(PROJECTS_DIR))
+                .expect("registry should be readable")
+                .count(),
+            0
+        );
+
+        let live = gvs.join("live@1.0.0-deadbeefdeadbeef");
+        std::fs::create_dir_all(&live).expect("live entry should be created");
+        std::os::unix::fs::symlink(&live, aube_dir.join("live@1.0.0"))
+            .expect("project link should be created");
+        register_project(&gvs, &project, &aube_dir).expect("project should register again");
+        unregister_if_unreferenced(&gvs, &project, &aube_dir)
+            .expect("referenced project record should be preserved");
+        assert_eq!(
+            std::fs::read_dir(gvs.join(PROJECTS_DIR))
+                .expect("registry should be readable")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
     fn prune_drops_registry_records_for_deleted_projects() {
         let tmp = tempfile::tempdir().expect("tempdir should be created");
         let gvs = tmp.path().join("virtual-store");
         std::fs::create_dir_all(&gvs).expect("global virtual store should be created");
-        initialize_for_install(&gvs).expect("legacy snapshot should initialize");
+        drop(lock_for_install(&gvs).expect("legacy snapshot should initialize"));
         let project = tmp.path().join("project");
         let aube_dir = project.join("node_modules/.aube");
         std::fs::create_dir_all(&aube_dir).expect("project virtual store should be created");

--- a/crates/aube/src/commands/gvs_registry.rs
+++ b/crates/aube/src/commands/gvs_registry.rs
@@ -191,6 +191,7 @@ pub(crate) fn prune(global_virtual_store: &Path, dry_run: bool) -> miette::Resul
     let mut reachable = legacy.clone();
     let mut known = HashSet::new();
     let mut stale_records = Vec::new();
+    let mut legacy_changed = false;
     let projects_dir = global_virtual_store.join(PROJECTS_DIR);
     if !projects_dir.exists() {
         let has_untracked_entries = graph_entries(global_virtual_store)?
@@ -218,18 +219,28 @@ pub(crate) fn prune(global_virtual_store: &Path, dry_run: bool) -> miette::Resul
             let bytes = std::fs::read(&path).map_err(|e| prune_error(&path, e))?;
             let project: RegisteredProject =
                 serde_json::from_slice(&bytes).map_err(|e| invalid_registry_error(&path, e))?;
+            if !project.project_dir.exists() || !project.aube_dir.exists() {
+                // A registry-unaware project may share any graph entry named
+                // by this stale record. There is no filesystem backlink from
+                // the GVS entry to that legacy checkout, so deleting it would
+                // be unsafe. Promote stale claims to legacy protection before
+                // dropping the record.
+                for entry in &project.entries {
+                    let entry = entry.as_os_str().to_os_string();
+                    legacy_changed |= legacy.insert(entry.clone());
+                    reachable.insert(entry);
+                }
+                if !dry_run {
+                    stale_records.push(path);
+                }
+                continue;
+            }
             known.extend(
                 project
                     .entries
                     .iter()
                     .map(|entry| entry.as_os_str().to_os_string()),
             );
-            if !project.project_dir.exists() || !project.aube_dir.exists() {
-                if !dry_run {
-                    stale_records.push(path);
-                }
-                continue;
-            }
             mark_project_entries(global_virtual_store, &project.aube_dir, &mut reachable)?;
         }
     }
@@ -246,9 +257,10 @@ pub(crate) fn prune(global_virtual_store: &Path, dry_run: bool) -> miette::Resul
     if !untracked.is_empty() {
         legacy.extend(untracked);
         reachable.extend(legacy.iter().cloned());
-        if !dry_run {
-            write_legacy_entries(global_virtual_store, &legacy)?;
-        }
+        legacy_changed = true;
+    }
+    if legacy_changed && !dry_run {
+        write_legacy_entries(global_virtual_store, &legacy)?;
     }
 
     let mut removed = 0;
@@ -458,7 +470,8 @@ mod tests {
             .expect("orphan project link should be created");
         register_project(&gvs, &orphan_project, &orphan_aube_dir)
             .expect("orphan project should register");
-        std::fs::remove_dir_all(&orphan_project).expect("orphan project should be removed");
+        std::fs::remove_file(orphan_aube_dir.join("orphan@1.0.0"))
+            .expect("orphan project link should be removed");
         assert_eq!(prune(&gvs, true).expect("dry run should succeed"), 1);
         assert!(orphan.exists(), "dry run must preserve the orphan");
 
@@ -490,7 +503,8 @@ mod tests {
             .expect("orphan project link should be created");
         register_project(&gvs, &orphan_project, &orphan_aube_dir)
             .expect("orphan project should register");
-        std::fs::remove_dir_all(&orphan_project).expect("orphan project should be removed");
+        std::fs::remove_file(orphan_aube_dir.join("orphan@1.0.0"))
+            .expect("orphan project link should be removed");
         assert_eq!(prune(&gvs, false).expect("prune should succeed"), 1);
         assert!(legacy.exists(), "unregistered legacy entry must survive");
         assert!(!orphan.exists(), "post-registry orphan must be removed");
@@ -584,6 +598,38 @@ mod tests {
         .expect("legacy snapshot should parse");
         assert!(legacy.entries.iter().any(|entry| {
             entry.as_os_str() == std::ffi::OsStr::new("old-aube@1.0.0-deadbeefdeadbeef")
+        }));
+    }
+
+    #[test]
+    fn prune_preserves_stale_claims_that_a_legacy_project_may_share() {
+        let tmp = tempfile::tempdir().expect("tempdir should be created");
+        let gvs = tmp.path().join("virtual-store");
+        drop(lock_for_install(&gvs).expect("legacy snapshot should initialize"));
+        let shared = gvs.join("shared@1.0.0-deadbeefdeadbeef");
+        std::fs::create_dir_all(&shared).expect("shared entry should be created");
+        let registered_project = tmp.path().join("registered-project");
+        let registered_aube_dir = registered_project.join("node_modules/.aube");
+        std::fs::create_dir_all(&registered_aube_dir)
+            .expect("registered project virtual store should be created");
+        std::os::unix::fs::symlink(&shared, registered_aube_dir.join("shared@1.0.0"))
+            .expect("registered project link should be created");
+        register_project(&gvs, &registered_project, &registered_aube_dir)
+            .expect("project should register");
+        std::fs::remove_dir_all(&registered_project).expect("registered project should be removed");
+
+        assert_eq!(prune(&gvs, false).expect("prune should succeed"), 0);
+        assert!(
+            shared.exists(),
+            "a stale claim may still be shared by a registry-unaware project"
+        );
+        let legacy: LegacyEntries = serde_json::from_slice(
+            &std::fs::read(gvs.join(LEGACY_ENTRIES_FILE))
+                .expect("legacy snapshot should be readable"),
+        )
+        .expect("legacy snapshot should parse");
+        assert!(legacy.entries.iter().any(|entry| {
+            entry.as_os_str() == std::ffi::OsStr::new("shared@1.0.0-deadbeefdeadbeef")
         }));
     }
 

--- a/crates/aube/src/commands/gvs_registry.rs
+++ b/crates/aube/src/commands/gvs_registry.rs
@@ -6,11 +6,17 @@ use std::path::{Path, PathBuf};
 
 const PROJECTS_DIR: &str = ".projects";
 const LOCK_FILE: &str = ".prune.lock";
+const LEGACY_ENTRIES_FILE: &str = ".legacy-entries.json";
 
 #[derive(Debug, Serialize, Deserialize)]
 struct RegisteredProject {
     project_dir: PathBuf,
     aube_dir: PathBuf,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct LegacyEntries {
+    entries: Vec<PathBuf>,
 }
 
 pub(crate) struct GvsLock(std::fs::File);
@@ -68,11 +74,18 @@ fn lock_for_prune(global_virtual_store: &Path) -> miette::Result<GvsLock> {
     Ok(GvsLock(file))
 }
 
+pub(crate) fn initialize_for_install(global_virtual_store: &Path) -> miette::Result<()> {
+    preserve_legacy_entries(global_virtual_store, false).map(|_| ())
+}
+
 pub(crate) fn register_project(
     global_virtual_store: &Path,
     project_dir: &Path,
     aube_dir: &Path,
 ) -> miette::Result<()> {
+    std::fs::create_dir_all(global_virtual_store)
+        .map_err(|e| registry_error(global_virtual_store, e))?;
+    preserve_legacy_entries(global_virtual_store, false)?;
     let projects_dir = global_virtual_store.join(PROJECTS_DIR);
     std::fs::create_dir_all(&projects_dir).map_err(|e| registry_error(&projects_dir, e))?;
     let project_dir = std::fs::canonicalize(project_dir).unwrap_or_else(|_| project_dir.into());
@@ -111,13 +124,13 @@ pub(crate) fn prune(global_virtual_store: &Path, dry_run: bool) -> miette::Resul
         return Ok(0);
     }
     let _lock = lock_for_prune(global_virtual_store)?;
+    let mut reachable = preserve_legacy_entries(global_virtual_store, dry_run)?;
     let projects_dir = global_virtual_store.join(PROJECTS_DIR);
     if !projects_dir.exists() {
         eprintln!("No registered projects for global virtual store");
         return Ok(0);
     }
 
-    let mut reachable = HashSet::new();
     for entry in read_dir(&projects_dir)? {
         let path = entry.path();
         if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
@@ -155,6 +168,64 @@ pub(crate) fn prune(global_virtual_store: &Path, dry_run: bool) -> miette::Resul
         removed += 1;
     }
     Ok(removed)
+}
+
+fn preserve_legacy_entries(
+    global_virtual_store: &Path,
+    dry_run: bool,
+) -> miette::Result<HashSet<OsString>> {
+    let path = global_virtual_store.join(LEGACY_ENTRIES_FILE);
+    if path.exists() {
+        let bytes = std::fs::read(&path).map_err(|e| prune_error(&path, e))?;
+        let legacy: LegacyEntries =
+            serde_json::from_slice(&bytes).map_err(|e| invalid_registry_error(&path, e))?;
+        return Ok(legacy
+            .entries
+            .into_iter()
+            .map(PathBuf::into_os_string)
+            .collect());
+    }
+
+    // The registry did not exist before GVS pruning was introduced. Preserve
+    // every entry found during migration because another live checkout may
+    // still reference it without having had a chance to register. Entries
+    // created after this snapshot are safe to sweep using the registry.
+    let entries: Vec<PathBuf> = graph_entries(global_virtual_store)?
+        .into_iter()
+        .map(PathBuf::from)
+        .collect();
+    if !dry_run {
+        let bytes = serde_json::to_vec(&LegacyEntries {
+            entries: entries.clone(),
+        })
+        .map_err(|e| {
+            miette!(
+                code = aube_codes::errors::ERR_AUBE_GVS_PRUNE_FAILED,
+                "failed to encode legacy global virtual store entries: {e}"
+            )
+        })?;
+        aube_util::fs_atomic::atomic_write(&path, &bytes).map_err(|e| registry_error(&path, e))?;
+    }
+    Ok(entries.into_iter().map(PathBuf::into_os_string).collect())
+}
+
+fn graph_entries(global_virtual_store: &Path) -> miette::Result<Vec<OsString>> {
+    let mut entries = Vec::new();
+    for entry in read_dir(global_virtual_store)? {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if name_str.starts_with('.') || name_str == "node_modules" {
+            continue;
+        }
+        if entry
+            .file_type()
+            .map_err(|e| prune_error(&entry.path(), e))?
+            .is_dir()
+        {
+            entries.push(name);
+        }
+    }
+    Ok(entries)
 }
 
 fn mark_project_entries(
@@ -253,17 +324,19 @@ mod tests {
     fn prune_keeps_registered_entries_and_removes_orphans() {
         let tmp = tempfile::tempdir().expect("tempdir should be created");
         let gvs = tmp.path().join("virtual-store");
+        std::fs::create_dir_all(&gvs).expect("global virtual store should be created");
+        initialize_for_install(&gvs).expect("legacy snapshot should initialize");
         let project = tmp.path().join("project");
         let aube_dir = project.join("node_modules/.aube");
         let live = gvs.join("live@1.0.0-deadbeefdeadbeef");
-        let orphan = gvs.join("orphan@1.0.0-deadbeefdeadbeef");
         std::fs::create_dir_all(&live).expect("live entry should be created");
-        std::fs::create_dir_all(&orphan).expect("orphan entry should be created");
         std::fs::create_dir_all(&aube_dir).expect("project virtual store should be created");
         std::os::unix::fs::symlink(&live, aube_dir.join("live@1.0.0"))
             .expect("project link should be created");
 
         register_project(&gvs, &project, &aube_dir).expect("project should register");
+        let orphan = gvs.join("orphan@1.0.0-deadbeefdeadbeef");
+        std::fs::create_dir_all(&orphan).expect("orphan entry should be created");
         assert_eq!(prune(&gvs, true).expect("dry run should succeed"), 1);
         assert!(orphan.exists(), "dry run must preserve the orphan");
 
@@ -273,9 +346,30 @@ mod tests {
     }
 
     #[test]
+    fn prune_preserves_entries_that_predate_the_registry() {
+        let tmp = tempfile::tempdir().expect("tempdir should be created");
+        let gvs = tmp.path().join("virtual-store");
+        let legacy = gvs.join("legacy@1.0.0-deadbeefdeadbeef");
+        std::fs::create_dir_all(&legacy).expect("legacy entry should be created");
+
+        let project = tmp.path().join("project");
+        let aube_dir = project.join("node_modules/.aube");
+        std::fs::create_dir_all(&aube_dir).expect("project virtual store should be created");
+        register_project(&gvs, &project, &aube_dir).expect("project should register");
+
+        let orphan = gvs.join("orphan@1.0.0-deadbeefdeadbeef");
+        std::fs::create_dir_all(&orphan).expect("new orphan should be created");
+        assert_eq!(prune(&gvs, false).expect("prune should succeed"), 1);
+        assert!(legacy.exists(), "unregistered legacy entry must survive");
+        assert!(!orphan.exists(), "post-registry orphan must be removed");
+    }
+
+    #[test]
     fn prune_drops_registry_records_for_deleted_projects() {
         let tmp = tempfile::tempdir().expect("tempdir should be created");
         let gvs = tmp.path().join("virtual-store");
+        std::fs::create_dir_all(&gvs).expect("global virtual store should be created");
+        initialize_for_install(&gvs).expect("legacy snapshot should initialize");
         let project = tmp.path().join("project");
         let aube_dir = project.join("node_modules/.aube");
         std::fs::create_dir_all(&aube_dir).expect("project virtual store should be created");

--- a/crates/aube/src/commands/gvs_registry.rs
+++ b/crates/aube/src/commands/gvs_registry.rs
@@ -235,13 +235,22 @@ pub(crate) fn prune(global_virtual_store: &Path, dry_run: bool) -> miette::Resul
                 }
                 continue;
             }
-            known.extend(
-                project
-                    .entries
-                    .iter()
-                    .map(|entry| entry.as_os_str().to_os_string()),
-            );
-            mark_project_entries(global_virtual_store, &project.aube_dir, &mut reachable)?;
+            let current = project_entries(global_virtual_store, &project.aube_dir)?;
+            reachable.extend(current.iter().cloned());
+            for entry in &project.entries {
+                let entry = entry.as_os_str().to_os_string();
+                if current.contains(&entry) {
+                    known.insert(entry);
+                } else {
+                    // An older aube can update this project without updating
+                    // its registry record. Its saved-but-unlinked claims may
+                    // therefore still be shared by another registry-unaware
+                    // checkout and need the same legacy protection as stale
+                    // project records.
+                    legacy_changed |= legacy.insert(entry.clone());
+                    reachable.insert(entry);
+                }
+            }
         }
     }
 
@@ -359,15 +368,6 @@ fn graph_entries(global_virtual_store: &Path) -> miette::Result<Vec<OsString>> {
     Ok(entries)
 }
 
-fn mark_project_entries(
-    global_virtual_store: &Path,
-    aube_dir: &Path,
-    reachable: &mut HashSet<OsString>,
-) -> miette::Result<()> {
-    reachable.extend(project_entries(global_virtual_store, aube_dir)?);
-    Ok(())
-}
-
 fn project_links_into(aube_dir: &Path, global_virtual_store: &Path) -> miette::Result<bool> {
     Ok(!project_entries(global_virtual_store, aube_dir)?.is_empty())
 }
@@ -446,7 +446,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn prune_keeps_registered_entries_and_removes_orphans() {
+    fn prune_keeps_registered_and_historical_entries() {
         let tmp = tempfile::tempdir().expect("tempdir should be created");
         let gvs = tmp.path().join("virtual-store");
         std::fs::create_dir_all(&gvs).expect("global virtual store should be created");
@@ -472,16 +472,19 @@ mod tests {
             .expect("orphan project should register");
         std::fs::remove_file(orphan_aube_dir.join("orphan@1.0.0"))
             .expect("orphan project link should be removed");
-        assert_eq!(prune(&gvs, true).expect("dry run should succeed"), 1);
-        assert!(orphan.exists(), "dry run must preserve the orphan");
+        assert_eq!(prune(&gvs, true).expect("dry run should succeed"), 0);
+        assert!(orphan.exists(), "dry run must preserve historical claims");
 
-        assert_eq!(prune(&gvs, false).expect("prune should succeed"), 1);
+        assert_eq!(prune(&gvs, false).expect("prune should succeed"), 0);
         assert!(live.exists(), "registered entry must survive");
-        assert!(!orphan.exists(), "orphan entry must be removed");
+        assert!(
+            orphan.exists(),
+            "a historical claim may still be shared by a legacy project"
+        );
     }
 
     #[test]
-    fn prune_preserves_entries_that_predate_the_registry() {
+    fn prune_preserves_legacy_and_historical_entries() {
         let tmp = tempfile::tempdir().expect("tempdir should be created");
         let gvs = tmp.path().join("virtual-store");
         let legacy = gvs.join("legacy@1.0.0-deadbeefdeadbeef");
@@ -505,9 +508,12 @@ mod tests {
             .expect("orphan project should register");
         std::fs::remove_file(orphan_aube_dir.join("orphan@1.0.0"))
             .expect("orphan project link should be removed");
-        assert_eq!(prune(&gvs, false).expect("prune should succeed"), 1);
+        assert_eq!(prune(&gvs, false).expect("prune should succeed"), 0);
         assert!(legacy.exists(), "unregistered legacy entry must survive");
-        assert!(!orphan.exists(), "post-registry orphan must be removed");
+        assert!(
+            orphan.exists(),
+            "a historical claim may still be shared by a legacy project"
+        );
     }
 
     #[test]

--- a/crates/aube/src/commands/gvs_registry.rs
+++ b/crates/aube/src/commands/gvs_registry.rs
@@ -1,0 +1,293 @@
+use miette::miette;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+const PROJECTS_DIR: &str = ".projects";
+const LOCK_FILE: &str = ".prune.lock";
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RegisteredProject {
+    project_dir: PathBuf,
+    aube_dir: PathBuf,
+}
+
+pub(crate) struct GvsLock(std::fs::File);
+
+impl Drop for GvsLock {
+    fn drop(&mut self) {
+        let _ = self.0.unlock();
+    }
+}
+
+fn open_lock(global_virtual_store: &Path) -> miette::Result<std::fs::File> {
+    std::fs::create_dir_all(global_virtual_store).map_err(|e| {
+        miette!(
+            code = aube_codes::errors::ERR_AUBE_GVS_PRUNE_FAILED,
+            "failed to create global virtual store {}: {e}",
+            global_virtual_store.display()
+        )
+    })?;
+    let path = global_virtual_store.join(LOCK_FILE);
+    std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(&path)
+        .map_err(|e| {
+            miette!(
+                code = aube_codes::errors::ERR_AUBE_GVS_PRUNE_FAILED,
+                "failed to open global virtual store lock {}: {e}",
+                path.display()
+            )
+        })
+}
+
+pub(crate) fn lock_for_install(global_virtual_store: &Path) -> miette::Result<GvsLock> {
+    let file = open_lock(global_virtual_store)?;
+    file.lock_shared().map_err(|e| {
+        miette!(
+            code = aube_codes::errors::ERR_AUBE_GVS_PRUNE_FAILED,
+            "failed to lock global virtual store {} for install: {e}",
+            global_virtual_store.display()
+        )
+    })?;
+    Ok(GvsLock(file))
+}
+
+fn lock_for_prune(global_virtual_store: &Path) -> miette::Result<GvsLock> {
+    let file = open_lock(global_virtual_store)?;
+    file.lock().map_err(|e| {
+        miette!(
+            code = aube_codes::errors::ERR_AUBE_GVS_PRUNE_FAILED,
+            "failed to lock global virtual store {} for pruning: {e}",
+            global_virtual_store.display()
+        )
+    })?;
+    Ok(GvsLock(file))
+}
+
+pub(crate) fn register_project(
+    global_virtual_store: &Path,
+    project_dir: &Path,
+    aube_dir: &Path,
+) -> miette::Result<()> {
+    let projects_dir = global_virtual_store.join(PROJECTS_DIR);
+    std::fs::create_dir_all(&projects_dir).map_err(|e| registry_error(&projects_dir, e))?;
+    let project_dir = std::fs::canonicalize(project_dir).unwrap_or_else(|_| project_dir.into());
+    let aube_dir = if aube_dir.is_absolute() {
+        aube_dir.to_path_buf()
+    } else {
+        project_dir.join(aube_dir)
+    };
+    let key = blake3::hash(project_dir.as_os_str().as_encoded_bytes()).to_hex();
+    let record = RegisteredProject {
+        project_dir,
+        aube_dir,
+    };
+    let bytes = serde_json::to_vec(&record).map_err(|e| {
+        miette!(
+            code = aube_codes::errors::ERR_AUBE_GVS_PRUNE_FAILED,
+            "failed to encode global virtual store project registry entry: {e}"
+        )
+    })?;
+    aube_util::fs_atomic::atomic_write(&projects_dir.join(format!("{key}.json")), &bytes)
+        .map_err(|e| registry_error(&projects_dir, e))
+}
+
+pub(crate) fn register_fast_path_project(project_dir: &Path) -> miette::Result<()> {
+    let global_virtual_store = super::global_virtual_store_dir(project_dir);
+    let aube_dir = super::resolve_virtual_store_dir_for_cwd(project_dir);
+    if !project_links_into(&aube_dir, &global_virtual_store)? {
+        return Ok(());
+    }
+    let _lock = lock_for_install(&global_virtual_store)?;
+    register_project(&global_virtual_store, project_dir, &aube_dir)
+}
+
+pub(crate) fn prune(global_virtual_store: &Path, dry_run: bool) -> miette::Result<usize> {
+    if !global_virtual_store.exists() {
+        return Ok(0);
+    }
+    let _lock = lock_for_prune(global_virtual_store)?;
+    let projects_dir = global_virtual_store.join(PROJECTS_DIR);
+    if !projects_dir.exists() {
+        eprintln!("No registered projects for global virtual store");
+        return Ok(0);
+    }
+
+    let mut reachable = HashSet::new();
+    for entry in read_dir(&projects_dir)? {
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        let bytes = std::fs::read(&path).map_err(|e| prune_error(&path, e))?;
+        let project: RegisteredProject =
+            serde_json::from_slice(&bytes).map_err(|e| invalid_registry_error(&path, e))?;
+        if !project.project_dir.exists() || !project.aube_dir.exists() {
+            if !dry_run {
+                std::fs::remove_file(&path).map_err(|e| prune_error(&path, e))?;
+            }
+            continue;
+        }
+        mark_project_entries(global_virtual_store, &project.aube_dir, &mut reachable)?;
+    }
+
+    let mut removed = 0;
+    for entry in read_dir(global_virtual_store)? {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if name_str.starts_with('.') || name_str == "node_modules" {
+            continue;
+        }
+        let file_type = entry
+            .file_type()
+            .map_err(|e| prune_error(&entry.path(), e))?;
+        if !file_type.is_dir() || reachable.contains(&name) {
+            continue;
+        }
+        if !dry_run {
+            aube_linker::remove_dir_all_with_retry(&entry.path())
+                .map_err(|e| prune_error(&entry.path(), e))?;
+        }
+        removed += 1;
+    }
+    Ok(removed)
+}
+
+fn mark_project_entries(
+    global_virtual_store: &Path,
+    aube_dir: &Path,
+    reachable: &mut HashSet<OsString>,
+) -> miette::Result<()> {
+    let canonical_gvs =
+        std::fs::canonicalize(global_virtual_store).unwrap_or_else(|_| global_virtual_store.into());
+    for entry in read_dir(aube_dir)? {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if name_str.starts_with('.') || name_str == "node_modules" {
+            continue;
+        }
+        let path = entry.path();
+        let Ok(target) = std::fs::read_link(&path) else {
+            continue;
+        };
+        let absolute = if target.is_absolute() {
+            target
+        } else {
+            path.parent().unwrap_or(aube_dir).join(target)
+        };
+        let canonical_target = std::fs::canonicalize(&absolute).unwrap_or(absolute);
+        let Ok(relative) = canonical_target.strip_prefix(&canonical_gvs) else {
+            continue;
+        };
+        if let Some(component) = relative.components().next() {
+            reachable.insert(component.as_os_str().to_os_string());
+        }
+    }
+    Ok(())
+}
+
+fn project_links_into(aube_dir: &Path, global_virtual_store: &Path) -> miette::Result<bool> {
+    if !aube_dir.exists() {
+        return Ok(false);
+    }
+    let canonical_gvs =
+        std::fs::canonicalize(global_virtual_store).unwrap_or_else(|_| global_virtual_store.into());
+    for entry in read_dir(aube_dir)? {
+        let path = entry.path();
+        let Ok(target) = std::fs::read_link(&path) else {
+            continue;
+        };
+        let absolute = if target.is_absolute() {
+            target
+        } else {
+            path.parent().unwrap_or(aube_dir).join(target)
+        };
+        let canonical_target = std::fs::canonicalize(&absolute).unwrap_or(absolute);
+        if canonical_target.starts_with(&canonical_gvs) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn read_dir(path: &Path) -> miette::Result<Vec<std::fs::DirEntry>> {
+    std::fs::read_dir(path)
+        .map_err(|e| prune_error(path, e))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| prune_error(path, e))
+}
+
+fn prune_error(path: &Path, error: std::io::Error) -> miette::Report {
+    miette!(
+        code = aube_codes::errors::ERR_AUBE_GVS_PRUNE_FAILED,
+        "failed to prune global virtual store path {}: {error}",
+        path.display()
+    )
+}
+
+fn invalid_registry_error(path: &Path, error: serde_json::Error) -> miette::Report {
+    miette!(
+        code = aube_codes::errors::ERR_AUBE_GVS_PRUNE_FAILED,
+        "invalid global virtual store project registry entry {}: {error}",
+        path.display()
+    )
+}
+
+fn registry_error(path: &Path, error: std::io::Error) -> miette::Report {
+    miette!(
+        code = aube_codes::errors::ERR_AUBE_GVS_PRUNE_FAILED,
+        "failed to update global virtual store project registry {}: {error}",
+        path.display()
+    )
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prune_keeps_registered_entries_and_removes_orphans() {
+        let tmp = tempfile::tempdir().expect("tempdir should be created");
+        let gvs = tmp.path().join("virtual-store");
+        let project = tmp.path().join("project");
+        let aube_dir = project.join("node_modules/.aube");
+        let live = gvs.join("live@1.0.0-deadbeefdeadbeef");
+        let orphan = gvs.join("orphan@1.0.0-deadbeefdeadbeef");
+        std::fs::create_dir_all(&live).expect("live entry should be created");
+        std::fs::create_dir_all(&orphan).expect("orphan entry should be created");
+        std::fs::create_dir_all(&aube_dir).expect("project virtual store should be created");
+        std::os::unix::fs::symlink(&live, aube_dir.join("live@1.0.0"))
+            .expect("project link should be created");
+
+        register_project(&gvs, &project, &aube_dir).expect("project should register");
+        assert_eq!(prune(&gvs, true).expect("dry run should succeed"), 1);
+        assert!(orphan.exists(), "dry run must preserve the orphan");
+
+        assert_eq!(prune(&gvs, false).expect("prune should succeed"), 1);
+        assert!(live.exists(), "registered entry must survive");
+        assert!(!orphan.exists(), "orphan entry must be removed");
+    }
+
+    #[test]
+    fn prune_drops_registry_records_for_deleted_projects() {
+        let tmp = tempfile::tempdir().expect("tempdir should be created");
+        let gvs = tmp.path().join("virtual-store");
+        let project = tmp.path().join("project");
+        let aube_dir = project.join("node_modules/.aube");
+        std::fs::create_dir_all(&aube_dir).expect("project virtual store should be created");
+        register_project(&gvs, &project, &aube_dir).expect("project should register");
+        std::fs::remove_dir_all(&project).expect("project should be removed");
+
+        prune(&gvs, false).expect("prune should remove stale registry record");
+        assert_eq!(
+            std::fs::read_dir(gvs.join(PROJECTS_DIR))
+                .expect("registry should be readable")
+                .count(),
+            0
+        );
+    }
+}

--- a/crates/aube/src/commands/gvs_registry.rs
+++ b/crates/aube/src/commands/gvs_registry.rs
@@ -6,19 +6,11 @@ use std::path::{Path, PathBuf};
 
 const PROJECTS_DIR: &str = ".projects";
 const LOCK_FILE: &str = ".prune.lock";
-const LEGACY_ENTRIES_FILE: &str = ".legacy-entries.json";
 
 #[derive(Debug, Serialize, Deserialize)]
 struct RegisteredProject {
     project_dir: PathBuf,
     aube_dir: PathBuf,
-    #[serde(default)]
-    entries: Vec<PathBuf>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct LegacyEntries {
-    entries: Vec<PathBuf>,
 }
 
 pub(crate) struct GvsLock(std::fs::File);
@@ -54,25 +46,6 @@ fn open_lock(global_virtual_store: &Path) -> miette::Result<std::fs::File> {
 
 pub(crate) fn lock_for_install(global_virtual_store: &Path) -> miette::Result<GvsLock> {
     let file = open_lock(global_virtual_store)?;
-    if !global_virtual_store.join(LEGACY_ENTRIES_FILE).exists() {
-        file.lock().map_err(|e| {
-            miette!(
-                code = aube_codes::errors::ERR_AUBE_GVS_PRUNE_FAILED,
-                "failed to lock global virtual store {} for initialization: {e}",
-                global_virtual_store.display()
-            )
-        })?;
-        // Re-check under the exclusive lock: another installer may have
-        // initialized the snapshot while this process was waiting.
-        preserve_legacy_entries(global_virtual_store, false)?;
-        file.unlock().map_err(|e| {
-            miette!(
-                code = aube_codes::errors::ERR_AUBE_GVS_PRUNE_FAILED,
-                "failed to unlock global virtual store {} after initialization: {e}",
-                global_virtual_store.display()
-            )
-        })?;
-    }
     file.lock_shared().map_err(|e| {
         miette!(
             code = aube_codes::errors::ERR_AUBE_GVS_PRUNE_FAILED,
@@ -124,15 +97,9 @@ pub(crate) fn register_project(
     } else {
         project_dir.join(aube_dir)
     };
-    let mut entries: Vec<PathBuf> = project_entries(global_virtual_store, &aube_dir)?
-        .into_iter()
-        .map(PathBuf::from)
-        .collect();
-    entries.sort_unstable();
     let record = RegisteredProject {
         project_dir,
         aube_dir,
-        entries,
     };
     let bytes = serde_json::to_vec(&record).map_err(|e| {
         miette!(
@@ -186,21 +153,14 @@ pub(crate) fn prune(global_virtual_store: &Path, dry_run: bool) -> miette::Resul
         return Ok(0);
     }
     let _lock = lock_for_prune(global_virtual_store)?;
-    let legacy_snapshot_existed = global_virtual_store.join(LEGACY_ENTRIES_FILE).exists();
-    let mut legacy = preserve_legacy_entries(global_virtual_store, dry_run)?;
-    let mut reachable = legacy.clone();
-    let mut known = HashSet::new();
+    let mut reachable = HashSet::new();
     let mut stale_records = Vec::new();
-    let mut legacy_changed = false;
     let projects_dir = global_virtual_store.join(PROJECTS_DIR);
     if !projects_dir.exists() {
-        let has_untracked_entries = graph_entries(global_virtual_store)?
-            .into_iter()
-            .any(|name| !reachable.contains(&name));
-        if legacy_snapshot_existed && has_untracked_entries {
+        if !graph_entries(global_virtual_store)?.is_empty() {
             return Err(miette!(
                 code = aube_codes::errors::ERR_AUBE_GVS_PRUNE_FAILED,
-                "global virtual store project registry {} is missing while untracked entries exist\nhelp: run {} in active projects before pruning again",
+                "global virtual store project registry {} is missing while entries exist\nhelp: run {} in active projects before pruning again",
                 projects_dir.display(),
                 aube_util::cmd("install")
             ));
@@ -220,56 +180,14 @@ pub(crate) fn prune(global_virtual_store: &Path, dry_run: bool) -> miette::Resul
             let project: RegisteredProject =
                 serde_json::from_slice(&bytes).map_err(|e| invalid_registry_error(&path, e))?;
             if !project.project_dir.exists() || !project.aube_dir.exists() {
-                // A registry-unaware project may share any graph entry named
-                // by this stale record. There is no filesystem backlink from
-                // the GVS entry to that legacy checkout, so deleting it would
-                // be unsafe. Promote stale claims to legacy protection before
-                // dropping the record.
-                for entry in &project.entries {
-                    let entry = entry.as_os_str().to_os_string();
-                    legacy_changed |= legacy.insert(entry.clone());
-                    reachable.insert(entry);
-                }
                 if !dry_run {
                     stale_records.push(path);
                 }
                 continue;
             }
             let current = project_entries(global_virtual_store, &project.aube_dir)?;
-            reachable.extend(current.iter().cloned());
-            for entry in &project.entries {
-                let entry = entry.as_os_str().to_os_string();
-                if current.contains(&entry) {
-                    known.insert(entry);
-                } else {
-                    // An older aube can update this project without updating
-                    // its registry record. Its saved-but-unlinked claims may
-                    // therefore still be shared by another registry-unaware
-                    // checkout and need the same legacy protection as stale
-                    // project records.
-                    legacy_changed |= legacy.insert(entry.clone());
-                    reachable.insert(entry);
-                }
-            }
+            reachable.extend(current);
         }
-    }
-
-    // Registry-unaware aube versions can still add graph entries after the
-    // migration snapshot was created. Entries that no registry record has
-    // ever claimed are therefore treated as legacy rather than deleted. New
-    // aube versions record the entries used by each project, so entries from
-    // deleted registered projects remain eligible for pruning.
-    let untracked: Vec<OsString> = graph_entries(global_virtual_store)?
-        .into_iter()
-        .filter(|name| !reachable.contains(name) && !known.contains(name))
-        .collect();
-    if !untracked.is_empty() {
-        legacy.extend(untracked);
-        reachable.extend(legacy.iter().cloned());
-        legacy_changed = true;
-    }
-    if legacy_changed && !dry_run {
-        write_legacy_entries(global_virtual_store, &legacy)?;
     }
 
     let mut removed = 0;
@@ -294,55 +212,6 @@ pub(crate) fn prune(global_virtual_store: &Path, dry_run: bool) -> miette::Resul
         std::fs::remove_file(&path).map_err(|e| prune_error(&path, e))?;
     }
     Ok(removed)
-}
-
-fn preserve_legacy_entries(
-    global_virtual_store: &Path,
-    dry_run: bool,
-) -> miette::Result<HashSet<OsString>> {
-    let path = global_virtual_store.join(LEGACY_ENTRIES_FILE);
-    if path.exists() {
-        let bytes = std::fs::read(&path).map_err(|e| prune_error(&path, e))?;
-        let legacy: LegacyEntries =
-            serde_json::from_slice(&bytes).map_err(|e| invalid_registry_error(&path, e))?;
-        return Ok(legacy
-            .entries
-            .into_iter()
-            .map(PathBuf::into_os_string)
-            .collect());
-    }
-
-    // The registry did not exist before GVS pruning was introduced. Preserve
-    // every entry found during migration because another live checkout may
-    // still reference it without having had a chance to register.
-    let entries: Vec<PathBuf> = graph_entries(global_virtual_store)?
-        .into_iter()
-        .map(PathBuf::from)
-        .collect();
-    if !dry_run {
-        let legacy = entries
-            .iter()
-            .map(|entry| entry.as_os_str().to_os_string())
-            .collect();
-        write_legacy_entries(global_virtual_store, &legacy)?;
-    }
-    Ok(entries.into_iter().map(PathBuf::into_os_string).collect())
-}
-
-fn write_legacy_entries(
-    global_virtual_store: &Path,
-    entries: &HashSet<OsString>,
-) -> miette::Result<()> {
-    let path = global_virtual_store.join(LEGACY_ENTRIES_FILE);
-    let mut entries: Vec<PathBuf> = entries.iter().cloned().map(PathBuf::from).collect();
-    entries.sort_unstable();
-    let bytes = serde_json::to_vec(&LegacyEntries { entries }).map_err(|e| {
-        miette!(
-            code = aube_codes::errors::ERR_AUBE_GVS_PRUNE_FAILED,
-            "failed to encode legacy global virtual store entries: {e}"
-        )
-    })?;
-    aube_util::fs_atomic::atomic_write(&path, &bytes).map_err(|e| registry_error(&path, e))
 }
 
 fn is_graph_entry_name(name: &std::ffi::OsStr) -> bool {
@@ -446,7 +315,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn prune_keeps_registered_and_historical_entries() {
+    fn prune_keeps_registered_and_removes_historical_entries() {
         let tmp = tempfile::tempdir().expect("tempdir should be created");
         let gvs = tmp.path().join("virtual-store");
         std::fs::create_dir_all(&gvs).expect("global virtual store should be created");
@@ -472,30 +341,18 @@ mod tests {
             .expect("orphan project should register");
         std::fs::remove_file(orphan_aube_dir.join("orphan@1.0.0"))
             .expect("orphan project link should be removed");
-        assert_eq!(prune(&gvs, true).expect("dry run should succeed"), 0);
-        assert!(orphan.exists(), "dry run must preserve historical claims");
+        assert_eq!(prune(&gvs, true).expect("dry run should succeed"), 1);
+        assert!(orphan.exists(), "dry run must not remove candidates");
 
-        assert_eq!(prune(&gvs, false).expect("prune should succeed"), 0);
+        assert_eq!(prune(&gvs, false).expect("prune should succeed"), 1);
         assert!(live.exists(), "registered entry must survive");
-        assert!(
-            orphan.exists(),
-            "a historical claim may still be shared by a legacy project"
-        );
+        assert!(!orphan.exists(), "unlinked historical claim must be pruned");
     }
 
     #[test]
-    fn prune_preserves_legacy_and_historical_entries() {
+    fn prune_removes_entries_from_deleted_projects() {
         let tmp = tempfile::tempdir().expect("tempdir should be created");
         let gvs = tmp.path().join("virtual-store");
-        let legacy = gvs.join("legacy@1.0.0-deadbeefdeadbeef");
-        std::fs::create_dir_all(&legacy).expect("legacy entry should be created");
-        drop(lock_for_install(&gvs).expect("legacy snapshot should initialize"));
-
-        let project = tmp.path().join("project");
-        let aube_dir = project.join("node_modules/.aube");
-        std::fs::create_dir_all(&aube_dir).expect("project virtual store should be created");
-        register_project(&gvs, &project, &aube_dir).expect("project should register");
-
         let orphan = gvs.join("orphan@1.0.0-deadbeefdeadbeef");
         std::fs::create_dir_all(&orphan).expect("new orphan should be created");
         let orphan_project = tmp.path().join("orphan-project");
@@ -506,21 +363,17 @@ mod tests {
             .expect("orphan project link should be created");
         register_project(&gvs, &orphan_project, &orphan_aube_dir)
             .expect("orphan project should register");
-        std::fs::remove_file(orphan_aube_dir.join("orphan@1.0.0"))
-            .expect("orphan project link should be removed");
-        assert_eq!(prune(&gvs, false).expect("prune should succeed"), 0);
-        assert!(legacy.exists(), "unregistered legacy entry must survive");
-        assert!(
-            orphan.exists(),
-            "a historical claim may still be shared by a legacy project"
-        );
+        std::fs::remove_dir_all(&orphan_project).expect("orphan project should be removed");
+
+        assert_eq!(prune(&gvs, false).expect("prune should succeed"), 1);
+        assert!(!orphan.exists(), "stale project entry must be pruned");
     }
 
     #[test]
     fn failed_link_cleanup_removes_only_unreferenced_records() {
         let tmp = tempfile::tempdir().expect("tempdir should be created");
         let gvs = tmp.path().join("virtual-store");
-        drop(lock_for_install(&gvs).expect("legacy snapshot should initialize"));
+        drop(lock_for_install(&gvs).expect("install lock should be acquired"));
         let project = tmp.path().join("project");
         let aube_dir = project.join("node_modules/.aube");
         std::fs::create_dir_all(&aube_dir).expect("project virtual store should be created");
@@ -551,18 +404,12 @@ mod tests {
     }
 
     #[test]
-    fn first_prune_initializes_a_missing_registry_without_sweeping_legacy_entries() {
+    fn first_prune_initializes_an_empty_registry() {
         let tmp = tempfile::tempdir().expect("tempdir should be created");
         let gvs = tmp.path().join("virtual-store");
-        let legacy = gvs.join("legacy@1.0.0-deadbeefdeadbeef");
-        std::fs::create_dir_all(&legacy).expect("legacy entry should be created");
+        std::fs::create_dir_all(&gvs).expect("global virtual store should be created");
 
-        assert_eq!(
-            prune(&gvs, false).expect("migration prune should succeed"),
-            0
-        );
-        assert!(legacy.exists(), "legacy entry must survive migration");
-        assert!(gvs.join(LEGACY_ENTRIES_FILE).exists());
+        assert_eq!(prune(&gvs, false).expect("empty prune should succeed"), 0);
         assert!(gvs.join(PROJECTS_DIR).exists());
     }
 
@@ -570,7 +417,7 @@ mod tests {
     fn prune_fails_closed_when_an_initialized_registry_disappears() {
         let tmp = tempfile::tempdir().expect("tempdir should be created");
         let gvs = tmp.path().join("virtual-store");
-        drop(lock_for_install(&gvs).expect("legacy snapshot should initialize"));
+        drop(lock_for_install(&gvs).expect("install lock should be acquired"));
         let untracked = gvs.join("untracked@1.0.0-deadbeefdeadbeef");
         std::fs::create_dir_all(&untracked).expect("untracked entry should be created");
 
@@ -583,60 +430,17 @@ mod tests {
     }
 
     #[test]
-    fn prune_preserves_untracked_entries_created_after_the_legacy_snapshot() {
+    fn prune_removes_untracked_entries_from_interrupted_installs() {
         let tmp = tempfile::tempdir().expect("tempdir should be created");
         let gvs = tmp.path().join("virtual-store");
-        drop(lock_for_install(&gvs).expect("legacy snapshot should initialize"));
+        drop(lock_for_install(&gvs).expect("install lock should be acquired"));
         std::fs::create_dir_all(gvs.join(PROJECTS_DIR))
             .expect("project registry should be initialized");
-        let old_aube_entry = gvs.join("old-aube@1.0.0-deadbeefdeadbeef");
-        std::fs::create_dir_all(&old_aube_entry).expect("untracked entry should be created");
+        let interrupted = gvs.join("interrupted@1.0.0-deadbeefdeadbeef");
+        std::fs::create_dir_all(&interrupted).expect("untracked entry should be created");
 
-        assert_eq!(prune(&gvs, false).expect("prune should succeed"), 0);
-        assert!(
-            old_aube_entry.exists(),
-            "an entry created by a registry-unaware aube must survive"
-        );
-        let legacy: LegacyEntries = serde_json::from_slice(
-            &std::fs::read(gvs.join(LEGACY_ENTRIES_FILE))
-                .expect("legacy snapshot should be readable"),
-        )
-        .expect("legacy snapshot should parse");
-        assert!(legacy.entries.iter().any(|entry| {
-            entry.as_os_str() == std::ffi::OsStr::new("old-aube@1.0.0-deadbeefdeadbeef")
-        }));
-    }
-
-    #[test]
-    fn prune_preserves_stale_claims_that_a_legacy_project_may_share() {
-        let tmp = tempfile::tempdir().expect("tempdir should be created");
-        let gvs = tmp.path().join("virtual-store");
-        drop(lock_for_install(&gvs).expect("legacy snapshot should initialize"));
-        let shared = gvs.join("shared@1.0.0-deadbeefdeadbeef");
-        std::fs::create_dir_all(&shared).expect("shared entry should be created");
-        let registered_project = tmp.path().join("registered-project");
-        let registered_aube_dir = registered_project.join("node_modules/.aube");
-        std::fs::create_dir_all(&registered_aube_dir)
-            .expect("registered project virtual store should be created");
-        std::os::unix::fs::symlink(&shared, registered_aube_dir.join("shared@1.0.0"))
-            .expect("registered project link should be created");
-        register_project(&gvs, &registered_project, &registered_aube_dir)
-            .expect("project should register");
-        std::fs::remove_dir_all(&registered_project).expect("registered project should be removed");
-
-        assert_eq!(prune(&gvs, false).expect("prune should succeed"), 0);
-        assert!(
-            shared.exists(),
-            "a stale claim may still be shared by a registry-unaware project"
-        );
-        let legacy: LegacyEntries = serde_json::from_slice(
-            &std::fs::read(gvs.join(LEGACY_ENTRIES_FILE))
-                .expect("legacy snapshot should be readable"),
-        )
-        .expect("legacy snapshot should parse");
-        assert!(legacy.entries.iter().any(|entry| {
-            entry.as_os_str() == std::ffi::OsStr::new("shared@1.0.0-deadbeefdeadbeef")
-        }));
+        assert_eq!(prune(&gvs, false).expect("prune should succeed"), 1);
+        assert!(!interrupted.exists(), "untracked entry must be pruned");
     }
 
     #[test]
@@ -644,7 +448,7 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir should be created");
         let gvs = tmp.path().join("virtual-store");
         std::fs::create_dir_all(&gvs).expect("global virtual store should be created");
-        drop(lock_for_install(&gvs).expect("legacy snapshot should initialize"));
+        drop(lock_for_install(&gvs).expect("install lock should be acquired"));
         let project = tmp.path().join("project");
         let aube_dir = project.join("node_modules/.aube");
         std::fs::create_dir_all(&aube_dir).expect("project virtual store should be created");

--- a/crates/aube/src/commands/gvs_registry.rs
+++ b/crates/aube/src/commands/gvs_registry.rs
@@ -12,6 +12,8 @@ const LEGACY_ENTRIES_FILE: &str = ".legacy-entries.json";
 struct RegisteredProject {
     project_dir: PathBuf,
     aube_dir: PathBuf,
+    #[serde(default)]
+    entries: Vec<PathBuf>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -83,14 +85,28 @@ pub(crate) fn lock_for_install(global_virtual_store: &Path) -> miette::Result<Gv
 
 fn lock_for_prune(global_virtual_store: &Path) -> miette::Result<GvsLock> {
     let file = open_lock(global_virtual_store)?;
-    file.lock().map_err(|e| {
-        miette!(
-            code = aube_codes::errors::ERR_AUBE_GVS_PRUNE_FAILED,
-            "failed to lock global virtual store {} for pruning: {e}",
-            global_virtual_store.display()
-        )
-    })?;
+    match file.try_lock() {
+        Ok(()) => {}
+        Err(std::fs::TryLockError::WouldBlock) => {
+            crate::progress::safe_eprintln(
+                "Waiting for a running global virtual store install to finish before pruning",
+            );
+            file.lock()
+                .map_err(|e| lock_error(global_virtual_store, e))?;
+        }
+        Err(std::fs::TryLockError::Error(e)) => {
+            return Err(lock_error(global_virtual_store, e));
+        }
+    }
     Ok(GvsLock(file))
+}
+
+fn lock_error(global_virtual_store: &Path, error: std::io::Error) -> miette::Report {
+    miette!(
+        code = aube_codes::errors::ERR_AUBE_GVS_PRUNE_FAILED,
+        "failed to lock global virtual store {} for pruning: {error}",
+        global_virtual_store.display()
+    )
 }
 
 pub(crate) fn register_project(
@@ -108,9 +124,15 @@ pub(crate) fn register_project(
     } else {
         project_dir.join(aube_dir)
     };
+    let mut entries: Vec<PathBuf> = project_entries(global_virtual_store, &aube_dir)?
+        .into_iter()
+        .map(PathBuf::from)
+        .collect();
+    entries.sort_unstable();
     let record = RegisteredProject {
         project_dir,
         aube_dir,
+        entries,
     };
     let bytes = serde_json::to_vec(&record).map_err(|e| {
         miette!(
@@ -131,7 +153,7 @@ pub(crate) fn unregister_if_unreferenced(
     aube_dir: &Path,
 ) -> miette::Result<()> {
     if project_links_into(aube_dir, global_virtual_store)? {
-        return Ok(());
+        return register_project(global_virtual_store, project_dir, aube_dir);
     }
     let project_dir = std::fs::canonicalize(project_dir).unwrap_or_else(|_| project_dir.into());
     let path = project_record_path(&global_virtual_store.join(PROJECTS_DIR), &project_dir);
@@ -148,6 +170,7 @@ fn project_record_path(projects_dir: &Path, project_dir: &Path) -> PathBuf {
 }
 
 pub(crate) fn register_fast_path_project(
+    _lock: &GvsLock,
     global_virtual_store: &Path,
     project_dir: &Path,
     aube_dir: &Path,
@@ -155,7 +178,6 @@ pub(crate) fn register_fast_path_project(
     if !project_links_into(aube_dir, global_virtual_store)? {
         return Ok(());
     }
-    let _lock = lock_for_install(global_virtual_store)?;
     register_project(global_virtual_store, project_dir, aube_dir)
 }
 
@@ -165,7 +187,10 @@ pub(crate) fn prune(global_virtual_store: &Path, dry_run: bool) -> miette::Resul
     }
     let _lock = lock_for_prune(global_virtual_store)?;
     let legacy_snapshot_existed = global_virtual_store.join(LEGACY_ENTRIES_FILE).exists();
-    let mut reachable = preserve_legacy_entries(global_virtual_store, dry_run)?;
+    let mut legacy = preserve_legacy_entries(global_virtual_store, dry_run)?;
+    let mut reachable = legacy.clone();
+    let mut known = HashSet::new();
+    let mut stale_records = Vec::new();
     let projects_dir = global_virtual_store.join(PROJECTS_DIR);
     if !projects_dir.exists() {
         let has_untracked_entries = graph_entries(global_virtual_store)?
@@ -193,9 +218,15 @@ pub(crate) fn prune(global_virtual_store: &Path, dry_run: bool) -> miette::Resul
             let bytes = std::fs::read(&path).map_err(|e| prune_error(&path, e))?;
             let project: RegisteredProject =
                 serde_json::from_slice(&bytes).map_err(|e| invalid_registry_error(&path, e))?;
+            known.extend(
+                project
+                    .entries
+                    .iter()
+                    .map(|entry| entry.as_os_str().to_os_string()),
+            );
             if !project.project_dir.exists() || !project.aube_dir.exists() {
                 if !dry_run {
-                    std::fs::remove_file(&path).map_err(|e| prune_error(&path, e))?;
+                    stale_records.push(path);
                 }
                 continue;
             }
@@ -203,11 +234,27 @@ pub(crate) fn prune(global_virtual_store: &Path, dry_run: bool) -> miette::Resul
         }
     }
 
+    // Registry-unaware aube versions can still add graph entries after the
+    // migration snapshot was created. Entries that no registry record has
+    // ever claimed are therefore treated as legacy rather than deleted. New
+    // aube versions record the entries used by each project, so entries from
+    // deleted registered projects remain eligible for pruning.
+    let untracked: Vec<OsString> = graph_entries(global_virtual_store)?
+        .into_iter()
+        .filter(|name| !reachable.contains(name) && !known.contains(name))
+        .collect();
+    if !untracked.is_empty() {
+        legacy.extend(untracked);
+        reachable.extend(legacy.iter().cloned());
+        if !dry_run {
+            write_legacy_entries(global_virtual_store, &legacy)?;
+        }
+    }
+
     let mut removed = 0;
     for entry in read_dir(global_virtual_store)? {
         let name = entry.file_name();
-        let name_str = name.to_string_lossy();
-        if name_str.starts_with('.') || name_str == "node_modules" {
+        if !is_graph_entry_name(&name) {
             continue;
         }
         let file_type = entry
@@ -221,6 +268,9 @@ pub(crate) fn prune(global_virtual_store: &Path, dry_run: bool) -> miette::Resul
                 .map_err(|e| prune_error(&entry.path(), e))?;
         }
         removed += 1;
+    }
+    for path in stale_records {
+        std::fs::remove_file(&path).map_err(|e| prune_error(&path, e))?;
     }
     Ok(removed)
 }
@@ -243,33 +293,47 @@ fn preserve_legacy_entries(
 
     // The registry did not exist before GVS pruning was introduced. Preserve
     // every entry found during migration because another live checkout may
-    // still reference it without having had a chance to register. Entries
-    // created after this snapshot are safe to sweep using the registry.
+    // still reference it without having had a chance to register.
     let entries: Vec<PathBuf> = graph_entries(global_virtual_store)?
         .into_iter()
         .map(PathBuf::from)
         .collect();
     if !dry_run {
-        let bytes = serde_json::to_vec(&LegacyEntries {
-            entries: entries.clone(),
-        })
-        .map_err(|e| {
-            miette!(
-                code = aube_codes::errors::ERR_AUBE_GVS_PRUNE_FAILED,
-                "failed to encode legacy global virtual store entries: {e}"
-            )
-        })?;
-        aube_util::fs_atomic::atomic_write(&path, &bytes).map_err(|e| registry_error(&path, e))?;
+        let legacy = entries
+            .iter()
+            .map(|entry| entry.as_os_str().to_os_string())
+            .collect();
+        write_legacy_entries(global_virtual_store, &legacy)?;
     }
     Ok(entries.into_iter().map(PathBuf::into_os_string).collect())
+}
+
+fn write_legacy_entries(
+    global_virtual_store: &Path,
+    entries: &HashSet<OsString>,
+) -> miette::Result<()> {
+    let path = global_virtual_store.join(LEGACY_ENTRIES_FILE);
+    let mut entries: Vec<PathBuf> = entries.iter().cloned().map(PathBuf::from).collect();
+    entries.sort_unstable();
+    let bytes = serde_json::to_vec(&LegacyEntries { entries }).map_err(|e| {
+        miette!(
+            code = aube_codes::errors::ERR_AUBE_GVS_PRUNE_FAILED,
+            "failed to encode legacy global virtual store entries: {e}"
+        )
+    })?;
+    aube_util::fs_atomic::atomic_write(&path, &bytes).map_err(|e| registry_error(&path, e))
+}
+
+fn is_graph_entry_name(name: &std::ffi::OsStr) -> bool {
+    let name = name.to_string_lossy();
+    !name.starts_with('.') && name != "node_modules"
 }
 
 fn graph_entries(global_virtual_store: &Path) -> miette::Result<Vec<OsString>> {
     let mut entries = Vec::new();
     for entry in read_dir(global_virtual_store)? {
         let name = entry.file_name();
-        let name_str = name.to_string_lossy();
-        if name_str.starts_with('.') || name_str == "node_modules" {
+        if !is_graph_entry_name(&name) {
             continue;
         }
         if entry
@@ -288,56 +352,50 @@ fn mark_project_entries(
     aube_dir: &Path,
     reachable: &mut HashSet<OsString>,
 ) -> miette::Result<()> {
-    let canonical_gvs =
-        std::fs::canonicalize(global_virtual_store).unwrap_or_else(|_| global_virtual_store.into());
-    for entry in read_dir(aube_dir)? {
-        let name = entry.file_name();
-        let name_str = name.to_string_lossy();
-        if name_str.starts_with('.') || name_str == "node_modules" {
-            continue;
-        }
-        let path = entry.path();
-        let Ok(target) = std::fs::read_link(&path) else {
-            continue;
-        };
-        let absolute = if target.is_absolute() {
-            target
-        } else {
-            path.parent().unwrap_or(aube_dir).join(target)
-        };
-        let canonical_target = std::fs::canonicalize(&absolute).unwrap_or(absolute);
-        let Ok(relative) = canonical_target.strip_prefix(&canonical_gvs) else {
-            continue;
-        };
-        if let Some(component) = relative.components().next() {
-            reachable.insert(component.as_os_str().to_os_string());
-        }
-    }
+    reachable.extend(project_entries(global_virtual_store, aube_dir)?);
     Ok(())
 }
 
 fn project_links_into(aube_dir: &Path, global_virtual_store: &Path) -> miette::Result<bool> {
+    Ok(!project_entries(global_virtual_store, aube_dir)?.is_empty())
+}
+
+fn project_entries(
+    global_virtual_store: &Path,
+    aube_dir: &Path,
+) -> miette::Result<HashSet<OsString>> {
+    let mut entries = HashSet::new();
     if !aube_dir.exists() {
-        return Ok(false);
+        return Ok(entries);
     }
     let canonical_gvs =
         std::fs::canonicalize(global_virtual_store).unwrap_or_else(|_| global_virtual_store.into());
     for entry in read_dir(aube_dir)? {
+        if !is_graph_entry_name(&entry.file_name()) {
+            continue;
+        }
         let path = entry.path();
-        let Ok(target) = std::fs::read_link(&path) else {
+        let Some(canonical_target) = resolved_link_target(&path, aube_dir) else {
             continue;
         };
-        let absolute = if target.is_absolute() {
-            target
-        } else {
-            path.parent().unwrap_or(aube_dir).join(target)
+        let Ok(relative) = canonical_target.strip_prefix(&canonical_gvs) else {
+            continue;
         };
-        let canonical_target = std::fs::canonicalize(&absolute).unwrap_or(absolute);
-        if canonical_target.starts_with(&canonical_gvs) {
-            return Ok(true);
+        if let Some(component) = relative.components().next() {
+            entries.insert(component.as_os_str().to_os_string());
         }
     }
-    Ok(false)
+    Ok(entries)
+}
+
+fn resolved_link_target(path: &Path, base: &Path) -> Option<PathBuf> {
+    let target = std::fs::read_link(path).ok()?;
+    let absolute = if target.is_absolute() {
+        target
+    } else {
+        path.parent().unwrap_or(base).join(target)
+    };
+    Some(std::fs::canonicalize(&absolute).unwrap_or(absolute))
 }
 
 fn read_dir(path: &Path) -> miette::Result<Vec<std::fs::DirEntry>> {
@@ -392,6 +450,15 @@ mod tests {
         register_project(&gvs, &project, &aube_dir).expect("project should register");
         let orphan = gvs.join("orphan@1.0.0-deadbeefdeadbeef");
         std::fs::create_dir_all(&orphan).expect("orphan entry should be created");
+        let orphan_project = tmp.path().join("orphan-project");
+        let orphan_aube_dir = orphan_project.join("node_modules/.aube");
+        std::fs::create_dir_all(&orphan_aube_dir)
+            .expect("orphan project virtual store should be created");
+        std::os::unix::fs::symlink(&orphan, orphan_aube_dir.join("orphan@1.0.0"))
+            .expect("orphan project link should be created");
+        register_project(&gvs, &orphan_project, &orphan_aube_dir)
+            .expect("orphan project should register");
+        std::fs::remove_dir_all(&orphan_project).expect("orphan project should be removed");
         assert_eq!(prune(&gvs, true).expect("dry run should succeed"), 1);
         assert!(orphan.exists(), "dry run must preserve the orphan");
 
@@ -415,6 +482,15 @@ mod tests {
 
         let orphan = gvs.join("orphan@1.0.0-deadbeefdeadbeef");
         std::fs::create_dir_all(&orphan).expect("new orphan should be created");
+        let orphan_project = tmp.path().join("orphan-project");
+        let orphan_aube_dir = orphan_project.join("node_modules/.aube");
+        std::fs::create_dir_all(&orphan_aube_dir)
+            .expect("orphan project virtual store should be created");
+        std::os::unix::fs::symlink(&orphan, orphan_aube_dir.join("orphan@1.0.0"))
+            .expect("orphan project link should be created");
+        register_project(&gvs, &orphan_project, &orphan_aube_dir)
+            .expect("orphan project should register");
+        std::fs::remove_dir_all(&orphan_project).expect("orphan project should be removed");
         assert_eq!(prune(&gvs, false).expect("prune should succeed"), 1);
         assert!(legacy.exists(), "unregistered legacy entry must survive");
         assert!(!orphan.exists(), "post-registry orphan must be removed");
@@ -484,6 +560,31 @@ mod tests {
             "unexpected error: {error}"
         );
         assert!(untracked.exists(), "failed prune must not delete entries");
+    }
+
+    #[test]
+    fn prune_preserves_untracked_entries_created_after_the_legacy_snapshot() {
+        let tmp = tempfile::tempdir().expect("tempdir should be created");
+        let gvs = tmp.path().join("virtual-store");
+        drop(lock_for_install(&gvs).expect("legacy snapshot should initialize"));
+        std::fs::create_dir_all(gvs.join(PROJECTS_DIR))
+            .expect("project registry should be initialized");
+        let old_aube_entry = gvs.join("old-aube@1.0.0-deadbeefdeadbeef");
+        std::fs::create_dir_all(&old_aube_entry).expect("untracked entry should be created");
+
+        assert_eq!(prune(&gvs, false).expect("prune should succeed"), 0);
+        assert!(
+            old_aube_entry.exists(),
+            "an entry created by a registry-unaware aube must survive"
+        );
+        let legacy: LegacyEntries = serde_json::from_slice(
+            &std::fs::read(gvs.join(LEGACY_ENTRIES_FILE))
+                .expect("legacy snapshot should be readable"),
+        )
+        .expect("legacy snapshot should parse");
+        assert!(legacy.entries.iter().any(|entry| {
+            entry.as_os_str() == std::ffi::OsStr::new("old-aube@1.0.0-deadbeefdeadbeef")
+        }));
     }
 
     #[test]

--- a/crates/aube/src/commands/gvs_registry.rs
+++ b/crates/aube/src/commands/gvs_registry.rs
@@ -147,14 +147,16 @@ fn project_record_path(projects_dir: &Path, project_dir: &Path) -> PathBuf {
     projects_dir.join(format!("{key}.json"))
 }
 
-pub(crate) fn register_fast_path_project(project_dir: &Path) -> miette::Result<()> {
-    let global_virtual_store = super::global_virtual_store_dir(project_dir);
-    let aube_dir = super::resolve_virtual_store_dir_for_cwd(project_dir);
-    if !project_links_into(&aube_dir, &global_virtual_store)? {
+pub(crate) fn register_fast_path_project(
+    global_virtual_store: &Path,
+    project_dir: &Path,
+    aube_dir: &Path,
+) -> miette::Result<()> {
+    if !project_links_into(aube_dir, global_virtual_store)? {
         return Ok(());
     }
-    let _lock = lock_for_install(&global_virtual_store)?;
-    register_project(&global_virtual_store, project_dir, &aube_dir)
+    let _lock = lock_for_install(global_virtual_store)?;
+    register_project(global_virtual_store, project_dir, aube_dir)
 }
 
 pub(crate) fn prune(global_virtual_store: &Path, dry_run: bool) -> miette::Result<usize> {
@@ -162,28 +164,43 @@ pub(crate) fn prune(global_virtual_store: &Path, dry_run: bool) -> miette::Resul
         return Ok(0);
     }
     let _lock = lock_for_prune(global_virtual_store)?;
+    let legacy_snapshot_existed = global_virtual_store.join(LEGACY_ENTRIES_FILE).exists();
     let mut reachable = preserve_legacy_entries(global_virtual_store, dry_run)?;
     let projects_dir = global_virtual_store.join(PROJECTS_DIR);
     if !projects_dir.exists() {
-        eprintln!("No registered projects for global virtual store");
-        return Ok(0);
+        let has_untracked_entries = graph_entries(global_virtual_store)?
+            .into_iter()
+            .any(|name| !reachable.contains(&name));
+        if legacy_snapshot_existed && has_untracked_entries {
+            return Err(miette!(
+                code = aube_codes::errors::ERR_AUBE_GVS_PRUNE_FAILED,
+                "global virtual store project registry {} is missing while untracked entries exist\nhelp: run {} in active projects before pruning again",
+                projects_dir.display(),
+                aube_util::cmd("install")
+            ));
+        }
+        if !dry_run {
+            std::fs::create_dir_all(&projects_dir).map_err(|e| registry_error(&projects_dir, e))?;
+        }
     }
 
-    for entry in read_dir(&projects_dir)? {
-        let path = entry.path();
-        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
-            continue;
-        }
-        let bytes = std::fs::read(&path).map_err(|e| prune_error(&path, e))?;
-        let project: RegisteredProject =
-            serde_json::from_slice(&bytes).map_err(|e| invalid_registry_error(&path, e))?;
-        if !project.project_dir.exists() || !project.aube_dir.exists() {
-            if !dry_run {
-                std::fs::remove_file(&path).map_err(|e| prune_error(&path, e))?;
+    if projects_dir.exists() {
+        for entry in read_dir(&projects_dir)? {
+            let path = entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+                continue;
             }
-            continue;
+            let bytes = std::fs::read(&path).map_err(|e| prune_error(&path, e))?;
+            let project: RegisteredProject =
+                serde_json::from_slice(&bytes).map_err(|e| invalid_registry_error(&path, e))?;
+            if !project.project_dir.exists() || !project.aube_dir.exists() {
+                if !dry_run {
+                    std::fs::remove_file(&path).map_err(|e| prune_error(&path, e))?;
+                }
+                continue;
+            }
+            mark_project_entries(global_virtual_store, &project.aube_dir, &mut reachable)?;
         }
-        mark_project_entries(global_virtual_store, &project.aube_dir, &mut reachable)?;
     }
 
     let mut removed = 0;
@@ -435,6 +452,38 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[test]
+    fn first_prune_initializes_a_missing_registry_without_sweeping_legacy_entries() {
+        let tmp = tempfile::tempdir().expect("tempdir should be created");
+        let gvs = tmp.path().join("virtual-store");
+        let legacy = gvs.join("legacy@1.0.0-deadbeefdeadbeef");
+        std::fs::create_dir_all(&legacy).expect("legacy entry should be created");
+
+        assert_eq!(
+            prune(&gvs, false).expect("migration prune should succeed"),
+            0
+        );
+        assert!(legacy.exists(), "legacy entry must survive migration");
+        assert!(gvs.join(LEGACY_ENTRIES_FILE).exists());
+        assert!(gvs.join(PROJECTS_DIR).exists());
+    }
+
+    #[test]
+    fn prune_fails_closed_when_an_initialized_registry_disappears() {
+        let tmp = tempfile::tempdir().expect("tempdir should be created");
+        let gvs = tmp.path().join("virtual-store");
+        drop(lock_for_install(&gvs).expect("legacy snapshot should initialize"));
+        let untracked = gvs.join("untracked@1.0.0-deadbeefdeadbeef");
+        std::fs::create_dir_all(&untracked).expect("untracked entry should be created");
+
+        let error = prune(&gvs, false).expect_err("missing registry must fail closed");
+        assert!(
+            error.to_string().contains("project registry"),
+            "unexpected error: {error}"
+        );
+        assert!(untracked.exists(), "failed prune must not delete entries");
     }
 
     #[test]

--- a/crates/aube/src/commands/install/link.rs
+++ b/crates/aube/src/commands/install/link.rs
@@ -286,6 +286,10 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
     if !patches_for_linker.is_empty() {
         linker = linker.with_patches(patches_for_linker);
     }
+    if linker.uses_global_virtual_store() {
+        super::super::gvs_registry::register_project(&store.virtual_store_dir(), cwd, aube_dir)
+            .wrap_err("failed to register project with global virtual store")?;
+    }
     let stats = if has_workspace {
         linker
             .link_workspace(cwd, graph_for_link, package_indices, ws_dirs)
@@ -297,11 +301,6 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
             .into_diagnostic()
             .wrap_err("failed to link node_modules")?
     };
-    if linker.uses_global_virtual_store() && !virtual_store_only {
-        super::super::gvs_registry::register_project(&store.virtual_store_dir(), cwd, aube_dir)
-            .wrap_err("failed to register project with global virtual store")?;
-    }
-
     tracing::debug!(
         "phase:link {:.1?} ({} files)",
         phase_start.elapsed(),

--- a/crates/aube/src/commands/install/link.rs
+++ b/crates/aube/src/commands/install/link.rs
@@ -314,6 +314,10 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
             return Err(error).into_diagnostic().wrap_err(context);
         }
     };
+    if linker.uses_global_virtual_store() {
+        super::super::gvs_registry::register_project(&store.virtual_store_dir(), cwd, aube_dir)
+            .wrap_err("failed to record project entries in the global virtual store")?;
+    }
     tracing::debug!(
         "phase:link {:.1?} ({} files)",
         phase_start.elapsed(),

--- a/crates/aube/src/commands/install/link.rs
+++ b/crates/aube/src/commands/install/link.rs
@@ -293,13 +293,26 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
     let stats = if has_workspace {
         linker
             .link_workspace(cwd, graph_for_link, package_indices, ws_dirs)
-            .into_diagnostic()
-            .wrap_err("failed to link workspace node_modules")?
+            .map_err(|error| (error, "failed to link workspace node_modules"))
     } else {
         linker
             .link_all(cwd, graph_for_link, package_indices)
-            .into_diagnostic()
-            .wrap_err("failed to link node_modules")?
+            .map_err(|error| (error, "failed to link node_modules"))
+    };
+    let stats = match stats {
+        Ok(stats) => stats,
+        Err((error, context)) => {
+            if linker.uses_global_virtual_store()
+                && let Err(cleanup_error) = super::super::gvs_registry::unregister_if_unreferenced(
+                    &store.virtual_store_dir(),
+                    cwd,
+                    aube_dir,
+                )
+            {
+                tracing::debug!("failed to clean up GVS project registration: {cleanup_error}");
+            }
+            return Err(error).into_diagnostic().wrap_err(context);
+        }
     };
     tracing::debug!(
         "phase:link {:.1?} ({} files)",

--- a/crates/aube/src/commands/install/link.rs
+++ b/crates/aube/src/commands/install/link.rs
@@ -297,6 +297,10 @@ pub(super) fn run_link_phase(input: LinkPhaseInput<'_>) -> miette::Result<LinkPh
             .into_diagnostic()
             .wrap_err("failed to link node_modules")?
     };
+    if linker.uses_global_virtual_store() && !virtual_store_only {
+        super::super::gvs_registry::register_project(&store.virtual_store_dir(), cwd, aube_dir)
+            .wrap_err("failed to register project with global virtual store")?;
+    }
 
     tracing::debug!(
         "phase:link {:.1?} ({} files)",

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -565,6 +565,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
         && let Some(total) =
             try_install_fast_path(&cwd, &opts, mode, modules_cache_sweep_is_default(&cwd))?
     {
+        super::gvs_registry::register_fast_path_project(&cwd)?;
         control::complete(total);
         return Ok(());
     }
@@ -953,6 +954,9 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     // 3. Parse or resolve lockfile, streaming tarball fetches during resolution
     let phase_start = std::time::Instant::now();
     let store = std::sync::Arc::new(super::open_store_with_ctx(&cwd, &settings_ctx)?);
+    let _gvs_lock = planned_gvs
+        .then(|| super::gvs_registry::lock_for_install(&store.virtual_store_dir()))
+        .transpose()?;
     // Pre-create all 256 two-char shard directories in the CAS root.
     // `import_bytes` is called once per stored file (~7.5k for a medium
     // install) and previously did `mkdirp(parent)` per call — a stat

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -83,8 +83,9 @@ use settings::{
     resolve_strict_store_pkg_content_check, resolve_verify_store_integrity,
 };
 use startup::{
-    apply_force_state_reset, merge_branch_lockfiles_if_needed, modules_cache_sweep_is_default,
-    resolve_project_cwd, try_install_fast_path, warn_accepted_noop_install_settings,
+    apply_force_state_reset, emit_up_to_date, merge_branch_lockfiles_if_needed,
+    modules_cache_sweep_is_default, resolve_project_cwd, try_install_fast_path,
+    warn_accepted_noop_install_settings,
 };
 use summary::print_already_up_to_date;
 use workspace::{
@@ -562,26 +563,20 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
         apply_force_state_reset(&cwd, &opts)?;
     }
 
-    // Load the workspace yaml *once* — both as the typed
-    // `WorkspaceConfig` (used below for `allow_builds_raw` and
-    // friends) and as a raw `BTreeMap` (used by
-    // `aube_settings::resolved::*` for metadata-driven lookups).
-    // Errors propagate here rather than silently defaulting later,
-    // so a malformed workspace file surfaces before we start
-    // resolving the dep graph. Also load `.npmrc` entries once so
-    // the same borrow feeds both the resolve-time settings and the
-    // later engine-check settings.
+    // The warm path historically tolerates workspace fields that cannot be
+    // deserialized into the typed config as long as the raw settings needed
+    // for freshness checks remain readable. Keep typed validation after the
+    // fast-path gate so an already-current install retains that behavior.
     let files = crate::commands::FileSources::load(&cwd);
-    let (ws_config_shared, raw_workspace) = aube_manifest::workspace::load_both(&cwd)
-        .into_diagnostic()
-        .wrap_err("failed to load workspace config")?;
-    let settings_ctx = files.ctx(&raw_workspace, &opts.env_snapshot, &opts.cli_flags);
+    let fast_path_workspace = aube_manifest::workspace::load_raw(&cwd).unwrap_or_default();
+    let fast_path_settings_ctx =
+        files.ctx(&fast_path_workspace, &opts.env_snapshot, &opts.cli_flags);
 
     let fast_path_total = if opts.dry_run {
         None
     } else {
-        let store = super::open_store_with_ctx(&cwd, &settings_ctx)?;
-        let global_virtual_store = store.virtual_store_dir();
+        let global_virtual_store =
+            super::global_virtual_store_dir_with_ctx(&cwd, &fast_path_settings_ctx);
         let gvs_lock = global_virtual_store
             .exists()
             .then(|| super::gvs_registry::lock_for_install(&global_virtual_store))
@@ -590,7 +585,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
         if total.is_some()
             && let Some(lock) = gvs_lock.as_ref()
         {
-            let aube_dir = super::resolve_virtual_store_dir(&settings_ctx, &cwd);
+            let aube_dir = super::resolve_virtual_store_dir(&fast_path_settings_ctx, &cwd);
             super::gvs_registry::register_fast_path_project(
                 lock,
                 &global_virtual_store,
@@ -604,9 +599,18 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
         total
     };
     if let Some(total) = fast_path_total {
+        emit_up_to_date(&cwd);
         control::complete(total);
         return Ok(());
     }
+
+    // Full installs require typed workspace fields. Load the raw and typed
+    // views together once the warm path has been ruled out, then use the same
+    // raw map for all remaining setting resolution.
+    let (ws_config_shared, raw_workspace) = aube_manifest::workspace::load_both(&cwd)
+        .into_diagnostic()
+        .wrap_err("failed to load workspace config")?;
+    let settings_ctx = files.ctx(&raw_workspace, &opts.env_snapshot, &opts.cli_flags);
 
     // Yaml-only workspace roots (`pnpm-workspace.yaml` only, no root
     // `package.json`) install with a synthesized empty manifest so

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -561,35 +561,6 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     if !opts.dry_run {
         apply_force_state_reset(&cwd, &opts)?;
     }
-    if !opts.dry_run
-        && let Some(total) =
-            try_install_fast_path(&cwd, &opts, mode, modules_cache_sweep_is_default(&cwd))?
-    {
-        let files = crate::commands::FileSources::load(&cwd);
-        let raw_workspace = aube_manifest::workspace::load_raw(&cwd)
-            .into_diagnostic()
-            .wrap_err("failed to load workspace config")?;
-        let settings_ctx = files.ctx(&raw_workspace, &opts.env_snapshot, &opts.cli_flags);
-        let store = super::open_store_with_ctx(&cwd, &settings_ctx)?;
-        let aube_dir = super::resolve_virtual_store_dir(&settings_ctx, &cwd);
-        super::gvs_registry::register_fast_path_project(
-            &store.virtual_store_dir(),
-            &cwd,
-            &aube_dir,
-        )?;
-        control::complete(total);
-        return Ok(());
-    }
-
-    // Yaml-only workspace roots (`pnpm-workspace.yaml` only, no root
-    // `package.json`) install with a synthesized empty manifest so
-    // every workspace member is installed without the root carrying
-    // any deps or scripts itself. The synthesized manifest naturally
-    // skips root lifecycle hooks, has no required-scripts to validate,
-    // and threads through the rest of the pipeline as a manifest with
-    // no direct deps would.
-    let manifest = super::load_manifest_or_default(&cwd)?;
-    let project_name = manifest.name.as_deref().unwrap_or("(unnamed)");
 
     // Load the workspace yaml *once* — both as the typed
     // `WorkspaceConfig` (used below for `allow_builds_raw` and
@@ -604,13 +575,55 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     let (ws_config_shared, raw_workspace) = aube_manifest::workspace::load_both(&cwd)
         .into_diagnostic()
         .wrap_err("failed to load workspace config")?;
+    let settings_ctx = files.ctx(&raw_workspace, &opts.env_snapshot, &opts.cli_flags);
+
+    let fast_path_total = if opts.dry_run {
+        None
+    } else {
+        let store = super::open_store_with_ctx(&cwd, &settings_ctx)?;
+        let global_virtual_store = store.virtual_store_dir();
+        let gvs_lock = global_virtual_store
+            .exists()
+            .then(|| super::gvs_registry::lock_for_install(&global_virtual_store))
+            .transpose()?;
+        let total = try_install_fast_path(&cwd, &opts, mode, modules_cache_sweep_is_default(&cwd))?;
+        if total.is_some()
+            && let Some(lock) = gvs_lock.as_ref()
+        {
+            let aube_dir = super::resolve_virtual_store_dir(&settings_ctx, &cwd);
+            super::gvs_registry::register_fast_path_project(
+                lock,
+                &global_virtual_store,
+                &cwd,
+                &aube_dir,
+            )
+            .wrap_err(
+                "install is current, but failed to register it with the global virtual store",
+            )?;
+        }
+        total
+    };
+    if let Some(total) = fast_path_total {
+        control::complete(total);
+        return Ok(());
+    }
+
+    // Yaml-only workspace roots (`pnpm-workspace.yaml` only, no root
+    // `package.json`) install with a synthesized empty manifest so
+    // every workspace member is installed without the root carrying
+    // any deps or scripts itself. The synthesized manifest naturally
+    // skips root lifecycle hooks, has no required-scripts to validate,
+    // and threads through the rest of the pipeline as a manifest with
+    // no direct deps would.
+    let manifest = super::load_manifest_or_default(&cwd)?;
+    let project_name = manifest.name.as_deref().unwrap_or("(unnamed)");
+
     // Catalog discovery walks up for the workspace yaml and also pulls
     // from package.json's `workspaces.catalog` / `pnpm.catalog`, so
     // `aube install` run from a monorepo subpackage still sees the root
     // workspace's catalog. See `discover_catalogs` for the precedence
     // order.
     let workspace_catalogs = super::discover_catalogs(&cwd)?;
-    let settings_ctx = files.ctx(&raw_workspace, &opts.env_snapshot, &opts.cli_flags);
     let packument_cache_dir =
         super::resolved_cache_dir_with_ctx(&cwd, &settings_ctx).join("packuments-v1");
     let explicit_store_dir_override = has_explicit_store_dir_override(&opts.cli_flags);

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -565,7 +565,18 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
         && let Some(total) =
             try_install_fast_path(&cwd, &opts, mode, modules_cache_sweep_is_default(&cwd))?
     {
-        super::gvs_registry::register_fast_path_project(&cwd)?;
+        let files = crate::commands::FileSources::load(&cwd);
+        let raw_workspace = aube_manifest::workspace::load_raw(&cwd)
+            .into_diagnostic()
+            .wrap_err("failed to load workspace config")?;
+        let settings_ctx = files.ctx(&raw_workspace, &opts.env_snapshot, &opts.cli_flags);
+        let store = super::open_store_with_ctx(&cwd, &settings_ctx)?;
+        let aube_dir = super::resolve_virtual_store_dir(&settings_ctx, &cwd);
+        super::gvs_registry::register_fast_path_project(
+            &store.virtual_store_dir(),
+            &cwd,
+            &aube_dir,
+        )?;
         control::complete(total);
         return Ok(());
     }

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -957,9 +957,6 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     let _gvs_lock = planned_gvs
         .then(|| super::gvs_registry::lock_for_install(&store.virtual_store_dir()))
         .transpose()?;
-    if planned_gvs {
-        super::gvs_registry::initialize_for_install(&store.virtual_store_dir())?;
-    }
     // Pre-create all 256 two-char shard directories in the CAS root.
     // `import_bytes` is called once per stored file (~7.5k for a medium
     // install) and previously did `mkdirp(parent)` per call — a stat

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -957,6 +957,9 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     let _gvs_lock = planned_gvs
         .then(|| super::gvs_registry::lock_for_install(&store.virtual_store_dir()))
         .transpose()?;
+    if planned_gvs {
+        super::gvs_registry::initialize_for_install(&store.virtual_store_dir())?;
+    }
     // Pre-create all 256 two-char shard directories in the CAS root.
     // `import_bytes` is called once per stored file (~7.5k for a medium
     // install) and previously did `mkdirp(parent)` per call — a stat

--- a/crates/aube/src/commands/install/side_effects_cache.rs
+++ b/crates/aube/src/commands/install/side_effects_cache.rs
@@ -191,8 +191,18 @@ fn should_remove_side_effects_tmp_dir(entry: &std::fs::DirEntry) -> bool {
 }
 
 pub(crate) fn side_effects_cache_root(store: &aube_store::Store) -> std::path::PathBuf {
-    store
-        .virtual_store_dir()
+    let virtual_store_dir = store.virtual_store_dir();
+    let virtual_store_root = if virtual_store_dir.file_name()
+        == Some(std::ffi::OsStr::new(
+            crate::commands::settings_context::GVS_REGISTRY_NAMESPACE_VERSION,
+        )) {
+        virtual_store_dir
+            .parent()
+            .unwrap_or(virtual_store_dir.as_path())
+    } else {
+        virtual_store_dir.as_path()
+    };
+    virtual_store_root
         .parent()
         .unwrap_or_else(|| store.root())
         .join("side-effects-v1")
@@ -424,6 +434,19 @@ fn create_symlink_like(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cache_root_is_a_sibling_of_the_versioned_virtual_store_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache_dir = dir.path().join("cache");
+        let store = aube_store::Store::with_dirs(dir.path().join("store/files"), cache_dir.clone())
+            .with_virtual_store_dir(cache_dir.join("virtual-store/v1"));
+
+        assert_eq!(
+            side_effects_cache_root(&store),
+            cache_dir.join("side-effects-v1")
+        );
+    }
 
     #[test]
     fn cache_path_segregates_by_platform() {

--- a/crates/aube/src/commands/install/startup.rs
+++ b/crates/aube/src/commands/install/startup.rs
@@ -45,7 +45,6 @@ pub(super) fn try_install_fast_path(
         return Ok(None);
     }
     opts.control.check_cancelled()?;
-    emit_up_to_date(cwd);
     let total = state::read_state_package_content_hashes(cwd)
         .map(|packages| packages.len())
         .or_else(|| {
@@ -165,7 +164,7 @@ fn trust_policy_requires_validation(cwd: &Path, opts: &InstallOptions) -> bool {
         )
 }
 
-fn emit_up_to_date(cwd: &Path) {
+pub(super) fn emit_up_to_date(cwd: &Path) {
     super::unreviewed_builds::emit_warning(&super::unreviewed_builds::from_state(cwd));
     super::print_already_up_to_date();
 }

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -28,6 +28,7 @@ pub mod exec;
 pub mod fetch;
 pub mod find_hash;
 pub mod global;
+pub(crate) mod gvs_registry;
 pub mod ignored_builds;
 pub mod import;
 pub mod init;

--- a/crates/aube/src/commands/settings_context.rs
+++ b/crates/aube/src/commands/settings_context.rs
@@ -551,9 +551,11 @@ pub(crate) fn resolved_cache_dir_with_ctx(
 /// materialized packages that project `node_modules/.aube/<dep_path>`
 /// entries symlink into.
 ///
-/// `globalVirtualStoreDir` wins when set and is used verbatim (no
-/// `virtual-store` suffix); otherwise the store lands under the
-/// resolved [`resolved_cache_dir`]. The dedicated setting exists
+/// `globalVirtualStoreDir` wins when set and is used as the store root (no
+/// `virtual-store` suffix); otherwise the root lands under the resolved
+/// [`resolved_cache_dir`]. Registry-aware entries live in a versioned child
+/// directory so older aube releases cannot create or reuse entries that the
+/// current project registry may later prune. The dedicated setting exists
 /// because this tree — unlike the rest of the cache — has to sit on
 /// the same volume as `storeDir` to be hardlinkable, which is not
 /// necessarily where the packument caches belong.
@@ -570,11 +572,13 @@ pub(crate) fn global_virtual_store_dir_with_ctx(
     cwd: &std::path::Path,
     ctx: &aube_settings::ResolveCtx<'_>,
 ) -> std::path::PathBuf {
-    aube_settings::resolved::global_virtual_store_dir(ctx)
+    let root = aube_settings::resolved::global_virtual_store_dir(ctx)
         .and_then(|raw| expand_setting_path(&raw, cwd))
         .unwrap_or_else(|| {
             resolved_cache_dir_with_ctx(cwd, ctx).join(aube_store::VIRTUAL_STORE_SUBDIR)
-        })
+        });
+    const REGISTRY_NAMESPACE_VERSION: &str = "v1";
+    root.join(REGISTRY_NAMESPACE_VERSION)
 }
 
 /// Resolve the `virtualStoreDirMaxLength` setting, falling back to the

--- a/crates/aube/src/commands/settings_context.rs
+++ b/crates/aube/src/commands/settings_context.rs
@@ -17,6 +17,7 @@ use super::{CatalogMap, config, install};
 static GLOBAL_FROZEN: OnceLock<Option<install::FrozenOverride>> = OnceLock::new();
 static GLOBAL_VIRTUAL_STORE: OnceLock<install::GlobalVirtualStoreFlags> = OnceLock::new();
 static SKIP_AUTO_INSTALL_ON_PM_MISMATCH: AtomicBool = AtomicBool::new(false);
+pub(crate) const GVS_REGISTRY_NAMESPACE_VERSION: &str = "v1";
 
 /// Process-wide registry override from the top-level `--registry=<url>`
 /// flag. Applied in `make_client` (and any direct `NpmConfig::load`
@@ -577,8 +578,7 @@ pub(crate) fn global_virtual_store_dir_with_ctx(
         .unwrap_or_else(|| {
             resolved_cache_dir_with_ctx(cwd, ctx).join(aube_store::VIRTUAL_STORE_SUBDIR)
         });
-    const REGISTRY_NAMESPACE_VERSION: &str = "v1";
-    root.join(REGISTRY_NAMESPACE_VERSION)
+    root.join(GVS_REGISTRY_NAMESPACE_VERSION)
 }
 
 /// Resolve the `virtualStoreDirMaxLength` setting, falling back to the

--- a/crates/aube/src/commands/store.rs
+++ b/crates/aube/src/commands/store.rs
@@ -56,7 +56,8 @@ pub enum StoreCommand {
     /// project node_modules directories, manifests, or lockfiles.
     ///
     /// It removes global virtual-store graph entries not referenced by any
-    /// registered project, then prunes content-store files.
+    /// registered project, except legacy entries preserved for older checkouts.
+    /// It then prunes content-store files.
     ///
     /// On reflink filesystems such as APFS or btrfs, link counts cannot prove
     /// project reachability, so content-store pruning relies on cached package
@@ -265,15 +266,17 @@ fn visit_indices_in_dir(
 fn prune(args: PruneArgs) -> miette::Result<()> {
     let store = open_store()?;
     let removed_gvs = super::gvs_registry::prune(&store.virtual_store_dir(), args.dry_run)?;
-    let gvs_verb = if args.dry_run {
-        "Would prune"
-    } else {
-        "Pruned"
-    };
-    eprintln!(
-        "{gvs_verb} {} from the global virtual store",
-        pluralizer::pluralize("package", removed_gvs as isize, true)
-    );
+    if removed_gvs > 0 {
+        let gvs_verb = if args.dry_run {
+            "Would prune"
+        } else {
+            "Pruned"
+        };
+        eprintln!(
+            "{gvs_verb} {} from the global virtual store",
+            pluralizer::pluralize("package", removed_gvs as isize, true)
+        );
+    }
     let root = store.root().to_path_buf();
     if !root.exists() {
         eprintln!("Store is empty: nothing to prune");

--- a/crates/aube/src/commands/store.rs
+++ b/crates/aube/src/commands/store.rs
@@ -56,8 +56,9 @@ pub enum StoreCommand {
     /// project node_modules directories, manifests, or lockfiles.
     ///
     /// It removes global virtual-store graph entries not referenced by any
-    /// registered project, except legacy entries preserved for older checkouts.
-    /// It then prunes content-store files.
+    /// registered project. Entries from older aube releases live outside the
+    /// registry-managed versioned namespace and are not touched. It then prunes
+    /// content-store files.
     ///
     /// On reflink filesystems such as APFS or btrfs, link counts cannot prove
     /// project reachability, so content-store pruning relies on cached package

--- a/crates/aube/src/commands/store.rs
+++ b/crates/aube/src/commands/store.rs
@@ -12,14 +12,11 @@
 //! - `aube store add <pkg>…` — resolve each spec against the registry, fetch
 //!   the tarball, and import it into the global CAS. Pre-warms the store
 //!   without touching any project's `node_modules/`.
-//! - `aube store prune` — remove files from the store that have no remaining
-//!   hardlink references. This is a best-effort heuristic (the same one
-//!   pnpm uses on hardlink filesystems): on APFS/btrfs reflinks produce
-//!   independent inodes so the nlink count is always 1 and pruning there
-//!   can't safely tell referenced from unreferenced files; in that case we
-//!   fall back to removing only files that no cached package index in
-//!   `<store>/v1/index/` points at. `--dry-run` reports the same totals
-//!   without unlinking anything.
+//! - `aube store prune` — mark global virtual-store entries reachable from
+//!   registered projects, remove the rest, then remove unreferenced CAS files.
+//!   CAS pruning uses hardlink counts where available and cached package
+//!   indexes on reflink filesystems. `--dry-run` reports the same totals
+//!   without deleting anything.
 //! - `aube store status` — verify every file referenced by a cached package
 //!   index still exists in the store and its BLAKE3 hash matches. Exits 0
 //!   when everything is consistent, 1 when any corruption is found.
@@ -58,11 +55,12 @@ pub enum StoreCommand {
     /// Operates on the store printed by `aube store path`; it does not touch
     /// project node_modules directories, manifests, or lockfiles.
     ///
-    /// It keeps files referenced by cached package indexes and, on hardlink
-    /// filesystems, files that still have project hardlink references.
+    /// It removes global virtual-store graph entries not referenced by any
+    /// registered project, then prunes content-store files.
     ///
     /// On reflink filesystems such as APFS or btrfs, link counts cannot prove
-    /// project reachability, so pruning relies on cached package indexes.
+    /// project reachability, so content-store pruning relies on cached package
+    /// indexes. Global virtual-store reachability comes from project links.
     Prune(PruneArgs),
     /// Verify the store against cached package indexes.
     ///
@@ -266,6 +264,16 @@ fn visit_indices_in_dir(
 
 fn prune(args: PruneArgs) -> miette::Result<()> {
     let store = open_store()?;
+    let removed_gvs = super::gvs_registry::prune(&store.virtual_store_dir(), args.dry_run)?;
+    let gvs_verb = if args.dry_run {
+        "Would prune"
+    } else {
+        "Pruned"
+    };
+    eprintln!(
+        "{gvs_verb} {} from the global virtual store",
+        pluralizer::pluralize("package", removed_gvs as isize, true)
+    );
     let root = store.root().to_path_buf();
     if !root.exists() {
         eprintln!("Store is empty: nothing to prune");

--- a/crates/aube/tests/embed.rs
+++ b/crates/aube/tests/embed.rs
@@ -244,7 +244,7 @@ async fn facade_warm_install_registers_the_host_virtual_store() {
         .await
         .unwrap();
 
-    let projects_dir = host_cache.join("virtual-store/.projects");
+    let projects_dir = host_cache.join("virtual-store/v1/.projects");
     std::fs::remove_dir_all(&projects_dir).unwrap();
 
     let mut options = InstallOptions::new(project.path());

--- a/crates/aube/tests/embed.rs
+++ b/crates/aube/tests/embed.rs
@@ -218,6 +218,49 @@ async fn facade_install_accepts_host_storage_overrides() {
 
 #[cfg(unix)]
 #[tokio::test]
+async fn facade_warm_install_registers_the_host_virtual_store() {
+    initialize_test_host();
+    let project = tempfile::tempdir().unwrap();
+    let host_cache = project.path().join("host-cache");
+    let host_store = project.path().join("host-store");
+    seed_cached_registry_package(&host_cache, &host_store);
+    std::fs::write(
+        project.path().join("package.json"),
+        r#"{"dependencies":{"cached-only":"1.0.0"}}
+"#,
+    )
+    .unwrap();
+    let overrides = aube::embed::EmbedderInstallOverrides {
+        use_global_virtual_store: Some(true),
+        cache_dir: Some(host_cache.clone()),
+        store_dir: Some(host_store),
+    };
+
+    let mut options = InstallOptions::new(project.path());
+    options.ignore_scripts = true;
+    options.network_mode = aube::embed::NetworkMode::Offline;
+    options.control = InstallControl::silent();
+    aube::embed::install_with_overrides(options, overrides.clone())
+        .await
+        .unwrap();
+
+    let projects_dir = host_cache.join("virtual-store/.projects");
+    std::fs::remove_dir_all(&projects_dir).unwrap();
+
+    let mut options = InstallOptions::new(project.path());
+    options.ignore_scripts = true;
+    options.network_mode = aube::embed::NetworkMode::Offline;
+    options.control = InstallControl::silent();
+    aube::embed::install_with_overrides(options, overrides)
+        .await
+        .unwrap();
+
+    assert!(projects_dir.is_dir());
+    assert!(std::fs::read_dir(projects_dir).unwrap().next().is_some());
+}
+
+#[cfg(unix)]
+#[tokio::test]
 async fn facade_install_preserves_non_utf8_storage_paths() {
     use std::os::unix::ffi::OsStringExt;
 

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -11241,7 +11241,7 @@
             "effect": "write",
             "hide": false,
             "help": "Remove unreferenced packages from the global store",
-            "help_long": "Remove unreferenced packages from the global store.\n\nOperates on the store printed by `aube store path`; it does not touch project node_modules directories, manifests, or lockfiles.\n\nIt keeps files referenced by cached package indexes and, on hardlink filesystems, files that still have project hardlink references.\n\nOn reflink filesystems such as APFS or btrfs, link counts cannot prove project reachability, so pruning relies on cached package indexes.",
+            "help_long": "Remove unreferenced packages from the global store.\n\nOperates on the store printed by `aube store path`; it does not touch project node_modules directories, manifests, or lockfiles.\n\nIt removes global virtual-store graph entries not referenced by any registered project, then prunes content-store files.\n\nOn reflink filesystems such as APFS or btrfs, link counts cannot prove project reachability, so content-store pruning relies on cached package indexes. Global virtual-store reachability comes from project links.",
             "name": "prune",
             "aliases": [],
             "hidden_aliases": [],

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -11241,7 +11241,7 @@
             "effect": "write",
             "hide": false,
             "help": "Remove unreferenced packages from the global store",
-            "help_long": "Remove unreferenced packages from the global store.\n\nOperates on the store printed by `aube store path`; it does not touch project node_modules directories, manifests, or lockfiles.\n\nIt removes global virtual-store graph entries not referenced by any registered project, except legacy entries preserved for older checkouts. It then prunes content-store files.\n\nOn reflink filesystems such as APFS or btrfs, link counts cannot prove project reachability, so content-store pruning relies on cached package indexes. Global virtual-store reachability comes from project links.",
+            "help_long": "Remove unreferenced packages from the global store.\n\nOperates on the store printed by `aube store path`; it does not touch project node_modules directories, manifests, or lockfiles.\n\nIt removes global virtual-store graph entries not referenced by any registered project. Entries from older aube releases live outside the registry-managed versioned namespace and are not touched. It then prunes content-store files.\n\nOn reflink filesystems such as APFS or btrfs, link counts cannot prove project reachability, so content-store pruning relies on cached package indexes. Global virtual-store reachability comes from project links.",
             "name": "prune",
             "aliases": [],
             "hidden_aliases": [],

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -11241,7 +11241,7 @@
             "effect": "write",
             "hide": false,
             "help": "Remove unreferenced packages from the global store",
-            "help_long": "Remove unreferenced packages from the global store.\n\nOperates on the store printed by `aube store path`; it does not touch project node_modules directories, manifests, or lockfiles.\n\nIt removes global virtual-store graph entries not referenced by any registered project, then prunes content-store files.\n\nOn reflink filesystems such as APFS or btrfs, link counts cannot prove project reachability, so content-store pruning relies on cached package indexes. Global virtual-store reachability comes from project links.",
+            "help_long": "Remove unreferenced packages from the global store.\n\nOperates on the store printed by `aube store path`; it does not touch project node_modules directories, manifests, or lockfiles.\n\nIt removes global virtual-store graph entries not referenced by any registered project, except legacy entries preserved for older checkouts. It then prunes content-store files.\n\nOn reflink filesystems such as APFS or btrfs, link counts cannot prove project reachability, so content-store pruning relies on cached package indexes. Global virtual-store reachability comes from project links.",
             "name": "prune",
             "aliases": [],
             "hidden_aliases": [],

--- a/docs/cli/store/prune.md
+++ b/docs/cli/store/prune.md
@@ -8,7 +8,7 @@ Remove unreferenced packages from the global store.
 
 Operates on the store printed by `aube store path`; it does not touch project node_modules directories, manifests, or lockfiles.
 
-It removes global virtual-store graph entries not referenced by any registered project, then prunes content-store files.
+It removes global virtual-store graph entries not referenced by any registered project, except legacy entries preserved for older checkouts. It then prunes content-store files.
 
 On reflink filesystems such as APFS or btrfs, link counts cannot prove project reachability, so content-store pruning relies on cached package indexes. Global virtual-store reachability comes from project links.
 

--- a/docs/cli/store/prune.md
+++ b/docs/cli/store/prune.md
@@ -8,9 +8,9 @@ Remove unreferenced packages from the global store.
 
 Operates on the store printed by `aube store path`; it does not touch project node_modules directories, manifests, or lockfiles.
 
-It keeps files referenced by cached package indexes and, on hardlink filesystems, files that still have project hardlink references.
+It removes global virtual-store graph entries not referenced by any registered project, then prunes content-store files.
 
-On reflink filesystems such as APFS or btrfs, link counts cannot prove project reachability, so pruning relies on cached package indexes.
+On reflink filesystems such as APFS or btrfs, link counts cannot prove project reachability, so content-store pruning relies on cached package indexes. Global virtual-store reachability comes from project links.
 
 ## Flags
 

--- a/docs/cli/store/prune.md
+++ b/docs/cli/store/prune.md
@@ -8,7 +8,7 @@ Remove unreferenced packages from the global store.
 
 Operates on the store printed by `aube store path`; it does not touch project node_modules directories, manifests, or lockfiles.
 
-It removes global virtual-store graph entries not referenced by any registered project, except legacy entries preserved for older checkouts. It then prunes content-store files.
+It removes global virtual-store graph entries not referenced by any registered project. Entries from older aube releases live outside the registry-managed versioned namespace and are not touched. It then prunes content-store files.
 
 On reflink filesystems such as APFS or btrfs, link counts cannot prove project reachability, so content-store pruning relies on cached package indexes. Global virtual-store reachability comes from project links.
 

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -145,6 +145,12 @@
       "exit_code": null
     },
     {
+      "name": "ERR_AUBE_GVS_PRUNE_FAILED",
+      "category": "Tarball / store",
+      "description": "The global virtual store project registry or prune walk failed.",
+      "exit_code": null
+    },
+    {
       "name": "ERR_AUBE_PACKAGE_NOT_FOUND",
       "category": "Registry / network",
       "description": "Registry returned 404 for the package name.",

--- a/docs/package-manager/global-virtual-store.md
+++ b/docs/package-manager/global-virtual-store.md
@@ -58,7 +58,7 @@ every checkout.
 
 ## Cleanup
 
-Run `aube store prune` to remove graph entries no registered project references.
+Run `aube store prune` to remove graph entries that are not referenced by any registered project.
 Each global-virtual-store install registers its project, and pruning removes
 records for projects that no longer exist before sweeping unreachable entries.
 On upgrade, entries that predate the project registry are preserved because

--- a/docs/package-manager/global-virtual-store.md
+++ b/docs/package-manager/global-virtual-store.md
@@ -56,6 +56,13 @@ The global virtual store still imports package files from the global content
 store. The win is that aube avoids rebuilding the same package directory tree in
 every checkout.
 
+## Cleanup
+
+Run `aube store prune` to remove graph entries no registered project references.
+Each global-virtual-store install registers its project, and pruning removes
+records for projects that no longer exist before sweeping unreachable entries.
+Use `aube store prune --dry-run` to report what would be removed.
+
 ## Package identity
 
 Entries are keyed by the resolved dependency graph, not just by package name and

--- a/docs/package-manager/global-virtual-store.md
+++ b/docs/package-manager/global-virtual-store.md
@@ -8,9 +8,9 @@ This is separate from the global content store:
 - The **global content store** (`$XDG_DATA_HOME/aube/store/v1/`) stores
   package files by BLAKE3 hash. Every install uses it.
 - The **global virtual store**
-  (`<cacheDir>/virtual-store/`, defaulting to
-  `$XDG_CACHE_HOME/aube/virtual-store/`, then
-  `~/.cache/aube/virtual-store/`) stores package directory trees keyed by
+  (`<cacheDir>/virtual-store/v1/`, defaulting to
+  `$XDG_CACHE_HOME/aube/virtual-store/v1/`, then
+  `~/.cache/aube/virtual-store/v1/`) stores package directory trees keyed by
   dependency graph. Project `node_modules` entries symlink into it.
 
 ## Default behavior
@@ -45,11 +45,11 @@ shared cache. Each project points directly at that shared tree:
 ```text
 project-a/
   node_modules/
-    react -> <cacheDir>/virtual-store/react@18.2.0/<graph-hash>/node_modules/react
+    react -> <cacheDir>/virtual-store/v1/react@18.2.0/<graph-hash>/node_modules/react
 
 project-b/
   node_modules/
-    react -> <cacheDir>/virtual-store/react@18.2.0/<graph-hash>/node_modules/react
+    react -> <cacheDir>/virtual-store/v1/react@18.2.0/<graph-hash>/node_modules/react
 ```
 
 The global virtual store still imports package files from the global content

--- a/docs/package-manager/global-virtual-store.md
+++ b/docs/package-manager/global-virtual-store.md
@@ -61,6 +61,8 @@ every checkout.
 Run `aube store prune` to remove graph entries no registered project references.
 Each global-virtual-store install registers its project, and pruning removes
 records for projects that no longer exist before sweeping unreachable entries.
+On upgrade, entries that predate the project registry are preserved because
+they may still belong to checkouts that have not run a newer aube version yet.
 Use `aube store prune --dry-run` to report what would be removed.
 
 ## Package identity

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -1215,7 +1215,9 @@ Location of the shared virtual store used by every project.
 Relocates the global virtual store — the shared tree of materialized
 package directories that `node_modules/.aube/<dep>` symlinks into when
 `enableGlobalVirtualStore` is on. Unset, it lives at
-`<cacheDir>/virtual-store/`.
+`<cacheDir>/virtual-store/`. Aube stores registry-managed entries in a
+versioned child directory below this root so older releases cannot share
+entries that a current `aube store prune` may remove.
 
 Set this when the global virtual store belongs somewhere other than
 the rest of the cache — typically to put it on the same volume as

--- a/test/modules_dir_settings.bats
+++ b/test/modules_dir_settings.bats
@@ -98,6 +98,10 @@ teardown() {
 	assert [ ! -e node_modules/is-odd ]
 	assert [ ! -e node_modules/is-even ]
 	assert [ ! -e node_modules/.bin ]
+	# The project still references GVS entries through `.aube`, so pruning
+	# must include it in reachability even without top-level links.
+	assert_dir_exists "$HOME/.cache/aube/virtual-store/.projects"
+	assert [ -n "$(find "$HOME/.cache/aube/virtual-store/.projects" -type f -name '*.json' -print -quit)" ]
 }
 
 @test "virtualStoreOnly=false (default) writes the usual top-level symlinks" {

--- a/test/modules_dir_settings.bats
+++ b/test/modules_dir_settings.bats
@@ -100,8 +100,8 @@ teardown() {
 	assert [ ! -e node_modules/.bin ]
 	# The project still references GVS entries through `.aube`, so pruning
 	# must include it in reachability even without top-level links.
-	assert_dir_exists "$HOME/.cache/aube/virtual-store/.projects"
-	assert [ -n "$(find "$HOME/.cache/aube/virtual-store/.projects" -type f -name '*.json' -print -quit)" ]
+	assert_dir_exists "$HOME/.cache/aube/virtual-store/v1/.projects"
+	assert [ -n "$(find "$HOME/.cache/aube/virtual-store/v1/.projects" -type f -name '*.json' -print -quit)" ]
 }
 
 @test "virtualStoreOnly=false (default) writes the usual top-level symlinks" {

--- a/test/nextjs_gvs_autodisable.bats
+++ b/test/nextjs_gvs_autodisable.bats
@@ -110,7 +110,7 @@ JSON
 
 	run sed -n 's/.*"virtualStoreDir": "\(.*\)".*/\1/p' node_modules/.modules.yaml
 	assert_success
-	[[ "$output" == /*/aube/virtual-store ]]
+	[[ "$output" == /*/aube/virtual-store/v1 ]]
 
 	rm node_modules/.modules.yaml
 	run aube install
@@ -139,7 +139,7 @@ JSON
 
 	run sed -n 's/.*"virtualStoreDir": "\(.*\)".*/\1/p' packages/app/node_modules/.modules.yaml
 	assert_success
-	[[ "$output" == /*/aube/virtual-store ]]
+	[[ "$output" == /*/aube/virtual-store/v1 ]]
 }
 
 @test "disableGlobalVirtualStoreForPackages=[] opts out of the auto-disable" {

--- a/test/store.bats
+++ b/test/store.bats
@@ -196,7 +196,7 @@ EOF
 	refute_output --partial "Pruned 0 files"
 }
 
-@test "aube store prune removes global virtual-store entries from deleted projects" {
+@test "aube store prune preserves stale entries that legacy projects may share" {
 	mkdir project
 	cat >project/package.json <<'JSON'
 {
@@ -222,13 +222,34 @@ JSON
 
 	run aube store prune --dry-run
 	assert_success
-	assert_output --partial "Would prune"
+	refute_output --partial "from the global virtual store"
 	assert [ -n "$(find "$gvs" -mindepth 1 -maxdepth 1 -type d ! -name node_modules ! -name '.*' -print -quit)" ]
 
 	run aube store prune
 	assert_success
-	assert_output --partial "from the global virtual store"
-	assert [ -z "$(find "$gvs" -mindepth 1 -maxdepth 1 -type d ! -name node_modules ! -name '.*' -print -quit)" ]
+	refute_output --partial "from the global virtual store"
+	assert [ -n "$(find "$gvs" -mindepth 1 -maxdepth 1 -type d ! -name node_modules ! -name '.*' -print -quit)" ]
+	assert [ -z "$(find "$gvs/.projects" -mindepth 1 -maxdepth 1 -type f -print -quit)" ]
+}
+
+@test "warm install reports success only after GVS registration succeeds" {
+	mkdir project
+	cat >project/package.json <<'JSON'
+{
+  "name": "gvs-registration-failure",
+  "version": "1.0.0",
+  "dependencies": { "is-odd": "3.0.1" }
+}
+JSON
+	run bash -c 'cd project && aube install'
+	assert_success
+
+	rm -rf "$AUBE_GLOBAL_VIRTUAL_STORE_DIR/.projects"
+	touch "$AUBE_GLOBAL_VIRTUAL_STORE_DIR/.projects"
+	run bash -c 'cd project && aube install'
+	assert_failure
+	refute_output --partial "Already up to date"
+	assert_output --partial "failed to register project with global virtual store"
 }
 
 @test "aube store prune --dry-run reports candidates without deleting them" {

--- a/test/store.bats
+++ b/test/store.bats
@@ -196,7 +196,7 @@ EOF
 	refute_output --partial "Pruned 0 files"
 }
 
-@test "aube store prune preserves stale entries that legacy projects may share" {
+@test "aube store prune removes entries from deleted registered projects" {
 	mkdir project
 	cat >project/package.json <<'JSON'
 {
@@ -208,11 +208,13 @@ JSON
 	run bash -c 'cd project && aube install'
 	assert_success
 
-	gvs="$AUBE_GLOBAL_VIRTUAL_STORE_DIR"
+	gvs="$AUBE_GLOBAL_VIRTUAL_STORE_DIR/v1"
+	legacy="$AUBE_GLOBAL_VIRTUAL_STORE_DIR/legacy@1.0.0-deadbeefdeadbeef"
+	mkdir -p "$legacy"
 	assert_dir_exists "$gvs"
 	assert [ -n "$(find "$gvs" -mindepth 1 -maxdepth 1 -type d ! -name node_modules ! -name '.*' -print -quit)" ]
-	# Simulate upgrading from aube before project registration existed. A warm
-	# install must register without forcing the linker to run again.
+	# A warm install must restore missing registration without forcing the
+	# linker to run again.
 	rm -rf "$gvs/.projects"
 	run bash -c 'cd project && aube install'
 	assert_success
@@ -222,14 +224,16 @@ JSON
 
 	run aube store prune --dry-run
 	assert_success
-	refute_output --partial "from the global virtual store"
+	assert_output --partial "Would prune"
+	assert_output --partial "from the global virtual store"
 	assert [ -n "$(find "$gvs" -mindepth 1 -maxdepth 1 -type d ! -name node_modules ! -name '.*' -print -quit)" ]
 
 	run aube store prune
 	assert_success
-	refute_output --partial "from the global virtual store"
-	assert [ -n "$(find "$gvs" -mindepth 1 -maxdepth 1 -type d ! -name node_modules ! -name '.*' -print -quit)" ]
+	assert_output --partial "from the global virtual store"
+	assert [ -z "$(find "$gvs" -mindepth 1 -maxdepth 1 -type d ! -name node_modules ! -name '.*' -print -quit)" ]
 	assert [ -z "$(find "$gvs/.projects" -mindepth 1 -maxdepth 1 -type f -print -quit)" ]
+	assert_dir_exists "$legacy"
 }
 
 @test "GVS registration failure does not report install success" {
@@ -244,9 +248,9 @@ JSON
 	run bash -c 'cd project && aube install'
 	assert_success
 
-	chmod a-w "$AUBE_GLOBAL_VIRTUAL_STORE_DIR/.projects"
+	chmod a-w "$AUBE_GLOBAL_VIRTUAL_STORE_DIR/v1/.projects"
 	run bash -c 'cd project && aube install'
-	chmod u+w "$AUBE_GLOBAL_VIRTUAL_STORE_DIR/.projects"
+	chmod u+w "$AUBE_GLOBAL_VIRTUAL_STORE_DIR/v1/.projects"
 	assert_failure
 	refute_output --partial "Already up to date"
 }

--- a/test/store.bats
+++ b/test/store.bats
@@ -232,7 +232,7 @@ JSON
 	assert [ -z "$(find "$gvs/.projects" -mindepth 1 -maxdepth 1 -type f -print -quit)" ]
 }
 
-@test "warm install reports success only after GVS registration succeeds" {
+@test "GVS registration failure does not report install success" {
 	mkdir project
 	cat >project/package.json <<'JSON'
 {
@@ -244,12 +244,11 @@ JSON
 	run bash -c 'cd project && aube install'
 	assert_success
 
-	rm -rf "$AUBE_GLOBAL_VIRTUAL_STORE_DIR/.projects"
-	touch "$AUBE_GLOBAL_VIRTUAL_STORE_DIR/.projects"
+	chmod a-w "$AUBE_GLOBAL_VIRTUAL_STORE_DIR/.projects"
 	run bash -c 'cd project && aube install'
+	chmod u+w "$AUBE_GLOBAL_VIRTUAL_STORE_DIR/.projects"
 	assert_failure
 	refute_output --partial "Already up to date"
-	assert_output --partial "failed to register project with global virtual store"
 }
 
 @test "aube store prune --dry-run reports candidates without deleting them" {

--- a/test/store.bats
+++ b/test/store.bats
@@ -195,6 +195,40 @@ EOF
 	refute_output --partial "Pruned 0 files"
 }
 
+@test "aube store prune removes global virtual-store entries from deleted projects" {
+	mkdir project
+	cat >project/package.json <<'JSON'
+{
+  "name": "gvs-prune-project",
+  "version": "1.0.0",
+  "dependencies": { "is-odd": "3.0.1" }
+}
+JSON
+	run bash -c 'cd project && aube install'
+	assert_success
+
+	gvs="$HOME/.cache/aube/virtual-store"
+	assert_dir_exists "$gvs"
+	assert [ -n "$(find "$gvs" -mindepth 1 -maxdepth 1 -type d ! -name node_modules ! -name '.*' -print -quit)" ]
+	# Simulate upgrading from aube before project registration existed. A warm
+	# install must register without forcing the linker to run again.
+	rm -rf "$gvs/.projects"
+	run bash -c 'cd project && aube install'
+	assert_success
+	assert_dir_exists "$gvs/.projects"
+	rm -rf project
+
+	run aube store prune --dry-run
+	assert_success
+	assert_output --partial "Would prune"
+	assert [ -n "$(find "$gvs" -mindepth 1 -maxdepth 1 -type d ! -name node_modules ! -name '.*' -print -quit)" ]
+
+	run aube store prune
+	assert_success
+	assert_output --partial "from the global virtual store"
+	assert [ -z "$(find "$gvs" -mindepth 1 -maxdepth 1 -type d ! -name node_modules ! -name '.*' -print -quit)" ]
+}
+
 @test "aube store prune --dry-run reports candidates without deleting them" {
 	run aube store add is-odd@3.0.1
 	assert_success

--- a/test/store.bats
+++ b/test/store.bats
@@ -3,6 +3,7 @@
 setup() {
 	load 'test_helper/common_setup'
 	_common_setup
+	export AUBE_GLOBAL_VIRTUAL_STORE_DIR="$TEST_TEMP_DIR/global-virtual-store"
 }
 
 teardown() {
@@ -207,7 +208,7 @@ JSON
 	run bash -c 'cd project && aube install'
 	assert_success
 
-	gvs="$HOME/.cache/aube/virtual-store"
+	gvs="$AUBE_GLOBAL_VIRTUAL_STORE_DIR"
 	assert_dir_exists "$gvs"
 	assert [ -n "$(find "$gvs" -mindepth 1 -maxdepth 1 -type d ! -name node_modules ! -name '.*' -print -quit)" ]
 	# Simulate upgrading from aube before project registration existed. A warm
@@ -215,6 +216,7 @@ JSON
 	rm -rf "$gvs/.projects"
 	run bash -c 'cd project && aube install'
 	assert_success
+	assert_output --partial "Already up to date"
 	assert_dir_exists "$gvs/.projects"
 	rm -rf project
 

--- a/test/virtual_store_hash.bats
+++ b/test/virtual_store_hash.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 #
 # Tests for content-addressed virtual-store paths. The global virtual
-# store (`~/.cache/aube/virtual-store/`) keys each entry by
+# store (`~/.cache/aube/virtual-store/v1/`) keys each entry by
 # `<dep_path>-<hex>` where `<hex>` is a sha256-based digest of the
 # package's dep subgraph (and, for packages that transitively require
 # build scripts, the engine string too). These tests verify that the
@@ -40,7 +40,7 @@ JSON
 	# Every subdir under the global virtual store carries a
 	# `-<hex>` suffix. Use a single run + grep rather than -regex
 	# so the assertion is portable.
-	run bash -c 'ls "$HOME/.cache/aube/virtual-store/"'
+	run bash -c 'ls "$HOME/.cache/aube/virtual-store/v1/"'
 	assert_success
 	# is-odd is a direct dep; every node in the graph gets hashed,
 	# and the suffix is 16 hex chars.


### PR DESCRIPTION
## Summary

- register projects that use the global virtual store, including warm installs after upgrading
- mark referenced graph entries and remove unreachable entries during `aube store prune`
- coordinate installs and pruning with shared/exclusive GVS locks
- support the GVS phase in `--dry-run` and document the cleanup behavior

## Root cause

`aube store prune` only walked the content-addressable store. Hashed graph directories under `<cacheDir>/virtual-store` were never considered, even after their projects were deleted. Link counts cannot identify project reachability because projects symlink to these shared entries.

The new project registry makes reachability explicit. Registry and traversal failures fail closed with `ERR_AUBE_GVS_PRUNE_FAILED`.

This addresses [discussion 1268](https://github.com/jdx/aube/discussions/1268).

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo build -p aube`
- `mise run test:bats test/store.bats` (15 passing)

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches store deletion and install-time GVS registration/locking, so bugs could remove shared packages or block installs. Mitigated by fail-closed registry checks, versioned namespaces for legacy entries, and dry-run support.
> 
> **Overview**
> **`aube store prune` can now reclaim unused global virtual-store packages**, not just content-store files.
> 
> Installs that use the global virtual store **register the project** (including warm/fast-path installs after upgrade). Prune walks those registrations, keeps entries still linked from live projects, and removes the rest—then continues with existing CAS pruning. Shared/exclusive locks coordinate installs vs prune; registry failures fail closed with `ERR_AUBE_GVS_PRUNE_FAILED`.
> 
> Registry-managed entries move under **`virtual-store/v1/`** so older aube releases' entries are left alone. Failed link cleanup drops unreferenced registrations, and `--dry-run` covers the GVS phase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7eb58b8afbb6d2c4eff62d34e1b4c8bda13c26c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic tracking of projects using the global virtual store.
  * `store prune` now removes stale registrations and unreachable virtual-store entries before cleaning content-store files.
  * Added `--dry-run` support for previewing virtual-store cleanup.
  * Legacy virtual-store entries are preserved during pruning.

* **Bug Fixes**
  * Improved cleanup after failed linking and deleted projects.
  * Warm installs restore missing project tracking metadata.
  * Added clear error reporting for pruning failures.

* **Documentation**
  * Updated pruning and global virtual-store documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->