### PR TITLE
ci: make API stability advisory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,25 +216,20 @@ jobs:
           fi
       - run: mise run docs:build
 
-  # Guards the embedding API surfaces `embed` introduced against
-  # unintended breaks:
-  #   * Rust library crates (aube-codes/aube-settings/aube-util) via
-  #     cargo-semver-checks, baselined against main.
+  # Guards published API surfaces against unintended breaks:
+  #   * Every published Rust library via cargo-semver-checks, baselined
+  #     against main. Findings are advisory so intentional API work does
+  #     not block the final gate, but it is visible before release-plz can
+  #     surprise us with a major bump.
   #   * The C ABI export set via the cdylib's dynamic symbol table diffed
   #     against the frozen crates/aube-ffi/abi-symbols.txt manifest.
-  # A Rust break is allowed only when the PR is explicitly marked
-  # breaking — a `!` in the conventional-commit title (feat(ffi)!: ...),
-  # a `BREAKING CHANGE:` footer in the body, or the `breaking-api`
-  # label — the same signals that drive release-plz's major bump, so the
-  # gate and the version bump agree.
   # Symbol drift always blocks (keeps the manifest honest); removing an
   # export shows as a manifest deletion in the diff and must ride a
   # breaking PR.
   api-stability:
-    # PR-time gate only: the checks read `github.event.pull_request.*` and
-    # baseline against main, which is meaningless on push/tag/dispatch runs
-    # (those fields are undefined there). `final` treats the resulting
-    # `skipped` as a pass.
+    # PR-time gate only: baselining the checked-out revision against main is
+    # meaningless on push/tag/dispatch runs. `final` treats the resulting
+    # `skipped` job as a pass.
     if: github.event_name == 'pull_request'
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
     timeout-minutes: 20
@@ -255,32 +250,28 @@ jobs:
           cache_save: ${{ github.ref == 'refs/heads/main' }}
       - name: Fetch semver baseline
         run: git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
-      - name: Determine breaking-change override
-        id: gate
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_BODY: ${{ github.event.pull_request.body }}
-          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
-        run: |
-          breaking=false
-          # conventional-commit breaking marker: type(scope)!: or type!:
-          if printf '%s' "$PR_TITLE" | grep -qE '^[a-z]+(\([^)]*\))?!:'; then breaking=true; fi
-          # conventional-commit breaking footer in the body (release-plz
-          # honors `BREAKING CHANGE:` / `BREAKING-CHANGE:` for the major bump).
-          if printf '%s' "$PR_BODY" | grep -qE '^BREAKING[ -]CHANGE:'; then breaking=true; fi
-          if printf '%s' "$PR_LABELS" | grep -q '"breaking-api"'; then breaking=true; fi
-          echo "breaking=$breaking" >> "$GITHUB_OUTPUT"
-          echo "breaking override: $breaking"
       # These checks use independent build profiles and outputs. Keep them on
       # one Namespace runner while overlapping their work.
       - parallel:
-          - name: Rust embedding API — cargo-semver-checks
+          - name: Published Rust APIs — cargo-semver-checks
             # Version pinned in bin/cargo-semver-checks (mise tool-stub).
             run: |
               set +e
               ./bin/cargo-semver-checks semver-checks \
                 --baseline-rev origin/main \
-                --package aube-codes --package aube-settings --package aube-util
+                --package aube \
+                --package aube-codes \
+                --package aube-linker \
+                --package aube-lockfile \
+                --package aube-manifest \
+                --package aube-registry \
+                --package aube-resolver \
+                --package aube-runtime \
+                --package aube-scripts \
+                --package aube-settings \
+                --package aube-store \
+                --package aube-util \
+                --package aube-workspace
               semver_status=$?
               set -e
               printf '%s\n' "$semver_status" > /tmp/semver-status
@@ -297,10 +288,8 @@ jobs:
               ffi_status=$?
               set -e
               printf '%s\n' "$ffi_status" > /tmp/ffi-status
