### PR TITLE
fix(resolver): avoid lowest-direct API break

### DIFF
--- a/V2.md
+++ b/V2.md
@@ -1,0 +1,29 @@
+# aube v2
+
+This file tracks worthwhile breaking changes to batch into a future major
+release. Items belong here when they improve the long-term API or defaults but
+do not justify a major release on their own.
+
+## Resolver API
+
+### Model `lowest-direct` as a distinct resolution mode
+
+Add `LowestDirect` to `aube_resolver::ResolutionMode` so library consumers can
+select it through the same API as `Highest` and `TimeBased`.
+
+Adding a variant to the currently exhaustive public enum breaks downstream
+exhaustive matches. Until v2, keep that distinction internal and expose any
+needed v1-compatible builder method instead.
+
+As part of the v2 change, consider marking public enums that are expected to
+grow as `#[non_exhaustive]`. Document the required wildcard match arm in the
+embedding migration guide.
+
+## Security defaults
+
+### Enable jailed dependency builds by default
+
+Change `jailBuilds` from `false` to `true`, as already noted in the security and
+lifecycle-script documentation. Call out the opt-out and permission settings in
+the migration guide for packages whose build scripts need broader filesystem,
+environment, or network access.

--- a/crates/aube-resolver/src/builder.rs
+++ b/crates/aube-resolver/src/builder.rs
@@ -37,6 +37,7 @@ impl Resolver {
             override_rules: Vec::new(),
             ignored_optional_dependencies: BTreeSet::new(),
             resolution_mode: ResolutionMode::Highest,
+            lowest_direct: false,
             project_root: PathBuf::from("."),
             ignore_scripts: false,
             minimum_release_age: None,
@@ -83,6 +84,7 @@ impl Resolver {
                 override_rules: Vec::new(),
                 ignored_optional_dependencies: BTreeSet::new(),
                 resolution_mode: ResolutionMode::Highest,
+                lowest_direct: false,
                 project_root: PathBuf::from("."),
                 ignore_scripts: false,
                 minimum_release_age: None,
@@ -126,6 +128,19 @@ impl Resolver {
     /// and constrains transitives by a publish-date cutoff.
     pub fn with_resolution_mode(mut self, mode: ResolutionMode) -> Self {
         self.resolution_mode = mode;
+        self.lowest_direct = false;
+        self
+    }
+
+    /// Pick the lowest satisfying version for direct dependencies while
+    /// resolving transitives normally. Unlike `ResolutionMode::TimeBased`,
+    /// this neither computes a publish-time cutoff nor records publish times
+    /// in the lockfile.
+    pub fn with_lowest_direct(mut self, enabled: bool) -> Self {
+        self.lowest_direct = enabled;
+        if enabled {
+            self.resolution_mode = ResolutionMode::Highest;
+        }
         self
     }
 

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -147,6 +147,11 @@ pub struct Resolver {
     ignored_optional_dependencies: BTreeSet<String>,
     /// pnpm's `resolution-mode` — `Highest` (default) or `TimeBased`.
     resolution_mode: ResolutionMode,
+    /// Pick the lowest satisfying version for direct dependencies without
+    /// enabling the publish-time cutoff used by `TimeBased`. Kept separate
+    /// from the public `ResolutionMode` enum so adding pnpm's `lowest-direct`
+    /// mode does not break downstream exhaustive matches in aube v1.
+    lowest_direct: bool,
     /// Project root used to resolve `file:` / `link:` paths to the
     /// target directory. Defaults to the current working directory;
     /// callers set it via `with_project_root`.

--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -553,10 +553,9 @@ impl<'a> ResolveDriver<'a> {
 
         // Direct deps in time-based and lowest-direct modes pick the
         // lowest satisfying version; everything else picks highest.
-        let pick_lowest = matches!(
-            self.resolver.resolution_mode,
-            ResolutionMode::TimeBased | ResolutionMode::LowestDirect
-        ) && task.is_root;
+        let pick_lowest = (self.resolver.resolution_mode == ResolutionMode::TimeBased
+            || self.resolver.lowest_direct)
+            && task.is_root;
         // `minimumReleaseAgeExclude` is applied per-candidate-version
         // inside `pick_version` via the `is_age_exempt` closure below. A
         // name-only exclude rule matches every version; a `pkg@1.2.3`

--- a/crates/aube-resolver/src/types.rs
+++ b/crates/aube-resolver/src/types.rs
@@ -240,9 +240,4 @@ pub enum ResolutionMode {
     /// before a cutoff date derived from the max publish time of
     /// already-locked packages. Matches pnpm's `time-based` mode.
     TimeBased,
-    /// Pick the lowest version satisfying each direct dependency range,
-    /// while resolving transitive dependencies normally. Unlike
-    /// `TimeBased`, this mode neither computes a publish-time cutoff nor
-    /// records package publish times in the lockfile.
-    LowestDirect,
 }

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -2,14 +2,30 @@ use super::version_from_dep_path;
 use miette::{Context, IntoDiagnostic, miette};
 use std::collections::BTreeMap;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ResolutionModeConfig {
+    mode: aube_resolver::ResolutionMode,
+    lowest_direct: bool,
+}
+
 /// Accept pnpm's documented aliases (`highest`, `time-based`, `time`,
-/// `lowest-direct`) and map them to our enum. Unknown values fall back
-/// to `None` so the caller's `.npmrc` / default path still runs.
-fn parse_resolution_mode(s: &str) -> Option<aube_resolver::ResolutionMode> {
+/// `lowest-direct`) and map them to the resolver's v1-compatible controls.
+/// Unknown values fall back to `None` so the caller's `.npmrc` / default path
+/// still runs.
+fn parse_resolution_mode(s: &str) -> Option<ResolutionModeConfig> {
     match s.trim().to_ascii_lowercase().as_str() {
-        "highest" => Some(aube_resolver::ResolutionMode::Highest),
-        "time-based" | "time" => Some(aube_resolver::ResolutionMode::TimeBased),
-        "lowest-direct" => Some(aube_resolver::ResolutionMode::LowestDirect),
+        "highest" => Some(ResolutionModeConfig {
+            mode: aube_resolver::ResolutionMode::Highest,
+            lowest_direct: false,
+        }),
+        "time-based" | "time" => Some(ResolutionModeConfig {
+            mode: aube_resolver::ResolutionMode::TimeBased,
+            lowest_direct: false,
+        }),
+        "lowest-direct" => Some(ResolutionModeConfig {
+            mode: aube_resolver::ResolutionMode::Highest,
+            lowest_direct: true,
+        }),
         _ => None,
     }
 }
@@ -18,7 +34,7 @@ fn parse_resolution_mode(s: &str) -> Option<aube_resolver::ResolutionMode> {
 /// (CLI > env > `.npmrc` > `aube-workspace.yaml` > default). The `.cli`
 /// source carries `--resolution-mode` via `to_cli_flag_bag`, so every
 /// caller feeds the same ctx and gets the same answer.
-fn resolve_resolution_mode(ctx: &aube_settings::ResolveCtx<'_>) -> aube_resolver::ResolutionMode {
+fn resolve_resolution_mode(ctx: &aube_settings::ResolveCtx<'_>) -> ResolutionModeConfig {
     // Legacy alias: pnpm's CLI / `.npmrc` / env accept the shorthand
     // `time` for `time-based`. The generator-side `from_str_normalized`
     // only knows the canonical variants declared in `settings.toml`,
@@ -48,17 +64,20 @@ fn resolve_resolution_mode(ctx: &aube_settings::ResolveCtx<'_>) -> aube_resolver
 
 /// Translate the settings-side `ResolutionMode` enum into the
 /// resolver's runtime enum.
-fn map_resolution_mode(
-    m: aube_settings::resolved::ResolutionMode,
-) -> aube_resolver::ResolutionMode {
+fn map_resolution_mode(m: aube_settings::resolved::ResolutionMode) -> ResolutionModeConfig {
     match m {
-        aube_settings::resolved::ResolutionMode::Highest => aube_resolver::ResolutionMode::Highest,
-        aube_settings::resolved::ResolutionMode::TimeBased => {
-            aube_resolver::ResolutionMode::TimeBased
-        }
-        aube_settings::resolved::ResolutionMode::LowestDirect => {
-            aube_resolver::ResolutionMode::LowestDirect
-        }
+        aube_settings::resolved::ResolutionMode::Highest => ResolutionModeConfig {
+            mode: aube_resolver::ResolutionMode::Highest,
+            lowest_direct: false,
+        },
+        aube_settings::resolved::ResolutionMode::TimeBased => ResolutionModeConfig {
+            mode: aube_resolver::ResolutionMode::TimeBased,
+            lowest_direct: false,
+        },
+        aube_settings::resolved::ResolutionMode::LowestDirect => ResolutionModeConfig {
+            mode: aube_resolver::ResolutionMode::Highest,
+            lowest_direct: true,
+        },
     }
 }
 
@@ -974,7 +993,8 @@ pub(crate) fn configure_resolver(
         .with_supported_architectures(supported_architectures)
         .with_overrides(effective_overrides)
         .with_ignored_optional_dependencies(ignored_optional)
-        .with_resolution_mode(resolution_mode)
+        .with_resolution_mode(resolution_mode.mode)
+        .with_lowest_direct(resolution_mode.lowest_direct)
         .with_minimum_release_age(minimum_release_age)
         .with_catalogs(workspace_catalogs.clone())
         .with_project_root(cwd.to_path_buf())
@@ -1146,6 +1166,33 @@ fn compile_peer_patterns(field: &str, raw: &[String]) -> Vec<glob::Pattern> {
             }
         })
         .collect()
+}
+
+#[cfg(test)]
+mod resolution_mode_tests {
+    use super::*;
+
+    #[test]
+    fn lowest_direct_uses_the_v1_compatible_resolver_controls() {
+        assert_eq!(
+            parse_resolution_mode("lowest-direct"),
+            Some(ResolutionModeConfig {
+                mode: aube_resolver::ResolutionMode::Highest,
+                lowest_direct: true,
+            })
+        );
+    }
+
+    #[test]
+    fn time_alias_keeps_time_based_mode() {
+        assert_eq!(
+            parse_resolution_mode("time"),
+            Some(ResolutionModeConfig {
+                mode: aube_resolver::ResolutionMode::TimeBased,
+                lowest_direct: false,
+            })
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- remove `LowestDirect` from the exhaustive public `aube_resolver::ResolutionMode` enum
- preserve `lowest-direct` behavior with private resolver state and an additive `with_lowest_direct` builder
- keep `time-based`, `highest`, and `lowest-direct` CLI behavior unchanged
- add a root `V2.md` backlog for batching this API change and other worthwhile breaking defaults into a future major

## Why

Adding `ResolutionMode::LowestDirect` broke downstream exhaustive matches. `cargo-semver-checks` therefore made release-plz propose v2.0.0 even though the user-facing change does not justify a major release by itself.

This keeps the v1 public enum stable while retaining the feature. The proper enum variant and `#[non_exhaustive]` hardening are recorded for an intentional v2.

## Validation

- `cargo fmt --check`
- `cargo test -p aube-resolver` — 253 passed
- `cargo test -p aube --lib commands::install::settings::resolution_mode_tests`
- `cargo clippy -p aube-resolver -p aube --all-targets -- -D warnings`
- `mise run test:bats test/resolution_mode.bats` — 4 passed
- `cargo-semver-checks` for `aube-resolver` against `v1.40.0` — no semver update required
- `git diff --check`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public resolver enum and how resolution mode is plumbed, but user-facing lowest-direct/time-based behavior is intended to stay the same; risk is mainly embedders who matched on the removed variant.
> 
> **Overview**
> **Keeps `lowest-direct` behavior while restoring a semver-safe public resolver API** by dropping `LowestDirect` from `aube_resolver::ResolutionMode` and driving the same picks through private `lowest_direct` state plus the additive `with_lowest_direct` builder.
> 
> Install settings now map `lowest-direct` (and settings `LowestDirect`) to `ResolutionMode::Highest` with `lowest_direct: true`, and `configure_resolver` wires both `with_resolution_mode` and `with_lowest_direct`. The resolve driver still uses lowest picks for root direct deps when time-based mode **or** `lowest_direct` is on, without time-based cutoff or lockfile `time:` recording.
> 
> Adds root **`V2.md`** to backlog a proper `LowestDirect` enum variant, `#[non_exhaustive]` enums, and default jailed builds for a future major.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b6356d61f4ae9985a123577b4d40cf0401054fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->