### PR TITLE
fix(lockfile): preserve npm remote tarball sources

### DIFF
--- a/crates/aube-lockfile/src/npm/read.rs
+++ b/crates/aube-lockfile/src/npm/read.rs
@@ -24,6 +24,25 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
         ..Default::default()
     };
 
+    // npm does not tag remote-tarball package entries separately from
+    // registry packages: both use an HTTP(S) `resolved` URL. The declared
+    // dependency specifier is the discriminator. Collect every URL spec so
+    // matching entries retain their non-registry identity instead of later
+    // being sent through packument validation.
+    let remote_tarball_specs: BTreeSet<&str> = raw
+        .packages
+        .values()
+        .flat_map(|entry| {
+            entry
+                .dependencies
+                .values()
+                .chain(entry.dev_dependencies.values())
+                .chain(entry.optional_dependencies.values())
+        })
+        .map(String::as_str)
+        .filter(|spec| LocalSource::looks_like_remote_tarball_url(spec))
+        .collect();
+
     // npm workspace links come in pairs:
     // - `node_modules/@scope/pkg: { resolved: "packages/pkg", link: true }`
     // - `packages/pkg: { name, version, dependencies, ... }`
@@ -108,6 +127,15 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
             let local_source = entry.resolved.as_deref().and_then(|r| {
                 crate::npm::source::local_git_source_from_resolved(r)
                     .or_else(|| crate::npm::source::local_file_source_from_resolved(r))
+                    .or_else(|| {
+                        remote_tarball_specs.contains(r).then(|| {
+                            LocalSource::RemoteTarball(crate::RemoteTarballSource {
+                                url: r.to_string(),
+                                integrity: entry.integrity.clone().unwrap_or_default(),
+                                git_hosted: false,
+                            })
+                        })
+                    })
             });
             let dep_path = local_source.as_ref().map_or_else(
                 || format!("{install_name}@{version}"),

--- a/crates/aube-lockfile/src/npm/source.rs
+++ b/crates/aube-lockfile/src/npm/source.rs
@@ -49,6 +49,7 @@ pub(super) fn npm_resolved_field(pkg: &LockedPackage) -> Option<String> {
                 None => Some(format!("{url}#{}", git.resolved)),
             }
         }
+        Some(LocalSource::RemoteTarball(tarball)) => Some(tarball.url.clone()),
         _ => None,
     })
 }

--- a/crates/aube-lockfile/src/npm/tests.rs
+++ b/crates/aube-lockfile/src/npm/tests.rs
@@ -417,10 +417,14 @@ fn test_parse_remote_tarball_from_declared_url() {
         .find(|dep| dep.name == "xlsx")
         .unwrap();
     let reparsed_pkg = &reparsed.packages[&reparsed_direct.dep_path];
-    assert!(matches!(
-        reparsed_pkg.local_source,
-        Some(LocalSource::RemoteTarball(_))
-    ));
+    let Some(LocalSource::RemoteTarball(reparsed_source)) = &reparsed_pkg.local_source else {
+        panic!(
+            "expected remote tarball source, got {:?}",
+            reparsed_pkg.local_source
+        );
+    };
+    assert_eq!(reparsed_source.url, url);
+    assert_eq!(reparsed_source.integrity, "sha512-sheetjs");
 }
 
 #[test]

--- a/crates/aube-lockfile/src/npm/tests.rs
+++ b/crates/aube-lockfile/src/npm/tests.rs
@@ -351,6 +351,79 @@ fn test_parse_file_resolved_without_link() {
 }
 
 #[test]