-      - name: Enforce API stability
+      - name: Enforce C ABI and report Rust API stability
         if: always()
-        env:
-          BREAKING: ${{ steps.gate.outputs.breaking }}
         run: |
           if [ ! -s /tmp/semver-status ] || [ ! -s /tmp/ffi-status ]; then
             echo "::error::one or more API stability checks did not report a result"
@@ -314,57 +303,9 @@ jobs:
             fail=1
           fi
           if [ "$SEMVER" -ne 0 ]; then
-            if [ "$BREAKING" = true ]; then
-              echo "::notice::Rust embedding API compatibility check failed; allowed because this PR is marked breaking. Inspect the cargo-semver-checks output to confirm the failure is expected."
-            else
-              echo "::error::Rust embedding API compatibility check failed. Inspect the cargo-semver-checks output above. If it reports an intentional breaking change, mark the PR breaking: a '!' in the conventional-commit title (e.g. feat(settings)!: ...), a 'BREAKING CHANGE:' footer in the body, or the 'breaking-api' label."
-              fail=1
-            fi
+            echo "::warning::A published Rust API has a semver-breaking change. Inspect the cargo-semver-checks output; release-plz will propose a major version unless the API is kept compatible."
           fi
           exit $fail
-
-  # Check every published Rust API against main so release-plz cannot be the
-  # first place an accidental major bump becomes visible. This is advisory:
-  # the job itself fails to make the break prominent on the PR, while `final`
-  # waits for it and reports the result without blocking the merge.
-  release-semver-advisory:
-    if: github.event_name == 'pull_request'
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
-    timeout-minutes: 20
-    permissions:
-      contents: read
-    env:
-      RUSTFLAGS: "-D warnings"
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
-        with:
-          cache: rust
-      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4 # zizmor: ignore[cache-poisoning] PRs restore only; saves are restricted to main
-        with:
-          cache_save: false
-      - name: Fetch semver baseline
-        run: git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
-      - name: Check published Rust APIs
-        run: |
-          ./bin/cargo-semver-checks semver-checks \
-            --baseline-rev origin/main \
-            --package aube \
-            --package aube-codes \
-            --package aube-linker \
-            --package aube-lockfile \
-            --package aube-manifest \
-            --package aube-registry \
-            --package aube-resolver \
-            --package aube-runtime \
-            --package aube-scripts \
-            --package aube-settings \
-            --package aube-store \
-            --package aube-util \
-            --package aube-workspace
 
   # BATS integration shards. Linux runs 4 shards (matches Buildkite),
   # macOS runs 2. Keep these on GitHub-hosted runners: the jail-build
@@ -499,9 +440,7 @@ jobs:
   # Aggregator that required-status-checks can target. If any upstream job
   # failed, was cancelled, or was skipped, this step exits non-zero so the PR is
   # blocked. Lets the branch-protection rule depend on one name instead of ten.
-  # Exceptions: PR-only jobs may skip outside pull requests, and the workspace
-  # semver check is advisory so its failure is reported without blocking the
-  # aggregate.
+  # Exception: api-stability is PR-only and may skip outside pull requests.
   final:
     needs:
       - build
@@ -511,7 +450,6 @@ jobs:
       - bats-serial
       - windows
       - api-stability
-      - release-semver-advisory
     runs-on: namespace-profile-endev-linux-amd64
     timeout-minutes: 2
     permissions: {}
@@ -532,8 +470,7 @@ jobs:
 
           # Jobs whose `if:` legitimately skips them in this event. A skip
           # here is a pass; every other job must actually succeed.
-          SKIP_OK = {"api-stability", "release-semver-advisory"}
-          ADVISORY = {"release-semver-advisory"}
+          SKIP_OK = {"api-stability"}
           if os.environ["EVENT_NAME"] == "workflow_dispatch" and os.environ["REF"] != "refs/heads/main":
               SKIP_OK.add("cache-qualification")
 
