### PR TITLE
feat(manifest): make workspace yaml preservation optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,7 +200,7 @@ aube-registry = { path = "crates/aube-registry", version = "1" }
 aube-store = { path = "crates/aube-store", version = "1" }
 aube-linker = { path = "crates/aube-linker", version = "1" }
 aube-lockfile = { path = "crates/aube-lockfile", version = "1" }
-aube-manifest = { path = "crates/aube-manifest", version = "1" }
+aube-manifest = { path = "crates/aube-manifest", version = "1", default-features = false }
 aube-runtime = { path = "crates/aube-runtime", version = "1" }
 aube-scripts = { path = "crates/aube-scripts", version = "1" }
 aube-workspace = { path = "crates/aube-workspace", version = "1" }

--- a/crates/aube-manifest/Cargo.toml
+++ b/crates/aube-manifest/Cargo.toml
@@ -18,10 +18,17 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sonic-rs = { workspace = true }
 yaml_serde = { workspace = true }
-yamlpatch = { workspace = true }
-yamlpath = { workspace = true }
-serde_yaml = { workspace = true }
+yamlpatch = { workspace = true, optional = true }
+yamlpath = { workspace = true, optional = true }
+serde_yaml = { workspace = true, optional = true }
 thiserror = { workspace = true }
+
+[features]
+default = ["workspace-yaml-preserve"]
+# Preserve comments and formatting when mutating existing workspace YAML.
+# Embedders can omit this to avoid the tree-sitter dependency chain; writes
+# then fall back to serializing the complete document with canonical layout.
+workspace-yaml-preserve = ["dep:serde_yaml", "dep:yamlpatch", "dep:yamlpath"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/aube-manifest/src/workspace.rs
+++ b/crates/aube-manifest/src/workspace.rs
@@ -8,9 +8,10 @@
 //!   workspace-level mutation.
 //! - [`mutations`] — the domain-specific mutations: `allowBuilds`
 //!   and `patchedDependencies`.
-//! - [`yaml_patch`] — comment-preserving diff-and-apply on top of
-//!   `yamlpatch`, with a manual injector for new sub-mappings (which
-//!   `yamlpatch::Op::Add` mishandles).
+//! - `yaml_patch` — optional comment-preserving diff-and-apply on top
+//!   of `yamlpatch`, with a manual injector for new sub-mappings (which
+//!   `yamlpatch::Op::Add` mishandles). Enabled by the
+//!   `workspace-yaml-preserve` feature.
 //!
 //! The submodules are private; the public API is re-exported from
 //! this module so callers continue to use `aube_manifest::workspace::X`.
@@ -18,6 +19,7 @@
 mod config;
 mod edits;
 mod mutations;
+#[cfg(feature = "workspace-yaml-preserve")]
 mod yaml_patch;
 
 pub use config::{
@@ -569,6 +571,7 @@ updateConfig:
         );
     }
 
+    #[cfg(feature = "workspace-yaml-preserve")]
     #[test]
     fn edit_workspace_yaml_preserves_comments_around_unchanged_keys() {
         // The whole point of going through yamlpatch: a structural
@@ -616,6 +619,7 @@ allowBuilds:
         );
     }
 
+    #[cfg(feature = "workspace-yaml-preserve")]
     #[test]
     fn upsert_workspace_patched_dependency_preserves_comments_on_real_change() {
         // patch-commit on a workspace yaml that already documents
@@ -859,6 +863,7 @@ patchedDependencies:
         );
     }
 
+    #[cfg(feature = "workspace-yaml-preserve")]
     #[test]
     fn remove_workspace_patched_dependency_preserves_comments_on_real_remove() {
         // Removing one patch entry from a multi-entry list must keep

--- a/crates/aube-manifest/src/workspace/edits.rs
+++ b/crates/aube-manifest/src/workspace/edits.rs
@@ -8,6 +8,7 @@
 //! to mutate whichever file holds the value today.
 
 use super::config::{ConfigWriteTarget, config_write_target, workspace_yaml_existing};
+#[cfg(feature = "workspace-yaml-preserve")]
 use super::yaml_patch;
 use std::path::{Path, PathBuf};
 
@@ -328,16 +329,16 @@ pub(super) fn workspace_yaml_submap<'a>(
 /// Apply `f` to the parsed top-level mapping of the workspace yaml at
 /// `path` and write it back. The helper exists so every workspace-yaml
 /// writer (allowBuilds, patchedDependencies, catalog cleanup, future
-/// settings) shares one comment-preserving rule: **user-authored
-/// comments and formatting in the file survive every edit**.
+/// settings) shares one write path. With the default
+/// `workspace-yaml-preserve` feature, user-authored comments and formatting
+/// survive every edit. Without it, the complete document is serialized with
+/// canonical formatting.
 ///
-/// The closure mutates a parsed `yaml_serde::Mapping`. After it runs,
-/// the helper diffs before-vs-after and reduces the change set to a
-/// minimal sequence of `yamlpatch` operations applied directly to the
-/// original source. yamlpatch is comment- and format-preserving, so
-/// keys, comments, and whitespace that the closure didn't touch land
-/// back on disk byte-identical. A no-op closure produces an empty
-/// patch list and the file isn't rewritten at all.
+/// The closure mutates a parsed `yaml_serde::Mapping`. With preservation
+/// enabled, the helper reduces the before-vs-after diff to a minimal sequence
+/// of `yamlpatch` operations against the original source, leaving untouched
+/// content byte-identical. A no-op closure never rewrites the file in either
+/// mode.
 ///
 /// For brand-new or empty files there is no source to preserve, so the
 /// helper falls back to `yaml_serde::to_string` for the initial write.
@@ -385,13 +386,10 @@ where
     Ok(path.to_path_buf())
 }
 
