### PR TITLE
fix(resolver): separate lowest-direct resolution

### DIFF
--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -540,11 +540,12 @@ impl<'a> ResolveDriver<'a> {
             .map(|p| p.version.as_str())
             .filter(|v| !is_vulnerable(task.registry_name(), v, &self.resolver.vulnerable_ranges));
 
-        // Direct deps in time-based mode pick the lowest
-        // satisfying version; everything else (transitives,
-        // and all picks in Highest mode) picks highest.
-        let pick_lowest =
-            self.resolver.resolution_mode == ResolutionMode::TimeBased && task.is_root;
+        // Direct deps in time-based and lowest-direct modes pick the
+        // lowest satisfying version; everything else picks highest.
+        let pick_lowest = matches!(
+            self.resolver.resolution_mode,
+            ResolutionMode::TimeBased | ResolutionMode::LowestDirect
+        ) && task.is_root;
         // `minimumReleaseAgeExclude` is applied per-candidate-version
         // inside `pick_version` via the `is_age_exempt` closure below. A
         // name-only exclude rule matches every version; a `pkg@1.2.3`

--- a/crates/aube-resolver/src/types.rs
+++ b/crates/aube-resolver/src/types.rs
@@ -240,4 +240,9 @@ pub enum ResolutionMode {
     /// before a cutoff date derived from the max publish time of
     /// already-locked packages. Matches pnpm's `time-based` mode.
     TimeBased,
+    /// Pick the lowest version satisfying each direct dependency range,
+    /// while resolving transitive dependencies normally. Unlike
+    /// `TimeBased`, this mode neither computes a publish-time cutoff nor
+    /// records package publish times in the lockfile.
+    LowestDirect,
 }

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -2837,8 +2837,9 @@ docs = """
 Controls how aube chooses versions during resolution. `highest` picks
 the newest satisfying version. `time-based` filters candidates through
 the lockfile / packument publish-time cutoff before picking. `lowest-direct`
-is accepted for pnpm parity and currently maps to the same time-aware
-resolver mode.
+picks the oldest satisfying version for direct dependencies without a
+publish-time cutoff, while transitive dependencies use the newest satisfying
+version.
 """
 sources.cli = ["resolution-mode"]
 sources.env = ["npm_config_resolution_mode", "NPM_CONFIG_RESOLUTION_MODE", "AUBE_RESOLUTION_MODE"]

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -8,12 +8,8 @@ use std::collections::BTreeMap;
 fn parse_resolution_mode(s: &str) -> Option<aube_resolver::ResolutionMode> {
     match s.trim().to_ascii_lowercase().as_str() {
         "highest" => Some(aube_resolver::ResolutionMode::Highest),
-        // pnpm treats `lowest-direct` and `time-based` as distinct
-        // modes; aube folds them into `TimeBased` and skips the cutoff
-        // filter when there's no publish time to compare against, so
-        // `lowest-direct` behavior emerges naturally from `TimeBased`
-        // with `time:` absent. Close enough for the first pass.
-        "time-based" | "time" | "lowest-direct" => Some(aube_resolver::ResolutionMode::TimeBased),
+        "time-based" | "time" => Some(aube_resolver::ResolutionMode::TimeBased),
+        "lowest-direct" => Some(aube_resolver::ResolutionMode::LowestDirect),
         _ => None,
     }
 }
@@ -51,19 +47,17 @@ fn resolve_resolution_mode(ctx: &aube_settings::ResolveCtx<'_>) -> aube_resolver
 }
 
 /// Translate the settings-side `ResolutionMode` enum into the
-/// resolver's runtime enum. pnpm treats `lowest-direct` and
-/// `time-based` as distinct modes, but aube folds them into
-/// `TimeBased` and lets the `time:` cutoff filter handle the
-/// difference — when publish times are missing the `lowest-direct`
-/// behavior emerges naturally. Close enough for the first pass.
+/// resolver's runtime enum.
 fn map_resolution_mode(
     m: aube_settings::resolved::ResolutionMode,
 ) -> aube_resolver::ResolutionMode {
     match m {
         aube_settings::resolved::ResolutionMode::Highest => aube_resolver::ResolutionMode::Highest,
-        aube_settings::resolved::ResolutionMode::TimeBased
-        | aube_settings::resolved::ResolutionMode::LowestDirect => {
+        aube_settings::resolved::ResolutionMode::TimeBased => {
             aube_resolver::ResolutionMode::TimeBased
+        }
+        aube_settings::resolved::ResolutionMode::LowestDirect => {
+            aube_resolver::ResolutionMode::LowestDirect
         }
     }
 }

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -2843,8 +2843,9 @@ Dependency version resolution strategy.
 Controls how aube chooses versions during resolution. `highest` picks
 the newest satisfying version. `time-based` filters candidates through
 the lockfile / packument publish-time cutoff before picking. `lowest-direct`
-is accepted for pnpm parity and currently maps to the same time-aware
-resolver mode.
+picks the oldest satisfying version for direct dependencies without a
+publish-time cutoff, while transitive dependencies use the newest satisfying
+version.
 
 ### `registrySupportsTimeField` {#setting-registrysupportstimefield}
 

--- a/test/resolution_mode.bats
+++ b/test/resolution_mode.bats
@@ -47,6 +47,18 @@ teardown() {
 	assert_failure
 }
 
+@test "aube install --resolution-mode=lowest-direct picks the lowest direct version without time metadata" {
+	_setup_basic_fixture
+	rm aube-lock.yaml
+	jq '.dependencies = {"is-number": ">=3"}' package.json >package.json.tmp
+	mv package.json.tmp package.json
+	run aube install --resolution-mode=lowest-direct
+	assert_success
+	assert_file_exists node_modules/.aube/is-number@3.0.0/node_modules/is-number/package.json
+	run grep -E '^time:' aube-lock.yaml
+	assert_failure
+}
+
 @test "aube install --resolution-mode rejects unknown values via .npmrc fallback" {
 	_setup_basic_fixture
 	rm aube-lock.yaml


### PR DESCRIPTION
## Summary

- model lowest-direct as a distinct resolver mode instead of folding it into time-based
- choose the lowest satisfying direct dependency without computing a publish-time cutoff
- keep transitive resolution on the highest satisfying versions and omit time metadata from the lockfile

## Validation

- cargo test -p aube-resolver
- mise run test:bats test/resolution_mode.bats
- cargo clippy --all-targets -- -D warnings

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core dependency resolution behavior for anyone using `resolution-mode=lowest-direct`, but scope is limited to that mode and is covered by resolver tests and Bats.
> 
> **Overview**
> **`lowest-direct` is no longer folded into `time-based`.** It is a first-class `ResolutionMode::LowestDirect` that picks the **oldest** satisfying version for **direct** dependencies while transitives still resolve to the **newest** satisfying version, with **no** publish-time cutoff and **no** `time:` block in the lockfile.
> 
> Install settings now parse `lowest-direct` into that mode instead of `TimeBased`, and the resolver driver treats `LowestDirect` like `TimeBased` only for the “pick lowest on root direct deps” branch—not for time-based filtering or lockfile publish-time recording. Docs and a Bats case (`is-number` at `3.0.0`, no `time:`) lock in the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4657d97740944ff1e1e04b21cae161bdd9639ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->