@@ -543,8 +480,6 @@ jobs:
               result = data.get("result", "unknown")
               if result == "success":
                   print(f"::notice::{name}: {result}")
-              elif name in ADVISORY and result == "failure":
-                  print(f"::warning::{name}: {result} (advisory; inspect for an unintended major bump)")
               elif result == "skipped" and name in SKIP_OK:
                   print(f"::notice::{name}: {result} (allowed to skip)")
               else:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,9 +216,9 @@ jobs:
           fi
       - run: mise run docs:build
 
-  # Guard the C ABI export set by diffing the cdylib's dynamic symbol table
-  # against the frozen crates/aube-ffi/abi-symbols.txt manifest. Symbol drift
-  # blocks the final gate so the manifest cannot silently become stale.
+  # Check every published Rust library against main and guard the C ABI export
+  # set against the frozen crates/aube-ffi/abi-symbols.txt manifest. Any failure
+  # makes this job red, while `final` treats the job as advisory.
   api-stability:
     # PR-time gate only. `final` treats the resulting skipped job as a pass on
     # push/tag/dispatch runs.
@@ -239,56 +239,65 @@ jobs:
           cache: rust
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4 # zizmor: ignore[cache-poisoning] PRs restore only; saves are restricted to main
         with:
-          cache_save: ${{ github.ref == 'refs/heads/main' }}
-      - name: C ABI — frozen export set
-        run: |
-          cargo build --locked --profile ffi -p aube-ffi
-          grep -vE '^[[:space:]]*(#|$)' crates/aube-ffi/abi-symbols.txt | sort -u > /tmp/abi-expected.txt
-          nm -D --defined-only --extern-only target/ffi/libaube_ffi.so \
-            | awk '{ print $3 }' | grep '^aube_' | sort -u > /tmp/abi-actual.txt
-          diff -u /tmp/abi-expected.txt /tmp/abi-actual.txt
-
-  # Check every published Rust library against main. This job intentionally
-  # fails when cargo-semver-checks finds a break so the PR shows a red check.
-  # `final` waits for it but treats only this job's failure as advisory.
-  rust-api-stability:
-    if: github.event_name == 'pull_request'
-    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
-    timeout-minutes: 20
-    permissions:
-      contents: read
-    env:
-      RUSTFLAGS: "-D warnings"
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
-        with:
-          cache: rust
-      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4 # zizmor: ignore[cache-poisoning] PRs restore only; saves are restricted to main
-        with:
           cache_save: false
       - name: Fetch semver baseline
         run: git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
-      - name: Published Rust APIs — cargo-semver-checks
+      # Run the independent Rust and C ABI checks concurrently, preserving both
+      # results so the final step can report every failure before failing the job.
+      - parallel:
+          - name: Published Rust APIs — cargo-semver-checks
+            run: |
+              set +e
+              ./bin/cargo-semver-checks semver-checks \
+                --baseline-rev origin/main \
+                --package aube \
+                --package aube-codes \
+                --package aube-linker \
+                --package aube-lockfile \
+                --package aube-manifest \
+                --package aube-registry \
+                --package aube-resolver \
+                --package aube-runtime \
+                --package aube-scripts \
+                --package aube-settings \
+                --package aube-store \
+                --package aube-util \
+                --package aube-workspace
+              semver_status=$?
+              set -e
+              printf '%s\n' "$semver_status" > /tmp/semver-status
+          - name: C ABI — frozen export set
+            run: |
+              set +e
+              (
+                cargo build --locked --profile ffi -p aube-ffi &&
+                grep -vE '^[[:space:]]*(#|$)' crates/aube-ffi/abi-symbols.txt | sort -u > /tmp/abi-expected.txt &&
+                nm -D --defined-only --extern-only target/ffi/libaube_ffi.so \
+                  | awk '{ print $3 }' | grep '^aube_' | sort -u > /tmp/abi-actual.txt &&
+                diff -u /tmp/abi-expected.txt /tmp/abi-actual.txt
+              )
+              ffi_status=$?
+              set -e
+              printf '%s\n' "$ffi_status" > /tmp/ffi-status
+      - name: Report API stability
+        if: always()
         run: |