+fn test_parse_remote_tarball_from_declared_url() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let url = "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz";
+    let content = format!(
+        r#"{{
+            "lockfileVersion": 3,
+            "packages": {{
+                "": {{
+                    "dependencies": {{
+                        "xlsx": "{url}",
+                        "semver": "^7.7.0"
+                    }}
+                }},
+                "node_modules/xlsx": {{
+                    "version": "0.20.3",
+                    "resolved": "{url}",
+                    "integrity": "sha512-sheetjs"
+                }},
+                "node_modules/semver": {{
+                    "version": "7.7.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+                    "integrity": "sha512-semver"
+                }}
+            }}
+        }}"#
+    );
+    std::fs::write(tmp.path(), content).unwrap();
+
+    let graph = parse(tmp.path()).unwrap();
+    let direct = graph.importers["."]
+        .iter()
+        .find(|dep| dep.name == "xlsx")
+        .unwrap();
+    let pkg = &graph.packages[&direct.dep_path];
+
+    assert_eq!(pkg.version, "0.20.3");
+    assert!(pkg.tarball_url.is_none());
+    let Some(LocalSource::RemoteTarball(source)) = &pkg.local_source else {
+        panic!("expected remote tarball source, got {:?}", pkg.local_source);
+    };
+    assert_eq!(source.url, url);
+    assert_eq!(source.integrity, "sha512-sheetjs");
+    let registry_pkg = graph
+        .packages
+        .values()
+        .find(|pkg| pkg.name == "semver")
+        .unwrap();
+    assert!(registry_pkg.local_source.is_none());
+
+    let manifest = aube_manifest::PackageJson {
+        dependencies: [
+            ("xlsx".to_string(), url.to_string()),
+            ("semver".to_string(), "^7.7.0".to_string()),
+        ]
+        .into_iter()
+        .collect(),
+        ..Default::default()
+    };
+    let out = tempfile::NamedTempFile::new().unwrap();
+    write(out.path(), &graph, &manifest).unwrap();
+    let reparsed = parse(out.path()).unwrap();
+    let reparsed_direct = reparsed.importers["."]
+        .iter()
+        .find(|dep| dep.name == "xlsx")
+        .unwrap();
+    let reparsed_pkg = &reparsed.packages[&reparsed_direct.dep_path];
+    assert!(matches!(
+        reparsed_pkg.local_source,
+        Some(LocalSource::RemoteTarball(_))
+    ));
+}
+
+#[test]
 fn test_parse_scoped_package() {
     let tmp = tempfile::NamedTempFile::new().unwrap();
     let content = r#"{

--- a/crates/aube-lockfile/src/npm/write.rs
+++ b/crates/aube-lockfile/src/npm/write.rs
@@ -122,8 +122,9 @@ struct WriteNpmPeerDepMeta {
 ///  - Registry `resolved` tarball URLs are emitted when they were
 ///    present in the parsed graph. Graphs synthesized without
 ///    `tarball_url` fall back to npm's tolerated no-`resolved` form.
-///  - Non-git local source entries (`file:`, URL tarballs) aren't
-///    emitted yet. Git sources emit their pinned `resolved:` URL.
+///  - Path-backed local source entries (`file:`, `link:`) aren't
+///    emitted yet. Git and remote-tarball sources emit their pinned
+///    `resolved:` URL.
 ///    Workspace `link:` packages are emitted as importer entries plus
 ///    a root `node_modules/<name>` link record.
 pub fn write(
@@ -135,11 +136,12 @@ pub fn write(
     // lookups from parent deps resolve to one canonical entry even if
     // the graph has several contextualized variants.
     let mut canonical = crate::build_canonical_map(graph);
-    for pkg in graph
-        .packages
-        .values()
-        .filter(|pkg| matches!(pkg.local_source, Some(LocalSource::Git(_))))
-    {
+    for pkg in graph.packages.values().filter(|pkg| {
+        matches!(
+            pkg.local_source,
+            Some(LocalSource::Git(_) | LocalSource::RemoteTarball(_))
+        )
+    }) {
         canonical
             .entry(super::canonical_key_from_dep_path(&pkg.dep_path))
             .or_insert(pkg);

--- a/crates/aube-lockfile/tests/proptest.rs
+++ b/crates/aube-lockfile/tests/proptest.rs
@@ -1,5 +1,5 @@
 use aube_lockfile::{
-    DepType, DirectDep, LockedPackage, LockfileGraph, LockfileKind, LockfileSettings,
+    DepType, DirectDep, LocalSource, LockedPackage, LockfileGraph, LockfileKind, LockfileSettings,
 };
 use proptest::prelude::*;
 use std::collections::BTreeMap;
@@ -210,6 +210,106 @@ fn roundtrip(
 }
 
 proptest! {
+    #[test]
+    fn npm_parser_classifies_declared_remote_tarballs(
+        nested in any::<bool>(),
+        scheme in prop_oneof![Just("http"), Just("https")],
+        host in "[a-z][a-z0-9-]{0,10}",
+        first_path in "[a-z][a-z0-9-]{0,10}",
+        second_path in "[a-z][a-z0-9-]{0,10}",
+        suffix in prop_oneof![Just(".tgz"), Just(".tar.gz?download=1"), Just("/download")],
+        integrity_tail in "[A-Za-z0-9]{8,24}",
+    ) {
+        let url = format!(
+            "{scheme}://{host}.example.test/{first_path}/{second_path}{suffix}"
+        );
+        let integrity = format!("sha512-{integrity_tail}");
+        let remote_path = if nested {
+            "node_modules/parent/node_modules/remote-pkg"
+        } else {
+            "node_modules/remote-pkg"
+        };
+
+        let mut packages = serde_json::Map::new();
+        let root_dependencies = if nested {
+            serde_json::json!({
+                "parent": "1.0.0",
+                "registry-pkg": "^2.0.0"
+            })
+        } else {
+            serde_json::json!({
+                "remote-pkg": url.clone(),
+                "registry-pkg": "^2.0.0"
+            })
+        };
+        packages.insert(
+            String::new(),
+            serde_json::json!({ "dependencies": root_dependencies }),
+        );
+        if nested {
+            packages.insert(
+                "node_modules/parent".to_string(),
+                serde_json::json!({
+                    "version": "1.0.0",
+                    "dependencies": { "remote-pkg": url.clone() }
+                }),
+            );
+        }
+        packages.insert(
+            remote_path.to_string(),
+            serde_json::json!({
+                "version": "3.0.0",
+                "resolved": url.clone(),
+                "integrity": integrity.clone()
+            }),
+        );
+        packages.insert(
+            "node_modules/registry-pkg".to_string(),
+            serde_json::json!({
+                "version": "2.1.0",
+                "resolved": "https://registry.npmjs.org/registry-pkg/-/registry-pkg-2.1.0.tgz",
+                "integrity": "sha512-registry"
+            }),
+        );
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let lockfile = serde_json::json!({
+            "lockfileVersion": 3,
+            "packages": packages
+        });
+        std::fs::write(
+            dir.path().join("package-lock.json"),
+            serde_json::to_vec(&lockfile).expect("serialize lockfile"),
+        )
+        .expect("write lockfile");
+
+        let graph = aube_lockfile::parse_lockfile(
+            dir.path(),
+            &aube_manifest::PackageJson::default(),
+        )
+        .expect("parse lockfile");
+        let remote = graph
+            .packages
+            .values()
+            .find(|pkg| pkg.name == "remote-pkg")
+            .expect("remote package");
+        let Some(LocalSource::RemoteTarball(source)) = &remote.local_source else {
+            return Err(TestCaseError::fail(format!(
+                "expected remote tarball source, got {:?}",
+                remote.local_source
+            )));
+        };
+        prop_assert_eq!(source.url.as_str(), url.as_str());
+        prop_assert_eq!(source.integrity.as_str(), integrity.as_str());
+
+        let registry = graph
+            .packages
+            .values()
+            .find(|pkg| pkg.name == "registry-pkg")
+            .expect("registry package");
+        prop_assert!(registry.local_source.is_none());
+    }
+
     #[test]
     fn pnpm_lockfile_roundtrips_generated_registry_graph(shape in graph_shapes()) {
         let (graph, manifest) = graph_from_shape(shape);


### PR DESCRIPTION
## Summary

- classify npm lockfile entries as remote tarballs when their `resolved` URL matches a declared HTTP(S) dependency specifier
- preserve remote-tarball integrity and URL identity across npm lockfile round-trips
- keep ordinary registry tarball URLs classified as registry packages

## Root cause

npm uses the same HTTP(S) `resolved` field for registry packages and direct tarball dependencies. The npm lockfile reader treated both as registry packages, so the default no-downgrade trust-policy validation queried the npm packument for direct tarballs. SheetJS 0.20.3 is distributed from its CDN rather than the npm registry, causing `registry packument has no metadata for xlsx@0.20.3`.

Fixes the failure reported in [Discussion #1276](https://github.com/jdx/aube/discussions/1276).

## Validation

- `cargo fmt --check`
- `cargo test -p aube-lockfile`
- `cargo test -p aube-lockfile npm::tests::test_parse_remote_tarball_from_declared_url`
- `cargo clippy -p aube-lockfile --all-targets -- -D warnings`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes npm lockfile package-source classification, which gates packument/trust-policy validation. Misclassification could skip registry checks or incorrectly treat registry packages as remote tarballs.
> 
> **Overview**
> Fixes npm lockfile parsing so **direct HTTP(S) tarball dependencies** (e.g. SheetJS CDN installs) are classified as `LocalSource::RemoteTarball` instead of registry packages.
> 
> npm uses the same `resolved` URL shape for both. The reader now collects declared URL dependency specs and matches package entries against them, preserving URL + integrity across round-trips and keeping ordinary registry tarballs unchanged. The writer also emits remote-tarball `resolved` URLs the same way it already does for git sources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81a054b8e7412fcfc0fc5cabb9847099d65d5694. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for recognizing npm packages installed from remote tarball URLs.
  - Preserves remote tarball URLs and integrity information when reading and writing lockfiles.
  - Includes remote tarball packages in canonical lockfile output.

- **Bug Fixes**
  - Improved npm lockfile round-trip handling for dependencies resolved from remote tarballs.
  - Clarified handling of path-based, Git, and remote-tarball package sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->