### PR TITLE
fix(sbom): filter unsupported optional packages

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -3454,6 +3454,7 @@ cmd sbom help="Generate a Software Bill of Materials (CycloneDX or SPDX)" effect
             choices cyclonedx spdx
         }
     }
+    flag --lockfile-only help="Describe the complete platform-independent lockfile graph"
     flag "-P --prod --production" help="Show only production dependencies (skip devDependencies)"
 }
 cmd search hide=#true help="Search the registry for packages (not implemented — use `npm search`)" effect=read {

--- a/crates/aube-resolver/src/platform.rs
+++ b/crates/aube-resolver/src/platform.rs
@@ -303,7 +303,13 @@ pub fn filter_graph(
             continue;
         }
         if let Some(pkg) = graph.packages.get(&dep_path) {
-            for (name, tail) in &pkg.dependencies {
+            // pnpm mirrors active optional edges into `dependencies`, but
+            // Yarn Berry records them only in `optional_dependencies`.
+            for (name, tail) in pkg
+                .dependencies
+                .iter()
+                .chain(pkg.optional_dependencies.iter())
+            {
                 // Resolve the edge through every reader convention,
                 // including the git/remote-tarball `name@url+<hash>` form
                 // — otherwise a canonically-keyed git/tarball child (and
@@ -634,6 +640,52 @@ mod tests {
         assert!(!host.dependencies.contains_key("native-linux"));
         assert!(graph.packages.contains_key("native-darwin@1.0.0"));
         assert!(!graph.packages.contains_key("native-linux@1.0.0"));
+    }
+
+    #[test]
+    fn filter_graph_keeps_supported_yarn_berry_optional_children() {
+        let supported = SupportedArchitectures {
+            os: s(&["darwin"]),
+            cpu: s(&["arm64"]),
+            ..Default::default()
+        };
+        let mut graph = aube_lockfile::LockfileGraph::default();
+        graph.importers.insert(
+            ".".to_string(),
+            vec![aube_lockfile::DirectDep {
+                name: "host".to_string(),
+                dep_path: "host@1.0.0".to_string(),
+                dep_type: aube_lockfile::DepType::Production,
+                specifier: Some("1.0.0".to_string()),
+            }],
+        );
+        graph.packages.insert(
+            "host@1.0.0".to_string(),
+            aube_lockfile::LockedPackage {
+                name: "host".to_string(),
+                version: "1.0.0".to_string(),
+                dep_path: "host@1.0.0".to_string(),
+                // Yarn Berry does not mirror optional edges here.
+                dependencies: Default::default(),
+                optional_dependencies: [("native-darwin".to_string(), "1.0.0".to_string())].into(),
+                ..Default::default()
+            },
+        );
+        graph.packages.insert(
+            "native-darwin@1.0.0".to_string(),
+            aube_lockfile::LockedPackage {
+                name: "native-darwin".to_string(),
+                version: "1.0.0".to_string(),
+                dep_path: "native-darwin@1.0.0".to_string(),
+                os: s(&["darwin"]).into(),
+                cpu: s(&["arm64"]).into(),
+                ..Default::default()
+            },
+        );
+
+        filter_graph(&mut graph, &supported, &Default::default());
+
+        assert!(graph.packages.contains_key("native-darwin@1.0.0"));
     }
 
     fn dep(name: &str, dep_type: aube_lockfile::DepType) -> aube_lockfile::DirectDep {

--- a/crates/aube/src/commands/sbom.rs
+++ b/crates/aube/src/commands/sbom.rs
@@ -64,12 +64,9 @@ pub async fn run(args: SbomArgs) -> miette::Result<()> {
     // platform. A normal SBOM describes what this host can install, while
     // --lockfile-only preserves the complete platform-independent graph.
     if !args.lockfile_only {
-        let workspace = aube_manifest::WorkspaceConfig::load(&cwd).map_err(|err| {
-            miette::miette!(
-                code = aube_codes::errors::ERR_AUBE_WORKSPACE_PARSE,
-                "failed to load workspace config: {err}"
-            )
-        })?;
+        let workspace = aube_manifest::WorkspaceConfig::load(&cwd)
+            .map_err(miette::Report::new)
+            .wrap_err("failed to load workspace config")?;
         let (os, cpu, libc) =
             aube_manifest::effective_supported_architectures(&manifest, &workspace);
         let supported = aube_resolver::SupportedArchitectures {

--- a/crates/aube/src/commands/sbom.rs
+++ b/crates/aube/src/commands/sbom.rs
@@ -26,6 +26,10 @@ pub struct SbomArgs {
     #[arg(long, value_enum, default_value_t = SbomFormat::Cyclonedx)]
     pub format: SbomFormat,
 
+    /// Describe the complete platform-independent lockfile graph
+    #[arg(long)]
+    pub lockfile_only: bool,
+
     /// Show only production dependencies (skip devDependencies)
     #[arg(
         short = 'P',
@@ -47,7 +51,7 @@ pub async fn run(args: SbomArgs) -> miette::Result<()> {
 
     let manifest = super::load_manifest(&cwd.join("package.json"))?;
 
-    let graph = super::load_graph(
+    let mut graph = super::load_graph(
         &cwd,
         &manifest,
         &format!(
@@ -55,6 +59,25 @@ pub async fn run(args: SbomArgs) -> miette::Result<()> {
             aube_util::cmd("install")
         ),
     )?;
+
+    // Lockfiles intentionally retain optional native packages for every
+    // platform. A normal SBOM describes what this host can install, while
+    // --lockfile-only preserves the complete platform-independent graph.
+    if !args.lockfile_only {
+        let workspace = aube_manifest::WorkspaceConfig::load(&cwd)
+            .into_diagnostic()
+            .wrap_err("failed to load workspace config")?;
+        let (os, cpu, libc) =
+            aube_manifest::effective_supported_architectures(&manifest, &workspace);
+        let supported = aube_resolver::SupportedArchitectures {
+            os,
+            cpu,
+            libc,
+            ..Default::default()
+        };
+        let ignored = aube_manifest::effective_ignored_optional_dependencies(&manifest, &workspace);
+        aube_resolver::platform::filter_graph(&mut graph, &supported, &ignored);
+    }
 
     let filter = DepFilter::from_flags(args.prod, args.dev);
     let closure = super::collect_dep_closure(&graph, filter, false);

--- a/crates/aube/src/commands/sbom.rs
+++ b/crates/aube/src/commands/sbom.rs
@@ -64,9 +64,12 @@ pub async fn run(args: SbomArgs) -> miette::Result<()> {
     // platform. A normal SBOM describes what this host can install, while
     // --lockfile-only preserves the complete platform-independent graph.
     if !args.lockfile_only {
-        let workspace = aube_manifest::WorkspaceConfig::load(&cwd)
-            .map_err(miette::Report::new)
-            .wrap_err("failed to load workspace config")?;
+        let workspace = aube_manifest::WorkspaceConfig::load(&cwd).map_err(|err| {
+            miette::miette!(
+                code = aube_codes::errors::ERR_AUBE_WORKSPACE_PARSE,
+                "failed to load workspace config: {err}"
+            )
+        })?;
         let (os, cpu, libc) =
             aube_manifest::effective_supported_architectures(&manifest, &workspace);
         let supported = aube_resolver::SupportedArchitectures {

--- a/crates/aube/src/commands/sbom.rs
+++ b/crates/aube/src/commands/sbom.rs
@@ -64,9 +64,12 @@ pub async fn run(args: SbomArgs) -> miette::Result<()> {
     // platform. A normal SBOM describes what this host can install, while
     // --lockfile-only preserves the complete platform-independent graph.
     if !args.lockfile_only {
-        let workspace = aube_manifest::WorkspaceConfig::load(&cwd)
-            .into_diagnostic()
-            .wrap_err("failed to load workspace config")?;
+        let workspace = aube_manifest::WorkspaceConfig::load(&cwd).map_err(|err| {
+            miette::miette!(
+                code = aube_codes::errors::ERR_AUBE_WORKSPACE_PARSE,
+                "failed to load workspace config: {err}"
+            )
+        })?;
         let (os, cpu, libc) =
             aube_manifest::effective_supported_architectures(&manifest, &workspace);
         let supported = aube_resolver::SupportedArchitectures {

--- a/crates/aube/src/commands/workspace_helpers.rs
+++ b/crates/aube/src/commands/workspace_helpers.rs
@@ -58,7 +58,28 @@ pub(crate) fn collect_dep_closure(
         };
         out.insert(dep_path.clone(), pkg);
         for (name, version) in &pkg.dependencies {
-            stack.push(format!("{name}@{version}"));
+            // pnpm mirrors optional edges into `dependencies`; omit those
+            // mirrors when --no-optional is active.
+            if no_optional && pkg.optional_dependencies.contains_key(name) {
+                continue;
+            }
+            if let Some(child) = aube_lockfile::resolve_dep_edge(name, version, |key| {
+                graph.packages.contains_key(key)
+            }) {
+                stack.push(child);
+            }
+        }
+        if !no_optional {
+            // Yarn Berry records optional children only in this map, while
+            // pnpm's duplicate edges are harmless because `out` deduplicates
+            // the traversal by dep_path.
+            for (name, version) in &pkg.optional_dependencies {
+                if let Some(child) = aube_lockfile::resolve_dep_edge(name, version, |key| {
+                    graph.packages.contains_key(key)
+                }) {
+                    stack.push(child);
+                }
+            }
         }
     }
     out
@@ -178,5 +199,49 @@ pub(crate) fn workspace_importer_path(workspace_root: &Path, dir: &Path) -> miet
         Ok(".".to_string())
     } else {
         Ok(rel.to_string_lossy().replace('\\', "/"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dep_closure_follows_yarn_optional_only_edges() {
+        let mut graph = aube_lockfile::LockfileGraph::default();
+        graph.importers.insert(
+            ".".to_string(),
+            vec![aube_lockfile::DirectDep {
+                name: "host".to_string(),
+                dep_path: "host@1.0.0".to_string(),
+                dep_type: aube_lockfile::DepType::Production,
+                specifier: Some("1.0.0".to_string()),
+            }],
+        );
+        graph.packages.insert(
+            "host@1.0.0".to_string(),
+            aube_lockfile::LockedPackage {
+                name: "host".to_string(),
+                version: "1.0.0".to_string(),
+                dep_path: "host@1.0.0".to_string(),
+                optional_dependencies: [("native".to_string(), "1.0.0".to_string())].into(),
+                ..Default::default()
+            },
+        );
+        graph.packages.insert(
+            "native@1.0.0".to_string(),
+            aube_lockfile::LockedPackage {
+                name: "native".to_string(),
+                version: "1.0.0".to_string(),
+                dep_path: "native@1.0.0".to_string(),
+                ..Default::default()
+            },
+        );
+
+        let closure = collect_dep_closure(&graph, DepFilter::All, false);
+        assert!(closure.contains_key("native@1.0.0"));
+
+        let closure = collect_dep_closure(&graph, DepFilter::All, true);
+        assert!(!closure.contains_key("native@1.0.0"));
     }
 }

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -10156,6 +10156,18 @@
             ]
           },
           {
+            "name": "lockfile-only",
+            "usage": "--lockfile-only",
+            "help": "Describe the complete platform-independent lockfile graph",
+            "help_first_line": "Describe the complete platform-independent lockfile graph",
+            "short": [],
+            "long": [
+              "lockfile-only"
+            ],
+            "hide": false,
+            "global": false
+          },
+          {
             "name": "prod",
             "usage": "-P --prod",
             "help": "Show only production dependencies (skip devDependencies)",

--- a/docs/cli/sbom.md
+++ b/docs/cli/sbom.md
@@ -27,6 +27,10 @@ Output format: `cyclonedx` (default) or `spdx`
 
 **Default:** `cyclonedx`
 
+### `--lockfile-only`
+
+Describe the complete platform-independent lockfile graph
+
 ### `-P --prod`
 
 Show only production dependencies (skip devDependencies)

--- a/test/sbom.bats
+++ b/test/sbom.bats
@@ -157,3 +157,30 @@ JSON
 	assert_failure
 	assert_output --partial "no lockfile"
 }
+
+@test "aube sbom filters foreign optional packages unless lockfile-only is requested" {
+	if [[ "$(uname -s)" == MINGW* || "$(uname -s)" == MSYS* || "$(uname -s)" == CYGWIN* ]]; then
+		skip "win32 host would install the win32 optional dependency"
+	fi
+	cat >package.json <<'JSON'
+{
+  "name": "sbom-platform-filter",
+  "version": "1.0.0",
+  "optionalDependencies": {
+    "aube-test-optional-win32": "1.0.0"
+  }
+}
+JSON
+	run aube install
+	assert_success
+	run grep -F 'aube-test-optional-win32@1.0.0' aube-lock.yaml
+	assert_success
+
+	run aube sbom
+	assert_success
+	refute_output --partial 'aube-test-optional-win32'
+
+	run aube sbom --lockfile-only
+	assert_success
+	assert_output --partial 'aube-test-optional-win32'
+}

--- a/test/sbom.bats
+++ b/test/sbom.bats
@@ -158,6 +158,17 @@ JSON
 	assert_output --partial "no lockfile"
 }
 
+@test "aube sbom classifies invalid workspace config" {
+	_setup_mixed_fixture
+	cat >pnpm-workspace.yaml <<'YAML'
+packages: [
+YAML
+
+	run aube sbom
+	assert_failure
+	assert_output --partial "ERR_AUBE_WORKSPACE_PARSE"
+}
+
 @test "aube sbom filters foreign optional packages unless lockfile-only is requested" {
 	if [[ "$(uname -s)" == MINGW* || "$(uname -s)" == MSYS* || "$(uname -s)" == CYGWIN* ]]; then
 		skip "win32 host would install the win32 optional dependency"


### PR DESCRIPTION
## Summary

- filter platform-incompatible optional packages from normal CycloneDX and SPDX output
- honor package and workspace supportedArchitectures and ignoredOptionalDependencies settings
- add --lockfile-only to retain the complete platform-independent lockfile graph
- document the new flag and cover both output modes end to end

## Validation

- cargo test -p aube sbom
- mise run test:bats test/sbom.bats
- cargo clippy --all-targets -- -D warnings

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default SBOM semantics and shared lockfile traversal; incorrect optional/platform handling could omit or include wrong packages in compliance output.
> 
> **Overview**
> Default **`aube sbom`** output now reflects what the **current host** can install: after loading the lockfile graph it applies **`filter_graph`** using effective **`supportedArchitectures`** and **`ignoredOptionalDependencies`** from the package and workspace. **`--lockfile-only`** skips that step so CycloneDX/SPDX still describe the full platform-independent lockfile.
> 
> Graph walking was aligned with **pnpm vs Yarn Berry** optional edges: **`filter_graph`** reachability and **`collect_dep_closure`** now follow **`optional_dependencies`** (and use **`resolve_dep_edge`**), while **`--no-optional`** skips pnpm’s mirrored optional entries in **`dependencies`**.
> 
> CLI/docs add **`--lockfile-only`**; bats cover invalid workspace config during SBOM and optional win32 packages absent from default SBOM but present with **`--lockfile-only`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a576a4c8eccff0b7124aab1a4c8c4ac7765d054b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a hidden `--lockfile-only` option to SBOM generation for describing the complete, platform-independent dependency graph.
  - SBOM output now supports preserving optional and platform-specific dependencies when requested.

- **Bug Fixes**
  - Improved dependency traversal so optional dependencies are correctly included or excluded according to configuration and platform support.

- **Documentation**
  - Documented the new SBOM option and its behavior.

- **Tests**
  - Added coverage for optional dependencies, malformed workspace configuration, and lockfile-only SBOM generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->