-          ./bin/cargo-semver-checks semver-checks \
-            --baseline-rev origin/main \
-            --package aube \
-            --package aube-codes \
-            --package aube-linker \
-            --package aube-lockfile \
-            --package aube-manifest \
-            --package aube-registry \
-            --package aube-resolver \
-            --package aube-runtime \
-            --package aube-scripts \
-            --package aube-settings \
-            --package aube-store \
-            --package aube-util \
-            --package aube-workspace
+          if [ ! -s /tmp/semver-status ] || [ ! -s /tmp/ffi-status ]; then
+            echo "::error::one or more API stability checks did not report a result"
+            exit 1
+          fi
+          SEMVER=$(cat /tmp/semver-status)
+          FFI=$(cat /tmp/ffi-status)
+          fail=0
+          if [ "$SEMVER" -ne 0 ]; then
+            echo "::error::Rust API compatibility check failed. Inspect the cargo-semver-checks output above."
+            fail=1
+          fi
+          if [ "$FFI" -ne 0 ]; then
+            echo "::error::C ABI exports drifted from crates/aube-ffi/abi-symbols.txt."
+            fail=1
+          fi
+          exit $fail
 
   # BATS integration shards. Linux runs 4 shards (matches Buildkite),
   # macOS runs 2. Keep these on GitHub-hosted runners: the jail-build
@@ -423,8 +432,8 @@ jobs:
   # Aggregator that required-status-checks can target. If any upstream job
   # failed, was cancelled, or was skipped, this step exits non-zero so the PR is
   # blocked. Lets the branch-protection rule depend on one name instead of ten.
-  # Exceptions: PR-only API jobs may skip outside pull requests, and a failed
-  # Rust semver check is advisory even though its own job remains red.
+  # Exception: the PR-only API job may skip outside pull requests, and any
+  # failure in that job is advisory even though the job itself remains red.
   final:
     needs:
       - build
@@ -434,7 +443,6 @@ jobs:
       - bats-serial
       - windows
       - api-stability
-      - rust-api-stability
     runs-on: namespace-profile-endev-linux-amd64
     timeout-minutes: 2
     permissions: {}
@@ -455,8 +463,8 @@ jobs:
 
           # Jobs whose `if:` legitimately skips them in this event. A skip
           # here is a pass; every other job must actually succeed.
-          SKIP_OK = {"api-stability", "rust-api-stability"}
-          ADVISORY_FAILURE = {"rust-api-stability"}
+          SKIP_OK = {"api-stability"}
+          ADVISORY_FAILURE = {"api-stability"}
           if os.environ["EVENT_NAME"] == "workflow_dispatch" and os.environ["REF"] != "refs/heads/main":
               SKIP_OK.add("cache-qualification")
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,7 @@ jobs:
     permissions:
       contents: read
     env:
+      CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback
       RUSTFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,20 +216,12 @@ jobs:
           fi
       - run: mise run docs:build
 
-  # Guards published API surfaces against unintended breaks:
-  #   * Every published Rust library via cargo-semver-checks, baselined
-  #     against main. Findings are advisory so intentional API work does
-  #     not block the final gate, but it is visible before release-plz can
-  #     surprise us with a major bump.
-  #   * The C ABI export set via the cdylib's dynamic symbol table diffed
-  #     against the frozen crates/aube-ffi/abi-symbols.txt manifest.
-  # Symbol drift always blocks (keeps the manifest honest); removing an
-  # export shows as a manifest deletion in the diff and must ride a
-  # breaking PR.
+  # Guard the C ABI export set by diffing the cdylib's dynamic symbol table
+  # against the frozen crates/aube-ffi/abi-symbols.txt manifest. Symbol drift
+  # blocks the final gate so the manifest cannot silently become stale.
   api-stability:
