### PR TITLE
fix(install): track actual hoisted direct entries

### DIFF
--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -1124,14 +1124,33 @@ impl InstallLayoutState {
         // "Already up to date" and never relinked the member.
         let mut direct_entries = BTreeMap::new();
         for (importer, deps) in &layout.graph.importers {
-            let modules_base = if importer == "." {
-                project_dir.join(layout.modules_dir_name)
+            let importer_dir = if importer == "." {
+                project_dir.to_path_buf()
             } else {
-                project_dir.join(importer).join(layout.modules_dir_name)
+                aube_util::path::normalize_lexical(&project_dir.join(importer))
             };
             let entries = deps
                 .iter()
-                .map(|dep| relative_path_or_original(&modules_base.join(&dep.name), project_dir))
+                .map(|dep| {
+                    let importer_entry = importer_dir.join(layout.modules_dir_name).join(&dep.name);
+                    // A workspace-wide hoist may satisfy this direct edge from
+                    // an ancestor node_modules. Record the first placement Node
+                    // can actually see instead of a local slot the linker
+                    // intentionally left absent.
+                    let entry = layout
+                        .placements
+                        .filter(|_| matches!(layout.node_linker, aube_linker::NodeLinker::Hoisted))
+                        .and_then(|placements| {
+                            let package_dirs = placements.all_package_dirs(&dep.dep_path);
+                            importer_dir.ancestors().find_map(|ancestor| {
+                                let candidate =
+                                    ancestor.join(layout.modules_dir_name).join(&dep.name);
+                                package_dirs.contains(&candidate).then_some(candidate)
+                            })
+                        })
+                        .unwrap_or(importer_entry);
+                    relative_path_or_original(&entry, project_dir)
+                })
                 .collect();
             direct_entries.insert(importer.clone(), entries);
         }
@@ -1736,6 +1755,47 @@ mod tests {
         assert_eq!(
             layout.direct_entries.get("packages/svc"),
             Some(&vec!["packages/svc/node_modules/zod".to_string()])
+        );
+    }
+
+    #[test]
+    fn from_graph_records_visible_hoisted_entries_for_workspace_importers() {
+        let project_dir = temp_project_dir("layout-hoisted-importer");
+        let aube_dir = project_dir.join("node_modules/.aube");
+        let dep = aube_lockfile::DirectDep {
+            name: "is-number".to_string(),
+            dep_path: "is-number@7.0.0".to_string(),
+            dep_type: aube_lockfile::DepType::Production,
+            specifier: None,
+        };
+        let graph = aube_lockfile::LockfileGraph {
+            importers: BTreeMap::from([
+                (".".to_string(), Vec::new()),
+                ("packages/app".to_string(), vec![dep]),
+            ]),
+            ..Default::default()
+        };
+        let placements = aube_linker::HoistedPlacements::from_package_dirs(BTreeMap::from([(
+            "is-number@7.0.0".to_string(),
+            vec![project_dir.join("node_modules/is-number")],
+        )]));
+
+        let layout = InstallLayoutState::from_graph(
+            &project_dir,
+            &WriteStateLayout {
+                graph: &graph,
+                node_linker: aube_linker::NodeLinker::Hoisted,
+                hoisting_limits: aube_linker::HoistingLimits::None,
+                modules_dir_name: "node_modules",
+                aube_dir: &aube_dir,
+                virtual_store_dir_max_length: 120,
+                placements: Some(&placements),
+            },
+        );
+
+        assert_eq!(
+            layout.direct_entries.get("packages/app"),
+            Some(&vec!["node_modules/is-number".to_string()])
         );
     }
 

--- a/test/hoisted.bats
+++ b/test/hoisted.bats
@@ -111,6 +111,35 @@ test "$(realpath "$app")" = "$(realpath "$lib")"
 	assert_success
 }
 
+@test "hoisted workspace root placements stay warm before scripts" {
+	mkdir -p packages/app
+	cat >package.json <<'JSON'
+{"name":"root","private":true,"scripts":{"ok":"printf 'ok\\n'"}}
+JSON
+	cat >pnpm-workspace.yaml <<'YAML'
+packages:
+  - packages/*
+nodeLinker: hoisted
+YAML
+	cat >packages/app/package.json <<'JSON'
+{"name":"app","private":true,"dependencies":{"is-number":"7.0.0"}}
+JSON
+
+	run aube install
+	assert_success
+	assert_dir_exists node_modules/is-number
+	assert_not_exists packages/app/node_modules/is-number
+
+	run aube run ok
+	assert_success
+	assert_output "ok"
+	refute_output --partial "Auto-installing"
+	run aube run ok
+	assert_success
+	assert_output "ok"
+	refute_output --partial "Auto-installing"
+}
+
 @test "hoistingLimits=workspaces keeps dependencies under each workspace" {
 	mkdir -p packages/app packages/lib
 	cat >package.json <<'JSON'


### PR DESCRIPTION
## Summary

- record the actual ancestor-visible placement for direct dependencies in hoisted workspaces
- retain importer-local fallback paths for isolated and non-planner entries
- cover repeated warm script checks after a dependency is shared at the workspace root

## Root cause

The install state always recorded `<importer>/node_modules/<name>` for every direct dependency. Workspace-wide hoisting intentionally leaves that path absent when the dependency is shared from an ancestor `node_modules`, so every freshness check treated a valid layout as stale and reinstalled the same tree.

## Validation

- `cargo test -p aube state::tests`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `mise run test:bats test/hoisted.bats --filter 'hoisted workspace root placements stay warm'`
- public reproduction from [discussion 1292](https://github.com/jdx/aube/discussions/1292)

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install freshness/layout verification on a hot path (`aube run`); behavior is scoped to hoisted linker with placements, with isolated fallback unchanged.
> 
> **Overview**
> Fixes false **install warm-path misses** in hoisted workspaces where a member’s direct dependency is satisfied from the **root** `node_modules` and the member-local slot is intentionally empty.
> 
> When persisting `direct_entries` in `InstallLayoutState::from_graph`, the code no longer always records `<importer>/node_modules/<name>`. For **hoisted** installs it uses `HoistedPlacements` to store the first **ancestor-visible** path Node can resolve (e.g. `node_modules/is-number` for `packages/app`), walking importer ancestors until a recorded placement matches. **Isolated** mode and missing placement data still use the local importer path.
> 
> Adds a unit test for hoisted workspace importers and a bats case that repeated `aube run` does not trigger **Auto-installing** when deps live only at the workspace root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44f16e56599a8f88049c793871ded7781c73efc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed dependency visibility for workspace projects using hoisted installations.
  - Lifecycle scripts can now reliably access hoisted dependencies before installation.
  - Ensured dependency availability remains consistent across repeated runs without unnecessary automatic installation.
- **Tests**
  - Added regression coverage for hoisted workspace dependency placement and repeated command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->