### PR TITLE
chore: release v2.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "aube-codes"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "aube-ffi"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "aube",
  "aube-codes",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "aube-node"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "aube",
  "aube-codes",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "aube-runtime"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "aube-util",
  "base64 0.23.1",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "aube-codes",
  "blake3",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "aube-codes",
  "aube-manifest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ inherits = "release"
 panic = "unwind"
 
 [workspace.package]
-version = "2.0.0"
+version = "2.0.1"
 edition = "2024"
 # Kept at the floor mise can build with (its distro packaging pins the
 # toolchain) so mise can embed the library crates. CI enforces this via

--- a/crates/aube-codes/CHANGELOG.md
+++ b/crates/aube-codes/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1](https://github.com/jdx/aube/compare/aube-codes-v2.0.0...aube-codes-v2.0.1) - 2026-08-23
+
+### Added
+
+- *(resolver)* [**breaking**] expose lowest-direct resolution mode ([#1345](https://github.com/jdx/aube/pull/1345))
+- *(global)* [**breaking**] keep aube's global dirs under its own data root ([#1231](https://github.com/jdx/aube/pull/1231))
+
 ## [1.41.0](https://github.com/jdx/aube/compare/aube-codes-v1.40.0...aube-codes-v1.41.0) - 2026-08-16
 
 ### Fixed

--- a/crates/aube-linker/CHANGELOG.md
+++ b/crates/aube-linker/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1](https://github.com/jdx/aube/compare/aube-linker-v2.0.0...aube-linker-v2.0.1) - 2026-08-23
+
+### Added
+
+- *(resolver)* [**breaking**] expose lowest-direct resolution mode ([#1345](https://github.com/jdx/aube/pull/1345))
+
 ## [1.41.0](https://github.com/jdx/aube/compare/aube-linker-v1.40.0...aube-linker-v1.41.0) - 2026-08-16
 
 ### Fixed

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1](https://github.com/jdx/aube/compare/aube-lockfile-v2.0.0...aube-lockfile-v2.0.1) - 2026-08-23
+
+### Added
+
+- *(resolver)* [**breaking**] expose lowest-direct resolution mode ([#1345](https://github.com/jdx/aube/pull/1345))
+
 ## [1.41.0](https://github.com/jdx/aube/compare/aube-lockfile-v1.40.0...aube-lockfile-v1.41.0) - 2026-08-16
 
 ### Fixed

--- a/crates/aube-manifest/CHANGELOG.md
+++ b/crates/aube-manifest/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1](https://github.com/jdx/aube/compare/aube-manifest-v2.0.0...aube-manifest-v2.0.1) - 2026-08-23
+
+### Added
+
+- *(resolver)* [**breaking**] expose lowest-direct resolution mode ([#1345](https://github.com/jdx/aube/pull/1345))
+
 ## [1.41.0](https://github.com/jdx/aube/compare/aube-manifest-v1.40.0...aube-manifest-v1.41.0) - 2026-08-16
 
 ### Added

--- a/crates/aube-settings/CHANGELOG.md
+++ b/crates/aube-settings/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1](https://github.com/jdx/aube/compare/aube-settings-v2.0.0...aube-settings-v2.0.1) - 2026-08-23
+
+### Added
+
+- *(resolver)* [**breaking**] expose lowest-direct resolution mode ([#1345](https://github.com/jdx/aube/pull/1345))
+- *(global)* [**breaking**] keep aube's global dirs under its own data root ([#1231](https://github.com/jdx/aube/pull/1231))
+
 ## [1.41.0](https://github.com/jdx/aube/compare/aube-settings-v1.40.0...aube-settings-v1.41.0) - 2026-08-16
 
 ### Added

--- a/crates/aube-store/CHANGELOG.md
+++ b/crates/aube-store/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1](https://github.com/jdx/aube/compare/aube-store-v2.0.0...aube-store-v2.0.1) - 2026-08-23
+
+### Added
+
+- *(resolver)* [**breaking**] expose lowest-direct resolution mode ([#1345](https://github.com/jdx/aube/pull/1345))
+
 ## [1.41.0](https://github.com/jdx/aube/compare/aube-store-v1.40.0...aube-store-v1.41.0) - 2026-08-16
 
 ### Fixed

--- a/crates/aube-util/CHANGELOG.md
+++ b/crates/aube-util/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1](https://github.com/jdx/aube/compare/aube-util-v2.0.0...aube-util-v2.0.1) - 2026-08-23
+
+### Added
+
+- *(resolver)* [**breaking**] expose lowest-direct resolution mode ([#1345](https://github.com/jdx/aube/pull/1345))
+
 ## [1.41.0](https://github.com/jdx/aube/compare/aube-util-v1.40.0...aube-util-v1.41.0) - 2026-08-16
 
 ### Fixed

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1](https://github.com/jdx/aube/compare/v1.41.0...v2.0.1) - 2026-08-23
+
+### Added
+
+- *(resolver)* [**breaking**] expose lowest-direct resolution mode ([#1345](https://github.com/jdx/aube/pull/1345))
+- *(global)* [**breaking**] keep aube's global dirs under its own data root ([#1231](https://github.com/jdx/aube/pull/1231))
+- *(util)* add EngineContext runtime embedder seam ([#1326](https://github.com/jdx/aube/pull/1326))
+- *(store)* add structured prune previews ([#1321](https://github.com/jdx/aube/pull/1321))
+
+### Fixed
+
+- *(install)* preserve applied builds after cache cleanup ([#1339](https://github.com/jdx/aube/pull/1339))
+- *(pack)* resolve catalog dependencies before archiving ([#1334](https://github.com/jdx/aube/pull/1334))
+- *(resolver)* compact exact optional package histories ([#1315](https://github.com/jdx/aube/pull/1315))
+
+### Other
+
+- replace clap with usage ([#1336](https://github.com/jdx/aube/pull/1336))
+- refresh benchmarks for v1.41.0 ([#1322](https://github.com/jdx/aube/pull/1322))
+- *(store)* stream large tar entries into CAS ([#1318](https://github.com/jdx/aube/pull/1318))
+
 ## [1.41.0](https://github.com/jdx/aube/compare/v1.40.0...v1.41.0) - 2026-08-16
 
 ### Added

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.41.0",
-  "releasedAt": "2026-08-16T19:21:57Z"
+  "version": "2.0.1",
+  "releasedAt": "2026-08-23T01:17:50Z"
 }


### PR DESCRIPTION
## Release recovery

Publishes the complete workspace as `2.0.1` after the interrupted `2.0.0` rollout left library crates on crates.io but failed before publishing the top-level `aube` crate.

This release includes:

- the aube 2 CLI migration
- global directories owned by aube rather than pnpm
- the public `LowestDirect` resolver mode
- automatic build jailing deferred to aube 3

After this release succeeds, the partial `2.0.0` library versions will be yanked.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata and changelog-only bump; no runtime or security logic changes.
> 
> **Overview**
> Cuts **v2.0.1** by bumping `[workspace.package]` / `Cargo.lock` crate versions from `2.0.0` and setting `release.json` to `2.0.1` (2026-08-23).
> 
> Per-crate `CHANGELOG.md` files get a `2.0.1` section. The main `aube` notes cover breaking lowest-direct resolution and global data-root dirs, plus install/pack/resolver fixes and the clap→usage switch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c36ad83a9c2d135a775a6848d3e45ce8699a1409. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->