-    # PR-time gate only: baselining the checked-out revision against main is
-    # meaningless on push/tag/dispatch runs. `final` treats the resulting
-    # `skipped` job as a pass.
+    # PR-time gate only. `final` treats the resulting skipped job as a pass on
+    # push/tag/dispatch runs.
     if: github.event_name == 'pull_request'
     runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
     timeout-minutes: 20
@@ -248,64 +240,55 @@ jobs:
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4 # zizmor: ignore[cache-poisoning] PRs restore only; saves are restricted to main
         with:
           cache_save: ${{ github.ref == 'refs/heads/main' }}
+      - name: C ABI — frozen export set
+        run: |
+          cargo build --locked --profile ffi -p aube-ffi
+          grep -vE '^[[:space:]]*(#|$)' crates/aube-ffi/abi-symbols.txt | sort -u > /tmp/abi-expected.txt
+          nm -D --defined-only --extern-only target/ffi/libaube_ffi.so \
+            | awk '{ print $3 }' | grep '^aube_' | sort -u > /tmp/abi-actual.txt
+          diff -u /tmp/abi-expected.txt /tmp/abi-actual.txt
+
+  # Check every published Rust library against main. This job intentionally
+  # fails when cargo-semver-checks finds a break so the PR shows a red check.
+  # `final` waits for it but treats only this job's failure as advisory.
+  rust-api-stability:
+    if: github.event_name == 'pull_request'
+    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    env:
+      RUSTFLAGS: "-D warnings"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
+        with:
+          cache: rust
+      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4 # zizmor: ignore[cache-poisoning] PRs restore only; saves are restricted to main
+        with:
+          cache_save: false
       - name: Fetch semver baseline
         run: git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
-      # These checks use independent build profiles and outputs. Keep them on
-      # one Namespace runner while overlapping their work.
-      - parallel:
-          - name: Published Rust APIs — cargo-semver-checks
-            # Version pinned in bin/cargo-semver-checks (mise tool-stub).
-            run: |
-              set +e
-              ./bin/cargo-semver-checks semver-checks \
-                --baseline-rev origin/main \
-                --package aube \
-                --package aube-codes \
-                --package aube-linker \
-                --package aube-lockfile \
-                --package aube-manifest \
-                --package aube-registry \
-                --package aube-resolver \
-                --package aube-runtime \
-                --package aube-scripts \
-                --package aube-settings \
-                --package aube-store \
-                --package aube-util \
-                --package aube-workspace
-              semver_status=$?
-              set -e
-              printf '%s\n' "$semver_status" > /tmp/semver-status
-          - name: C ABI — frozen export set
-            run: |
-              set +e
-              (
-                cargo build --locked --profile ffi -p aube-ffi &&
-                grep -vE '^[[:space:]]*(#|$)' crates/aube-ffi/abi-symbols.txt | sort -u > /tmp/abi-expected.txt &&
-                nm -D --defined-only --extern-only target/ffi/libaube_ffi.so \
-                  | awk '{ print $3 }' | grep '^aube_' | sort -u > /tmp/abi-actual.txt &&
-                diff -u /tmp/abi-expected.txt /tmp/abi-actual.txt
-              )
-              ffi_status=$?
-              set -e
-              printf '%s\n' "$ffi_status" > /tmp/ffi-status
-      - name: Enforce C ABI and report Rust API stability
-        if: always()
+      - name: Published Rust APIs — cargo-semver-checks
         run: |
