### PR TITLE
chore(ci): require remote cache restore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,8 @@ jobs:
 
   # Qualify mise's experimental Rust action cache against the production
   # service without replacing Namespace's cache yet. Pull requests can read
-  # jdx/aube but must not write; main uses the same job to seed verified
-  # entries for subsequent qualification runs.
+  # jdx/aube but must not write. Pull requests start with empty local state and
+  # must restore entries previously seeded by main; main can seed a cold cache.
   cache-qualification:
     if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'
     runs-on: namespace-profile-endev-linux-amd64
@@ -140,8 +140,24 @@ jobs:
           set -o pipefail
           log="$RUNNER_TEMP/mise-cache-qualification.log"
           mise run cache:qualify 2>&1 | tee "$log"
-          cargo clean --target-dir "$CARGO_TARGET_DIR"
-          mise run cache:qualify 2>&1 | tee -a "$log"
+          if [ "$GITHUB_EVENT_NAME" = pull_request ]; then
+            remote_summary=$(grep -Eo \
+              'Action cache: [0-9]+ hits, [0-9]+ misses, [0-9]+ prefetched; [^,]+ downloaded,' \
+              "$log" | tail -n 1 || true)
+            if [[ ! "$remote_summary" =~ ^Action\ cache:\ [0-9]+\ hits,\ [0-9]+\ misses,\ ([0-9]+)\ prefetched\;\ (.+)\ downloaded,$ ]]; then
+              echo "::error::mise did not report Rust remote action-cache results"
+              exit 1
+            fi
+            prefetched=${BASH_REMATCH[1]}
+            downloaded=${BASH_REMATCH[2]}
+            if (( prefetched == 0 )) || [[ "$downloaded" == "0 B" ]]; then
+              echo "::error::Rust remote action cache reported $prefetched prefetched actions and $downloaded downloaded"
+              exit 1
+            fi
+          else
+            cargo clean --target-dir "$CARGO_TARGET_DIR"
+            mise run cache:qualify 2>&1 | tee -a "$log"
+          fi
           summary=$(grep -Eo \
             'Action cache qualification: [0-9]+ verified, [0-9]+ diverged' \
             "$log" | tail -n 1 || true)


### PR DESCRIPTION
## Summary

- make pull-request qualification a single build from empty local cache state
- require pull requests to prefetch at least one action and download nonzero content from `cache.mise.jdx.dev`
- retain shadow verification and require verified actions with zero divergence
- keep main's two-pass path so it can seed and verify a cold or wiped namespace

## Why

The qualification merged in #1270 proved the Rust action cache locally and allowed `main` to seed the production namespace. This follow-up proves the part a same-job replay cannot: a fresh pull-request runner can restore compiler outputs produced by a prior main-branch run.

Namespace caching remains enabled while this remote path is qualified.

## Live validation

Main seed run:

- 910.0 MiB uploaded
- 382 actions verified
- 0 actions diverged

Fresh pull-request run on `e43f9569`:

- 382 actions prefetched
- 910.0 MiB downloaded and 0 B uploaded
- 382 actions verified
- 0 actions diverged
- `cache-qualification` passed in 4m14s

Local checks:

- `actionlint .github/workflows/ci.yml`
- `cargo fmt --all --check`
- `git diff --check`
- remote-summary parser fixture

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*