### PR TITLE
fix(install): disable global virtual store for Metro apps

### DIFF
--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -1183,7 +1183,7 @@ examples = [
 [disableGlobalVirtualStoreForPackages]
 description = "Package names whose presence in any importer forces per-project materialization."
 type = "list<string>"
-default = "[\"next\", \"nuxt\", \"parcel\"]"
+default = "[\"next\", \"nuxt\", \"parcel\", \"expo\", \"react-native\", \"metro\"]"
 docs = """
 aube's global virtual store makes `node_modules/.aube/<pkg>` an
 absolute symlink into `~/.cache/aube/virtual-store/`. Tools whose
@@ -1197,11 +1197,15 @@ When `aube install` finds one of these names in any importer's
 forces per-project materialization for that install and prints a
 one-line warning naming the trigger.
 
-The default list — `next`, `nuxt`, `parcel` —
-covers the tools with concrete walk-up failures: Next.js's Turbopack
+The default list — `next`, `nuxt`, `parcel`, `expo`, `react-native`, `metro` —
+covers the tools with concrete filesystem-root failures: Next.js's Turbopack
 canonicalizes through symlinks and walks up for app-router/monorepo detection,
 Nuxt plugins walk up for config discovery, and Parcel's resolver walks up for
-`.parcelrc`. Vite and VitePress are compatible with the global virtual store:
+`.parcelrc`. Metro's file map requires symlink targets to stay within the project
+root or configured watch folders; Expo and React Native use Metro but normally
+declare their framework package rather than `metro` directly.
+
+Vite and VitePress are compatible with the global virtual store:
 aube writes `node_modules/.modules.yaml` with the store location, which Vite
 8.1+ reads when constructing its filesystem allow-list. For older Vite
 versions, aube materializes only the Vite dependency path locally and backports

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -1245,7 +1245,7 @@ Examples:
 Package names whose presence in any importer forces per-project materialization.
 
 - Type: `list<string>`
-- Default: `["next", "nuxt", "parcel"]`
+- Default: `["next", "nuxt", "parcel", "expo", "react-native", "metro"]`
 - Environment: `npm_config_disable_global_virtual_store_for_packages`, `NPM_CONFIG_DISABLE_GLOBAL_VIRTUAL_STORE_FOR_PACKAGES`, `AUBE_DISABLE_GLOBAL_VIRTUAL_STORE_FOR_PACKAGES`
 - .npmrc keys: `disableGlobalVirtualStoreForPackages`, `disable-global-virtual-store-for-packages`
 - Workspace YAML keys: `disableGlobalVirtualStoreForPackages`
@@ -1262,11 +1262,15 @@ When `aube install` finds one of these names in any importer's
 forces per-project materialization for that install and prints a
 one-line warning naming the trigger.
 
-The default list — `next`, `nuxt`, `parcel` —
-covers the tools with concrete walk-up failures: Next.js's Turbopack
+The default list — `next`, `nuxt`, `parcel`, `expo`, `react-native`, `metro` —
+covers the tools with concrete filesystem-root failures: Next.js's Turbopack
 canonicalizes through symlinks and walks up for app-router/monorepo detection,
 Nuxt plugins walk up for config discovery, and Parcel's resolver walks up for
-`.parcelrc`. Vite and VitePress are compatible with the global virtual store:
+`.parcelrc`. Metro's file map requires symlink targets to stay within the project
+root or configured watch folders; Expo and React Native use Metro but normally
+declare their framework package rather than `metro` directly.
+
+Vite and VitePress are compatible with the global virtual store:
 aube writes `node_modules/.modules.yaml` with the store location, which Vite
 8.1+ reads when constructing its filesystem allow-list. For older Vite
 versions, aube materializes only the Vite dependency path locally and backports

--- a/test/nextjs_gvs_autodisable.bats
+++ b/test/nextjs_gvs_autodisable.bats
@@ -93,19 +93,19 @@ JSON
 	for package in expo react-native metro; do
 		_make_fake_dep "$package"
 		mkdir "app-$package"
-		cd "app-$package"
-		cat >package.json <<JSON
+		(
+			cd "app-$package"
+			cat >package.json <<JSON
 {"name":"app-$package","version":"0.0.0","dependencies":{"$package":"link:../fake-$package","is-odd":"3.0.1"}}
 JSON
 
-		run aube install
-		assert_success
-		assert_output --partial "disableGlobalVirtualStoreForPackages"
-		assert_output --partial "\`$package\`"
-		[ -d node_modules/.aube/is-odd@3.0.1 ]
-		[ ! -L node_modules/.aube/is-odd@3.0.1 ]
-
-		cd ..
+			run aube install
+			assert_success
+			assert_output --partial "disableGlobalVirtualStoreForPackages"
+			assert_output --partial "\`$package\`"
+			[ -d node_modules/.aube/is-odd@3.0.1 ]
+			[ ! -L node_modules/.aube/is-odd@3.0.1 ]
+		)
 	done
 }
 

--- a/test/nextjs_gvs_autodisable.bats
+++ b/test/nextjs_gvs_autodisable.bats
@@ -4,7 +4,10 @@
 # `disableGlobalVirtualStoreForPackages` is present in an importer's
 # deps. Next.js's Turbopack canonicalizes every `node_modules/<pkg>`
 # symlink and rejects targets outside the project root, which aube's
-# gvs layout produces by default. Vite is deliberately absent because
+# gvs layout produces by default. Metro's file map likewise requires
+# external symlink targets to be included in `watchFolders`; Expo and
+# React Native use Metro but normally declare their framework package.
+# Vite is deliberately absent because
 # 8.1+ reads the `.modules.yaml` metadata aube writes. The setting is
 # the extension point: add any tool with the same restriction, or set
 # to `[]` to disable the heuristic.
@@ -84,6 +87,26 @@ JSON
 	assert_success
 	assert_output --partial "disableGlobalVirtualStoreForPackages"
 	assert_output --partial "\`next\`"
+}
+
+@test "Metro ecosystem packages disable the global virtual store by default" {
+	for package in expo react-native metro; do
+		_make_fake_dep "$package"
+		mkdir "app-$package"
+		cd "app-$package"
+		cat >package.json <<JSON
+{"name":"app-$package","version":"0.0.0","dependencies":{"$package":"link:../fake-$package","is-odd":"3.0.1"}}
+JSON
+
+		run aube install
+		assert_success
+		assert_output --partial "disableGlobalVirtualStoreForPackages"
+		assert_output --partial "\`$package\`"
+		[ -d node_modules/.aube/is-odd@3.0.1 ]
+		[ ! -L node_modules/.aube/is-odd@3.0.1 ]
+
+		cd ..
+	done
 }
 
 @test "aube install does not warn when no listed package is present" {


### PR DESCRIPTION
## Summary

- add `expo`, `react-native`, and `metro` to the default `disableGlobalVirtualStoreForPackages` list
- document Metro's requirement that external symlink targets appear in `watchFolders`
- cover all three new direct-dependency triggers in the GVS auto-disable BATS suite

## Why

Metro's file map cannot resolve packages whose realpaths live in aube's global virtual store outside the project root. This affects standalone Metro projects as well as typical Expo and React Native apps. Per-project materialization keeps those realpaths inside the project and restores resolution.

Explicit `--enable-global-virtual-store` continues to override the compatibility heuristic by design.

Closes the compatibility gap reported in https://github.com/jdx/aube/discussions/1294.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `mise run test:bats test/nextjs_gvs_autodisable.bats`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default-only config change with existing heuristic; affects install layout/disk for Metro/Expo/RN projects but does not alter override flags or core linker logic.
> 
> **Overview**
> Extends the default **`disableGlobalVirtualStoreForPackages`** list with **`expo`**, **`react-native`**, and **`metro`**, so `aube install` automatically switches to **per-project** virtual-store materialization when any of those names appear in an importer’s deps (same warning/heuristic as Next/Nuxt/Parcel).
> 
> Docs in **`settings.toml`** and **`docs/settings/index.md`** now describe Metro’s symlink/`watchFolders` constraint and note that Expo/React Native usually depend on the framework package rather than `metro` directly.
> 
> A new BATS case loops over all three packages and asserts the disable warning plus non-symlinked **`node_modules/.aube/`** layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8e078d7fea8230e2fa83150f24a1d6059e38ca5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for Expo, React Native, and Metro projects by automatically disabling the global virtual store when needed.
  * Prevented Metro-related filesystem-root failures and ensured project dependencies are materialized correctly.

* **Documentation**
  * Expanded settings documentation with the updated default package list and guidance for Metro, Expo, and React Native projects.

* **Tests**
  * Added coverage confirming the compatibility behavior for Metro-based frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->