### PR TITLE
fix(packaging): support npm 12 allow-scripts

### DIFF
--- a/npm/installArchSpecificPackage.js
+++ b/npm/installArchSpecificPackage.js
@@ -65,15 +65,19 @@ function main() {
 
 function childNpmEnv(parentEnv) {
     var env = Object.assign({}, parentEnv);
-    // Nested `npm install` must stay local; otherwise it'd try to write
-    // into the global prefix when the user ran `npm i -g @endevco/aube`.
-    env.npm_config_global = 'false';
     // npm 12 exports the outer global install's allowlist into lifecycle
     // scripts. The nested project-scoped install rejects that global-only
     // setting with EALLOWSCRIPTS even though it already uses --ignore-scripts.
     Object.keys(env).forEach(function(key) {
-        if (key.toLowerCase() === 'npm_config_allow_scripts') delete env[key];
+        var normalized = key.toLowerCase();
+        if (normalized === 'npm_config_allow_scripts' || normalized === 'npm_config_global') {
+            delete env[key];
+        }
     });
+    // Nested `npm install` must stay local; otherwise it'd try to write
+    // into the global prefix when the user ran `npm i -g @endevco/aube`.
+    // Add one canonical key after removing case variants for Windows.
+    env.npm_config_global = 'false';
     return env;
 }
 

--- a/npm/installArchSpecificPackage.js
+++ b/npm/installArchSpecificPackage.js
@@ -20,10 +20,6 @@ function main() {
     var pjson = require('./package.json');
     var version = pjson.version;
 
-    // Nested `npm install` must stay local; otherwise it'd try to write
-    // into the global prefix when the user ran `npm i -g @endevco/aube`.
-    process.env.npm_config_global = 'false';
-
     var platform = process.platform; // darwin | linux | win32
     var arch = process.arch;         // arm64 | x64
     // On Linux, `process.report` exposes `glibcVersionRuntime` when the
@@ -43,7 +39,7 @@ function main() {
     // when the user installs the trusted root @endevco/aube.
     var args = ['install', '--no-save', '--no-package-lock', '--ignore-scripts', subpkgName + '@' + version];
 
-    var cp = spawn(npmCmd, args, { stdio: 'inherit', shell: true });
+    var cp = spawn(npmCmd, args, { stdio: 'inherit', shell: true, env: childNpmEnv(process.env) });
     cp.on('close', function(code, signal) {
         // `code` is null when the child was killed by a signal (e.g.
         // OOM). `process.exit(null)` coerces to 0, which would tell
@@ -65,6 +61,20 @@ function main() {
             process.exit(1);
         }
     });
+}
+
+function childNpmEnv(parentEnv) {
+    var env = Object.assign({}, parentEnv);
+    // Nested `npm install` must stay local; otherwise it'd try to write
+    // into the global prefix when the user ran `npm i -g @endevco/aube`.
+    env.npm_config_global = 'false';
+    // npm 12 exports the outer global install's allowlist into lifecycle
+    // scripts. The nested project-scoped install rejects that global-only
+    // setting with EALLOWSCRIPTS even though it already uses --ignore-scripts.
+    Object.keys(env).forEach(function(key) {
+        if (key.toLowerCase() === 'npm_config_allow_scripts') delete env[key];
+    });
+    return env;
 }
 
 // Only these names are ever produced by aube's own build pipeline; ignore
@@ -145,4 +155,6 @@ function linkSubpkgBins(subpkgName, platform) {
     });
 }
 
-main();
+if (require.main === module) main();
+
+module.exports = { childNpmEnv: childNpmEnv };

