### PR TITLE
fix(install): enable embedded memory diagnostics

### DIFF
--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -268,10 +268,21 @@ impl<'a> ResolveDriver<'a> {
         let resolved_count = self.resolved.len();
         let lockfile_reuse_count = self.lockfile_reuse_count;
         let packument_fetch_count = self.packument_fetch_count;
+        let packument_cache_count = self.resolver.cache.len();
+        let packument_version_count: usize = self
+            .resolver
+            .cache
+            .values()
+            .map(|packument| packument.versions.len())
+            .sum();
         aube_util::diag::instant_lazy(aube_util::diag::Category::Resolver, "decision_mix", || {
             format!(
-                r#"{{"resolved":{},"lockfile_reused":{},"packuments_fetched":{}}}"#,
-                resolved_count, lockfile_reuse_count, packument_fetch_count
+                r#"{{"resolved":{},"lockfile_reused":{},"packuments_fetched":{},"packuments_cached":{},"packument_versions_cached":{}}}"#,
+                resolved_count,
+                lockfile_reuse_count,
+                packument_fetch_count,
+                packument_cache_count,
+                packument_version_count
             )
         });
 

--- a/crates/aube-resolver/src/resolve/fetch.rs
+++ b/crates/aube-resolver/src/resolve/fetch.rs
@@ -181,7 +181,13 @@ async fn fetch_one_packument(inputs: FetchInputs) -> Result<(String, Packument, 
         aube_util::diag::instant_lazy(
             aube_util::diag::Category::Resolver,
             "packument_disk_hit",
-            || format!(r#"{{"name":{}}}"#, aube_util::diag::jstr(&name)),
+            || {
+                format!(
+                    r#"{{"name":{},"versions":{}}}"#,
+                    aube_util::diag::jstr(&name),
+                    packument.versions.len()
+                )
+            },
         );
         permit.record_cancelled();
         return Ok((name, packument, false));
@@ -227,7 +233,13 @@ async fn fetch_one_packument(inputs: FetchInputs) -> Result<(String, Packument, 
         aube_util::diag::instant_lazy(
             aube_util::diag::Category::Resolver,
             "packument_primer_hit",
-            || format!(r#"{{"name":{}}}"#, aube_util::diag::jstr(&name)),
+            || {
+                format!(
+                    r#"{{"name":{},"versions":{}}}"#,
+                    aube_util::diag::jstr(&name),
+                    packument.versions.len()
+                )
+            },
         );
         permit.record_cancelled();
         return Ok((name, packument, true));
@@ -265,7 +277,13 @@ async fn fetch_one_packument(inputs: FetchInputs) -> Result<(String, Packument, 
     aube_util::diag::instant_lazy(
         aube_util::diag::Category::Resolver,
         "packument_network_hit",
-        || format!(r#"{{"name":{}}}"#, aube_util::diag::jstr(&name)),
+        || {
+            format!(
+                r#"{{"name":{},"versions":{}}}"#,
+                aube_util::diag::jstr(&name),
+                packument.versions.len()
+            )
+        },
     );
     Ok((name, packument, false))
 }

--- a/crates/aube-store/src/tarball.rs
+++ b/crates/aube-store/src/tarball.rs
@@ -291,6 +291,7 @@ impl Store {
         let mut staged: Vec<(String, Vec<u8>, bool)> = Vec::new();
         let mut entries_seen: usize = 0;
         let mut total_uncompressed: u64 = 0;
+        let mut max_entry_bytes: u64 = 0;
         let mut decode_ns: u128 = 0;
         let mut cas_ns: u128 = 0;
         let mut index = PackageIndex::default();
@@ -434,6 +435,7 @@ impl Store {
             let mode = entry.header().mode().unwrap_or(0o644);
             let executable = mode & 0o111 != 0;
             total_uncompressed = total_uncompressed.saturating_add(content.len() as u64);
+            max_entry_bytes = max_entry_bytes.max(content.len() as u64);
             staged.push((rel_path, content, executable));
             staged_count += 1;
 
@@ -447,7 +449,11 @@ impl Store {
             aube_util::diag::Category::Store,
             "tar_extract_complete",
             extract_t0.elapsed(),
-            || format!(r#"{{"entries":{staged_count},"bytes_uncompressed":{total_uncompressed}}}"#),
+            || {
+                format!(
+                    r#"{{"entries":{staged_count},"bytes_uncompressed":{total_uncompressed},"max_entry_bytes":{max_entry_bytes}}}"#
+                )
+            },
         );
         if aube_util::diag::enabled() {
             aube_util::diag::event_lazy(

--- a/crates/aube-util/src/diag.rs
+++ b/crates/aube-util/src/diag.rs
@@ -13,6 +13,7 @@
  *   - `AUBE_DIAG_SUMMARY=1` enables the end-of-run aggregate table only.
  *   - `AUBE_DIAG_CRITPATH=1` retains per-event records for the
  *     critical-path / lifecycle / what-if / starvation analyzers.
+ *   - `AUBE_DIAG_FLUSH=1` flushes every JSONL event so a trace survives OOM.
  *
  * Event wire format (JSONL, one event per line):
  *
@@ -66,6 +67,7 @@ use std::time::{Duration, Instant};
 struct Recorder {
     start: Instant,
     file: Option<Mutex<BufWriter<File>>>,
+    flush_each_event: bool,
     print_stderr: bool,
     threshold_ms: u64,
     summary: bool,
@@ -423,6 +425,7 @@ pub fn init_with_config(cfg: Option<DiagConfig>) {
         let recorder = Recorder {
             start: Instant::now(),
             file,
+            flush_each_event: crate::env::embedder_env("DIAG_FLUSH").is_some(),
             print_stderr: cfg.print_stderr,
             threshold_ms: cfg.threshold_ms,
             summary: cfg.summary,
@@ -548,6 +551,9 @@ pub fn event(category: Category, name: &'static str, duration: Duration, meta: O
                 t_ms, cat_wire, name, dur_ms
             ),
         };
+        if r.flush_each_event {
+            let _ = f.flush();
+        }
     }
 
     if r.print_stderr && (dur_ms as u64) >= r.threshold_ms {
@@ -1064,6 +1070,14 @@ pub fn sample_concurrency() {
         let value = slot_counter(r, *slot).load(Ordering::Relaxed);
         let _ = write!(meta, r#""{}":{}"#, slot.sample_key(), value);
     }
+    if crate::diag_kernel::enabled()
+        && let Some(snapshot) = crate::diag_kernel::snapshot()
+    {
+        let _ = write!(meta, r#","rss_peak":{}"#, snapshot.max_rss_bytes);
+        if let Some(current) = crate::diag_kernel::current_rss_bytes() {
+            let _ = write!(meta, r#","rss_current":{current}"#);
+        }
+    }
     meta.push('}');
     instant(Category::Sample, "concurrency", Some(&meta));
 }
@@ -1072,8 +1086,12 @@ pub fn spawn_concurrency_sampler() {
     if !enabled() {
         return;
     }
+    // Capture a baseline even when a warm/empty install finishes before the
+    // spawned sampler receives its first runtime poll.
+    sample_concurrency();
     tokio::spawn(async {
-        let mut iv = tokio::time::interval(Duration::from_millis(50));
+        let period = Duration::from_millis(50);
+        let mut iv = tokio::time::interval_at(tokio::time::Instant::now() + period, period);
         iv.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         let mut tick = 0u32;
         loop {
@@ -1088,11 +1106,21 @@ pub fn spawn_concurrency_sampler() {
     });
 }
 
+/// Flush only the JSONL sink without printing end-of-run analysis.
+///
+/// Embedded hosts remain alive after an aube operation, so their static
+/// recorder's `BufWriter` is not dropped when an install returns. The embed
+/// facade calls this at operation boundaries; `AUBE_DIAG_FLUSH=1` remains the
+/// stronger option when every event must survive an abrupt OOM kill.
+pub fn flush_file() {
+    if let Some(file) = rec().and_then(|r| r.file.as_ref()) {
+        let _ = file.lock().unwrap_or_else(|e| e.into_inner()).flush();
+    }
+}
+
 pub fn flush() {
     if let Some(r) = rec() {
-        if let Some(file) = &r.file {
-            let _ = file.lock().unwrap_or_else(|e| e.into_inner()).flush();
-        }
+        flush_file();
         let n = r.event_count.load(Ordering::Relaxed);
         let total_ms = r.start.elapsed().as_secs_f64() * 1000.0;
 

--- a/crates/aube-util/src/diag.rs
+++ b/crates/aube-util/src/diag.rs
@@ -269,14 +269,14 @@ impl DiagConfig {
      * per-event log is the costly bit.
      */
     pub fn from_env() -> Option<Self> {
-        let file = crate::env::embedder_env("DIAG_FILE").map(PathBuf::from);
-        let print = crate::env::embedder_env("DIAG_PRINT").is_some();
-        let summary_env = crate::env::embedder_env("DIAG_SUMMARY").is_some();
-        let critpath_env = crate::env::embedder_env("DIAG_CRITPATH").is_some();
+        let file = diag_env("DIAG_FILE").map(PathBuf::from);
+        let print = diag_env("DIAG_PRINT").is_some();
+        let summary_env = diag_env("DIAG_SUMMARY").is_some();
+        let critpath_env = diag_env("DIAG_CRITPATH").is_some();
         if file.is_none() && !print && !summary_env && !critpath_env {
             return None;
         }
-        let threshold_ms = crate::env::embedder_env("DIAG_THRESHOLD_MS")
+        let threshold_ms = diag_env("DIAG_THRESHOLD_MS")
             .as_deref()
             .and_then(|s| s.to_str())
             .and_then(|s| s.parse::<u64>().ok())
@@ -292,6 +292,14 @@ impl DiagConfig {
             threshold_ms,
         })
     }
+}
+
+/// Read diagnostics through the host's debug prefix, with a fixed `AUBE_*`
+/// fallback for embedders that intentionally expose no branded debug family.
+/// Diagnostics describe the embedded aube component itself, so operators need
+/// one stable escape hatch even when the host's normal debug toggles are gated.
+pub(crate) fn diag_env(suffix: &str) -> Option<std::ffi::OsString> {
+    crate::env::embedder_env(suffix).or_else(|| std::env::var_os(format!("AUBE_{suffix}")))
 }
 
 /**
@@ -425,7 +433,7 @@ pub fn init_with_config(cfg: Option<DiagConfig>) {
         let recorder = Recorder {
             start: Instant::now(),
             file,
-            flush_each_event: crate::env::embedder_env("DIAG_FLUSH").is_some(),
+            flush_each_event: diag_env("DIAG_FLUSH").is_some(),
             print_stderr: cfg.print_stderr,
             threshold_ms: cfg.threshold_ms,
             summary: cfg.summary,
@@ -1058,7 +1066,7 @@ pub fn sample_channels() {
 /// out the discriminator literals.
 const ALL_SLOTS: [Slot; SLOT_COUNT] = [Slot::Pack, Slot::Tar, Slot::Imp, Slot::Link, Slot::Decode];
 
-pub fn sample_concurrency() {
+fn sample_concurrency_with_rss(current_rss: Option<u64>) {
     let Some(r) = rec() else { return };
     use std::fmt::Write;
     let mut meta = String::with_capacity(80);
@@ -1074,7 +1082,7 @@ pub fn sample_concurrency() {
         && let Some(snapshot) = crate::diag_kernel::snapshot()
     {
         let _ = write!(meta, r#","rss_peak":{}"#, snapshot.max_rss_bytes);
-        if let Some(current) = crate::diag_kernel::current_rss_bytes() {
+        if let Some(current) = current_rss {
             let _ = write!(meta, r#","rss_current":{current}"#);
         }
     }
@@ -1082,21 +1090,45 @@ pub fn sample_concurrency() {
     instant(Category::Sample, "concurrency", Some(&meta));
 }
 
-pub fn spawn_concurrency_sampler() {
+pub fn sample_concurrency() {
+    sample_concurrency_with_rss(None);
+}
+
+/// Aborts the operation-scoped sampler when the install returns.
+pub struct ConcurrencySampler(tokio::task::JoinHandle<()>);
+
+impl Drop for ConcurrencySampler {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+async fn current_rss_off_runtime() -> Option<u64> {
+    if !crate::diag_kernel::enabled() {
+        return None;
+    }
+    tokio::task::spawn_blocking(crate::diag_kernel::current_rss_bytes)
+        .await
+        .ok()
+        .flatten()
+}
+
+pub async fn spawn_concurrency_sampler() -> Option<ConcurrencySampler> {
     if !enabled() {
-        return;
+        return None;
     }
     // Capture a baseline even when a warm/empty install finishes before the
-    // spawned sampler receives its first runtime poll.
-    sample_concurrency();
-    tokio::spawn(async {
+    // spawned sampler receives its first runtime poll. Linux procfs IO runs on
+    // the blocking pool so a current-thread host is not paused by sampling.
+    sample_concurrency_with_rss(current_rss_off_runtime().await);
+    let handle = tokio::spawn(async {
         let period = Duration::from_millis(50);
         let mut iv = tokio::time::interval_at(tokio::time::Instant::now() + period, period);
         iv.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         let mut tick = 0u32;
         loop {
             iv.tick().await;
-            sample_concurrency();
+            sample_concurrency_with_rss(current_rss_off_runtime().await);
             // Channel sampler runs at 1/4 the rate (200ms)
             tick = tick.wrapping_add(1);
             if tick.is_multiple_of(4) {
@@ -1104,6 +1136,7 @@ pub fn spawn_concurrency_sampler() {
             }
         }
     });
+    Some(ConcurrencySampler(handle))
 }
 
 /// Flush only the JSONL sink without printing end-of-run analysis.

--- a/crates/aube-util/src/diag_kernel.rs
+++ b/crates/aube-util/src/diag_kernel.rs
@@ -5,7 +5,8 @@
  * with the env var also set, since the kernel sampler is opt-in even
  * when diag itself is on). Emits `cat=kernel,name=<phase>` events with
  * deltas for user CPU, system CPU, peak resident set size, and page
- * faults around bracketed scopes.
+ * faults around bracketed scopes. The 50 ms concurrency sampler also
+ * records peak RSS and, on Linux, current RSS for timeline correlation.
  *
  * Linux and macOS use `libc::getrusage` directly; the macOS variant
  * reports `ru_maxrss` in bytes while Linux reports it in kibibytes, so
@@ -87,6 +88,27 @@ pub fn enabled() -> bool {
     crate::env::embedder_env("DIAG_KERNEL").is_some() && snapshot().is_some()
 }
 
+/// Current resident set size for timeline sampling.
+///
+/// Linux exposes resident pages as the second field of `/proc/self/statm`.
+/// Other kernels keep reporting the portable high-water mark from
+/// [`snapshot`]; current RSS can be added when a dependency-free API is
+/// available there.
+#[cfg(target_os = "linux")]
+pub fn current_rss_bytes() -> Option<u64> {
+    let statm = std::fs::read_to_string("/proc/self/statm").ok()?;
+    let resident_pages = statm.split_whitespace().nth(1)?.parse::<u64>().ok()?;
+    // Safety: sysconf is a read-only libc query. A non-positive result means
+    // the kernel did not provide a usable page size.
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    (page_size > 0).then(|| resident_pages.saturating_mul(page_size as u64))
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn current_rss_bytes() -> Option<u64> {
+    None
+}
+
 /**
  * Emit a `cat=kernel,name=<phase>` event with the deltas between
  * `before` and `after`.
@@ -134,4 +156,12 @@ where
     let after = snapshot().unwrap_or_default();
     emit_phase_delta(phase, before, after);
     result
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    #[test]
+    fn current_rss_is_available() {
+        assert!(super::current_rss_bytes().is_some_and(|rss| rss > 0));
+    }
 }

--- a/crates/aube-util/src/diag_kernel.rs
+++ b/crates/aube-util/src/diag_kernel.rs
@@ -85,7 +85,7 @@ pub fn snapshot() -> Option<KernelSnapshot> {
  * other platforms.
  */
 pub fn enabled() -> bool {
-    crate::env::embedder_env("DIAG_KERNEL").is_some() && snapshot().is_some()
+    crate::diag::diag_env("DIAG_KERNEL").is_some() && snapshot().is_some()
 }
 
 /// Current resident set size for timeline sampling.

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -556,7 +556,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     let mode = opts.mode;
     let start = std::time::Instant::now();
     let mut phase_timings = InstallPhaseTimings::from_env();
-    aube_util::diag::spawn_concurrency_sampler();
+    let _diag_sampler = aube_util::diag::spawn_concurrency_sampler().await;
     aube_util::diag::instant(aube_util::diag::Category::Install, "begin", None);
     let _diag_install = aube_util::diag::Span::new(aube_util::diag::Category::Install, "total");
 

--- a/crates/aube/src/embed.rs
+++ b/crates/aube/src/embed.rs
@@ -148,6 +148,11 @@ pub async fn install_with_overrides(
     options: InstallOptions,
     overrides: EmbedderInstallOverrides,
 ) -> Result<()> {
+    // The CLI initializes diagnostics during argument dispatch, but hosts that
+    // call the embedding facade never pass through that path. Honor the same
+    // env-driven AUBE_DIAG_* surface here so embedded installs can produce a
+    // low-overhead trace without requiring host-specific plumbing.
+    aube_util::diag::init();
     let mut command_options =
         crate::commands::install::InstallOptions::with_mode(options.frozen_mode);
     command_options.project_dir = Some(options.project_dir);
@@ -165,11 +170,13 @@ pub async fn install_with_overrides(
     command_options.control = options.control;
     command_options.embedder_runtime = options.runtime;
     overrides.append_to(&mut command_options.cli_flags);
-    crate::commands::scope_embedder_install_overrides(
+    let result = crate::commands::scope_embedder_install_overrides(
         overrides,
         crate::commands::install::run(command_options),
     )
-    .await
+    .await;
+    aube_util::diag::flush_file();
+    result
 }
 
 /// Add packages to a project's manifest and install the resulting graph.
@@ -203,7 +210,9 @@ pub async fn add_with_overrides(
     options: AddToProjectOptions,
     overrides: EmbedderInstallOverrides,
 ) -> Result<()> {
-    crate::commands::scope_embedder_install_overrides(
+    // See install_with_overrides: embedded adds bypass CLI diagnostic init.
+    aube_util::diag::init();
+    let result = crate::commands::scope_embedder_install_overrides(
         overrides.clone(),
         crate::commands::add::add_to_project_with_overrides(
             project_dir,
@@ -212,7 +221,9 @@ pub async fn add_with_overrides(
             overrides,
         ),
     )
-    .await
+    .await;
+    aube_util::diag::flush_file();
+    result
 }
 
 /// Run a package's script (`package.json` `scripts.<name>`) in `project_dir`,

--- a/crates/aube/tests/embed_diag.rs
+++ b/crates/aube/tests/embed_diag.rs
@@ -1,7 +1,30 @@
-use aube::embed::{InstallControl, InstallOptions, NetworkMode};
+use aube::embed::{Host, InstallControl, InstallOptions, NetworkMode};
+
+static TEST_HOST: Host = Host {
+    name: "embed-diag-test",
+    display_name: "Embed Diagnostics Test",
+    vendor: None,
+    version: "1.0.0",
+    user_agent: "embed-diag-test/1.0.0",
+    self_names: &[],
+    compatible_names: &["pnpm"],
+    lockfile_basename: "aube-lock.yaml",
+    workspace_yaml: None,
+    manifest_namespace: "",
+    env_prefix: None,
+    config_env_prefix: None,
+    cache_namespace: "embed-diag-test",
+    data_namespace: "embed-diag-test",
+    canonical_lockfile_always_wins: false,
+    runtime_switching: false,
+    self_engines_check: false,
+    self_update_enabled: false,
+};
 
 #[test]
 fn embedded_install_honors_env_driven_diagnostics() {
+    aube::embed::initialize(&TEST_HOST, Vec::new());
+    assert!(aube::embed::host().env_prefix.is_none());
     let sandbox = tempfile::tempdir().unwrap();
     let project = sandbox.path().join("project");
     std::fs::create_dir_all(&project).unwrap();
@@ -36,6 +59,16 @@ fn embedded_install_honors_env_driven_diagnostics() {
         .await
         .unwrap();
     });
+
+    let bytes_after_install = std::fs::metadata(&trace).unwrap().len();
+    runtime.block_on(async {
+        tokio::time::sleep(std::time::Duration::from_millis(120)).await;
+    });
+    assert_eq!(
+        std::fs::metadata(&trace).unwrap().len(),
+        bytes_after_install,
+        "the operation-scoped sampler must stop when the embedded install returns"
+    );
 
     let contents = std::fs::read_to_string(&trace).unwrap();
     assert!(contents.contains(r#""cat":"install","name":"begin""#));

--- a/crates/aube/tests/embed_diag.rs
+++ b/crates/aube/tests/embed_diag.rs
@@ -1,0 +1,44 @@
+use aube::embed::{InstallControl, InstallOptions, NetworkMode};
+
+#[test]
+fn embedded_install_honors_env_driven_diagnostics() {
+    let sandbox = tempfile::tempdir().unwrap();
+    let project = sandbox.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::write(project.join("package.json"), "{}\n").unwrap();
+    let trace = sandbox.path().join("embed-diag.jsonl");
+
+    // Safety: this integration-test binary contains one test and has not
+    // created the Tokio runtime or any other threads yet.
+    unsafe {
+        std::env::set_var("AUBE_DIAG_FILE", &trace);
+        std::env::set_var("AUBE_DIAG_FLUSH", "1");
+        std::env::set_var("AUBE_DIAG_KERNEL", "1");
+    }
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let mut options = InstallOptions::new(&project);
+        options.ignore_scripts = true;
+        options.network_mode = NetworkMode::Offline;
+        options.control = InstallControl::silent();
+        aube::embed::install_with_overrides(
+            options,
+            aube::embed::EmbedderInstallOverrides {
+                use_global_virtual_store: Some(false),
+                cache_dir: Some(sandbox.path().join("cache")),
+                store_dir: Some(sandbox.path().join("store")),
+            },
+        )
+        .await
+        .unwrap();
+    });
+
+    let contents = std::fs::read_to_string(&trace).unwrap();
+    assert!(contents.contains(r#""cat":"install","name":"begin""#));
+    #[cfg(target_os = "linux")]
+    assert!(contents.contains(r#""rss_current":"#));
+}


### PR DESCRIPTION
## Summary

- initialize and flush diagnostics for embedded install/add operations used by hosts such as mise
- add OOM-safe per-event flushing plus periodic current/peak RSS samples
- record packument cardinality and largest extracted tar entry to distinguish resolver retention from extraction spikes

This adds targeted evidence collection for [Discussion #1301](https://github.com/jdx/aube/discussions/1301) without changing install behavior.

## Debugging after this lands

```sh
AUBE_DIAG_FILE=/tmp/aube-memory.jsonl \
AUBE_DIAG_KERNEL=1 \
AUBE_DIAG_FLUSH=1 \
/usr/bin/time -v mise install npm:opencode-ai \
2>/tmp/aube-memory.txt
```

The JSONL trace can then be correlated with the process high-water mark. `AUBE_DIAG_FLUSH=1` preserves the last emitted event if the process is killed by the OOM killer.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo test -p aube --test embed_diag`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostics-only changes with no install graph, fetch, or linking behavior changes; embed paths only add init/flush and optional env-driven tracing.
> 
> **Overview**
> **Embedded hosts** (e.g. mise) now honor the same `AUBE_DIAG_*` env surface as the CLI: `install_with_overrides` / `add_with_overrides` call `diag::init()` and `flush_file()` at operation boundaries so JSONL traces are written even when the process stays alive after install.
> 
> **Diagnostics plumbing** gains `diag_env()` (embedder debug prefix with `AUBE_*` fallback), optional **`AUBE_DIAG_FLUSH=1`** per-event JSONL flush, and **`flush_file()`** for boundary flush without end-of-run analysis. The concurrency sampler is **operation-scoped** (`ConcurrencySampler` aborts on drop), is **awaited** at install start, records an immediate baseline sample, and—when **`AUBE_DIAG_KERNEL=1`**—adds **`rss_peak`** / Linux **`rss_current`** to `sample.concurrency` via blocking `/proc/self/statm` reads.
> 
> **Trace enrichment** (observability only): resolver `decision_mix` reports packument cache size and version counts; packument hit events include `versions`; tarball extract completion includes **`max_entry_bytes`**.
> 
> New integration test **`embed_diag`** verifies env-driven embedded traces and that sampling stops after the install returns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72975baad82605c967e3754523207ea2657c21fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Diagnostics**
  * Added detailed cache, package version, tarball extraction, and memory usage metrics to diagnostic output.
  * Added an option to flush diagnostic events immediately for more up-to-date JSONL traces.
  * Diagnostic sampling now records an initial baseline and current memory usage where supported.
* **Reliability**
  * Embedded installation and package-add operations now capture and finalize diagnostic output consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->