### PR TITLE
feat(catalog): support catalogPrune setting

### DIFF
--- a/crates/aube-manifest/src/workspace/config.rs
+++ b/crates/aube-manifest/src/workspace/config.rs
@@ -472,9 +472,13 @@ pub struct WorkspaceConfig {
 
     // -- Catalog Settings --
     /// Drop catalog entries that no importer references after resolve.
-    /// Wired through `aube_settings::resolved::cleanup_unused_catalogs`;
+    /// Wired through `aube_settings::resolved::catalog_prune`;
     /// the typed field exists only so `meta::workspace_yaml_keys_...`
     /// sees the key as a real field and doesn't fall through to `extra`.
+    #[serde(default)]
+    pub catalog_prune: Option<bool>,
+
+    /// Deprecated pre-pnpm-11.22 alias for `catalogPrune`.
     #[serde(default)]
     pub cleanup_unused_catalogs: Option<bool>,
 

--- a/crates/aube-settings/build.rs
+++ b/crates/aube-settings/build.rs
@@ -424,7 +424,7 @@ fn default_expr(name: &str, def: &SettingDef, kind: Kind, rust_ty: &str) -> Opti
     // this literal value".
     if matches!(
         name,
-        "preferFrozenLockfile" | "storeDir" | "cacheDir" | "nodeVersion"
+        "preferFrozenLockfile" | "storeDir" | "cacheDir" | "nodeVersion" | "catalogPrune"
     ) {
         return None;
     }

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -3068,7 +3068,7 @@ examples = ["CI=1 aube install"]
 # `ResolveCtx` for a one-liner isn't worth the plumbing.
 typedAccessorUnused = true
 
-[cleanupUnusedCatalogs]
+[catalogPrune]
 description = "Remove unused catalog entries during install."
 type = "bool"
 default = "false"
@@ -3082,6 +3082,21 @@ stay intact. yamlpatch's `Remove` op only deletes the line carrying
 the entry's `key: value`, so a `# annotation` line above a pruned
 entry is left in place rather than guessed-at; clean those up by
 hand if you don't want orphaned annotations.
+"""
+sources.cli = []
+sources.env = ["npm_config_catalog_prune", "NPM_CONFIG_CATALOG_PRUNE", "AUBE_CATALOG_PRUNE"]
+sources.npmrc = ["catalogPrune"]
+sources.workspaceYaml = ["catalogPrune"]
+examples = []
+
+[cleanupUnusedCatalogs]
+description = "Deprecated alias for catalogPrune."
+type = "bool"
+default = "false"
+docs = """
+Deprecated in pnpm 11.22. Use `catalogPrune` instead. The legacy name remains
+accepted for compatibility, but `catalogPrune` takes precedence when both are
+configured.
 """
 sources.cli = []
 sources.env = ["npm_config_cleanup_unused_catalogs", "NPM_CONFIG_CLEANUP_UNUSED_CATALOGS", "AUBE_CLEANUP_UNUSED_CATALOGS"]

--- a/crates/aube/src/commands/catalogs.rs
+++ b/crates/aube/src/commands/catalogs.rs
@@ -3,7 +3,7 @@
 //! Two settings land here:
 //! - `catalogMode` governs how `add` writes the manifest specifier for a
 //!   package that already appears in the default workspace catalog.
-//! - `cleanupUnusedCatalogs` trims workspace-yaml catalog entries that
+//! - `catalogPrune` trims workspace-yaml catalog entries that
 //!   no importer references, after a successful resolve.
 //!
 //! Both features share the same source of truth (`WorkspaceConfig::catalog`
@@ -125,7 +125,7 @@ pub(crate) fn range_compatible(
 ///
 /// Goes through `aube_manifest::workspace::edit_workspace_yaml`, which
 /// no-ops the rewrite when the closure produces no structural change —
-/// catalog cleanup runs on every install under `cleanupUnusedCatalogs`
+/// catalog cleanup runs on every install under `catalogPrune`
 /// and we don't want to strip user comments on the steady-state pass
 /// where every declared entry is still referenced.
 pub(crate) fn prune_unused_catalog_entries(
@@ -207,7 +207,7 @@ pub(crate) fn prune_unused_catalog_entries(
     .map_err(miette::Report::new)
     .wrap_err_with(|| {
         format!(
-            "failed to write {} after cleanupUnusedCatalogs",
+            "failed to write {} after catalogPrune",
             workspace_path.display()
         )
     })?;
@@ -594,7 +594,7 @@ mod tests {
         // annotations on the catalog entries that survive — the whole
         // reason aube routes catalog rewrites through
         // `edit_workspace_yaml` is so the daily install (which runs
-        // `cleanupUnusedCatalogs`) doesn't silently strip comments off
+        // `catalogPrune`) doesn't silently strip comments off
         // the entries the user took the time to document.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("pnpm-workspace.yaml");

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -73,6 +73,7 @@ use materialize::{
     GvsPrewarmInputs, combine_install_pipeline_errors, materialize_channel, spawn_gvs_prewarm,
 };
 pub(crate) use settings::PeerDependencyRules;
+pub(crate) use settings::resolve_catalog_prune;
 pub(crate) use settings::resolve_minimum_release_age;
 pub(crate) use settings::{ResolverConfigInputs, configure_resolver, finalize_lockfile_graph};
 pub(crate) use side_effects_cache::{SideEffectsCacheConfig, side_effects_cache_root};
@@ -2369,7 +2370,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
 
     tracing::debug!("Packages: {cached_count} cached, {fetch_count} fetched");
 
-    // `cleanupUnusedCatalogs` (gated by the setting) rewrites
+    // `catalogPrune` (gated by the setting) rewrites
     // `aube-workspace.yaml` / `pnpm-workspace.yaml` to drop entries no
     // importer references. Runs once after we have the final graph so
     // the same helper covers both lockfile-read and fresh-resolve

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -231,8 +231,13 @@ mod gvs_mode_tests {
     }
 }
 
-/// Honor `catalogPrune` (or its deprecated `cleanupUnusedCatalogs` alias) by pruning declared-but-unreferenced
-/// catalog entries from the workspace yaml. No-op when the setting is
+pub(crate) fn resolve_catalog_prune(ctx: &aube_settings::ResolveCtx<'_>) -> bool {
+    aube_settings::resolved::catalog_prune(ctx)
+        .unwrap_or_else(|| aube_settings::resolved::cleanup_unused_catalogs(ctx))
+}
+
+/// Honor `catalogPrune` (or its deprecated `cleanupUnusedCatalogs` alias) by
+/// pruning declared-but-unreferenced catalog entries from the workspace yaml. No-op when the setting is
 /// off, when there is no workspace yaml file on disk, or when every
 /// declared entry was referenced by an importer.
 pub(super) fn maybe_cleanup_unused_catalogs(
@@ -244,9 +249,7 @@ pub(super) fn maybe_cleanup_unused_catalogs(
         std::collections::BTreeMap<String, aube_lockfile::CatalogEntry>,
     >,
 ) -> miette::Result<()> {
-    let enabled = aube_settings::resolved::catalog_prune(ctx)
-        .unwrap_or_else(|| aube_settings::resolved::cleanup_unused_catalogs(ctx));
-    if !enabled {
+    if !resolve_catalog_prune(ctx) {
         return Ok(());
     }
     if declared.is_empty() {
@@ -262,7 +265,7 @@ pub(super) fn maybe_cleanup_unused_catalogs(
             .map(|n| n.to_string_lossy().into_owned())
             .unwrap_or_else(|| ws_path.display().to_string());
         tracing::info!(
-            "cleanupUnusedCatalogs: pruned {} from {filename}",
+            "catalogPrune: pruned {} from {filename}",
             pluralizer::pluralize("entry", dropped.len() as isize, true)
         );
     }

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -231,7 +231,7 @@ mod gvs_mode_tests {
     }
 }
 
-/// Honor `cleanupUnusedCatalogs` by pruning declared-but-unreferenced
+/// Honor `catalogPrune` (or its deprecated `cleanupUnusedCatalogs` alias) by pruning declared-but-unreferenced
 /// catalog entries from the workspace yaml. No-op when the setting is
 /// off, when there is no workspace yaml file on disk, or when every
 /// declared entry was referenced by an importer.
@@ -244,7 +244,9 @@ pub(super) fn maybe_cleanup_unused_catalogs(
         std::collections::BTreeMap<String, aube_lockfile::CatalogEntry>,
     >,
 ) -> miette::Result<()> {
-    if !aube_settings::resolved::cleanup_unused_catalogs(ctx) {
+    let enabled = aube_settings::resolved::catalog_prune(ctx)
+        .unwrap_or_else(|| aube_settings::resolved::cleanup_unused_catalogs(ctx));
+    if !enabled {
         return Ok(());
     }
     if declared.is_empty() {

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -1480,6 +1480,11 @@ fn hash_settings(project_dir: &Path, cli_flags: &[(String, String)]) -> String {
     hasher.update(b"\0");
     let lockfile_enabled = aube_settings::resolved::lockfile(&ctx);
     hasher.update(format!("lockfile={lockfile_enabled}\0").as_bytes());
+    // Catalog pruning runs after resolution, so a false→true environment
+    // change must invalidate the warm path even though it does not alter the
+    // installed dependency tree itself.
+    let catalog_prune = crate::commands::install::resolve_catalog_prune(&ctx);
+    hasher.update(format!("catalog_prune={catalog_prune}\0").as_bytes());
     // additional tree shape settings. cover enable_modules_dir flip
     // (pnpm equivalent of --lockfile-only persistent), virtual_store_only,
     // hoist_workspace_packages, dedupe_direct_deps, symlink,

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -153,7 +153,8 @@ Aube generates this page from [`settings.toml`](https://github.com/jdx/aube/blob
 | [`shellEmulator`](#setting-shellemulator) | `bool` | Use a JavaScript bash-like shell to run scripts cross-platform. |
 | [`catalogMode`](#setting-catalogmode) | `"manual" \| "strict" \| "prefer"` | How catalog references in package.json are handled by `add`. |
 | [`ci`](#setting-ci) | `bool` | Explicitly mark the environment as CI. |
-| [`cleanupUnusedCatalogs`](#setting-cleanupunusedcatalogs) | `bool` | Remove unused catalog entries during install. |
+| [`catalogPrune`](#setting-catalogprune) | `bool` | Remove unused catalog entries during install. |
+| [`cleanupUnusedCatalogs`](#setting-cleanupunusedcatalogs) | `bool` | Deprecated alias for catalogPrune. |
 | [`linkConcurrency`](#setting-linkconcurrency) | `int` | Maximum concurrent package materialization/linking tasks. |
 | [`aubeNoLock`](#setting-aubenolock) | `bool` | Disable aube's project-level advisory lock. |
 | [`aubeNoAutoInstall`](#setting-aubenoautoinstall) | `bool` | Skip the auto-install staleness check in `aube run` / `aube exec`. |
@@ -3060,15 +3061,15 @@ Examples:
 
 - `CI=1 aube install`
 
-### `cleanupUnusedCatalogs` {#setting-cleanupunusedcatalogs}
+### `catalogPrune` {#setting-catalogprune}
 
 Remove unused catalog entries during install.
 
 - Type: `bool`
 - Default: `false`
-- Environment: `npm_config_cleanup_unused_catalogs`, `NPM_CONFIG_CLEANUP_UNUSED_CATALOGS`, `AUBE_CLEANUP_UNUSED_CATALOGS`
-- .npmrc keys: `cleanupUnusedCatalogs`, `cleanup-unused-catalogs`
-- Workspace YAML keys: `cleanupUnusedCatalogs`
+- Environment: `npm_config_catalog_prune`, `NPM_CONFIG_CATALOG_PRUNE`, `AUBE_CATALOG_PRUNE`
+- .npmrc keys: `catalogPrune`, `catalog-prune`
+- Workspace YAML keys: `catalogPrune`
 
 When enabled, `aube install` rewrites `aube-workspace.yaml` (or
 `pnpm-workspace.yaml`, whichever is present) after resolution to drop
@@ -3079,6 +3080,20 @@ stay intact. yamlpatch's `Remove` op only deletes the line carrying
 the entry's `key: value`, so a `# annotation` line above a pruned
 entry is left in place rather than guessed-at; clean those up by
 hand if you don't want orphaned annotations.
+
+### `cleanupUnusedCatalogs` {#setting-cleanupunusedcatalogs}
+
+Deprecated alias for catalogPrune.
+
+- Type: `bool`
+- Default: `false`
+- Environment: `npm_config_cleanup_unused_catalogs`, `NPM_CONFIG_CLEANUP_UNUSED_CATALOGS`, `AUBE_CLEANUP_UNUSED_CATALOGS`
+- .npmrc keys: `cleanupUnusedCatalogs`, `cleanup-unused-catalogs`
+- Workspace YAML keys: `cleanupUnusedCatalogs`
+
+Deprecated in pnpm 11.22. Use `catalogPrune` instead. The legacy name remains
+accepted for compatibility, but `catalogPrune` takes precedence when both are
+configured.
 
 ## aube-specific
 

--- a/test/catalogs.bats
+++ b/test/catalogs.bats
@@ -572,6 +572,37 @@ _setup_catalog_workspace() {
 	assert_success
 }
 
+@test "aube install: catalogPrune environment change bypasses the warm path" {
+	mkdir -p packages/lib
+	cat >pnpm-workspace.yaml <<-'EOF'
+		packages:
+		  - packages/*
+		catalog:
+		  is-odd: ^3.0.1
+		  is-even: ^1.0.0
+	EOF
+	cat >package.json <<-'EOF'
+		{ "name": "aube-test", "version": "0.0.0", "private": true }
+	EOF
+	cat >packages/lib/package.json <<-'EOF'
+		{
+		  "name": "@test/lib",
+		  "version": "1.0.0",
+		  "dependencies": { "is-odd": "catalog:" }
+		}
+	EOF
+
+	run aube install
+	assert_success
+	run grep "is-even" pnpm-workspace.yaml
+	assert_success
+
+	run env AUBE_CATALOG_PRUNE=true aube install
+	assert_success
+	run grep "is-even" pnpm-workspace.yaml
+	assert_failure
+}
+
 @test "aube install: overrides value of catalog: resolves through catalog" {
 	# Regression: `"overrides": {"pkg": "catalog:"}` used to leak the
 	# raw `catalog:` string through to the registry resolver because

--- a/test/catalogs.bats
+++ b/test/catalogs.bats
@@ -542,6 +542,36 @@ _setup_catalog_workspace() {
 	[ "$before" = "$after" ]
 }
 
+@test "aube install: catalogPrune takes precedence over cleanupUnusedCatalogs" {
+	mkdir -p packages/lib
+	cat >pnpm-workspace.yaml <<-'EOF'
+		packages:
+		  - packages/*
+		catalog:
+		  is-odd: ^3.0.1
+		  is-even: ^1.0.0
+	EOF
+	cat >package.json <<-'EOF'
+		{ "name": "aube-test", "version": "0.0.0", "private": true }
+	EOF
+	cat >packages/lib/package.json <<-'EOF'
+		{
+		  "name": "@test/lib",
+		  "version": "1.0.0",
+		  "dependencies": { "is-odd": "catalog:" }
+		}
+	EOF
+	cat >.npmrc <<-'EOF'
+		catalogPrune=false
+		cleanupUnusedCatalogs=true
+	EOF
+
+	run aube install
+	assert_success
+	run grep "is-even" pnpm-workspace.yaml
+	assert_success
+}
+
 @test "aube install: overrides value of catalog: resolves through catalog" {
 	# Regression: `"overrides": {"pkg": "catalog:"}` used to leak the
 	# raw `catalog:` string through to the registry resolver because


### PR DESCRIPTION
## Summary

- add the pnpm 11.22 catalogPrune setting for catalog cleanup
- retain cleanupUnusedCatalogs as a deprecated compatibility setting
- make catalogPrune take precedence whenever both names are configured
- update generated settings documentation

## Validation

- cargo test -p aube-settings
- cargo clippy --all-targets -- -D warnings
- catalog BATS: the new precedence test and 23 other cases passed; one unrelated existing case failed because its direct node invocation resolves to a broken mise shim in the test HOME

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is a settings rename with backward-compatible alias and precedence rules; the warm-path hash change only affects install caching when catalog pruning is toggled.
> 
> **Overview**
> Adds **pnpm 11.22**’s **`catalogPrune`** setting as the canonical name for pruning unused workspace catalog entries after install. **`cleanupUnusedCatalogs`** remains as a deprecated alias; when both are set, **`catalogPrune` wins**.
> 
> Resolution goes through **`resolve_catalog_prune`**, which reads `catalogPrune` first and falls back to the legacy key. Install logging and error text now say **`catalogPrune`** instead of the old name. **`catalogPrune`** is wired in **`settings.toml`** (env, npmrc, workspace YAML), **`WorkspaceConfig`** gains a typed **`catalog_prune`** field, and docs list the new setting plus the deprecated alias.
> 
> The install **warm-path** cache key now includes **`catalog_prune`**, so toggling pruning via env invalidates the fast path even though the dependency tree is unchanged. **BATS** cover precedence when both keys conflict and warm-path bypass when **`AUBE_CATALOG_PRUNE`** is turned on mid-run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e751c56d232591758551d4ddf4bc2b6b49118377. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->