### PR TITLE
fix(linker): repair stale nested gvs links

### DIFF
--- a/crates/aube-linker/src/link.rs
+++ b/crates/aube-linker/src/link.rs
@@ -7,8 +7,8 @@ use crate::patches::{
 use crate::pool::with_link_pool;
 use crate::sweep::{
     EntryState, classify_entry_state, classify_local_entry_state, is_physical_importer, mkdirp,
-    remove_hidden_hoist_tree, sweep_dead_hidden_hoist_entries, sweep_stale_tmp_dirs,
-    sweep_stale_top_level_entries, try_remove_entry,
+    reconcile_dir_link, remove_hidden_hoist_tree, sweep_dead_hidden_hoist_entries,
+    sweep_stale_tmp_dirs, sweep_stale_top_level_entries, try_remove_entry,
 };
 use crate::{Error, HoistedPlacements, LinkStats, Linker, NodeLinker, hoisted, sys};
 use aube_lockfile::{LocalSource, LockedPackage, LockfileGraph};
@@ -322,6 +322,13 @@ impl Linker {
                             };
 
                             if matches!(state, EntryState::Fresh) {
+                                if !project_local {
+                                    self.reconcile_virtual_store_entry(
+                                        dep_path,
+                                        pkg,
+                                        nested_link_targets.as_ref(),
+                                    )?;
+                                }
                                 local_stats.packages_cached += 1;
                                 return Ok(local_stats);
                             }
@@ -533,7 +540,7 @@ impl Linker {
                         let link_parent = target_dir.parent().unwrap_or(&nm);
                         let rel_target =
                             pathdiff::diff_paths(&abs_target, link_parent).unwrap_or(abs_target);
-                        if reconcile_top_level_link(&target_dir, &rel_target)? {
+                        if reconcile_dir_link(&target_dir, &rel_target)? {
                             return Ok(false);
                         }
                         if let Some(parent) = target_dir.parent() {
@@ -564,7 +571,7 @@ impl Linker {
                     // old `node_modules/<name>` symlink but it now points
                     // at a stale `.aube/<old-dep-path>`; we need to
                     // rewrite it to the new `.aube/<new-dep-path>`.
-                    if reconcile_top_level_link(&target_dir, &rel_target)? {
+                    if reconcile_dir_link(&target_dir, &rel_target)? {
                         return Ok(false);
                     }
                     if let Some(parent) = target_dir.parent() {
@@ -916,6 +923,13 @@ impl Linker {
                             };
 
                             if matches!(state, EntryState::Fresh) {
+                                if !project_local {
+                                    self.reconcile_virtual_store_entry(
+                                        dep_path,
+                                        pkg,
+                                        nested_link_targets.as_ref(),
+                                    )?;
+                                }
                                 local_stats.packages_cached += 1;
                                 return Ok(local_stats);
                             }
@@ -1262,7 +1276,7 @@ impl Linker {
                         let link_parent = link_path.parent().unwrap_or(nm);
                         let rel_target =
                             pathdiff::diff_paths(ws_dir, link_parent).unwrap_or(ws_dir.clone());
-                        if reconcile_top_level_link(&link_path, &rel_target)? {
+                        if reconcile_dir_link(&link_path, &rel_target)? {
                             return Ok(false);
                         }
                         if let Some(parent) = link_path.parent() {
@@ -1281,7 +1295,7 @@ impl Linker {
                         let link_parent = link_path.parent().unwrap_or(nm);
                         let rel_target =
                             pathdiff::diff_paths(&abs_target, link_parent).unwrap_or(abs_target);
-                        if reconcile_top_level_link(&link_path, &rel_target)? {
+                        if reconcile_dir_link(&link_path, &rel_target)? {
                             return Ok(false);
                         }
                         if let Some(parent) = link_path.parent() {
@@ -1304,7 +1318,7 @@ impl Linker {
                     let link_parent = link_path.parent().unwrap_or(nm);
                     let rel_target = pathdiff::diff_paths(&source_dir, link_parent)
                         .unwrap_or_else(|| source_dir.clone());
-                    if reconcile_top_level_link(&link_path, &rel_target)? {
+                    if reconcile_dir_link(&link_path, &rel_target)? {
                         return Ok(false);
                     }
                     if let Some(parent) = link_path.parent() {
@@ -1475,7 +1489,7 @@ impl Linker {
             let link_parent = target_dir.parent().unwrap_or(&hidden);
             let rel_target = pathdiff::diff_paths(&source_dir, link_parent)
                 .unwrap_or_else(|| source_dir.clone());
-            if reconcile_top_level_link(&target_dir, &rel_target)? {
+            if reconcile_dir_link(&target_dir, &rel_target)? {
                 continue;
             }
             sys::create_dir_link(&rel_target, &target_dir)
@@ -1579,7 +1593,7 @@ impl Linker {
             let link_parent = target_dir.parent().unwrap_or(nm);
             let rel_target = pathdiff::diff_paths(&source_dir, link_parent)
                 .unwrap_or_else(|| source_dir.clone());
-            if reconcile_top_level_link(&target_dir, &rel_target)? {
+            if reconcile_dir_link(&target_dir, &rel_target)? {
                 continue;
             }
             if let Some(parent) = target_dir.parent() {
@@ -1591,119 +1605,6 @@ impl Linker {
             stats.top_level_linked += 1;
         }
         Ok(())
-    }
-}
-
-/// Decide whether an existing `node_modules/<name>` entry can be left
-/// alone, or must be removed so the caller can recreate it.
-///
-/// Returns `Ok(true)` when a live entry is present and should be
-/// preserved. Returns `Ok(false)` when nothing is there (or a broken
-/// link was reclaimed) and the caller should proceed to create the
-/// entry. `symlink_metadata().is_ok()` on its own treats a dangling
-/// symlink — whose `.aube/<dep_path>/...` target has been deleted — as
-/// "already in place", which silently leaves the project unresolvable.
-///
-/// `sys::create_dir_link` produces a Unix symlink on Unix and an NTFS
-/// junction on Windows. A junction's `file_type().is_symlink()` is
-/// `false`, so we trust the `symlink_metadata().is_ok() && !exists()`
-/// pair to identify "something is at `path` but its target is gone",
-/// and use the same `remove_dir().or_else(remove_file())` fallback
-/// used elsewhere in this file to unlink both shapes.
-/// Reconcile a top-level `node_modules/<name>` entry against the
-/// expected symlink target. Compares the link's *target* — a version
-/// upgrade that leaves `.aube/<old-dep-path>/` resolvable on disk is
-/// correctly classified as stale instead of silently keeping the old
-/// symlink.
-///
-/// - `Ok(true)`  – existing entry is a symlink pointing at
-///   `expected_target`; caller skips creation.
-/// - `Ok(false)` – no entry exists, or a stale entry (wrong target,
-///   dangling symlink, regular directory) has been best-effort
-///   removed; caller should proceed to create the symlink.
-///
-/// Unix and Windows use different comparison strategies because
-/// `create_dir_link` writes the target differently on each platform:
-/// Unix preserves the relative target bytes-for-bytes as a POSIX
-/// symlink, Windows normalizes to an absolute path before calling
-/// `junction::create`. A plain `read_link == expected` check that
-/// works on Unix would miss every warm run on Windows.
-fn reconcile_top_level_link(link_path: &Path, expected_target: &Path) -> Result<bool, Error> {
-    #[cfg(windows)]
-    {
-        // NTFS junctions store normalized absolute targets
-        // (sometimes `\\?\`-prefixed), so comparing against the
-        // relative `pathdiff::diff_paths` output the callers compute
-        // would never match. Compare the canonical forms instead: if
-        // the junction resolves to the same directory
-        // `expected_target` points at, the link is fresh. Anything
-        // else (dangling, wrong target, not a reparse point) falls
-        // through to a best-effort reclaim.
-        //
-        // Canonicalize is ~5 syscalls on NTFS (open reparse, read
-        // reparse data, close, query attrs ×2). With ~1000 top-level
-        // links per warm install that's 5000 syscalls just for
-        // expected_abs. Cache canonical forms keyed by the absolute
-        // path so a second call to the same target returns
-        // immediately.
-        use std::sync::OnceLock;
-        static CANON_CACHE: OnceLock<
-            std::sync::RwLock<std::collections::HashMap<PathBuf, PathBuf>>,
-        > = OnceLock::new();
-        fn cached_canonicalize(p: &Path) -> std::io::Result<PathBuf> {
-            let map = CANON_CACHE.get_or_init(Default::default);
-            if let Some(hit) = map.read().expect("canon cache poisoned").get(p) {
-                return Ok(hit.clone());
-            }
-            let canon = p.canonicalize()?;
-            map.write()
-                .expect("canon cache poisoned")
-                .insert(p.to_path_buf(), canon.clone());
-            Ok(canon)
-        }
-        let expected_abs = if expected_target.is_absolute() {
-            expected_target.to_path_buf()
-        } else {
-            let parent = link_path.parent().unwrap_or_else(|| Path::new(""));
-            parent.join(expected_target)
-        };
-        if let Ok(link_canon) = cached_canonicalize(link_path)
-            && let Ok(exp_canon) = cached_canonicalize(&expected_abs)
-            && link_canon == exp_canon
-        {
-            return Ok(true);
-        }
-        if link_path.symlink_metadata().is_err() {
-            return Ok(false);
-        }
-        match std::fs::remove_dir(link_path).or_else(|_| std::fs::remove_file(link_path)) {
-            Ok(()) => Ok(false),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
-            Err(e) => Err(Error::Io(link_path.to_path_buf(), e)),
-        }
-    }
-    #[cfg(not(windows))]
-    {
-        match std::fs::read_link(link_path) {
-            Ok(existing) if existing == expected_target => Ok(true),
-            Ok(_) => {
-                // Wrong target — remove the stale symlink so the
-                // caller's `create_dir_link` below doesn't EEXIST.
-                let _ = std::fs::remove_dir(link_path).or_else(|_| std::fs::remove_file(link_path));
-                Ok(false)
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
-            Err(_) => {
-                // `read_link` failed with EINVAL (entry exists but
-                // isn't a symlink — e.g. a regular directory left by
-                // a prior hoisted install) or another error.
-                // Best-effort reclaim so the create call lands on a
-                // clean slot.
-                let _ =
-                    std::fs::remove_dir_all(link_path).or_else(|_| std::fs::remove_file(link_path));
-                Ok(false)
-            }
-        }
     }
 }
 

--- a/crates/aube-linker/src/materialize.rs
+++ b/crates/aube-linker/src/materialize.rs
@@ -413,6 +413,7 @@ impl Linker {
         let global_entry = self.virtual_store.join(self.virtual_store_subdir(dep_path));
         let state = classify_entry_state(&local_aube_entry, &global_entry);
         if matches!(state, EntryState::Fresh) {
+            self.reconcile_virtual_store_entry(dep_path, pkg, nested_link_targets)?;
             stats.packages_cached += 1;
             return Ok(());
         }

--- a/crates/aube-linker/src/materialize.rs
+++ b/crates/aube-linker/src/materialize.rs
@@ -1,7 +1,9 @@
 use tracing::{debug, trace, warn};
 
 use crate::patches::apply_multi_file_patch;
-use crate::sweep::{EntryState, classify_entry_state, mkdirp, try_remove_entry};
+use crate::sweep::{
+    EntryState, classify_entry_state, mkdirp, reconcile_dir_link, try_remove_entry,
+};
 use crate::{Error, LinkStats, LinkStrategy, Linker, sys};
 use aube_lockfile::{LockedPackage, shared_local_dep_path};
 use aube_store::{PackageIndex, StoredFile};
@@ -238,6 +240,7 @@ impl Linker {
             .join(&pkg.name);
 
         if pkg_nm_dir.exists() {
+            self.reconcile_virtual_store_entry(dep_path, pkg, nested_link_targets)?;
             trace!("virtual store hit: {dep_path}");
             stats.packages_cached += 1;
             return Ok(());
@@ -319,6 +322,64 @@ impl Linker {
             );
         }
 
+        Ok(())
+    }
+
+    /// Validate and repair the dependency links inside an existing global
+    /// virtual-store package entry. The package directory itself can be a
+    /// valid cache hit while one of its sibling links still targets an old
+    /// graph identity.
+    pub(crate) fn reconcile_virtual_store_entry(
+        &self,
+        dep_path: &str,
+        pkg: &LockedPackage,
+        nested_link_targets: Option<&BTreeMap<String, PathBuf>>,
+    ) -> Result<(), Error> {
+        let pkg_nm_parent = self
+            .virtual_store
+            .join(self.virtual_store_subdir(dep_path))
+            .join("node_modules");
+        for (dep_name, dep_version) in &pkg.dependencies {
+            if dep_name == &pkg.name {
+                continue;
+            }
+            let dep_dep_path = shared_local_dep_path(dep_name, dep_version)
+                .unwrap_or_else(|| format!("{dep_name}@{dep_version}"));
+            let symlink_path = pkg_nm_parent.join(dep_name);
+            let target = if let Some(abs_target) =
+                nested_link_targets.and_then(|targets| targets.get(&dep_dep_path))
+            {
+                abs_target.clone()
+            } else {
+                let sibling_subdir = self.virtual_store_subdir(&dep_dep_path);
+                #[cfg(not(windows))]
+                {
+                    let sibling_abs = self
+                        .virtual_store
+                        .join(sibling_subdir)
+                        .join("node_modules")
+                        .join(dep_name);
+                    let link_parent = symlink_path.parent().unwrap_or(&pkg_nm_parent);
+                    pathdiff::diff_paths(&sibling_abs, link_parent)
+                        .unwrap_or_else(|| sibling_abs.clone())
+                }
+                #[cfg(windows)]
+                {
+                    self.virtual_store
+                        .join(sibling_subdir)
+                        .join("node_modules")
+                        .join(dep_name)
+                }
+            };
+            if reconcile_dir_link(&symlink_path, &target)? {
+                continue;
+            }
+            if let Some(parent) = symlink_path.parent() {
+                mkdirp(parent)?;
+            }
+            sys::create_dir_link(&target, &symlink_path)
+                .map_err(|e| Error::Io(symlink_path.clone(), e))?;
+        }
         Ok(())
     }
 

--- a/crates/aube-linker/src/materialize.rs
+++ b/crates/aube-linker/src/materialize.rs
@@ -343,6 +343,7 @@ impl Linker {
             if dep_name == &pkg.name {
                 continue;
             }
+            validate_package_link_name(dep_name)?;
             let dep_dep_path = shared_local_dep_path(dep_name, dep_version)
                 .unwrap_or_else(|| format!("{dep_name}@{dep_version}"));
             let symlink_path = pkg_nm_parent.join(dep_name);

--- a/crates/aube-linker/src/materialize.rs
+++ b/crates/aube-linker/src/materialize.rs
@@ -377,8 +377,13 @@ impl Linker {
             if let Some(parent) = symlink_path.parent() {
                 mkdirp(parent)?;
             }
-            sys::create_dir_link(&target, &symlink_path)
-                .map_err(|e| Error::Io(symlink_path.clone(), e))?;
+            if let Err(create_err) = sys::create_dir_link(&target, &symlink_path) {
+                let won_race = create_err.kind() == std::io::ErrorKind::AlreadyExists
+                    && reconcile_dir_link(&symlink_path, &target).unwrap_or(false);
+                if !won_race {
+                    return Err(Error::Io(symlink_path, create_err));
+                }
+            }
         }
         Ok(())
     }

--- a/crates/aube-linker/src/sweep.rs
+++ b/crates/aube-linker/src/sweep.rs
@@ -347,22 +347,6 @@ pub(crate) fn reconcile_dir_link(link_path: &Path, expected_target: &Path) -> Re
         // NTFS junctions store normalized absolute targets, sometimes with a
         // `\\?\` prefix, so compare canonical destinations rather than the
         // relative target passed to `create_dir_link`.
-        use std::path::PathBuf;
-        use std::sync::OnceLock;
-        static CANON_CACHE: OnceLock<
-            std::sync::RwLock<std::collections::HashMap<PathBuf, PathBuf>>,
-        > = OnceLock::new();
-        fn cached_canonicalize(p: &Path) -> std::io::Result<PathBuf> {
-            let map = CANON_CACHE.get_or_init(Default::default);
-            if let Some(hit) = map.read().expect("canon cache poisoned").get(p) {
-                return Ok(hit.clone());
-            }
-            let canon = p.canonicalize()?;
-            map.write()
-                .expect("canon cache poisoned")
-                .insert(p.to_path_buf(), canon.clone());
-            Ok(canon)
-        }
         let expected_abs = if expected_target.is_absolute() {
             expected_target.to_path_buf()
         } else {
@@ -371,8 +355,10 @@ pub(crate) fn reconcile_dir_link(link_path: &Path, expected_target: &Path) -> Re
                 .unwrap_or_else(|| Path::new(""))
                 .join(expected_target)
         };
-        if let Ok(link_canon) = cached_canonicalize(link_path)
-            && let Ok(exp_canon) = cached_canonicalize(&expected_abs)
+        // The link destination is mutable during reconciliation and shared
+        // installs can repair it concurrently, so it must never be cached.
+        if let Ok(link_canon) = link_path.canonicalize()
+            && let Ok(exp_canon) = expected_abs.canonicalize()
             && link_canon == exp_canon
         {
             return Ok(true);

--- a/crates/aube-linker/src/sweep.rs
+++ b/crates/aube-linker/src/sweep.rs
@@ -337,9 +337,10 @@ pub(crate) fn classify_local_entry_state(path: &Path) -> EntryState {
 
 /// Reconcile a directory link against its expected target.
 ///
-/// Returns `Ok(true)` when the existing link is current. Missing, dangling,
-/// incorrectly-targeted, and non-link entries are removed and return
-/// `Ok(false)` so the caller can recreate the link.
+/// Returns `Ok(true)` when the existing link stores the expected target.
+/// Missing, incorrectly-targeted, and non-link entries are removed and return
+/// `Ok(false)` so the caller can recreate the link. The target is not probed,
+/// so a dangling link that stores the expected target is considered current.
 pub(crate) fn reconcile_dir_link(link_path: &Path, expected_target: &Path) -> Result<bool, Error> {
     #[cfg(windows)]
     {

--- a/crates/aube-linker/src/sweep.rs
+++ b/crates/aube-linker/src/sweep.rs
@@ -335,6 +335,74 @@ pub(crate) fn classify_local_entry_state(path: &Path) -> EntryState {
     }
 }
 
+/// Reconcile a directory link against its expected target.
+///
+/// Returns `Ok(true)` when the existing link is current. Missing, dangling,
+/// incorrectly-targeted, and non-link entries are removed and return
+/// `Ok(false)` so the caller can recreate the link.
+pub(crate) fn reconcile_dir_link(link_path: &Path, expected_target: &Path) -> Result<bool, Error> {
+    #[cfg(windows)]
+    {
+        // NTFS junctions store normalized absolute targets, sometimes with a
+        // `\\?\` prefix, so compare canonical destinations rather than the
+        // relative target passed to `create_dir_link`.
+        use std::path::PathBuf;
+        use std::sync::OnceLock;
+        static CANON_CACHE: OnceLock<
+            std::sync::RwLock<std::collections::HashMap<PathBuf, PathBuf>>,
+        > = OnceLock::new();
+        fn cached_canonicalize(p: &Path) -> std::io::Result<PathBuf> {
+            let map = CANON_CACHE.get_or_init(Default::default);
+            if let Some(hit) = map.read().expect("canon cache poisoned").get(p) {
+                return Ok(hit.clone());
+            }
+            let canon = p.canonicalize()?;
+            map.write()
+                .expect("canon cache poisoned")
+                .insert(p.to_path_buf(), canon.clone());
+            Ok(canon)
+        }
+        let expected_abs = if expected_target.is_absolute() {
+            expected_target.to_path_buf()
+        } else {
+            link_path
+                .parent()
+                .unwrap_or_else(|| Path::new(""))
+                .join(expected_target)
+        };
+        if let Ok(link_canon) = cached_canonicalize(link_path)
+            && let Ok(exp_canon) = cached_canonicalize(&expected_abs)
+            && link_canon == exp_canon
+        {
+            return Ok(true);
+        }
+        if link_path.symlink_metadata().is_err() {
+            return Ok(false);
+        }
+        match std::fs::remove_dir(link_path).or_else(|_| std::fs::remove_file(link_path)) {
+            Ok(()) => Ok(false),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(e) => Err(Error::Io(link_path.to_path_buf(), e)),
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        match std::fs::read_link(link_path) {
+            Ok(existing) if existing == expected_target => Ok(true),
+            Ok(_) => {
+                let _ = std::fs::remove_dir(link_path).or_else(|_| std::fs::remove_file(link_path));
+                Ok(false)
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(_) => {
+                let _ =
+                    std::fs::remove_dir_all(link_path).or_else(|_| std::fs::remove_file(link_path));
+                Ok(false)
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::is_physical_importer;

--- a/crates/aube-linker/src/tests.rs
+++ b/crates/aube-linker/src/tests.rs
@@ -955,6 +955,38 @@ fn test_global_virtual_store_is_populated() {
 }
 
 #[test]
+fn warm_link_repairs_stale_global_virtual_store_dependency_link() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = dir.path().join("project");
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    let (store, indices) = setup_store_with_files(dir.path());
+    let virtual_store = store.virtual_store_dir();
+    let linker = Linker::new_with_gvs(&store, LinkStrategy::Copy, true);
+    let graph = make_graph();
+    linker.link_all(&project_dir, &graph, &indices).unwrap();
+
+    let nested_bar = virtual_store.join("foo@1.0.0/node_modules/bar");
+    let stale_bar = virtual_store.join("bar@2.0.0-stale/node_modules/bar");
+    std::fs::create_dir_all(&stale_bar).unwrap();
+    crate::sweep::try_remove_entry(&nested_bar);
+    crate::sys::create_dir_link(&stale_bar, &nested_bar).unwrap();
+    assert_eq!(
+        std::fs::canonicalize(&nested_bar).unwrap(),
+        std::fs::canonicalize(&stale_bar).unwrap()
+    );
+
+    linker.link_all(&project_dir, &graph, &indices).unwrap();
+
+    let expected_bar = virtual_store.join("bar@2.0.0/node_modules/bar");
+    assert_eq!(
+        std::fs::canonicalize(&nested_bar).unwrap(),
+        std::fs::canonicalize(&expected_bar).unwrap(),
+        "a cached parent entry must reconcile its nested dependency identity"
+    );
+}
+
+#[test]
 fn test_global_virtual_store_gets_hidden_hoist() {
     let dir = tempfile::tempdir().unwrap();
     let project_dir = dir.path().join("project");

--- a/crates/aube-linker/src/tests.rs
+++ b/crates/aube-linker/src/tests.rs
@@ -987,6 +987,27 @@ fn warm_link_repairs_stale_global_virtual_store_dependency_link() {
 }
 
 #[test]
+fn cached_entry_repair_rejects_dependency_path_escape() {
+    let dir = tempfile::tempdir().unwrap();
+    let (store, _) = setup_store_with_files(dir.path());
+    let linker = Linker::new_with_gvs(&store, LinkStrategy::Copy, true);
+    let outside = dir.path().join("outside");
+    std::fs::create_dir_all(&outside).unwrap();
+    let sentinel = outside.join("sentinel");
+    std::fs::write(&sentinel, "keep").unwrap();
+    let mut pkg = make_graph().packages.remove("foo@1.0.0").unwrap();
+    pkg.dependencies =
+        BTreeMap::from([(outside.to_string_lossy().into_owned(), "1.0.0".to_string())]);
+
+    assert!(
+        linker
+            .reconcile_virtual_store_entry("foo@1.0.0", &pkg, None)
+            .is_err()
+    );
+    assert_eq!(std::fs::read_to_string(sentinel).unwrap(), "keep");
+}
+
+#[test]
 fn test_global_virtual_store_gets_hidden_hoist() {
     let dir = tempfile::tempdir().unwrap();
     let project_dir = dir.path().join("project");

--- a/crates/aube-linker/src/tests.rs
+++ b/crates/aube-linker/src/tests.rs
@@ -1196,6 +1196,87 @@ fn gvs_shareable_source_dep_without_index_errors_loudly() {
     );
 }
 
+#[test]
+fn warm_link_repairs_stale_shared_source_dependency_link() {
+    use aube_lockfile::{GitSource, LocalSource};
+
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = dir.path().join("project");
+    std::fs::create_dir_all(&project_dir).unwrap();
+    let (store, mut indices) = setup_store_with_files(dir.path());
+    let git = LocalSource::Git(GitSource {
+        url: "https://github.com/example/source-parent.git".to_string(),
+        committish: None,
+        resolved: "0123456789abcdef0123456789abcdef01234567".to_string(),
+        integrity: None,
+        subpath: None,
+    });
+    let parent_dep_path = git.dep_path("source-parent");
+    let parent_file = store
+        .import_bytes(b"module.exports = 'parent';", false)
+        .unwrap();
+    let mut parent_index = PackageIndex::default();
+    parent_index.insert("index.js".to_string(), parent_file);
+    indices.insert(parent_dep_path.clone(), parent_index);
+
+    let graph = LockfileGraph {
+        importers: BTreeMap::from([(
+            ".".to_string(),
+            vec![DirectDep {
+                name: "source-parent".to_string(),
+                dep_path: parent_dep_path.clone(),
+                dep_type: DepType::Production,
+                specifier: None,
+            }],
+        )]),
+        packages: BTreeMap::from([
+            (
+                parent_dep_path.clone(),
+                LockedPackage {
+                    name: "source-parent".to_string(),
+                    version: "1.0.0".to_string(),
+                    dependencies: BTreeMap::from([("bar".to_string(), "2.0.0".to_string())]),
+                    dep_path: parent_dep_path.clone(),
+                    local_source: Some(git),
+                    ..Default::default()
+                },
+            ),
+            (
+                "bar@2.0.0".to_string(),
+                LockedPackage {
+                    name: "bar".to_string(),
+                    version: "2.0.0".to_string(),
+                    dep_path: "bar@2.0.0".to_string(),
+                    ..Default::default()
+                },
+            ),
+        ]),
+        ..Default::default()
+    };
+    let linker = Linker::new_with_gvs(&store, LinkStrategy::Copy, true);
+    linker.link_all(&project_dir, &graph, &indices).unwrap();
+
+    let parent_entry = store.virtual_store_dir().join(dep_path_to_filename(
+        &parent_dep_path,
+        DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH,
+    ));
+    let nested_bar = parent_entry.join("node_modules/bar");
+    let stale_bar = store
+        .virtual_store_dir()
+        .join("bar@2.0.0-stale/node_modules/bar");
+    std::fs::create_dir_all(&stale_bar).unwrap();
+    crate::sweep::try_remove_entry(&nested_bar);
+    crate::sys::create_dir_link(&stale_bar, &nested_bar).unwrap();
+
+    linker.link_all(&project_dir, &graph, &indices).unwrap();
+
+    assert_eq!(
+        std::fs::canonicalize(&nested_bar).unwrap(),
+        std::fs::canonicalize(store.virtual_store_dir().join("bar@2.0.0/node_modules/bar"))
+            .unwrap()
+    );
+}
+
 /// Regression: a version bump keeps the same top-level name
 /// (`foo`) but must repoint `node_modules/foo` at the new
 /// `.aube/foo@<new>` entry. The old `.aube/foo@<old>/` is left

--- a/crates/aube/src/commands/install/bin_linking.rs
+++ b/crates/aube/src/commands/install/bin_linking.rs
@@ -54,7 +54,7 @@ pub(crate) fn materialized_pkg_dir(
 /// packages (`@scope/name`) `package_dir` is two levels below that
 /// `node_modules/`, so we strip the extra `@scope` hop. Used to
 /// locate the per-dep `.bin/` for transitive lifecycle-script bins.
-pub(super) fn dep_modules_dir_for(package_dir: &std::path::Path, name: &str) -> std::path::PathBuf {
+pub(crate) fn dep_modules_dir_for(package_dir: &std::path::Path, name: &str) -> std::path::PathBuf {
     if name.starts_with('@') {
         package_dir
             .parent()

--- a/crates/aube/src/commands/install/finalize.rs
+++ b/crates/aube/src/commands/install/finalize.rs
@@ -399,6 +399,7 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
                     aube_dir,
                     virtual_store_dir_max_length,
                     placements: placements_ref,
+                    use_global_virtual_store: planned_gvs,
                 },
                 unreviewed_builds: unreviewed_builds_for_state,
             },

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -34,7 +34,9 @@ mod workspace;
 
 use advisory::resolve_osv_routing_settings;
 pub use args::{EmbedderInstallOverrides, InstallArgs, InstallOptions};
-pub(crate) use bin_linking::{PkgJsonCache, link_dep_bins, materialized_pkg_dir};
+pub(crate) use bin_linking::{
+    PkgJsonCache, dep_modules_dir_for, link_dep_bins, materialized_pkg_dir,
+};
 pub use control::{
     INSTALL_OUTPUT_CODE_LIFECYCLE_SCRIPT, InstallControl, InstallEvent, InstallOutputLevel,
     InstallOutputMode, InstallPhase, InstallProgressSnapshot, InstallPrompt, InstallPromptFuture,

--- a/crates/aube/src/commands/install/startup.rs
+++ b/crates/aube/src/commands/install/startup.rs
@@ -122,6 +122,12 @@ fn compatibility_metadata_is_current(cwd: &Path, opts: &InstallOptions) -> bool 
                 Some(true) => {
                     legacy_vite_patches_current =
                         super::gvs::legacy_vite_patches_are_current(&aube_dir);
+                    if !state::gvs_nested_links_are_current(cwd, &layout) {
+                        tracing::debug!(
+                            "install warm path skipped: global virtual store links are stale"
+                        );
+                        return false;
+                    }
                     Some(global_virtual_store)
                 }
                 Some(false) => Some(aube_dir),

--- a/crates/aube/src/commands/install/startup.rs
+++ b/crates/aube/src/commands/install/startup.rs
@@ -122,6 +122,12 @@ fn compatibility_metadata_is_current(cwd: &Path, opts: &InstallOptions) -> bool 
                 Some(true) => {
                     legacy_vite_patches_current =
                         super::gvs::legacy_vite_patches_are_current(&aube_dir);
+                    if layout.gvs_nested_links.is_none() {
+                        tracing::debug!(
+                            "install warm path skipped: install state predates global virtual store link tracking"
+                        );
+                        return false;
+                    }
                     if !state::gvs_nested_links_are_current(cwd, &layout) {
                         tracing::debug!(
                             "install warm path skipped: global virtual store links are stale"

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -648,6 +648,67 @@ pub struct WriteStateLayout<'a> {
     pub use_global_virtual_store: bool,
 }
 
+fn collect_gvs_nested_links(
+    project_dir: &Path,
+    layout: &WriteStateLayout<'_>,
+) -> std::io::Result<Option<BTreeMap<String, String>>> {
+    let mut links = BTreeMap::new();
+    for (dep_path, pkg) in &layout.graph.packages {
+        let globally_shareable = pkg
+            .local_source
+            .as_ref()
+            .is_none_or(aube_lockfile::LocalSource::is_globally_shareable);
+        if !globally_shareable {
+            continue;
+        }
+        let aube_entry =
+            layout
+                .aube_dir
+                .join(aube_lockfile::dep_path_filename::dep_path_to_filename(
+                    dep_path,
+                    layout.virtual_store_dir_max_length,
+                ));
+        if std::fs::read_link(aube_entry).is_err() {
+            // Compatibility-selected registry packages can be materialized
+            // physically in the project even while the rest of the graph uses
+            // GVS. Their links are not shared cache topology and the linker
+            // handles them separately.
+            continue;
+        }
+        let package_dir = crate::commands::install::materialized_pkg_dir(
+            layout.aube_dir,
+            dep_path,
+            &pkg.name,
+            layout.virtual_store_dir_max_length,
+            layout.placements,
+        );
+        let node_modules_dir =
+            crate::commands::install::dep_modules_dir_for(&package_dir, &pkg.name);
+        for dep_name in pkg.dependencies.keys().filter(|name| *name != &pkg.name) {
+            let link_path = node_modules_dir.join(dep_name);
+            let Ok(target) = std::fs::read_link(&link_path) else {
+                tracing::debug!(
+                    path = %link_path.display(),
+                    "global virtual store link topology is not recordable"
+                );
+                return Ok(None);
+            };
+            let Some(target) = target.to_str() else {
+                tracing::debug!(
+                    path = %link_path.display(),
+                    "global virtual store link target is not valid UTF-8"
+                );
+                return Ok(None);
+            };
+            links.insert(
+                relative_path_or_original(&link_path, project_dir),
+                target.to_string(),
+            );
+        }
+    }
+    Ok(Some(links))
+}
+
 pub struct WriteStateInput<'a> {
     pub section_filtered: bool,
     pub package_json_hashes: BTreeMap<String, String>,
@@ -1207,56 +1268,7 @@ impl InstallLayoutState {
         let gvs_nested_links = if layout.use_global_virtual_store
             && matches!(layout.node_linker, aube_linker::NodeLinker::Isolated)
         {
-            let mut links = BTreeMap::new();
-            for (dep_path, pkg) in &layout.graph.packages {
-                let globally_shareable = pkg
-                    .local_source
-                    .as_ref()
-                    .is_none_or(aube_lockfile::LocalSource::is_globally_shareable);
-                if !globally_shareable {
-                    continue;
-                }
-                let aube_entry =
-                    layout
-                        .aube_dir
-                        .join(aube_lockfile::dep_path_filename::dep_path_to_filename(
-                            dep_path,
-                            layout.virtual_store_dir_max_length,
-                        ));
-                if std::fs::read_link(aube_entry).is_err() {
-                    // Compatibility-selected registry packages can be
-                    // materialized physically in the project even while the
-                    // rest of the graph uses GVS. Their links are not shared
-                    // cache topology and the linker handles them separately.
-                    continue;
-                }
-                let package_dir = crate::commands::install::materialized_pkg_dir(
-                    layout.aube_dir,
-                    dep_path,
-                    &pkg.name,
-                    layout.virtual_store_dir_max_length,
-                    layout.placements,
-                );
-                let node_modules_dir =
-                    crate::commands::install::dep_modules_dir_for(&package_dir, &pkg.name);
-                for dep_name in pkg.dependencies.keys().filter(|name| *name != &pkg.name) {
-                    let link_path = node_modules_dir.join(dep_name);
-                    let target = std::fs::read_link(&link_path).map_err(|err| {
-                        std::io::Error::new(
-                            err.kind(),
-                            format!(
-                                "failed to record global virtual store link {}: {err}",
-                                link_path.display()
-                            ),
-                        )
-                    })?;
-                    links.insert(
-                        relative_path_or_original(&link_path, project_dir),
-                        target.to_string_lossy().into_owned(),
-                    );
-                }
-            }
-            Some(links)
+            collect_gvs_nested_links(project_dir, layout)?
         } else {
             None
         };
@@ -1946,6 +1958,52 @@ mod tests {
                 .and_then(|links| links.get(&expected_path)),
             Some(&"../../child@1.0.0/node_modules/child".to_string())
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn from_graph_skips_unreadable_gvs_link_topology() {
+        let project_dir = temp_project_dir("unreadable-gvs-links");
+        let aube_dir = project_dir.join("node_modules/.aube");
+        let dep_path = "parent@1.0.0";
+        let entry_name = aube_lockfile::dep_path_filename::dep_path_to_filename(dep_path, 120);
+        let global_entry = project_dir.join("gvs/parent");
+        std::fs::create_dir_all(global_entry.join("node_modules/parent"))
+            .expect("package should write");
+        std::fs::create_dir_all(&aube_dir).expect("virtual store should write");
+        std::os::unix::fs::symlink(&global_entry, aube_dir.join(entry_name))
+            .expect("project GVS link should write");
+
+        let graph = aube_lockfile::LockfileGraph {
+            packages: BTreeMap::from([(
+                dep_path.to_string(),
+                aube_lockfile::LockedPackage {
+                    name: "parent".to_string(),
+                    version: "1.0.0".to_string(),
+                    dep_path: dep_path.to_string(),
+                    dependencies: BTreeMap::from([("missing".to_string(), "1.0.0".to_string())]),
+                    ..Default::default()
+                },
+            )]),
+            ..Default::default()
+        };
+
+        let layout = InstallLayoutState::from_graph(
+            &project_dir,
+            &WriteStateLayout {
+                graph: &graph,
+                node_linker: aube_linker::NodeLinker::Isolated,
+                hoisting_limits: aube_linker::HoistingLimits::None,
+                modules_dir_name: "node_modules",
+                aube_dir: &aube_dir,
+                virtual_store_dir_max_length: 120,
+                placements: None,
+                use_global_virtual_store: true,
+            },
+        )
+        .expect("unreadable topology should not fail state recording");
+
+        assert_eq!(layout.gvs_nested_links, None);
     }
 
     #[test]

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -1218,9 +1218,8 @@ impl InstallLayoutState {
                     layout.virtual_store_dir_max_length,
                     layout.placements,
                 );
-                let Some(node_modules_dir) = package_dir.parent() else {
-                    continue;
-                };
+                let node_modules_dir =
+                    crate::commands::install::dep_modules_dir_for(&package_dir, &pkg.name);
                 for dep_name in pkg.dependencies.keys().filter(|name| *name != &pkg.name) {
                     let link_path = node_modules_dir.join(dep_name);
                     let target = std::fs::read_link(&link_path).map_err(|err| {
@@ -1868,6 +1867,65 @@ mod tests {
         assert_eq!(
             layout.direct_entries.get("packages/svc"),
             Some(&vec!["packages/svc/node_modules/zod".to_string()])
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn from_graph_records_scoped_gvs_links_from_package_node_modules() {
+        let project_dir = temp_project_dir("scoped-gvs-links");
+        let aube_dir = project_dir.join("node_modules/.aube");
+        let dep_path = "@scope/parent@1.0.0";
+        let entry_name = aube_lockfile::dep_path_filename::dep_path_to_filename(dep_path, 120);
+        let global_entry = project_dir.join("gvs/scoped-parent");
+        let global_modules = global_entry.join("node_modules");
+        std::fs::create_dir_all(global_modules.join("@scope/parent"))
+            .expect("scoped package should write");
+        std::os::unix::fs::symlink(
+            "../../child@1.0.0/node_modules/child",
+            global_modules.join("child"),
+        )
+        .expect("nested link should write");
+        std::fs::create_dir_all(&aube_dir).expect("virtual store should write");
+        std::os::unix::fs::symlink(&global_entry, aube_dir.join(&entry_name))
+            .expect("project GVS link should write");
+
+        let graph = aube_lockfile::LockfileGraph {
+            packages: BTreeMap::from([(
+                dep_path.to_string(),
+                aube_lockfile::LockedPackage {
+                    name: "@scope/parent".to_string(),
+                    version: "1.0.0".to_string(),
+                    dep_path: dep_path.to_string(),
+                    dependencies: BTreeMap::from([("child".to_string(), "1.0.0".to_string())]),
+                    ..Default::default()
+                },
+            )]),
+            ..Default::default()
+        };
+
+        let layout = InstallLayoutState::from_graph(
+            &project_dir,
+            &WriteStateLayout {
+                graph: &graph,
+                node_linker: aube_linker::NodeLinker::Isolated,
+                hoisting_limits: aube_linker::HoistingLimits::None,
+                modules_dir_name: "node_modules",
+                aube_dir: &aube_dir,
+                virtual_store_dir_max_length: 120,
+                placements: None,
+                use_global_virtual_store: true,
+            },
+        )
+        .expect("scoped GVS layout should build");
+
+        let expected_path = format!("node_modules/.aube/{entry_name}/node_modules/child");
+        assert_eq!(
+            layout
+                .gvs_nested_links
+                .as_ref()
+                .and_then(|links| links.get(&expected_path)),
+            Some(&"../../child@1.0.0/node_modules/child".to_string())
         );
     }
 

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -1980,8 +1980,10 @@ mod tests {
                 aube_dir: &aube_dir,
                 virtual_store_dir_max_length: 120,
                 placements: Some(&placements),
+                use_global_virtual_store: false,
             },
-        );
+        )
+        .expect("hoisted layout should build");
 
         assert_eq!(
             layout.direct_entries.get("packages/app"),

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -250,6 +250,12 @@ pub struct InstallLayoutState {
     pub virtual_store_dir_max_length: Option<usize>,
     pub direct_entries: BTreeMap<String, Vec<String>>,
     pub packages: BTreeMap<String, InstalledPackageState>,
+    /// Expected targets for dependency links nested inside shared global
+    /// virtual-store entries. Keys are project-relative paths reached through
+    /// `node_modules/.aube/<dep_path>`; values are the exact link targets.
+    /// `None` identifies state written before this topology check existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gvs_nested_links: Option<BTreeMap<String, String>>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -639,6 +645,7 @@ pub struct WriteStateLayout<'a> {
     pub aube_dir: &'a Path,
     pub virtual_store_dir_max_length: usize,
     pub placements: Option<&'a aube_linker::HoistedPlacements>,
+    pub use_global_virtual_store: bool,
 }
 
 pub struct WriteStateInput<'a> {
@@ -669,7 +676,7 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
     let (lockfile_hash, lockfile_snapshot_name) =
         snapshot_active_lockfile(project_dir, &state_path)?;
     let settings_hash = hash_settings(project_dir, cli_flags);
-    let install_layout = InstallLayoutState::from_graph(project_dir, &layout);
+    let install_layout = InstallLayoutState::from_graph(project_dir, &layout)?;
 
     let package_json_shape_digests: BTreeMap<String, String> = package_json_hashes
         .keys()
@@ -1104,7 +1111,10 @@ fn remove_legacy_state_file(state_path: &Path) -> Result<(), std::io::Error> {
 }
 
 impl InstallLayoutState {
-    fn from_graph(project_dir: &Path, layout: &WriteStateLayout<'_>) -> Self {
+    fn from_graph(
+        project_dir: &Path,
+        layout: &WriteStateLayout<'_>,
+    ) -> Result<Self, std::io::Error> {
         let linker = match layout.node_linker {
             aube_linker::NodeLinker::Isolated => InstallLayoutMode::Isolated,
             aube_linker::NodeLinker::Hoisted => InstallLayoutMode::Hoisted,
@@ -1175,14 +1185,73 @@ impl InstallLayoutState {
             );
         }
 
-        Self {
+        let gvs_nested_links = if layout.use_global_virtual_store
+            && matches!(layout.node_linker, aube_linker::NodeLinker::Isolated)
+        {
+            let mut links = BTreeMap::new();
+            for (dep_path, pkg) in &layout.graph.packages {
+                let globally_shareable = pkg
+                    .local_source
+                    .as_ref()
+                    .is_none_or(aube_lockfile::LocalSource::is_globally_shareable);
+                if !globally_shareable {
+                    continue;
+                }
+                let aube_entry =
+                    layout
+                        .aube_dir
+                        .join(aube_lockfile::dep_path_filename::dep_path_to_filename(
+                            dep_path,
+                            layout.virtual_store_dir_max_length,
+                        ));
+                if std::fs::read_link(aube_entry).is_err() {
+                    // Compatibility-selected registry packages can be
+                    // materialized physically in the project even while the
+                    // rest of the graph uses GVS. Their links are not shared
+                    // cache topology and the linker handles them separately.
+                    continue;
+                }
+                let package_dir = crate::commands::install::materialized_pkg_dir(
+                    layout.aube_dir,
+                    dep_path,
+                    &pkg.name,
+                    layout.virtual_store_dir_max_length,
+                    layout.placements,
+                );
+                let Some(node_modules_dir) = package_dir.parent() else {
+                    continue;
+                };
+                for dep_name in pkg.dependencies.keys().filter(|name| *name != &pkg.name) {
+                    let link_path = node_modules_dir.join(dep_name);
+                    let target = std::fs::read_link(&link_path).map_err(|err| {
+                        std::io::Error::new(
+                            err.kind(),
+                            format!(
+                                "failed to record global virtual store link {}: {err}",
+                                link_path.display()
+                            ),
+                        )
+                    })?;
+                    links.insert(
+                        relative_path_or_original(&link_path, project_dir),
+                        target.to_string_lossy().into_owned(),
+                    );
+                }
+            }
+            Some(links)
+        } else {
+            None
+        };
+
+        Ok(Self {
             linker,
             modules_dir_name: layout.modules_dir_name.to_string(),
             hoisting_limits,
             virtual_store_dir_max_length: Some(layout.virtual_store_dir_max_length),
             direct_entries,
             packages,
-        }
+            gvs_nested_links,
+        })
     }
 }
 
@@ -1249,6 +1318,26 @@ fn verify_install_layout(
         }
     }
 
+    if let Some(reason) = stale_gvs_nested_link(project_dir, layout) {
+        return Some(reason);
+    }
+
+    None
+}
+
+pub fn gvs_nested_links_are_current(project_dir: &Path, layout: &InstallLayoutState) -> bool {
+    layout.gvs_nested_links.is_some() && stale_gvs_nested_link(project_dir, layout).is_none()
+}
+
+fn stale_gvs_nested_link(project_dir: &Path, layout: &InstallLayoutState) -> Option<String> {
+    for (rel, expected) in layout.gvs_nested_links.as_ref()? {
+        let path = project_dir.join(rel);
+        match std::fs::read_link(&path) {
+            Ok(actual) if actual == Path::new(expected) => {}
+            Ok(_) => return Some(format!("global virtual store link changed: {rel}")),
+            Err(_) => return Some(format!("global virtual store link missing: {rel}")),
+        }
+    }
     None
 }
 
@@ -1535,9 +1624,10 @@ mod tests {
     use super::{
         InstallLayoutMode, InstallLayoutState, InstallState, InstalledPackageState,
         WriteStateLayout, collect_package_json_hashes_from_manifests, empty_blake3_hash,
-        fresh_state_file, hash_file, hash_settings, install_state_file, member_lockfiles_stale,
-        read_hoisted_placements, read_or_migrate_fresh_state, relative_path_or_original,
-        remove_state, verify_install_layout, write_hoisted_placements,
+        fresh_state_file, gvs_nested_links_are_current, hash_file, hash_settings,
+        install_state_file, member_lockfiles_stale, read_hoisted_placements,
+        read_or_migrate_fresh_state, relative_path_or_original, remove_state,
+        verify_install_layout, write_hoisted_placements,
     };
     use std::collections::BTreeMap;
     use std::path::{Path, PathBuf};
@@ -1611,6 +1701,7 @@ mod tests {
                         link: false,
                     },
                 )]),
+                gvs_nested_links: None,
             }),
             unreviewed_builds: Vec::new(),
         };
@@ -1660,6 +1751,7 @@ mod tests {
                     link: true,
                 },
             )]),
+            gvs_nested_links: None,
         };
 
         assert_eq!(verify_install_layout(&project_dir, Some(&state)), None);
@@ -1683,12 +1775,50 @@ mod tests {
                 vec!["node_modules/@scope/api".to_string()],
             )]),
             packages: BTreeMap::new(),
+            gvs_nested_links: None,
         };
 
         assert_eq!(
             verify_install_layout(&project_dir, Some(&state)),
             Some("installed entry missing: node_modules/@scope/api".to_string())
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn verify_install_layout_flags_retargeted_gvs_nested_link() {
+        let project_dir = temp_project_dir("retargeted-gvs-link");
+        let link_path = project_dir.join("node_modules/.aube/parent@1.0.0/node_modules/child");
+        std::fs::create_dir_all(link_path.parent().expect("link parent"))
+            .expect("link parent should write");
+        std::os::unix::fs::symlink("../../child@1.0.0/node_modules/child", &link_path)
+            .expect("nested link should write");
+        let state = InstallLayoutState {
+            linker: InstallLayoutMode::Isolated,
+            modules_dir_name: "node_modules".to_string(),
+            hoisting_limits: None,
+            virtual_store_dir_max_length: Some(120),
+            direct_entries: BTreeMap::new(),
+            packages: BTreeMap::new(),
+            gvs_nested_links: Some(BTreeMap::from([(
+                "node_modules/.aube/parent@1.0.0/node_modules/child".to_string(),
+                "../../child@1.0.0/node_modules/child".to_string(),
+            )])),
+        };
+        assert!(gvs_nested_links_are_current(&project_dir, &state));
+
+        std::fs::remove_file(&link_path).expect("old link should remove");
+        std::os::unix::fs::symlink("../../child@1.0.0-stale/node_modules/child", &link_path)
+            .expect("stale link should write");
+
+        assert_eq!(
+            verify_install_layout(&project_dir, Some(&state)),
+            Some(
+                "global virtual store link changed: node_modules/.aube/parent@1.0.0/node_modules/child"
+                    .to_string()
+            )
+        );
+        assert!(!gvs_nested_links_are_current(&project_dir, &state));
     }
 
     #[test]
@@ -1719,8 +1849,10 @@ mod tests {
                 aube_dir: &aube_dir,
                 virtual_store_dir_max_length: 120,
                 placements: None,
+                use_global_virtual_store: false,
             },
-        );
+        )
+        .expect("layout should build");
 
         // The root importer's direct symlink sits under the workspace
         // root's node_modules.
@@ -1799,6 +1931,7 @@ mod tests {
                 virtual_store_dir_max_length: None,
                 direct_entries: BTreeMap::new(),
                 packages: BTreeMap::new(),
+                gvs_nested_links: None,
             }),
             unreviewed_builds: Vec::new(),
         };


### PR DESCRIPTION
## Summary

- record isolated GVS nested dependency-link targets in install state
- invalidate the warm-install fast path when shared topology drifts
- reconcile stale, missing, or incorrectly targeted nested links in cached GVS entries
- share the target-aware directory-link reconciliation across top-level and nested links

## Root cause

The install warm path only verified project-facing entries and returned before the linker. A forced/full install also treated a valid project `.aube` link or existing GVS package directory as a complete cache hit without checking the dependency links inside that shared entry. A stale nested link could therefore preserve a second package identity indefinitely.

Fixes the behavior reported in [discussion #1298](https://github.com/jdx/aube/discussions/1298).

## Validation

- reporter's `isolated-patched-gvs-stale-identity/repro.sh`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes linker cache-hit behavior and install warm-path gating for GVS nested topology; incorrect reconciliation could break module resolution, but behavior is covered by new tests and path validation on repair.
> 
> **Overview**
> Fixes a case where **warm installs and GVS cache hits** could leave nested `node_modules` links inside shared global virtual-store packages pointing at an **old dependency identity** even when the lockfile graph had moved on.
> 
> The linker now **`reconcile_virtual_store_entry`**: on a fresh-looking GVS package it walks declared dependencies and uses shared **`reconcile_dir_link`** (moved from `reconcile_top_level_link` in `sweep.rs`) to fix or recreate wrong/missing nested links, including on the fast path when the parent entry is cached. Windows junction reconciliation **drops the process-wide canonicalize cache** so concurrent repairs stay correct.
> 
> Install state gains optional **`gvs_nested_links`** (project-relative path → expected link target) for isolated + GVS layouts. The **warm path is skipped** when that map is absent (pre-tracking state) or **`gvs_nested_links_are_current`** fails; layout verification flags changed/missing nested links. **`use_global_virtual_store`** is passed when writing state so recording only runs when GVS is active.
> 
> Tests cover stale nested link repair on warm `link_all`, git/GVS parents, and rejection of path-escape dependency names during repair.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 891bce2ff0df7d9ed08497f74275da4c815e8c28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Repairs missing, stale, dangling, or incorrectly targeted dependency links during installation.
  * Refreshes nested dependency links when reusing existing global virtual-store entries.
  * Prevents invalid cached installation paths from being reused.

* **Improvements**
  * Installation state now tracks virtual-store link targets and verifies them before using warm paths.
  * Preserves valid links to reduce unnecessary recreation and improve installation reliability.
  * Automatically rebuilds invalid links when expected targets change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->