### PR TITLE
fix(access): resolve identity before listing own packages

### DIFF
--- a/crates/aube-registry/src/client/access.rs
+++ b/crates/aube-registry/src/client/access.rs
@@ -20,40 +20,65 @@ impl RegistryClient {
         &self,
         entity: Option<&str>,
     ) -> Result<serde_json::Value, Error> {
-        let scope_package = entity
-            .filter(|entity| entity.starts_with('@'))
-            .map(|entity| {
-                let scope = entity.split_once(':').map_or(entity, |(scope, _)| scope);
-                format!("{scope}/access")
-            });
+        let identity;
+        let entity = match entity {
+            Some(entity) => entity,
+            None => {
+                let registry_url = self.config.registry.as_str();
+                let url = format!("{}/-/whoami", registry_url.trim_end_matches('/'));
+                let value = self
+                    .access_request(
+                        reqwest::Method::GET,
+                        &url,
+                        AccessTarget {
+                            registry_url,
+                            auth_package_name: None,
+                            not_found: None,
+                        },
+                        None,
+                        None,
+                    )
+                    .await?;
+                identity = value
+                    .get("username")
+                    .and_then(serde_json::Value::as_str)
+                    .filter(|username| !username.is_empty())
+                    .ok_or_else(|| {
+                        Error::Io(std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            "registry returned an invalid identity",
+                        ))
+                    })?
+                    .to_string();
+                &identity
+            }
+        };
+        let scope_package = entity.starts_with('@').then(|| {
+            let scope = entity.split_once(':').map_or(entity, |(scope, _)| scope);
+            format!("{scope}/access")
+        });
         let registry_url = scope_package
             .as_deref()
             .map_or(self.config.registry.as_str(), |package| {
                 self.registry_url_for(package)
             });
-        let url = match entity {
-            None => format!(
-                "{}/-/package?format=cli",
-                registry_url.trim_end_matches('/')
+        let url = match entity.split_once(':') {
+            Some((scope, team)) => format!(
+                "{}/-/team/{}/{}/package?format=cli",
+                registry_url.trim_end_matches('/'),
+                encode_access_component(scope.trim_start_matches('@')),
+                encode_access_component(team),
             ),
-            Some(entity) => match entity.split_once(':') {
-                Some((scope, team)) => format!(
-                    "{}/-/team/{}/{}/package?format=cli",
-                    registry_url.trim_end_matches('/'),
-                    encode_access_component(scope.trim_start_matches('@')),
-                    encode_access_component(team),
-                ),
-                None if entity.starts_with('@') => format!(
-                    "{}/-/org/{}/package?format=cli",
-                    registry_url.trim_end_matches('/'),
-                    encode_access_component(entity.trim_start_matches('@')),
-                ),
-                None => format!(
-                    "{}/-/user/{}/package?format=cli",
-                    registry_url.trim_end_matches('/'),
-                    encode_access_component(entity),
-                ),
-            },
+            None if entity.starts_with('@') => format!(
+                "{}/-/org/{}/package?format=cli",
+                registry_url.trim_end_matches('/'),
+                encode_access_component(entity.trim_start_matches('@')),
+            ),
+            None => format!(
+                "{}/-/user/{}/package?format=cli",
+                registry_url.trim_end_matches('/'),
+                encode_access_component(entity),
+            ),
         };
         self.access_request(
             reqwest::Method::GET,
@@ -61,7 +86,7 @@ impl RegistryClient {
             AccessTarget {
                 registry_url,
                 auth_package_name: scope_package.as_deref(),
-                not_found: entity.map(AccessNotFound::Entity),
+                not_found: Some(AccessNotFound::Entity(entity)),
             },
             None,
             None,
@@ -401,6 +426,39 @@ mod tests {
             .access_list_packages(Some("@scope"))
             .await
             .expect("list organization packages");
+    }
+
+    #[tokio::test]
+    async fn package_list_resolves_the_current_user() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/-/whoami"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "username": "alice" })),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/-/user/alice/package"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "@alice/pkg": "read-write" })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = RegistryClient::from_config(NpmConfig {
+            registry: format!("{}/", server.uri()),
+            ..Default::default()
+        });
+        assert_eq!(
+            client
+                .access_list_packages(None)
+                .await
+                .expect("list current user's packages"),
+            serde_json::json!({ "@alice/pkg": "read-write" })
+        );
     }
 
     #[tokio::test]

--- a/crates/aube-registry/src/client/access.rs
+++ b/crates/aube-registry/src/client/access.rs
@@ -10,6 +10,7 @@ struct AccessTarget<'a> {
 
 enum AccessNotFound<'a> {
     Entity(&'a str),
+    Identity,
     Package(&'a str),
 }
 
@@ -33,7 +34,7 @@ impl RegistryClient {
                         AccessTarget {
                             registry_url,
                             auth_package_name: None,
-                            not_found: None,
+                            not_found: Some(AccessNotFound::Identity),
                         },
                         None,
                         None,
@@ -290,6 +291,7 @@ impl RegistryClient {
                         AccessNotFound::Entity(name) => {
                             Error::AccessEntityNotFound(name.to_string())
                         }
+                        AccessNotFound::Identity => Error::AccessIdentityUnavailable,
                         AccessNotFound::Package(name) => Error::NotFound(name.to_string()),
                     });
                 }
@@ -437,6 +439,7 @@ mod tests {
                 ResponseTemplate::new(200)
                     .set_body_json(serde_json::json!({ "username": "alice" })),
             )
+            .expect(1)
             .mount(&server)
             .await;
         Mock::given(method("GET"))
@@ -445,6 +448,7 @@ mod tests {
                 ResponseTemplate::new(200)
                     .set_body_json(serde_json::json!({ "@alice/pkg": "read-write" })),
             )
+            .expect(1)
             .mount(&server)
             .await;
 
@@ -459,6 +463,26 @@ mod tests {
                 .expect("list current user's packages"),
             serde_json::json!({ "@alice/pkg": "read-write" })
         );
+    }
+
+    #[tokio::test]
+    async fn package_list_reports_an_unavailable_identity_endpoint() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/-/whoami"))
+            .respond_with(ResponseTemplate::new(404))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = RegistryClient::from_config(NpmConfig {
+            registry: format!("{}/", server.uri()),
+            ..Default::default()
+        });
+        assert!(matches!(
+            client.access_list_packages(None).await,
+            Err(Error::AccessIdentityUnavailable)
+        ));
     }
 
     #[tokio::test]