-          if [ ! -s /tmp/semver-status ] || [ ! -s /tmp/ffi-status ]; then
-            echo "::error::one or more API stability checks did not report a result"
-            exit 1
-          fi
-          SEMVER=$(cat /tmp/semver-status)
-          FFI=$(cat /tmp/ffi-status)
-          fail=0
-          if [ "$FFI" -ne 0 ]; then
-            echo "::error::C ABI exports drifted from crates/aube-ffi/abi-symbols.txt. Update the manifest to match; removing or renaming an export is a breaking change — also mark the PR breaking (a '!' in the title or the 'breaking-api' label)."
-            fail=1
-          fi
-          if [ "$SEMVER" -ne 0 ]; then
-            echo "::warning::A published Rust API has a semver-breaking change. Inspect the cargo-semver-checks output; release-plz will propose a major version unless the API is kept compatible."
-          fi
-          exit $fail
+          ./bin/cargo-semver-checks semver-checks \
+            --baseline-rev origin/main \
+            --package aube \
+            --package aube-codes \
+            --package aube-linker \
+            --package aube-lockfile \
+            --package aube-manifest \
+            --package aube-registry \
+            --package aube-resolver \
+            --package aube-runtime \
+            --package aube-scripts \
+            --package aube-settings \
+            --package aube-store \
+            --package aube-util \
+            --package aube-workspace
 
   # BATS integration shards. Linux runs 4 shards (matches Buildkite),
   # macOS runs 2. Keep these on GitHub-hosted runners: the jail-build
@@ -440,7 +423,8 @@ jobs:
   # Aggregator that required-status-checks can target. If any upstream job
   # failed, was cancelled, or was skipped, this step exits non-zero so the PR is
   # blocked. Lets the branch-protection rule depend on one name instead of ten.
-  # Exception: api-stability is PR-only and may skip outside pull requests.
+  # Exceptions: PR-only API jobs may skip outside pull requests, and a failed
+  # Rust semver check is advisory even though its own job remains red.
   final:
     needs:
       - build
@@ -450,6 +434,7 @@ jobs:
       - bats-serial
       - windows
       - api-stability
+      - rust-api-stability
     runs-on: namespace-profile-endev-linux-amd64
     timeout-minutes: 2
     permissions: {}
@@ -470,7 +455,8 @@ jobs:
 
           # Jobs whose `if:` legitimately skips them in this event. A skip
           # here is a pass; every other job must actually succeed.
-          SKIP_OK = {"api-stability"}
+          SKIP_OK = {"api-stability", "rust-api-stability"}
+          ADVISORY_FAILURE = {"rust-api-stability"}
           if os.environ["EVENT_NAME"] == "workflow_dispatch" and os.environ["REF"] != "refs/heads/main":
               SKIP_OK.add("cache-qualification")
 
@@ -480,6 +466,8 @@ jobs:
               result = data.get("result", "unknown")
               if result == "success":
                   print(f"::notice::{name}: {result}")
+              elif result == "failure" and name in ADVISORY_FAILURE:
+                  print(f"::warning::{name}: {result} (advisory; inspect for an unintended major bump)")
               elif result == "skipped" and name in SKIP_OK:
                   print(f"::notice::{name}: {result} (allowed to skip)")
               else:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,6 +323,49 @@ jobs:
           fi
           exit $fail
 
+  # Check every published Rust API against main so release-plz cannot be the
+  # first place an accidental major bump becomes visible. This is advisory:
+  # the job itself fails to make the break prominent on the PR, while `final`
+  # waits for it and reports the result without blocking the merge.
+  release-semver-advisory:
+    if: github.event_name == 'pull_request'
+    runs-on: namespace-profile-endev-linux-amd64;overrides.cache-tag=aube-rust-linux
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    env:
+      RUSTFLAGS: "-D warnings"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
+        with:
+          cache: rust
+      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4 # zizmor: ignore[cache-poisoning] PRs restore only; saves are restricted to main
+        with:
+          cache_save: false
+      - name: Fetch semver baseline
+        run: git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+      - name: Check published Rust APIs
+        run: |
+          ./bin/cargo-semver-checks semver-checks \
+            --baseline-rev origin/main \
+            --package aube \
+            --package aube-codes \
+            --package aube-linker \
+            --package aube-lockfile \
+            --package aube-manifest \
+            --package aube-registry \
+            --package aube-resolver \
+            --package aube-runtime \
+            --package aube-scripts \
+            --package aube-settings \
+            --package aube-store \
+            --package aube-util \
+            --package aube-workspace
+
   # BATS integration shards. Linux runs 4 shards (matches Buildkite),
   # macOS runs 2. Keep these on GitHub-hosted runners: the jail-build
   # tests assert native OS sandbox behavior that does not match the
