### PR TITLE
perf(runtime): skip index for exact Node versions

### DIFF
--- a/crates/aube-runtime/src/resolver.rs
+++ b/crates/aube-runtime/src/resolver.rs
@@ -127,9 +127,14 @@ impl NodeRuntime {
         // Network: pin the spec to an exact version.
         progress.on_phase(None, crate::progress::InstallPhase::Resolving);
         let platform = Platform::current()?;
-        let (version, fresh_pin) = match pinned {
-            Some(p) => (p.version.clone(), None),
-            None => {
+        let (version, fresh_pin) = match (pinned, &target) {
+            (Some(p), _) => (p.version.clone(), None),
+            // An exact version can go straight to the immutable
+            // per-release SHASUMS file. Besides saving the index
+            // round-trip, this lets an exact request resolve when a
+            // mirror serves release artifacts but no global index.
+            (None, NodeSpec::Exact(version)) => (version.clone(), None),
+            (None, _) => {
                 let selected = match index::load_index(&self.http, &self.cfg).await {
                     Ok(entries) => index::select(&entries, &target, &platform)
                         .map(|e| e.version.clone())
@@ -305,6 +310,9 @@ impl NodeRuntime {
     /// artifact set — the lockfile-pin path. Always network-backed
     /// (through the disk caches).
     pub async fn resolve_for_lockfile(&self, spec: &NodeSpec) -> Result<PinnedNode, Error> {
+        if let NodeSpec::Exact(version) = spec {
+            return self.build_full_pin(version).await;
+        }
         let platform = Platform::current()?;
         let entries = index::load_index(&self.http, &self.cfg).await?;
         let entry =
@@ -452,6 +460,51 @@ fn variants_from_shasums<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn exact_lockfile_pin_skips_release_index() {
+        use std::io::{Read, Write};
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 2048];
+            let read = stream.read(&mut request).unwrap();
+            let request = String::from_utf8_lossy(&request[..read]);
+            let path = request
+                .lines()
+                .next()
+                .and_then(|line| line.split_whitespace().nth(1))
+                .unwrap()
+                .to_string();
+            let body = concat!(
+                "0000000000000000000000000000000000000000000000000000000000000000",
+                "  node-v22.23.2-linux-x64.tar.gz\n"
+            );
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            )
+            .unwrap();
+            path
+        });
+
+        let runtime = NodeRuntime::new(RuntimeConfig {
+            mirror: Some(format!("http://{address}")),
+            retries: 0,
+            ..RuntimeConfig::default()
+        });
+        let version = node_semver::Version::parse("22.23.2").unwrap();
+        let pin = runtime
+            .resolve_for_lockfile(&NodeSpec::Exact(version.clone()))
+            .await
+            .unwrap();
+
+        assert_eq!(pin.version, version);
+        assert_eq!(server.join().unwrap(), "/v22.23.2/SHASUMS256.txt");
+    }
 
     #[test]
     fn shasums_variant_mapping() {

--- a/crates/aube-runtime/src/resolver.rs
+++ b/crates/aube-runtime/src/resolver.rs
@@ -310,34 +310,35 @@ impl NodeRuntime {
     /// artifact set — the lockfile-pin path. Always network-backed
     /// (through the disk caches).
     pub async fn resolve_for_lockfile(&self, spec: &NodeSpec) -> Result<PinnedNode, Error> {
-        if let NodeSpec::Exact(version) = spec {
-            let pin = self.build_full_pin(version).await?;
-            let platform = Platform::current()?;
-            // Exact specs bypass the release-index availability gate. Apply
-            // an equivalent check for official Node distributions, while
-            // leaving FreeBSD and best-effort musl pins usable: those hosts
-            // intentionally rely on system/mise Node or a later live-checksum
-            // lookup rather than requiring an official lockfile variant.
-            if requires_official_host_variant(&platform)
-                && pin
-                    .variant_for(&platform.os, &platform.cpu, platform.libc.as_deref())
-                    .is_none()
-            {
-                return Err(Error::UnsupportedPlatform {
-                    platform: platform.label(),
-                });
-            }
-            return Ok(pin);
-        }
         let platform = Platform::current()?;
-        let entries = index::load_index(&self.http, &self.cfg).await?;
-        let entry =
-            index::select(&entries, spec, &platform).ok_or_else(|| Error::NoMatchingVersion {
-                requested: spec.display(),
-                platform_note: String::new(),
-            })?;
-        let version = entry.version.clone();
-        self.build_full_pin(&version).await
+        let version = match spec {
+            NodeSpec::Exact(version) => version.clone(),
+            _ => {
+                let entries = index::load_index(&self.http, &self.cfg).await?;
+                index::select(&entries, spec, &platform)
+                    .ok_or_else(|| Error::NoMatchingVersion {
+                        requested: spec.display(),
+                        platform_note: String::new(),
+                    })?
+                    .version
+                    .clone()
+            }
+        };
+        let pin = self.build_full_pin(&version).await?;
+        // The release index is only a coarse availability gate. Validate the
+        // selected release against its checksums as well, while leaving
+        // FreeBSD and best-effort musl pins usable: those hosts intentionally
+        // rely on system/mise Node or a later live-checksum lookup.
+        if requires_official_host_variant(&platform)
+            && pin
+                .variant_for(&platform.os, &platform.cpu, platform.libc.as_deref())
+                .is_none()
+        {
+            return Err(Error::UnsupportedPlatform {
+                platform: platform.label(),
+            });
+        }
+        Ok(pin)
     }
 
     /// Build a full pin (all platforms) from SHASUMS data: the

--- a/crates/aube-runtime/src/resolver.rs
+++ b/crates/aube-runtime/src/resolver.rs
@@ -347,10 +347,20 @@ impl NodeRuntime {
                 }
             }
         }
-        Ok(PinnedNode {
+        let pin = PinnedNode {
             version: version.clone(),
             variants,
-        })
+        };
+        let platform = Platform::current()?;
+        if pin
+            .variant_for(&platform.os, &platform.cpu, platform.libc.as_deref())
+            .is_none()
+        {
+            return Err(Error::UnsupportedPlatform {
+                platform: platform.label(),
+            });
+        }
+        Ok(pin)
     }
 }
 
@@ -467,6 +477,23 @@ mod tests {
 
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let address = listener.local_addr().unwrap();
+        let mirror = format!("http://{address}");
+        let version = node_semver::Version::parse("22.23.2").unwrap();
+        let cache_path = crate::paths::shasums_cache_path(&mirror, &version);
+        if let Some(path) = cache_path.as_deref() {
+            let _ = std::fs::remove_file(path);
+        }
+        struct CacheCleanup(Option<std::path::PathBuf>);
+        impl Drop for CacheCleanup {
+            fn drop(&mut self) {
+                if let Some(path) = self.0.as_deref() {
+                    let _ = std::fs::remove_file(path);
+                }
+            }
+        }
+        let _cache_cleanup = CacheCleanup(cache_path);
+        let platform = Platform::current().unwrap();
+        let filename = artifact_filename(&version, &platform);
         let server = std::thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let mut request = [0_u8; 2048];
@@ -478,9 +505,9 @@ mod tests {
                 .and_then(|line| line.split_whitespace().nth(1))
                 .unwrap()
                 .to_string();
-            let body = concat!(
-                "0000000000000000000000000000000000000000000000000000000000000000",
-                "  node-v22.23.2-linux-x64.tar.gz\n"
+            let body = format!(
+                "{}  {filename}\n",
+                "0000000000000000000000000000000000000000000000000000000000000000"
             );
             write!(
                 stream,
@@ -492,11 +519,10 @@ mod tests {
         });
 
         let runtime = NodeRuntime::new(RuntimeConfig {
-            mirror: Some(format!("http://{address}")),
+            mirror: Some(mirror),
             retries: 0,
             ..RuntimeConfig::default()
         });
-        let version = node_semver::Version::parse("22.23.2").unwrap();
         let pin = runtime
             .resolve_for_lockfile(&NodeSpec::Exact(version.clone()))
             .await

--- a/crates/aube-runtime/src/resolver.rs
+++ b/crates/aube-runtime/src/resolver.rs
@@ -311,7 +311,23 @@ impl NodeRuntime {
     /// (through the disk caches).
     pub async fn resolve_for_lockfile(&self, spec: &NodeSpec) -> Result<PinnedNode, Error> {
         if let NodeSpec::Exact(version) = spec {
-            return self.build_full_pin(version).await;
+            let pin = self.build_full_pin(version).await?;
+            let platform = Platform::current()?;
+            // Exact specs bypass the release-index availability gate. Apply
+            // an equivalent check for official Node distributions, while
+            // leaving FreeBSD and best-effort musl pins usable: those hosts
+            // intentionally rely on system/mise Node or a later live-checksum
+            // lookup rather than requiring an official lockfile variant.
+            if requires_official_host_variant(&platform)
+                && pin
+                    .variant_for(&platform.os, &platform.cpu, platform.libc.as_deref())
+                    .is_none()
+            {
+                return Err(Error::UnsupportedPlatform {
+                    platform: platform.label(),
+                });
+            }
+            return Ok(pin);
         }
         let platform = Platform::current()?;
         let entries = index::load_index(&self.http, &self.cfg).await?;
@@ -347,21 +363,15 @@ impl NodeRuntime {
                 }
             }
         }
-        let pin = PinnedNode {
+        Ok(PinnedNode {
             version: version.clone(),
             variants,
-        };
-        let platform = Platform::current()?;
-        if pin
-            .variant_for(&platform.os, &platform.cpu, platform.libc.as_deref())
-            .is_none()
-        {
-            return Err(Error::UnsupportedPlatform {
-                platform: platform.label(),
-            });
-        }
-        Ok(pin)
+        })
     }
+}
+
+fn requires_official_host_variant(platform: &Platform) -> bool {
+    platform.os != "freebsd" && platform.libc.as_deref() != Some("musl")
 }
 
 fn warn_version_mismatch(req: &NodeRequest) {
@@ -470,6 +480,23 @@ fn variants_from_shasums<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn host_variant_validation_skips_non_official_distributions() {
+        let platform = |os: &str, libc: Option<&str>| Platform {
+            os: os.to_string(),
+            cpu: "x64".to_string(),
+            libc: libc.map(str::to_string),
+        };
+
+        assert!(requires_official_host_variant(&platform("linux", None)));
+        assert!(requires_official_host_variant(&platform("darwin", None)));
+        assert!(!requires_official_host_variant(&platform(
+            "linux",
+            Some("musl")
+        )));
+        assert!(!requires_official_host_variant(&platform("freebsd", None)));
+    }
 
     #[tokio::test]
     async fn exact_lockfile_pin_skips_release_index() {


### PR DESCRIPTION
## Summary

- resolve exact Node versions directly from their immutable `SHASUMS256.txt` metadata
- skip `index.json` for both runtime installation and lockfile pin generation
- retain index resolution for ranges, latest/LTS aliases, and codenames
- add a local HTTP regression test proving the only request is the versioned checksum file

## Why

An exact version contains no selection ambiguity. Fetching the full release index adds latency and prevents artifact-only mirrors from serving exact pins, even though the checksum metadata already verifies availability.

## Validation

- `cargo fmt --check`
- `cargo test -p aube-runtime exact_lockfile_pin_skips_release_index`
- `cargo clippy -p aube-runtime --all-targets -- -D warnings`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core version resolution and lockfile validation paths; mis-handling could break installs on custom mirrors or tighten errors on official platforms when SHASUMS lack a host build.
> 
> **Overview**
> **Exact Node specs** no longer fetch the global release `index.json` during runtime resolution or lockfile pin generation—they jump straight to the immutable `SHASUMS256.txt` for that version. Ranges, LTS/latest aliases, and codenames still use the index.
> 
> This supports **artifact-only mirrors** that ship release files and checksums but not a full index, and cuts a network round-trip when the version is already unambiguous.
> 
> **Lockfile pinning** (`resolve_for_lockfile`) now checks that the built pin includes a variant for the current host on “official” distributions (typical Linux glibc and macOS). **FreeBSD** and **musl** hosts skip that gate so pins can stay best-effort there. Missing host variant yields `UnsupportedPlatform` instead of a pin that would fail later.
> 
> Regression coverage: unit tests for the platform gate and a local HTTP test asserting lockfile resolve for an exact version only requests `/v{version}/SHASUMS256.txt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a104c823da7a4ab059aa4f22811aa7bdb444450b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Exact version requests now resolve more reliably using their checksum data.
  * Lockfile resolution now validates pinned platform variants for official hosts.
  * FreeBSD and musl environments are supported without requiring a pinned variant.
  * Exact version resolutions avoid unnecessary release index lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->