--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -740,6 +740,9 @@ pub enum Error {
     #[error("access entity not found: {0}")]
     #[diagnostic(code(ERR_AUBE_ACCESS_ENTITY_NOT_FOUND))]
     AccessEntityNotFound(String),
+    #[error("registry identity endpoint is unavailable")]
+    #[diagnostic(code(ERR_AUBE_REGISTRY_ERROR))]
+    AccessIdentityUnavailable,
     #[error("version not found: {0}@{1}")]
     #[diagnostic(code(ERR_AUBE_VERSION_NOT_FOUND))]
     VersionNotFound(String, String),


### PR DESCRIPTION
## Summary

- resolve the authenticated registry identity before listing packages when no entity is supplied
- request the existing user-package endpoint instead of the stale `/-/package` route
- cover the identity-to-package-list request sequence with a registry-client regression test

## Root cause

`aube access ls` sent `GET /-/package?format=cli` when the user omitted an entity. npm's current flow resolves the authenticated username first and then requests `/-/user/<username>/package`. The stale route is rejected by npm-compatible registries; npmmirror surfaced that rejection as an unrelated `semver-spec` validation error.

Explicit user, organization, and team package-list routes are unchanged.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

Fixes the behavior reported in https://github.com/jdx/aube/discussions/1279.

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow registry-client bug fix for the no-entity package list path, with regression tests and no changes to credential handling or other access routes.
> 
> **Overview**
> Fixes `aube access ls` with no entity by matching npm's current flow: resolve the authenticated username via `/-/whoami`, then list packages from `/-/user/<username>/package` instead of the stale `/-/package` route that npm-compatible registries reject.
> 
> Adds `Error::AccessIdentityUnavailable` when the identity endpoint is missing, and covers the whoami → package-list path (plus the 404 case) with registry-client regression tests. Explicit user, org, and team listing routes are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13ee5b96a86b2147ad5a89f8962f46f04a60fbaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Package listings can now be retrieved automatically for the currently signed-in user when no account is specified.
  * Explicit package listings continue to support users, teams, and organizations with scoped registry selection.

* **Bug Fixes**
  * Improved handling of usernames and URL components when retrieving package lists.
  * Added clearer error reporting when the registry cannot provide identity information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->