@@ -456,8 +499,9 @@ jobs:
   # Aggregator that required-status-checks can target. If any upstream job
   # failed, was cancelled, or was skipped, this step exits non-zero so the PR is
   # blocked. Lets the branch-protection rule depend on one name instead of ten.
-  # Exception: jobs in SKIP_OK below (api-stability, a PR-only gate) are allowed
-  # to skip on push/tag/dispatch runs without failing the aggregate.
+  # Exceptions: PR-only jobs may skip outside pull requests, and the workspace
+  # semver check is advisory so its failure is reported without blocking the
+  # aggregate.
   final:
     needs:
       - build
@@ -467,6 +511,7 @@ jobs:
       - bats-serial
       - windows
       - api-stability
+      - release-semver-advisory
     runs-on: namespace-profile-endev-linux-amd64
     timeout-minutes: 2
     permissions: {}
@@ -487,7 +532,8 @@ jobs:
 
           # Jobs whose `if:` legitimately skips them in this event. A skip
           # here is a pass; every other job must actually succeed.
-          SKIP_OK = {"api-stability"}
+          SKIP_OK = {"api-stability", "release-semver-advisory"}
+          ADVISORY = {"release-semver-advisory"}
           if os.environ["EVENT_NAME"] == "workflow_dispatch" and os.environ["REF"] != "refs/heads/main":
               SKIP_OK.add("cache-qualification")
 
@@ -497,6 +543,8 @@ jobs:
               result = data.get("result", "unknown")
               if result == "success":
                   print(f"::notice::{name}: {result}")
+              elif name in ADVISORY and result == "failure":
+                  print(f"::warning::{name}: {result} (advisory; inspect for an unintended major bump)")
               elif result == "skipped" and name in SKIP_OK:
                   print(f"::notice::{name}: {result} (allowed to skip)")
               else:


### PR DESCRIPTION
## Summary

- expand the existing PR-only `api-stability` job to cover every published Rust library
- keep the Rust semver and C ABI checks together and run them concurrently
- make `api-stability` fail visibly when either check fails
- make the required `final` aggregator wait for `api-stability` but treat any failure from that job as advisory

## Why

`aube-resolver::ResolutionMode::LowestDirect` was detected as breaking only when release-plz regenerated the release PR because the existing API check covered only three Rust packages.

Keeping both compatibility checks in `api-stability` provides one visible API health signal. The job remains red for Rust or C ABI drift, while the required `final` gate does not block a merge on API compatibility findings.

## Validation

- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- simulated a failed `api-stability` result and confirmed `final` succeeds

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI merge policy so API/ABI regressions no longer block PRs, which increases the chance of unintended semver breaks landing despite a red advisory job.
> 
> **Overview**
> **Broadens PR API checks** so `cargo-semver-checks` runs against every published Rust crate (not just three embedding crates), while Rust semver and C ABI manifest checks still run in parallel and the job stays **red** on any failure.
> 
> **Relaxes merge blocking:** the `final` aggregator now treats a failed `api-stability` job as **advisory** (warning only), so required checks can pass even when semver or C ABI drift is reported. The PR also **drops** the breaking-change override path (`!` in the title, `BREAKING CHANGE:` footer, `breaking-api` label) that previously allowed Rust semver failures without failing the gate.
> 
> Minor job tweaks: `CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback` on `api-stability`, and mise cache writes disabled for that job (`cache_save: false`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b15b1854f90c28904124b1d83d35c0f84b6da1b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pull request API compatibility checks for all published Rust packages.
  * Added dedicated validation for the stable C ABI.
  * Updated reporting so compatibility failures are clearly identified, while non-pull-request workflows may continue with advisory warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->