### PR TITLE
fix(install): keep gvs enabled for nuxt and parcel

### DIFF
--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -1183,7 +1183,7 @@ examples = [
 [disableGlobalVirtualStoreForPackages]
 description = "Package names whose presence in any importer forces per-project materialization."
 type = "list<string>"
-default = "[\"next\", \"nuxt\", \"parcel\", \"expo\", \"react-native\", \"metro\"]"
+default = "[\"next\", \"expo\", \"react-native\", \"metro\"]"
 docs = """
 aube's global virtual store makes `node_modules/.aube/<pkg>` an
 absolute symlink into `~/.cache/aube/virtual-store/`. Tools whose
@@ -1197,16 +1197,17 @@ When `aube install` finds one of these names in any importer's
 forces per-project materialization for that install and prints a
 one-line warning naming the trigger.
 
-The default list — `next`, `nuxt`, `parcel`, `expo`, `react-native`, `metro` —
-covers the tools with concrete filesystem-root failures: Next.js's Turbopack
-canonicalizes through symlinks and walks up for app-router/monorepo detection,
-Nuxt plugins walk up for config discovery, and Parcel's resolver walks up for
-`.parcelrc`. Metro's file map requires symlink targets to stay within the project
-root or configured watch folders; Expo and React Native use Metro but normally
-declare their framework package rather than `metro` directly.
+The default list — `next`, `expo`, `react-native`, `metro` — covers the tools
+with concrete filesystem-root failures. Next.js's Turbopack canonicalizes
+through symlinks and walks up for app-router/monorepo detection. Metro's file
+map requires symlink targets to stay within the project root or configured
+watch folders; Expo and React Native use Metro but normally declare their
+framework package rather than `metro` directly.
 
-Vite and VitePress are compatible with the global virtual store:
-aube writes `node_modules/.modules.yaml` with the store location, which Vite
+Nuxt, Parcel, Vite, and VitePress are compatible with the global virtual store.
+For Nuxt and Parcel, aube's sibling dependency links keep resolution inside the
+installed graph. For Vite and VitePress, aube writes
+`node_modules/.modules.yaml` with the store location, which Vite
 8.1+ reads when constructing its filesystem allow-list. For older Vite
 versions, aube materializes only the Vite dependency path locally and backports
 the same allow-list lookup into that project-local copy; unrelated dependencies

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -1204,6 +1204,14 @@ map requires symlink targets to stay within the project root or configured
 watch folders; Expo and React Native use Metro but normally declare their
 framework package rather than `metro` directly.
 
+Track upstream compatibility in
+[vercel/next.js#93556](https://github.com/vercel/next.js/issues/93556) for
+Next.js and
+[expo/expo#45460](https://github.com/expo/expo/pull/45460) for the Metro
+file-map change that follows global-store symlinks. The Metro-family entries
+remain in the default list until that behavior is available across the Expo,
+React Native, and direct Metro versions aube supports.
+
 Nuxt, Parcel, Vite, and VitePress are compatible with the global virtual store.
 For Nuxt and Parcel, aube's sibling dependency links keep resolution inside the
 installed graph. For Vite and VitePress, aube writes

--- a/docs/package-manager/global-virtual-store.md
+++ b/docs/package-manager/global-virtual-store.md
@@ -163,12 +163,18 @@ depends on a package with a known global-virtual-store incompatibility. The
 default trigger list is:
 
 - `next`
-- `nuxt`
-- `parcel`
+- `expo`
+- `react-native`
+- `metro`
 
 When that happens, install still succeeds and aube prints a warning. Repeat
 installs of that project just won't share materialized package directories
 across projects.
+
+Nuxt and Parcel work with the shared layout because aube records each
+package's complete sibling dependency links inside the global virtual store.
+This keeps Node resolution inside the installed dependency graph even after a
+tool follows a package symlink to its physical location.
 
 Vite 8.1 and newer supports shared virtual stores. aube writes the effective
 store location to `node_modules/.modules.yaml`, including in linked workspace

--- a/docs/package-manager/global-virtual-store.md
+++ b/docs/package-manager/global-virtual-store.md
@@ -162,10 +162,12 @@ aube automatically falls back to per-project materialization when an importer
 depends on a package with a known global-virtual-store incompatibility. The
 default trigger list is:
 
-- `next`
-- `expo`
-- `react-native`
-- `metro`
+- `next` — track the upstream Turbopack compatibility bug in
+  [vercel/next.js#93556](https://github.com/vercel/next.js/issues/93556)
+- `expo`, `react-native`, and `metro` — track the merged Metro file-map support
+  in [expo/expo#45460](https://github.com/expo/expo/pull/45460). aube keeps the
+  fallback for now because the compatible behavior is not yet available across
+  the framework and Metro versions these package names can select.
 
 When that happens, install still succeeds and aube prints a warning. Repeat
 installs of that project just won't share materialized package directories

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -1270,6 +1270,14 @@ map requires symlink targets to stay within the project root or configured
 watch folders; Expo and React Native use Metro but normally declare their
 framework package rather than `metro` directly.
 
+Track upstream compatibility in
+[vercel/next.js#93556](https://github.com/vercel/next.js/issues/93556) for
+Next.js and
+[expo/expo#45460](https://github.com/expo/expo/pull/45460) for the Metro
+file-map change that follows global-store symlinks. The Metro-family entries
+remain in the default list until that behavior is available across the Expo,
+React Native, and direct Metro versions aube supports.
+
 Nuxt, Parcel, Vite, and VitePress are compatible with the global virtual store.
 For Nuxt and Parcel, aube's sibling dependency links keep resolution inside the
 installed graph. For Vite and VitePress, aube writes

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -1246,7 +1246,7 @@ Examples:
 Package names whose presence in any importer forces per-project materialization.
 
 - Type: `list<string>`
-- Default: `["next", "nuxt", "parcel", "expo", "react-native", "metro"]`
+- Default: `["next", "expo", "react-native", "metro"]`
 - Environment: `npm_config_disable_global_virtual_store_for_packages`, `NPM_CONFIG_DISABLE_GLOBAL_VIRTUAL_STORE_FOR_PACKAGES`, `AUBE_DISABLE_GLOBAL_VIRTUAL_STORE_FOR_PACKAGES`
 - .npmrc keys: `disableGlobalVirtualStoreForPackages`, `disable-global-virtual-store-for-packages`
 - Workspace YAML keys: `disableGlobalVirtualStoreForPackages`
@@ -1263,16 +1263,17 @@ When `aube install` finds one of these names in any importer's
 forces per-project materialization for that install and prints a
 one-line warning naming the trigger.
 
-The default list — `next`, `nuxt`, `parcel`, `expo`, `react-native`, `metro` —
-covers the tools with concrete filesystem-root failures: Next.js's Turbopack
-canonicalizes through symlinks and walks up for app-router/monorepo detection,
-Nuxt plugins walk up for config discovery, and Parcel's resolver walks up for
-`.parcelrc`. Metro's file map requires symlink targets to stay within the project
-root or configured watch folders; Expo and React Native use Metro but normally
-declare their framework package rather than `metro` directly.
+The default list — `next`, `expo`, `react-native`, `metro` — covers the tools
+with concrete filesystem-root failures. Next.js's Turbopack canonicalizes
+through symlinks and walks up for app-router/monorepo detection. Metro's file
+map requires symlink targets to stay within the project root or configured
+watch folders; Expo and React Native use Metro but normally declare their
+framework package rather than `metro` directly.
 
-Vite and VitePress are compatible with the global virtual store:
-aube writes `node_modules/.modules.yaml` with the store location, which Vite
+Nuxt, Parcel, Vite, and VitePress are compatible with the global virtual store.
+For Nuxt and Parcel, aube's sibling dependency links keep resolution inside the
+installed graph. For Vite and VitePress, aube writes
+`node_modules/.modules.yaml` with the store location, which Vite
 8.1+ reads when constructing its filesystem allow-list. For older Vite
 versions, aube materializes only the Vite dependency path locally and backports
 the same allow-list lookup into that project-local copy; unrelated dependencies

--- a/test/gvs_ecosystem_slow.bats
+++ b/test/gvs_ecosystem_slow.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+#
+# Network-dependent compatibility checks for real frameworks that use aube's
+# global virtual store. Gated so the default BATS suite remains hermetic.
+
+setup() {
+	load 'test_helper/common_setup'
+	local node_bin_dir
+	node_bin_dir="$(dirname "$(mise which node)")"
+	_common_setup
+	export PATH="$node_bin_dir:$PATH"
+	if [ "${AUBE_NETWORK_TESTS:-}" != "1" ]; then
+		skip "set AUBE_NETWORK_TESTS=1 to run network tests"
+	fi
+	printf 'registry=https://registry.npmjs.org/\n' >.npmrc
+}
+
+teardown() {
+	_common_teardown
+}
+
+@test "Nuxt 3 and 4 prepare and build with the global virtual store" {
+	for version in 3.21.11 4.5.2; do
+		mkdir "nuxt-$version"
+		(
+			cd "nuxt-$version"
+			cat >package.json <<JSON
+{
+  "name": "nuxt-gvs-$version",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "nuxt build",
+    "postinstall": "nuxt prepare"
+  },
+  "dependencies": {
+    "nuxt": "$version"
+  }
+}
+JSON
+
+			run aube install
+			assert_success
+			refute_output --partial "disableGlobalVirtualStoreForPackages"
+			run find node_modules/.aube -mindepth 1 -maxdepth 1 -type l
+			assert_success
+			[ -n "$output" ]
+
+			run aube run build
+			assert_success
+			assert_file_exists .output/server/index.mjs
+		)
+	done
+}
+
+@test "Parcel discovers .parcelrc and builds with the global virtual store" {
+	mkdir -p parcel/src
+	cd parcel
+	# Strict layouts require configs referenced by the project to be direct.
+	cat >package.json <<'JSON'
+{
+  "name": "parcel-gvs",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "parcel build src/index.html"
+  },
+  "devDependencies": {
+    "@parcel/config-default": "2.16.4",
+    "parcel": "2.16.4"
+  }
+}
+JSON
+	cat >.parcelrc <<'JSON'
+{
+  "extends": "@parcel/config-default"
+}
+JSON
+	cat >src/index.html <<'HTML'
+<!doctype html>
+<title>Parcel GVS compatibility</title>
+<script type="module" src="./index.js"></script>
+HTML
+	cat >src/index.js <<'JS'
+document.body.textContent = "parcel works";
+JS
+
+	run aube install
+	assert_success
+	refute_output --partial "disableGlobalVirtualStoreForPackages"
+	run realpath node_modules/parcel
+	assert_success
+	[[ "$output" == */aube/virtual-store/v1/* ]]
+
+	run aube run build
+	assert_success
+	assert_file_exists dist/index.html
+}

--- a/test/nextjs_gvs_autodisable.bats
+++ b/test/nextjs_gvs_autodisable.bats
@@ -7,7 +7,9 @@
 # gvs layout produces by default. Metro's file map likewise requires
 # external symlink targets to be included in `watchFolders`; Expo and
 # React Native use Metro but normally declare their framework package.
-# Vite is deliberately absent because
+# Nuxt and Parcel are deliberately absent because aube's complete sibling
+# dependency links keep their resolution inside the installed graph. Vite is
+# absent because
 # 8.1+ reads the `.modules.yaml` metadata aube writes. The setting is
 # the extension point: add any tool with the same restriction, or set
 # to `[]` to disable the heuristic.
@@ -105,6 +107,24 @@ JSON
 			assert_output --partial "\`$package\`"
 			[ -d node_modules/.aube/is-odd@3.0.1 ]
 			[ ! -L node_modules/.aube/is-odd@3.0.1 ]
+		)
+	done
+}
+
+@test "Nuxt and Parcel keep the global virtual store enabled by default" {
+	for package in nuxt parcel; do
+		_make_fake_dep "$package"
+		mkdir "app-$package"
+		(
+			cd "app-$package"
+			cat >package.json <<JSON
+{"name":"app-$package","version":"0.0.0","dependencies":{"$package":"link:../fake-$package","is-odd":"3.0.1"}}
+JSON
+
+			run aube install
+			assert_success
+			refute_output --partial "disableGlobalVirtualStoreForPackages"
+			[ -L node_modules/.aube/is-odd@3.0.1 ]
 		)
 	done
 }


### PR DESCRIPTION
## Summary

- keep the global virtual store enabled by default for Nuxt and Parcel projects
- retain automatic per-project fallback for Next.js and the Metro ecosystem
- link the remaining fallbacks to their upstream compatibility trackers
- add hermetic selection coverage plus gated real-framework GVS builds
- update generated and package-manager documentation

## Why

Nuxt and Parcel were added to `disableGlobalVirtualStoreForPackages` based on the general risk that tools following package symlinks into the global store would lose access to project dependencies or configuration. Aube’s GVS already writes each package’s complete sibling dependency links, so their resolvers remain inside the installed graph.

Real compatibility probes confirmed:

- Nuxt 3.21.11 runs `nuxt prepare` and builds successfully while unrelated packages remain shared through GVS
- Nuxt 4.5.2 runs `nuxt prepare` and builds successfully from the external GVS
- Parcel 2.16.4 discovers an explicit `.parcelrc` and builds successfully with Parcel in the external GVS

The Parcel config fixture declares `@parcel/config-default` directly, as required by strict isolated layouts. Omitting that direct declaration fails with or without GVS and is not a GVS compatibility problem.

## Upstream status

- Next.js remains tracked by [vercel/next.js#93556](https://github.com/vercel/next.js/issues/93556), which reproduces Turbopack failing to resolve `next/package.json` with pnpm’s global virtual store.
- Expo merged [expo/expo#45460](https://github.com/expo/expo/pull/45460) so Metro’s on-demand file map can follow global-store symlinks. Aube retains the Expo, React Native, and Metro fallbacks until compatible behavior is available across the versions those package names can select.

## Impact

Nuxt and Parcel projects now retain aube’s shared materialization fast path by default. Users can still add either package to `disableGlobalVirtualStoreForPackages` if a specific plugin needs per-project materialization.

## Validation

- `mise run test:bats test/nextjs_gvs_autodisable.bats`
- `AUBE_NETWORK_TESTS=1 mise run test:bats test/gvs_ecosystem_slow.bats`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `mise run lint`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nuxt and Parcel projects now support the global virtual store by default.
  * Added compatibility coverage for Nuxt 3/4 and Parcel builds.

* **Bug Fixes**
  * Updated automatic compatibility handling to keep the global virtual store enabled for Nuxt and Parcel.
  * Refined default exclusions to retain safeguards for Next.js, Expo, React Native, and Metro.

* **Documentation**
  * Updated global virtual store and settings guidance to reflect supported frameworks, compatibility details, and default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->