--- a/npm/installArchSpecificPackage.test.js
+++ b/npm/installArchSpecificPackage.test.js
@@ -9,6 +9,7 @@ test('child npm env drops the outer allow-scripts policy', function() {
         NPM_CONFIG_ALLOW_SCRIPTS: '@endevco/aube',
         npm_config_registry: 'https://registry.example.test',
         npm_config_global: 'true',
+        NPM_CONFIG_GLOBAL: 'true',
     };
 
     var childEnv = childNpmEnv(parentEnv);
@@ -16,7 +17,9 @@ test('child npm env drops the outer allow-scripts policy', function() {
     assert.equal(childEnv.npm_config_allow_scripts, undefined);
     assert.equal(childEnv.NPM_CONFIG_ALLOW_SCRIPTS, undefined);
     assert.equal(childEnv.npm_config_global, 'false');
+    assert.equal(childEnv.NPM_CONFIG_GLOBAL, undefined);
     assert.equal(childEnv.npm_config_registry, parentEnv.npm_config_registry);
     assert.equal(parentEnv.npm_config_allow_scripts, '@endevco/aube');
     assert.equal(parentEnv.npm_config_global, 'true');
+    assert.equal(parentEnv.NPM_CONFIG_GLOBAL, 'true');
 });

--- a/npm/installArchSpecificPackage.test.js
+++ b/npm/installArchSpecificPackage.test.js
@@ -1,0 +1,22 @@
+var test = require('node:test');
+var assert = require('node:assert/strict');
+
+var childNpmEnv = require('./installArchSpecificPackage.js').childNpmEnv;
+
+test('child npm env drops the outer allow-scripts policy', function() {
+    var parentEnv = {
+        npm_config_allow_scripts: '@endevco/aube',
+        NPM_CONFIG_ALLOW_SCRIPTS: '@endevco/aube',
+        npm_config_registry: 'https://registry.example.test',
+        npm_config_global: 'true',
+    };
+
+    var childEnv = childNpmEnv(parentEnv);
+
+    assert.equal(childEnv.npm_config_allow_scripts, undefined);
+    assert.equal(childEnv.NPM_CONFIG_ALLOW_SCRIPTS, undefined);
+    assert.equal(childEnv.npm_config_global, 'false');
+    assert.equal(childEnv.npm_config_registry, parentEnv.npm_config_registry);
+    assert.equal(parentEnv.npm_config_allow_scripts, '@endevco/aube');
+    assert.equal(parentEnv.npm_config_global, 'true');
+});


### PR DESCRIPTION
## Summary

- isolate the environment passed to the nested npm install used by `@endevco/aube`
- remove the outer global install's `npm_config_allow_scripts` policy before starting the project-scoped child
- retain `--ignore-scripts` for the passive platform package and add a regression test for the environment boundary

## Root cause

npm 12 blocks dependency lifecycle scripts by default, so users must allowlist `@endevco/aube` for its platform-selection preinstall. npm exports that allowlist into lifecycle scripts, and Aube's nested project-scoped `npm install --ignore-scripts` rejects the inherited global-only setting with `EALLOWSCRIPTS`.

The child does not need the allowlist because its platform package is installed with lifecycle scripts disabled. Removing only that inherited setting lets the outer allowlisted preinstall and nested npm 12 install both succeed.

This unblocks the npm 12 installation path needed by vltpkg/benchmarks#147.

## Validation

- `node --test npm/installArchSpecificPackage.test.js`
- `node --check npm/installArchSpecificPackage.js`
- `hk check npm/installArchSpecificPackage.js npm/installArchSpecificPackage.test.js`
- staged the root package at version 1.40.0, ran the installer with npm 12.0.1 and `npm_config_allow_scripts=@endevco/aube`, and verified the resulting binary reports Aube 1.40.0

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Install-time packaging change with narrow env scrubbing; regression test covers behavior and does not touch auth or runtime application logic.
> 
> **Overview**
> Fixes **global `@endevco/aube` installs on npm 12** when users allowlist the root package for lifecycle scripts. npm 12 injects that allowlist into the preinstall environment; the nested `npm install --ignore-scripts` for the platform package then fails with **EALLOWSCRIPTS** because it inherits a global-only setting it does not need.
> 
> The preinstall now passes a **sanitized child environment** via new `childNpmEnv()`: it copies the parent env, removes `npm_config_allow_scripts` / `npm_config_global` (including case variants on Windows), and sets `npm_config_global` to `false` so the nested install stays project-scoped. The script is **exportable and test-gated** (`require.main === module`) so the env boundary is covered by `installArchSpecificPackage.test.js` without running the full installer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 341f56d2cfb7537dfad39894e7b320fd2ff57592. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation of architecture-specific packages by ensuring they install locally and use the configured registry.
  * Prevented inherited script-blocking settings from interfering with nested package installation.
  * Avoided unintended changes to the parent environment during installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->