-/// Persist a structural change against `path`. When `original_source`
-/// is `Some`, the change is encoded as a list of `yamlpatch`
-/// operations applied to the original text — comments and formatting
-/// the closure didn't touch survive the round trip. When it is `None`
-/// (fresh file or one that was empty), the after-state is serialized
-/// directly via `yaml_serde::to_string`; there is no source to
-/// preserve. Both paths atomic-write the result.
+/// Persist a structural change against `path` while preserving untouched
+/// comments and formatting. Fresh files are serialized directly because
+/// there is no original source to preserve.
+#[cfg(feature = "workspace-yaml-preserve")]
 fn write_workspace_yaml(
     path: &Path,
     original_source: Option<&str>,
@@ -409,6 +407,20 @@ fn write_workspace_yaml(
     aube_util::fs_atomic::atomic_write(path, &bytes)
         .map_err(|e| crate::Error::Io(path.to_path_buf(), e))?;
     Ok(())
+}
+
+#[cfg(not(feature = "workspace-yaml-preserve"))]
+fn write_workspace_yaml(
+    path: &Path,
+    _original_source: Option<&str>,
+    _before: &yaml_serde::Mapping,
+    after: &yaml_serde::Mapping,
+) -> Result<(), crate::Error> {
+    let raw = yaml_serde::to_string(&yaml_serde::Value::Mapping(after.clone()))
+        .map_err(|e| crate::Error::YamlParse(path.to_path_buf(), e.to_string()))?;
+    let bytes = indent_block_sequences(&raw);
+    aube_util::fs_atomic::atomic_write(path, bytes.as_bytes())
+        .map_err(|e| crate::Error::Io(path.to_path_buf(), e))
 }
 
 /// Bump every block-sequence item line (`- ...`) by two spaces. Leaves

--- a/crates/aube/Cargo.toml
+++ b/crates/aube/Cargo.toml
@@ -108,7 +108,14 @@ ratatui = { version = "0.30", default-features = false, features = ["crossterm",
 crossterm = { version = "0.29", optional = true }
 
 [features]
-default = ["mimalloc", "config-tui", "publish", "rustls", "hickory-dns"]
+default = [
+    "mimalloc",
+    "config-tui",
+    "publish",
+    "rustls",
+    "hickory-dns",
+    "workspace-yaml-preserve",
+]
 # Include the interactive `aube config tui` browser. Builds that want the
 # smallest dependency graph can disable default features and omit this.
 config-tui = ["dep:crossterm", "dep:ratatui"]
@@ -130,6 +137,9 @@ rustls = ["reqwest/rustls", "aube-registry/rustls", "aube-util/rustls"]
 # reqwest/hickory-dns directly — mirroring `rustls` — so the crate's own
 # reqwest clients keep it even if aube-registry's feature graph changes.
 hickory-dns = ["reqwest/hickory-dns", "aube-registry/hickory-dns"]
+# Preserve comments and formatting when commands mutate existing workspace
+# YAML. Embedders can omit this to avoid yamlpatch's tree-sitter dependencies.
+workspace-yaml-preserve = ["aube-manifest/workspace-yaml-preserve"]
 
 [dev-dependencies]
 clap-sort = "1"


### PR DESCRIPTION
## Summary

- add a default-on `workspace-yaml-preserve` feature to `aube-manifest` and forward it from `aube`
- make `yamlpatch`, `yamlpath`, and `serde_yaml` optional behind that feature
- retain comment- and format-preserving workspace YAML edits for standalone Aube
- fall back to a canonical full-document rewrite when embedders disable preservation

## Why

Mise embeds Aube's install API with default features disabled. It does not need Aube's comment-preserving `pnpm-workspace.yaml` mutation path, but that path currently pulls in `yamlpath` and `tree-sitter-iter` unconditionally. `tree-sitter-iter` 1.28+ requires Rust 1.97, above the distro compiler used to build mise.

This feature boundary lets embedders omit that dependency chain without changing the default Aube CLI behavior.

## Validation

- `cargo test -p aube-manifest`
- `cargo test -p aube-manifest --no-default-features`
- `cargo check -p aube --no-default-features --features rustls`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy -p aube --no-default-features --features rustls -- -D warnings`
- verified `cargo tree -p aube --no-default-features --features rustls` contains none of `yamlpath`, `yamlpatch`, or `tree-sitter-iter`

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Feature-gates an existing write path with a simple serialization fallback; default CLI behavior is unchanged and no security-sensitive logic is modified.
> 
> **Overview**
> Makes comment-preserving workspace YAML edits **optional** behind a default-on `workspace-yaml-preserve` feature, so embedders can drop the `yamlpatch`/`yamlpath`/tree-sitter dependency chain without changing standalone Aube behavior.
> 
> `yamlpatch`, `yamlpath`, and `serde_yaml` are now optional in `aube-manifest`. With the feature enabled (Aube CLI default), edits still preserve comments and formatting. Without it, `write_workspace_yaml` falls back to a full canonical rewrite. Comment-preservation tests are gated to the feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 815922a2d4d11284e5d67775a36c1187c80b1b42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional workspace YAML comment-preservation support.
  * Comment preservation is enabled by default for existing workspace files.
  * Projects can disable the feature to reduce related processing and dependencies.

* **Improvements**
  * When comment preservation is disabled, workspace YAML is saved in a consistent canonical format.
  * Newly created files continue to use the existing serialization behavior.
  * No-op edits avoid rewriting files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->