### PR TITLE
fix(lockfile): preserve existing npm hoist choices

### DIFF
--- a/crates/aube-lockfile/src/bun/write.rs
+++ b/crates/aube-lockfile/src/bun/write.rs
@@ -76,7 +76,7 @@ pub fn write(
             all_roots.push(d.clone());
         }
     }
-    let tree = crate::npm::build_hoist_tree(&canonical, &all_roots);
+    let tree = crate::npm::build_hoist_tree(&canonical, &all_roots, None);
 
     // Non-root workspaces are read fresh from disk because the caller
     // doesn't thread them through — the root manifest is the only one

--- a/crates/aube-lockfile/src/npm/layout.rs
+++ b/crates/aube-lockfile/src/npm/layout.rs
@@ -1,5 +1,5 @@
 use crate::{DirectDep, LockedPackage};
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use super::raw::InstallPathInfo;
 
@@ -117,6 +117,7 @@ pub(crate) fn segments_to_install_path(segs: &[String]) -> String {
 pub(crate) fn build_hoist_tree(
     canonical: &BTreeMap<String, &LockedPackage>,
     roots: &[DirectDep],
+    preferred_roots: Option<&BTreeMap<String, String>>,
 ) -> BTreeMap<Vec<String>, String> {
     let mut placed: BTreeMap<Vec<String>, String> = BTreeMap::new();
     let mut queue: VecDeque<(Vec<String>, String)> = VecDeque::new();
@@ -129,6 +130,27 @@ pub(crate) fn build_hoist_tree(
         let segs = vec![dep.name.clone()];
         if placed.insert(segs.clone(), key.clone()).is_none() {
             queue.push_back((segs, key));
+        }
+    }
+
+    // npm preserves an existing valid top-level placement when an install
+    // changes an unrelated dependency. Seed those choices before traversing
+    // transitives so the first BFS path to a multi-version package does not
+    // arbitrarily replace the version npm had already hoisted. Direct roots
+    // above remain authoritative, and the reachability gate prevents stale
+    // lockfile entries from surviving after their last edge is removed.
+    if let Some(preferred_roots) = preferred_roots {
+        let reachable = reachable_canonical_keys(canonical, roots);
+        for (name, key) in preferred_roots {
+            if !reachable.contains(key) {
+                continue;
+            }
+            let root_slot = vec![name.clone()];
+            if placed.contains_key(&root_slot) {
+                continue;
+            }
+            placed.insert(root_slot.clone(), key.clone());
+            queue.push_back((root_slot, key.clone()));
         }
     }
 
@@ -185,6 +207,32 @@ pub(crate) fn build_hoist_tree(
     }
 
     placed
+}
+
+fn reachable_canonical_keys(
+    canonical: &BTreeMap<String, &LockedPackage>,
+    roots: &[DirectDep],
+) -> BTreeSet<String> {
+    let mut reachable = BTreeSet::new();
+    let mut queue = VecDeque::new();
+    for dep in roots {
+        let key = canonical_key_from_dep_path(&dep.dep_path);
+        if canonical.contains_key(&key) && reachable.insert(key.clone()) {
+            queue.push_back(key);
+        }
+    }
+    while let Some(key) = queue.pop_front() {
+        let Some(pkg) = canonical.get(&key).copied() else {
+            continue;
+        };
+        for (child_name, child_value) in &pkg.dependencies {
+            let child_key = child_canonical_key(child_name, child_value);
+            if canonical.contains_key(&child_key) && reachable.insert(child_key.clone()) {
+                queue.push_back(child_key);
+            }
+        }
+    }
+    reachable
 }
 
 /// Three-way result of an ancestor-chain lookup. Differentiating

--- a/crates/aube-lockfile/src/npm/tests.rs
+++ b/crates/aube-lockfile/src/npm/tests.rs
@@ -499,6 +499,69 @@ fn test_parse_multi_version_nested() {
     assert_eq!(root_bar.dep_path, "bar@2.0.0");
 }
 
+#[test]
+fn test_write_preserves_reachable_existing_root_version() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let content = r#"{
+        "lockfileVersion": 3,
+        "packages": {
+            "": { "dependencies": { "app": "1.0.0" } },
+            "node_modules/app": {
+                "version": "1.0.0",
+                "dependencies": { "a-newer": "1.0.0", "z-older": "1.0.0" }
+            },
+            "node_modules/a-newer": {
+                "version": "1.0.0",
+                "dependencies": { "shared": "^2.0.0" }
+            },
+            "node_modules/a-newer/node_modules/shared": { "version": "2.0.0" },
+            "node_modules/shared": { "version": "1.0.0" },
+            "node_modules/z-older": {
+                "version": "1.0.0",
+                "dependencies": { "shared": "^1.0.0" }
+            }
+        }
+    }"#;
+    std::fs::write(tmp.path(), content).unwrap();
+
+    let mut graph = parse(tmp.path()).unwrap();
+    let manifest = aube_manifest::PackageJson {
+        dependencies: [("app".to_string(), "1.0.0".to_string())]
+            .into_iter()
+            .collect(),
+        ..Default::default()
+    };
+    write(tmp.path(), &graph, &manifest).unwrap();
+
+    let json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(tmp.path()).unwrap()).unwrap();
+    assert_eq!(json["packages"]["node_modules/shared"]["version"], "1.0.0");
+    assert_eq!(
+        json["packages"]["node_modules/a-newer/node_modules/shared"]["version"],
+        "2.0.0"
+    );
+
+    // Once the last edge to the preferred version disappears, it must not be
+    // kept merely because the previous lockfile had hoisted it.
+    graph
+        .packages
+        .get_mut("app@1.0.0")
+        .unwrap()
+        .dependencies
+        .remove("z-older");
+    graph.packages.remove("z-older@1.0.0");
+    write(tmp.path(), &graph, &manifest).unwrap();
+    let json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(tmp.path()).unwrap()).unwrap();
+    assert_eq!(json["packages"]["node_modules/shared"]["version"], "2.0.0");
+    assert!(
+        json["packages"]
+            .get("node_modules/a-newer/node_modules/shared")
+            .is_none(),
+        "the stale preferred root must be replaced instead of nested"
+    );
+}
+
 /// Regression: a package reachable from both a dev root and
 /// an optional root (but *not* from any production root) must
 /// be written with `devOptional: true`, not with both `dev: true`

