### PR TITLE
fix(settings): validate package extensions

### DIFF
--- a/crates/aube-codes/src/errors.rs
+++ b/crates/aube-codes/src/errors.rs
@@ -88,6 +88,7 @@ pub const ERR_AUBE_FILTER_GIT_FAILED: &str = "ERR_AUBE_FILTER_GIT_FAILED";
 // ── manifest ────────────────────────────────────────────────────────
 pub const ERR_AUBE_MANIFEST_PARSE: &str = "ERR_AUBE_MANIFEST_PARSE";
 pub const ERR_AUBE_MANIFEST_YAML_PARSE: &str = "ERR_AUBE_MANIFEST_YAML_PARSE";
+pub const ERR_AUBE_INVALID_PACKAGE_EXTENSION: &str = "ERR_AUBE_INVALID_PACKAGE_EXTENSION";
 
 // ── engine / cli ────────────────────────────────────────────────────
 pub const ERR_AUBE_UNSUPPORTED_ENGINE: &str = "ERR_AUBE_UNSUPPORTED_ENGINE";
@@ -480,6 +481,12 @@ pub const ALL: &[CodeMeta] = &[
         name: ERR_AUBE_MANIFEST_YAML_PARSE,
         category: category::MANIFEST_WORKSPACE,
         description: "A workspace YAML helper file was structurally invalid (no source pointer available).",
+        exit_code: None,
+    },
+    CodeMeta {
+        name: ERR_AUBE_INVALID_PACKAGE_EXTENSION,
+        category: category::MANIFEST_WORKSPACE,
+        description: "A `packageExtensions` entry had an invalid object shape or non-string dependency range.",
         exit_code: None,
     },
     CodeMeta {

--- a/crates/aube-manifest/src/lib.rs
+++ b/crates/aube-manifest/src/lib.rs
@@ -775,27 +775,29 @@ impl PackageJson {
         unresolved
     }
 
+    /// Return every raw `packageExtensions` value in precedence order so
+    /// callers can validate the enclosing shape before object extraction.
+    pub fn package_extension_values(&self) -> Vec<&serde_json::Value> {
+        let mut out = self
+            .pnpm_aube_objects()
+            .filter_map(|ns| ns.get("packageExtensions"))
+            .collect::<Vec<_>>();
+        if let Some(value) = self.extra.get("packageExtensions") {
+            out.push(value);
+        }
+        out
+    }
+
     /// Extract `packageExtensions` from root package.json. Supports
     /// top-level `packageExtensions`, `pnpm.packageExtensions`, and
-    /// `aube.packageExtensions`. Precedence (low → high):
-    /// `pnpm.packageExtensions`, `aube.packageExtensions`, top-level
-    /// `packageExtensions` — later writes win for duplicate selectors.
+    /// `aube.packageExtensions`. Later values win for duplicate selectors.
     pub fn package_extensions(&self) -> BTreeMap<String, serde_json::Value> {
         let mut out = BTreeMap::new();
-        for ns in self.pnpm_aube_objects() {
-            if let Some(obj) = ns.get("packageExtensions").and_then(|v| v.as_object()) {
+        for value in self.package_extension_values() {
+            if let Some(obj) = value.as_object() {
                 for (k, v) in obj {
                     out.insert(k.clone(), v.clone());
                 }
-            }
-        }
-        if let Some(obj) = self
-            .extra
-            .get("packageExtensions")
-            .and_then(|v| v.as_object())
-        {
-            for (k, v) in obj {
-                out.insert(k.clone(), v.clone());
             }
         }
         out

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -689,7 +689,7 @@ async fn write_fix_lockfile_update(
     widen_vulnerable_direct_pins(&mut resolver_manifest, graph, &vulnerable_ranges);
 
     let workspace_catalogs = super::load_workspace_catalogs(cwd)?;
-    let mut resolver = super::build_resolver(cwd, &resolver_manifest, workspace_catalogs)
+    let mut resolver = super::build_resolver(cwd, &resolver_manifest, workspace_catalogs)?
         .with_vulnerable_ranges(vulnerable_ranges.clone());
     let mut new_graph = resolver
         .resolve(&resolver_manifest, Some(graph))

--- a/crates/aube/src/commands/dedupe.rs
+++ b/crates/aube/src/commands/dedupe.rs
@@ -74,7 +74,7 @@ pub async fn run(args: DedupeArgs) -> miette::Result<()> {
     }
 
     let workspace_catalogs = super::load_workspace_catalogs(&cwd)?;
-    let mut resolver = super::build_resolver(&cwd, &manifest, workspace_catalogs);
+    let mut resolver = super::build_resolver(&cwd, &manifest, workspace_catalogs)?;
     let mut graph = resolver
         .resolve_workspace(&manifests, None, &ws_package_versions)
         .await

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -77,15 +77,17 @@ use materialize::{
 pub(crate) use settings::PeerDependencyRules;
 pub(crate) use settings::resolve_catalog_prune;
 pub(crate) use settings::resolve_minimum_release_age;
-pub(crate) use settings::{ResolverConfigInputs, configure_resolver, finalize_lockfile_graph};
+pub(crate) use settings::{
+    ResolverConfigInputs, configure_resolver, finalize_lockfile_graph, resolve_dependency_policy,
+};
 pub(crate) use side_effects_cache::{SideEffectsCacheConfig, side_effects_cache_root};
 
 use settings::{
     check_unmet_peers, default_lockfile_network_concurrency, default_streaming_network_concurrency,
-    maybe_cleanup_unused_catalogs, resolve_dependency_policy, resolve_git_shallow_hosts,
-    resolve_link_concurrency, resolve_network_concurrency, resolve_side_effects_cache,
-    resolve_side_effects_cache_readonly, resolve_strict_peer_dependencies,
-    resolve_strict_store_pkg_content_check, resolve_verify_store_integrity,
+    maybe_cleanup_unused_catalogs, resolve_git_shallow_hosts, resolve_link_concurrency,
+    resolve_network_concurrency, resolve_side_effects_cache, resolve_side_effects_cache_readonly,
+    resolve_strict_peer_dependencies, resolve_strict_store_pkg_content_check,
+    resolve_verify_store_integrity,
 };
 use startup::{
     apply_force_state_reset, emit_up_to_date, merge_branch_lockfiles_if_needed,
@@ -637,7 +639,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     let packument_cache_dir =
         super::resolved_cache_dir_with_ctx(&cwd, &settings_ctx).join("packuments-v1");
     let explicit_store_dir_override = has_explicit_store_dir_override(&opts.cli_flags);
-    let dependency_policy = resolve_dependency_policy(&manifest, &settings_ctx);
+    let dependency_policy = resolve_dependency_policy(&manifest, &settings_ctx)?;
     // Resolve the project's Node runtime before anything can spawn
     // node: the root `preinstall` hooks below must already run on the
     // switched runtime, and the virtual-store keys downstream fold
@@ -1401,7 +1403,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
                     // widening to every common platform doesn't happen
                     // just to be discarded.
                     target_lockfile_kind: lockfile_enabled.then_some(write_kind),
-                    dependency_policy: Some(dependency_policy.clone()),
+                    dependency_policy: dependency_policy.clone(),
                     cache_full_packuments: true,
                     ignore_scripts: opts.ignore_scripts,
                 },

--- a/crates/aube/src/commands/install/resolve.rs
+++ b/crates/aube/src/commands/install/resolve.rs
@@ -252,7 +252,7 @@ pub(super) async fn run_lockfile_only(input: LockfileOnlyInput<'_>) -> miette::R
             // With lockfiles enabled, `write_kind` is either the existing
             // format or the configured creation default.
             target_lockfile_kind: lockfile_enabled.then_some(write_kind),
-            dependency_policy: Some(dependency_policy.clone()),
+            dependency_policy: dependency_policy.clone(),
             cache_full_packuments: true,
             ignore_scripts,
         },

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -441,11 +441,11 @@ pub(crate) fn resolve_force_metadata_primer(ctx: &aube_settings::ResolveCtx<'_>)
 pub(crate) fn resolve_dependency_policy(
     manifest: &aube_manifest::PackageJson,
     ctx: &aube_settings::ResolveCtx<'_>,
-) -> aube_resolver::DependencyPolicy {
+) -> miette::Result<aube_resolver::DependencyPolicy> {
     let mut policy = aube_resolver::DependencyPolicy::default();
 
     let package_extensions = effective_package_extensions(manifest, ctx);
-    policy.package_extensions = parse_package_extensions(package_extensions);
+    policy.package_extensions = parse_package_extensions(package_extensions)?;
 
     let mut allowed_deprecated = manifest.allowed_deprecated_versions();
     merge_string_map_setting(ctx, "allowedDeprecatedVersions", &mut allowed_deprecated);
@@ -481,7 +481,7 @@ pub(crate) fn resolve_dependency_policy(
     policy.trust_policy_ignore_after = aube_settings::resolved::trust_policy_ignore_after(ctx);
     policy.block_exotic_subdeps = aube_settings::resolved::block_exotic_subdeps(ctx);
 
-    policy
+    Ok(policy)
 }
 
 /// Assemble the effective `packageExtensions` object — the root
@@ -740,52 +740,96 @@ fn json_string_map(map: BTreeMap<String, serde_json::Value>) -> BTreeMap<String,
 
 fn parse_package_extensions(
     raw: BTreeMap<String, serde_json::Value>,
-) -> Vec<aube_resolver::PackageExtension> {
+) -> miette::Result<Vec<aube_resolver::PackageExtension>> {
     raw.into_iter()
-        .filter_map(|(selector, value)| {
-            let obj = value.as_object()?;
-            Some(aube_resolver::PackageExtension {
+        .map(|(selector, value)| {
+            let obj = value
+                .as_object()
+                .ok_or_else(|| invalid_package_extension(&selector, "entry must be an object"))?;
+            let dependencies_path = format!("{selector}.dependencies");
+            let optional_dependencies_path = format!("{selector}.optionalDependencies");
+            let peer_dependencies_path = format!("{selector}.peerDependencies");
+            let peer_dependencies_meta_path = format!("{selector}.peerDependenciesMeta");
+            Ok(aube_resolver::PackageExtension {
                 selector,
-                dependencies: read_json_string_map(obj.get("dependencies")),
-                optional_dependencies: read_json_string_map(obj.get("optionalDependencies")),
-                peer_dependencies: read_json_string_map(obj.get("peerDependencies")),
+                dependencies: read_json_string_map(obj.get("dependencies"), &dependencies_path)?,
+                optional_dependencies: read_json_string_map(
+                    obj.get("optionalDependencies"),
+                    &optional_dependencies_path,
+                )?,
+                peer_dependencies: read_json_string_map(
+                    obj.get("peerDependencies"),
+                    &peer_dependencies_path,
+                )?,
                 peer_dependencies_meta: read_peer_dependencies_meta(
                     obj.get("peerDependenciesMeta"),
-                ),
+                    &peer_dependencies_meta_path,
+                )?,
             })
         })
         .collect()
 }
 
-fn read_json_string_map(value: Option<&serde_json::Value>) -> BTreeMap<String, String> {
-    value
-        .and_then(|v| v.as_object())
-        .map(|obj| {
-            obj.iter()
-                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
-                .collect()
+fn read_json_string_map(
+    value: Option<&serde_json::Value>,
+    field: &str,
+) -> miette::Result<BTreeMap<String, String>> {
+    let Some(value) = value else {
+        return Ok(BTreeMap::new());
+    };
+    let obj = value
+        .as_object()
+        .ok_or_else(|| invalid_package_extension(field, "field must be an object"))?;
+    obj.iter()
+        .map(|(name, value)| {
+            let range = value.as_str().ok_or_else(|| {
+                invalid_package_extension(
+                    &format!("{field}.{name}"),
+                    "dependency range must be a string",
+                )
+            })?;
+            Ok((name.clone(), range.to_string()))
         })
-        .unwrap_or_default()
+        .collect()
 }
 
 fn read_peer_dependencies_meta(
     value: Option<&serde_json::Value>,
-) -> BTreeMap<String, aube_registry::PeerDepMeta> {
-    value
-        .and_then(|v| v.as_object())
-        .map(|obj| {
-            obj.iter()
-                .map(|(name, meta)| {
-                    let optional = meta
-                        .as_object()
-                        .and_then(|m| m.get("optional"))
-                        .and_then(|v| v.as_bool())
-                        .unwrap_or(false);
-                    (name.clone(), aube_registry::PeerDepMeta { optional })
-                })
-                .collect()
+    field: &str,
+) -> miette::Result<BTreeMap<String, aube_registry::PeerDepMeta>> {
+    let Some(value) = value else {
+        return Ok(BTreeMap::new());
+    };
+    let obj = value
+        .as_object()
+        .ok_or_else(|| invalid_package_extension(field, "field must be an object"))?;
+    obj.iter()
+        .map(|(name, meta)| {
+            let meta = meta.as_object().ok_or_else(|| {
+                invalid_package_extension(
+                    &format!("{field}.{name}"),
+                    "peer metadata must be an object",
+                )
+            })?;
+            let optional = match meta.get("optional") {
+                Some(value) => value.as_bool().ok_or_else(|| {
+                    invalid_package_extension(
+                        &format!("{field}.{name}.optional"),
+                        "optional must be a boolean",
+                    )
+                })?,
+                None => false,
+            };
+            Ok((name.clone(), aube_registry::PeerDepMeta { optional }))
         })
-        .unwrap_or_default()
+        .collect()
+}
+
+fn invalid_package_extension(path: &str, reason: &str) -> miette::Report {
+    miette::miette!(
+        code = aube_codes::errors::ERR_AUBE_INVALID_PACKAGE_EXTENSION,
+        "invalid packageExtensions entry at {path:?}: {reason}"
+    )
 }
 
 /// Apply the install-time resolver configuration that's shared between
@@ -823,7 +867,7 @@ pub(crate) struct ResolverConfigInputs<'a> {
     /// resolutions. Callers compute this as
     /// `lockfile_enabled.then(|| source_kind_before.unwrap_or(Aube))`.
     pub(crate) target_lockfile_kind: Option<aube_lockfile::LockfileKind>,
-    pub(crate) dependency_policy: Option<aube_resolver::DependencyPolicy>,
+    pub(crate) dependency_policy: aube_resolver::DependencyPolicy,
     /// When `true`, the resolver caches full (non-corgi) packuments on
     /// disk so the next install/update can reuse them without a
     /// round-trip. Install opts in (`true`) to amortize the cost of
@@ -926,8 +970,6 @@ pub(crate) fn configure_resolver(
     if !effective_overrides.is_empty() {
         tracing::debug!("applying {} overrides", effective_overrides.len());
     }
-    let dependency_policy =
-        dependency_policy.unwrap_or_else(|| resolve_dependency_policy(manifest, settings_ctx));
     if !dependency_policy.package_extensions.is_empty() {
         tracing::debug!(
             "applying {} packageExtensions",

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -444,6 +444,7 @@ pub(crate) fn resolve_dependency_policy(
 ) -> miette::Result<aube_resolver::DependencyPolicy> {
     let mut policy = aube_resolver::DependencyPolicy::default();
 
+    validate_package_extension_containers(manifest, ctx)?;
     let package_extensions = effective_package_extensions(manifest, ctx);
     policy.package_extensions = parse_package_extensions(package_extensions)?;
 
@@ -730,6 +731,77 @@ fn parse_json_object(raw: &str) -> Option<BTreeMap<String, serde_json::Value>> {
         return None;
     };
     Some(obj.into_iter().collect())
+}
+
+fn validate_package_extension_containers(
+    manifest: &aube_manifest::PackageJson,
+    ctx: &aube_settings::ResolveCtx<'_>,
+) -> miette::Result<()> {
+    for value in manifest.package_extension_values() {
+        if !value.is_object() {
+            return Err(invalid_package_extension(
+                "packageExtensions",
+                "setting must be an object",
+            ));
+        }
+    }
+
+    let meta = aube_settings::find("packageExtensions").ok_or_else(|| {
+        invalid_package_extension("packageExtensions", "setting is not registered")
+    })?;
+    for entries in [
+        ctx.user_npmrc,
+        ctx.user_aube_config,
+        ctx.project_npmrc,
+        ctx.project_aube_config,
+    ] {
+        for (key, raw) in entries.iter().rev() {
+            if !meta.npmrc_keys.contains(&key.as_str()) {
+                continue;
+            }
+            let value: serde_json::Value = serde_json::from_str(raw).map_err(|_| {
+                invalid_package_extension("packageExtensions", "setting must be valid JSON")
+            })?;
+            if !value.is_object() {
+                return Err(invalid_package_extension(
+                    "packageExtensions",
+                    "setting must be an object",
+                ));
+            }
+            break;
+        }
+    }
+    for key in meta.workspace_yaml_keys {
+        let Some(value) = aube_settings::workspace_yaml_value(ctx.workspace_yaml, key) else {
+            continue;
+        };
+        let value = serde_json::to_value(value).map_err(|_| {
+            invalid_package_extension("packageExtensions", "setting must be an object")
+        })?;
+        if !value.is_object() {
+            return Err(invalid_package_extension(
+                "packageExtensions",
+                "setting must be an object",
+            ));
+        }
+        break;
+    }
+    for (key, raw) in ctx.env.iter().rev() {
+        if !meta.env_vars.contains(&key.as_str()) {
+            continue;
+        }
+        let value: serde_json::Value = serde_json::from_str(raw).map_err(|_| {
+            invalid_package_extension("packageExtensions", "setting must be valid JSON")
+        })?;
+        if !value.is_object() {
+            return Err(invalid_package_extension(
+                "packageExtensions",
+                "setting must be an object",
+            ));
+        }
+        break;
+    }
+    Ok(())
 }
 
 fn json_string_map(map: BTreeMap<String, serde_json::Value>) -> BTreeMap<String, String> {

--- a/crates/aube/src/commands/remove.rs
+++ b/crates/aube/src/commands/remove.rs
@@ -110,6 +110,13 @@ pub async fn run(
         eprintln!("  - {name}");
     }
 
+    // Build and validate resolver configuration before persisting the
+    // manifest mutation. A malformed policy must leave package.json and
+    // the installed graph in their original, consistent state.
+    let existing = aube_lockfile::parse_lockfile(&cwd, &manifest).ok();
+    let workspace_catalogs = super::load_workspace_catalogs(&cwd)?;
+    let mut resolver = super::build_resolver(&cwd, &manifest, workspace_catalogs.clone())?;
+
     // Write updated package.json atomically. Crash mid-write would
     // otherwise truncate the user manifest, worst-case aube failure
     // mode. Tempfile + persist keeps the swap atomic.
@@ -165,10 +172,8 @@ pub async fn run(
     let workspace_config = aube_manifest::WorkspaceConfig::load(&cwd)
         .map_err(miette::Report::new)
         .wrap_err("failed to load workspace config")?;
-    let workspace_catalogs = super::load_workspace_catalogs(&cwd)?;
     let lockfile_kind = aube_lockfile::detect_existing_lockfile_kind(&cwd)
         .unwrap_or(aube_lockfile::LockfileKind::Aube);
-    let existing = aube_lockfile::parse_lockfile(&cwd, &manifest).ok();
     let patch_status = existing
         .as_ref()
         .map(|graph| install::check_patch_drift(&cwd, graph, lockfile_kind))
@@ -198,7 +203,6 @@ pub async fn run(
             (graph, true)
         }
         None => {
-            let mut resolver = super::build_resolver(&cwd, &manifest, workspace_catalogs)?;
             let graph = resolver
                 .resolve(&manifest, existing.as_ref())
                 .await

--- a/crates/aube/src/commands/remove.rs
+++ b/crates/aube/src/commands/remove.rs
@@ -106,8 +106,6 @@ pub async fn run(
             };
             return Err(miette!("package '{name}' is not {section}"));
         }
-
-        eprintln!("  - {name}");
     }
 
     // Build and validate resolver configuration before persisting the
@@ -162,6 +160,9 @@ pub async fn run(
         }
         Ok(())
     })?;
+    for name in packages {
+        eprintln!("  - {name}");
+    }
     eprintln!("Updated package.json");
 
     // Removing a direct dependency normally needs no registry work: trim

--- a/crates/aube/src/commands/remove.rs
+++ b/crates/aube/src/commands/remove.rs
@@ -198,7 +198,7 @@ pub async fn run(
             (graph, true)
         }
         None => {
-            let mut resolver = super::build_resolver(&cwd, &manifest, workspace_catalogs);
+            let mut resolver = super::build_resolver(&cwd, &manifest, workspace_catalogs)?;
             let graph = resolver
                 .resolve(&manifest, existing.as_ref())
                 .await

--- a/crates/aube/src/commands/settings_context.rs
+++ b/crates/aube/src/commands/settings_context.rs
@@ -461,7 +461,7 @@ pub(crate) fn build_resolver(
     cwd: &std::path::Path,
     manifest: &aube_manifest::PackageJson,
     catalogs: CatalogMap,
-) -> aube_resolver::Resolver {
+) -> miette::Result<aube_resolver::Resolver> {
     let (ws_config, raw_workspace) = aube_manifest::workspace::load_both(cwd).unwrap_or_default();
     let files = FileSources::load(cwd);
     let env = aube_settings::values::process_env();
@@ -472,7 +472,8 @@ pub(crate) fn build_resolver(
     // that record per-package platform metadata keep optional natives for
     // every platform, while formats without that metadata stay host-only.
     let target_lockfile_kind = Some(lockfile_kind_for_write_with_ctx(cwd, &ctx));
-    install::configure_resolver(
+    let dependency_policy = install::resolve_dependency_policy(manifest, &ctx)?;
+    Ok(install::configure_resolver(
         aube_resolver::Resolver::new(std::sync::Arc::new(make_client(cwd))),
         cwd,
         manifest,
@@ -482,7 +483,7 @@ pub(crate) fn build_resolver(
             workspace_catalogs: &catalogs,
             minimum_release_age_override: None,
             target_lockfile_kind,
-            dependency_policy: None,
+            dependency_policy,
             // Update / add / dedupe / audit deliberately skip the
             // full-packument disk cache install populates: the cache's
             // freshness window can outlive a registry dist-tag bump,
@@ -494,7 +495,7 @@ pub(crate) fn build_resolver(
             ignore_scripts: false,
         },
         None,
-    )
+    ))
 }
 
 /// Resolve [`aube_registry::config::FetchPolicy`] from the same

--- a/crates/aube/src/commands/update.rs
+++ b/crates/aube/src/commands/update.rs
@@ -708,7 +708,7 @@ async fn run_inner(
             None => (None, Vec::new()),
         };
     let workspace_package_versions = workspace_package_versions(&cwd)?;
-    let mut resolver = super::build_resolver(&cwd, &manifest, workspace_catalogs);
+    let mut resolver = super::build_resolver(&cwd, &manifest, workspace_catalogs)?;
     if let Some(host) = read_package_host {
         resolver = resolver
             .with_read_package_hook(Box::new(host) as Box<dyn aube_resolver::ReadPackageHook>);

--- a/docs/error-codes.data.json
+++ b/docs/error-codes.data.json
@@ -325,6 +325,12 @@
       "exit_code": null
     },
     {
+      "name": "ERR_AUBE_INVALID_PACKAGE_EXTENSION",
+      "category": "Manifest / workspace",
+      "description": "A `packageExtensions` entry had an invalid object shape or non-string dependency range.",
+      "exit_code": null
+    },
+    {
       "name": "ERR_AUBE_FILTER_EMPTY",
       "category": "Manifest / workspace",
       "description": "`--filter` was passed an empty selector.",

--- a/test/overrides.bats
+++ b/test/overrides.bats
@@ -22,6 +22,20 @@ teardown() {
 	assert_output --partial "dependencies.is-number"
 }
 
+@test "non-object packageExtensions fail before resolution" {
+	cat >package.json <<-'EOF'
+		{
+		  "name": "invalid-package-extensions",
+		  "version": "1.0.0",
+		  "packageExtensions": []
+		}
+	EOF
+	run aube install --no-frozen-lockfile
+	assert_failure
+	assert_output --partial "ERR_AUBE_INVALID_PACKAGE_EXTENSION"
+	assert_output --partial "setting must be an"
+}
+
 # Sanity baseline: with no override, is-odd@3.0.1's `is-number: ^6.0.0`
 # range resolves to is-number@6.0.0 (the highest matching version in
 # the fixture registry).

--- a/test/overrides.bats
+++ b/test/overrides.bats
@@ -9,6 +9,19 @@ teardown() {
 	_common_teardown
 }
 
+@test "malformed packageExtensions fail before resolution" {
+	cat >pnpm-workspace.yaml <<-'EOF'
+		packageExtensions:
+		  is-odd@3:
+		    dependencies:
+		      is-number: null
+	EOF
+	run aube install --no-frozen-lockfile
+	assert_failure
+	assert_output --partial "ERR_AUBE_INVALID_PACKAGE_EXTENSION"
+	assert_output --partial "dependencies.is-number"
+}
+
 # Sanity baseline: with no override, is-odd@3.0.1's `is-number: ^6.0.0`
 # range resolves to is-number@6.0.0 (the highest matching version in
 # the fixture registry).

--- a/test/remove.bats
+++ b/test/remove.bats
@@ -207,6 +207,26 @@ EOF
 	assert_output --partial "not a dependency"
 }
 
+@test "aube remove: invalid packageExtensions leave package.json unchanged" {
+	cat >package.json <<'EOF'
+{
+  "name": "test-remove-invalid-extensions",
+  "version": "0.0.0",
+  "dependencies": {
+    "is-odd": "^3.0.1"
+  },
+  "packageExtensions": []
+}
+EOF
+	before="$(cat package.json)"
+
+	run aube remove is-odd
+	assert_failure
+	assert_output --partial "ERR_AUBE_INVALID_PACKAGE_EXTENSION"
+	after="$(cat package.json)"
+	[ "$before" = "$after" ]
+}
+
 @test "aube remove: removes dev dependency" {
 	cat >package.json <<'EOF'
 {

--- a/test/remove.bats
+++ b/test/remove.bats
@@ -223,6 +223,7 @@ EOF
 	run aube remove is-odd
 	assert_failure
 	assert_output --partial "ERR_AUBE_INVALID_PACKAGE_EXTENSION"
+	refute_output --partial "  - is-odd"
 	after="$(cat package.json)"
 	[ "$before" = "$after" ]
 }


### PR DESCRIPTION
## Summary

- reject malformed `packageExtensions` objects before dependency resolution
- validate dependency ranges and peer metadata instead of silently dropping invalid values
- add stable `ERR_AUBE_INVALID_PACKAGE_EXTENSION` diagnostics with the invalid field path
- apply validation consistently to install, update, remove, dedupe, and audit resolver construction

## Root cause

The parser used `filter_map` and `as_str`, so invalid objects and values such as a `null` dependency range disappeared from the effective policy without an error.

## Validation

- `cargo fmt --check`
- `cargo check -p aube`
- `cargo test -p aube-codes`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build`
- `mise run test:bats test/overrides.bats`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared resolver setup for install, update, remove, dedupe, and audit; projects with previously ignored invalid packageExtensions will now fail until fixed.
> 
> **Overview**
> Malformed **`packageExtensions`** now fail **before** dependency resolution instead of being dropped silently. Invalid container shapes (non-objects), bad entry objects, non-string dependency ranges, and invalid **`peerDependenciesMeta`** produce **`ERR_AUBE_INVALID_PACKAGE_EXTENSION`** with a field path in the message.
> 
> Validation runs when building **`DependencyPolicy`** from the root manifest, merged config (**.npmrc**, workspace YAML, env), and parsed entries. **`resolve_dependency_policy`** and **`build_resolver`** return **`Result`**, and install/update/audit/dedupe/remove propagate those errors. **`aube remove`** builds and validates the resolver **before** writing **`package.json`** so a bad policy cannot leave the manifest and lockfile inconsistent.
> 
> **`PackageJson::package_extension_values()`** exposes raw values for shape checks; **`configure_resolver`** always takes a resolved policy (no optional lazy default).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24084b2ca984d9e0c9ba140b70dbfd6da4034724. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for `packageExtensions` configuration, including dependency ranges, peer metadata, and optional flags.
  * Added a dedicated error code and diagnostic details for invalid package extension entries.

* **Bug Fixes**
  * Invalid package extension settings now fail early with clear guidance instead of being silently ignored.
  * Improved error handling across install, audit, dedupe, remove, and update workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->