--- a/crates/aube-lockfile/src/npm/write.rs
+++ b/crates/aube-lockfile/src/npm/write.rs
@@ -3,6 +3,8 @@ use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::path::Path;
 
+use super::raw::RawNpmLockfile;
+
 #[derive(Debug, Serialize)]
 struct WriteNpmLockfile<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -167,7 +169,8 @@ pub fn write(
     // `["foo", "bar"]` for `node_modules/foo/node_modules/bar`. Shared
     // with bun (which renders the same segment list as `foo/bar`).
     let root_tree_roots = non_link_roots(graph, &roots);
-    let tree = super::build_hoist_tree(&canonical, &root_tree_roots);
+    let preferred_roots = preferred_root_placements(path, &canonical);
+    let tree = super::build_hoist_tree(&canonical, &root_tree_roots, Some(&preferred_roots));
     // For the npm writer, re-key the tree by install_path strings.
     let mut placed: BTreeMap<String, String> = tree
         .into_iter()
@@ -225,7 +228,7 @@ pub fn write(
         );
 
         let workspace_tree_roots = non_link_roots(graph, importer_roots);
-        let workspace_tree = super::build_hoist_tree(&canonical, &workspace_tree_roots);
+        let workspace_tree = super::build_hoist_tree(&canonical, &workspace_tree_roots, None);
         // Skip subtrees whose top-level segment is already hoisted to
         // `node_modules/<name>` at the same canonical version: Node's
         // upward `node_modules` walk from `<importer>/...` resolves to
@@ -416,6 +419,45 @@ pub fn write(
     body.push('\n');
     crate::atomic_write_lockfile(path, body.as_bytes())?;
     Ok(())
+}
+
+/// Read npm's existing top-level install choices before replacing the file.
+/// This is best-effort: new destinations and malformed files have no layout
+/// preference, while the caller's normal parse path remains responsible for
+/// surfacing errors from an existing project lockfile.
+fn preferred_root_placements(
+    path: &Path,
+    canonical: &BTreeMap<String, &LockedPackage>,
+) -> BTreeMap<String, String> {
+    let Ok(content) = crate::read_lockfile(path) else {
+        return BTreeMap::new();
+    };
+    let Ok(raw) = crate::parse_json::<RawNpmLockfile>(path, content) else {
+        return BTreeMap::new();
+    };
+    let mut preferred = BTreeMap::new();
+    for (install_path, entry) in raw.packages {
+        if entry.link {
+            continue;
+        }
+        let Some(rest) = install_path.strip_prefix("node_modules/") else {
+            continue;
+        };
+        if rest.contains("/node_modules/") {
+            continue;
+        }
+        let Some(name) = super::layout::package_name_from_install_path(&install_path) else {
+            continue;
+        };
+        let Some(version) = entry.version else {
+            continue;
+        };
+        let key = format!("{name}@{version}");
+        if canonical.contains_key(&key) {
+            preferred.insert(name, key);
+        }
+    }
+    preferred
 }
 
 fn workspace_package_for_importer<'a>(


### PR DESCRIPTION
## Summary

- preserve still-reachable top-level placements from an existing npm lockfile
- seed the npm hoist walk with those placements before traversing transitives
- discard stale preferences after their last dependency edge is removed
- add regression coverage for both preservation and pruning

## Root cause

The npm reader flattens physical `node_modules/...` paths into canonical package identities. When `aube add` or `install --fix-lockfile` rewrote the lockfile, the writer rebuilt the entire hoist tree with aube's BFS ordering. A different valid version could therefore win a top-level slot even when the operation changed an unrelated dependency.

Fixes the behavior reported in [discussion #1286](https://github.com/jdx/aube/discussions/1286).

## Validation

- `cargo fmt --check`
- `cargo test -p aube-lockfile` (410 passed, 1 ignored, plus integration/property tests)
- `cargo clippy --all-targets -- -D warnings`
- reporter's `npm-lock-add-reresolve/repro.sh` against rebuilt aube 1.38.1 debug
- manual `aube install --fix-lockfile` check on the same fixture

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes npm lockfile physical layout logic, which affects install resolution; mitigated by reachability gating, direct-root precedence, and new regression tests.
> 
> **Overview**
> Rewriting **package-lock.json** no longer picks arbitrary top-level versions when only unrelated deps change. The npm writer reads existing **top-level** `node_modules/<pkg>` placements from disk and passes them into **`build_hoist_tree`** as optional seeds before the BFS hoist walk.
> 
> **Direct root deps** still win occupied slots. Seeds apply only when the canonical package is **still reachable** from current roots, so a version kept only because the old lockfile hoisted it is dropped once its last dependency edge is gone. Bun and per-workspace hoist trees still call **`build_hoist_tree`** with no preferences (`None`).
> 
> Regression test **`test_write_preserves_reachable_existing_root_version`** covers stable multi-version layout on rewrite and cleanup after removing the edge that required the old root version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5322da3272154fa489a079898ab782c32d68110b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved npm lockfile updates to preserve compatible existing top-level package placements.
  * Prevented stale hoisted package entries from being retained when they are no longer reachable.
  * Preserved reachable hoisted versions while maintaining newer nested versions where applicable.
  * Added coverage for lockfile updates involving removed dependency paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->