### PR TITLE
fix(resolver): compact exact optional package histories

### DIFF
--- a/crates/aube-registry/src/client.rs
+++ b/crates/aube-registry/src/client.rs
@@ -27,7 +27,7 @@ use dist_tags::*;
 pub use endpoints::PackageSearchResult;
 pub(crate) use http::probe_client_builder;
 use http::*;
-use parse::parse_full_response;
+use parse::{parse_full_response, parse_full_response_seed};
 
 /// Accept header for packument requests. `vnd.npm.install-v1+json` is the
 /// abbreviated (corgi) format npmjs emits for installs; the `application/json`

--- a/crates/aube-registry/src/client/endpoints.rs
+++ b/crates/aube-registry/src/client/endpoints.rs
@@ -2,7 +2,7 @@ use super::body::{check_body_cap, read_body_capped};
 use super::cache::packument_full_cache_path;
 use super::{
     AUDIT_BODY_CAP, PACKUMENT_FULL_ACCEPT, RegistryClient, check_dist_tag_status,
-    dist_tag_root_url, dist_tag_url, parse_full_response,
+    dist_tag_root_url, dist_tag_url, parse_full_response, parse_full_response_seed,
 };
 use crate::{Error, NetworkMode};
 use serde::Deserialize;
@@ -163,13 +163,14 @@ impl RegistryClient {
         parse_full_response(resp).await
     }
 
-    /// Fetch only publish times and trust evidence from a full packument.
-    /// This still transfers the registry document, but serde skips the large
-    /// dependency and distribution payload retained by normal resolution.
-    pub async fn fetch_packument_trust_history(
+    /// Fetch one exact release plus compact publish-time/trust history from a
+    /// single full-packument response. Historical dependency and distribution
+    /// metadata is discarded during deserialization.
+    pub async fn fetch_exact_version_packument(
         &self,
         name: &str,
-    ) -> Result<crate::PackumentTrustHistory, Error> {
+        version: &str,
+    ) -> Result<crate::ExactVersionPackument, Error> {
         if self.network_mode == NetworkMode::Offline {
             return Err(Error::Offline(format!("trust history for {name}")));
         }
@@ -189,7 +190,7 @@ impl RegistryClient {
             self.fetch_policy.packument_max_bytes,
             "packument-trust-history",
         )?;
-        parse_full_response(resp).await
+        parse_full_response_seed(resp, crate::ExactVersionPackumentSeed { version }).await
     }
 
     /// Fetch the *full* (non-corgi) packument as raw JSON, bypassing the

--- a/crates/aube-registry/src/client/endpoints.rs
+++ b/crates/aube-registry/src/client/endpoints.rs
@@ -4,7 +4,7 @@ use super::{
     AUDIT_BODY_CAP, PACKUMENT_FULL_ACCEPT, RegistryClient, check_dist_tag_status,
     dist_tag_root_url, dist_tag_url, parse_full_response,
 };
-use crate::Error;
+use crate::{Error, NetworkMode};
 use serde::Deserialize;
 use std::borrow::Cow;
 use std::path::Path;
@@ -138,6 +138,11 @@ impl RegistryClient {
         name: &str,
         version: &str,
     ) -> Result<crate::VersionMetadata, Error> {
+        if self.network_mode == NetworkMode::Offline {
+            return Err(Error::Offline(format!(
+                "version metadata for {name}@{version}"
+            )));
+        }
         let (packument_url, registry_url) = self.packument_url(name);
         let url = format!("{packument_url}/{version}");
         let resp = self
@@ -154,6 +159,35 @@ impl RegistryClient {
             &resp,
             self.fetch_policy.packument_max_bytes,
             "version-metadata",
+        )?;
+        parse_full_response(resp).await
+    }
+
+    /// Fetch only publish times and trust evidence from a full packument.
+    /// This still transfers the registry document, but serde skips the large
+    /// dependency and distribution payload retained by normal resolution.
+    pub async fn fetch_packument_trust_history(
+        &self,
+        name: &str,
+    ) -> Result<crate::PackumentTrustHistory, Error> {
+        if self.network_mode == NetworkMode::Offline {
+            return Err(Error::Offline(format!("trust history for {name}")));
+        }
+        let (url, registry_url) = self.packument_url(name);
+        let resp = self
+            .send_metadata_with_retry(&format!("trust history {name}"), || {
+                self.authed_get_for_package(&url, registry_url, name)
+                    .header("Accept", PACKUMENT_FULL_ACCEPT)
+            })
+            .await?;
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(Error::NotFound(name.to_string()));
+        }
+        let resp = resp.error_for_status()?;
+        check_body_cap(
+            &resp,
+            self.fetch_policy.packument_max_bytes,
+            "packument-trust-history",
         )?;
         parse_full_response(resp).await
     }

--- a/crates/aube-registry/src/client/parse.rs
+++ b/crates/aube-registry/src/client/parse.rs
@@ -1,4 +1,5 @@
 use crate::Error;
+use serde::de::DeserializeSeed;
 
 pub(super) async fn parse_full_response<T>(resp: reqwest::Response) -> Result<T, Error>
 where
@@ -24,6 +25,40 @@ where
     let parse_t0 = std::time::Instant::now();
     let result = sonic_rs::from_slice::<T>(&bytes)
         .map_err(|e| Error::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, e)));
+    aube_util::diag::event_lazy(
+        aube_util::diag::Category::Registry,
+        "json_parse_sonic_rs",
+        parse_t0.elapsed(),
+        || format!(r#"{{"bytes":{}}}"#, body_size),
+    );
+    result
+}
+
+pub(super) async fn parse_full_response_seed<S, T>(
+    resp: reqwest::Response,
+    seed: S,
+) -> Result<T, Error>
+where
+    for<'de> S: DeserializeSeed<'de, Value = T>,
+{
+    let body_t0 = std::time::Instant::now();
+    let bytes = resp.bytes().await?;
+    let body_size = bytes.len();
+    aube_util::diag::event_lazy(
+        aube_util::diag::Category::Registry,
+        "http_body_read",
+        body_t0.elapsed(),
+        || format!(r#"{{"bytes":{}}}"#, body_size),
+    );
+    let parse_t0 = std::time::Instant::now();
+    let mut deserializer = sonic_rs::Deserializer::from_slice(&bytes);
+    let result = seed
+        .deserialize(&mut deserializer)
+        .and_then(|value| {
+            deserializer.end()?;
+            Ok(value)
+        })
+        .map_err(|error| Error::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, error)));
     aube_util::diag::event_lazy(
         aube_util::diag::Category::Registry,
         "json_parse_sonic_rs",

--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -1,4 +1,4 @@
-use serde::de::{IgnoredAny, MapAccess, SeqAccess, Visitor};
+use serde::de::{DeserializeSeed, IgnoredAny, MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::BTreeMap;
 use std::fmt;
@@ -221,6 +221,143 @@ pub struct PackumentTrustHistory {
     #[serde(default)]
     pub versions: BTreeMap<String, VersionTrustMetadata>,
 }
+
+/// One exact release plus the compact history needed for time and trust
+/// policy checks. The full registry document is decoded in a single pass:
+/// the selected release uses [`VersionMetadata`], while every other release
+/// uses [`VersionTrustMetadata`].
+#[derive(Debug)]
+pub struct ExactVersionPackument {
+    pub metadata: VersionMetadata,
+    pub history: PackumentTrustHistory,
+}
+
+pub(crate) struct ExactVersionPackumentSeed<'a> {
+    pub version: &'a str,
+}
+
+impl<'de> DeserializeSeed<'de> for ExactVersionPackumentSeed<'_> {
+    type Value = ExactVersionPackument;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_map(ExactVersionPackumentVisitor {
+            version: self.version,
+        })
+    }
+}
+
+struct ExactVersionPackumentVisitor<'a> {
+    version: &'a str,
+}
+
+impl<'de> Visitor<'de> for ExactVersionPackumentVisitor<'_> {
+    type Value = ExactVersionPackument;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("an npm packument containing the requested exact version")
+    }
+
+    fn visit_map<A>(self, mut access: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut metadata = None;
+        let mut history = BTreeMap::new();
+        let mut time = BTreeMap::new();
+
+        while let Some(field) = access.next_key::<String>()? {
+            match field.as_str() {
+                "versions" => {
+                    let decoded = access.next_value_seed(ExactVersionMapSeed {
+                        version: self.version,
+                    })?;
+                    metadata = decoded.0;
+                    history = decoded.1;
+                }
+                "time" => {
+                    time = access.next_value::<TolerantStringMap>()?.0;
+                }
+                _ => {
+                    access.next_value::<IgnoredAny>()?;
+                }
+            }
+        }
+
+        let metadata = metadata.ok_or_else(|| {
+            serde::de::Error::custom(format!(
+                "packument does not contain requested version {}",
+                self.version
+            ))
+        })?;
+        Ok(ExactVersionPackument {
+            metadata,
+            history: PackumentTrustHistory {
+                time,
+                versions: history,
+            },
+        })
+    }
+}
+
+struct ExactVersionMapSeed<'a> {
+    version: &'a str,
+}
+
+impl<'de> DeserializeSeed<'de> for ExactVersionMapSeed<'_> {
+    type Value = (
+        Option<VersionMetadata>,
+        BTreeMap<String, VersionTrustMetadata>,
+    );
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_map(ExactVersionMapVisitor {
+            version: self.version,
+        })
+    }
+}
+
+struct ExactVersionMapVisitor<'a> {
+    version: &'a str,
+}
+
+impl<'de> Visitor<'de> for ExactVersionMapVisitor<'_> {
+    type Value = (
+        Option<VersionMetadata>,
+        BTreeMap<String, VersionTrustMetadata>,
+    );
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("an npm packument versions map")
+    }
+
+    fn visit_map<A>(self, mut access: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut metadata = None;
+        let mut history = BTreeMap::new();
+        while let Some(version) = access.next_key::<String>()? {
+            if version == self.version {
+                metadata = Some(access.next_value::<VersionMetadata>()?);
+            } else {
+                history.insert(version, access.next_value::<VersionTrustMetadata>()?);
+            }
+        }
+        Ok((metadata, history))
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(transparent)]
+struct TolerantStringMap(
+    #[serde(deserialize_with = "non_string_tolerant_map")] BTreeMap<String, String>,
+);
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -830,6 +967,56 @@ mod tests {
 
     fn parse(json: &str) -> VersionMetadata {
         serde_json::from_str(json).unwrap()
+    }
+
+    #[test]
+    fn exact_version_packument_seed_keeps_only_selected_full_metadata() {
+        let json = br#"{
+            "name":"platform-package",
+            "versions":{
+                "1.0.0":{
+                    "name":"platform-package",
+                    "version":"1.0.0",
+                    "dependencies":{"discarded":"1"},
+                    "approver":{"name":"release-manager"}
+                },
+                "2.0.0":{
+                    "name":"platform-package",
+                    "version":"2.0.0",
+                    "dependencies":{"retained":"2"},
+                    "dist":{"tarball":"https://registry.example/pkg.tgz"}
+                }
+            },
+            "time":{"1.0.0":"2025-01-01T00:00:00.000Z","2.0.0":"2025-02-01T00:00:00.000Z"}
+        }"#;
+        let mut deserializer = sonic_rs::Deserializer::from_slice(json);
+        let decoded = serde::de::DeserializeSeed::deserialize(
+            ExactVersionPackumentSeed { version: "2.0.0" },
+            &mut deserializer,
+        )
+        .unwrap();
+
+        assert_eq!(decoded.metadata.version, "2.0.0");
+        assert_eq!(
+            decoded.metadata.dependencies.get("retained"),
+            Some(&"2".to_string())
+        );
+        assert!(!decoded.history.versions.contains_key("2.0.0"));
+        assert!(decoded.history.versions.contains_key("1.0.0"));
+        assert_eq!(decoded.history.time.len(), 2);
+    }
+
+    #[test]
+    fn exact_version_packument_seed_rejects_missing_selected_version() {
+        let json = br#"{"versions":{"1.0.0":{"name":"x","version":"1.0.0"}}}"#;
+        let mut deserializer = sonic_rs::Deserializer::from_slice(json);
+        let error = serde::de::DeserializeSeed::deserialize(
+            ExactVersionPackumentSeed { version: "2.0.0" },
+            &mut deserializer,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("requested version 2.0.0"));
     }
 
     #[test]

--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -210,6 +210,35 @@ pub struct Packument {
     pub time: BTreeMap<String, String>,
 }
 
+/// The subset of a full packument needed to enforce publish-time and
+/// trust-downgrade policies for an exact version. Deserializing this shape
+/// skips dependency maps and distribution metadata for every historical
+/// release, avoiding the large retained heap of a full [`Packument`].
+#[derive(Debug, Clone, Deserialize)]
+pub struct PackumentTrustHistory {
+    #[serde(default, deserialize_with = "non_string_tolerant_map")]
+    pub time: BTreeMap<String, String>,
+    #[serde(default)]
+    pub versions: BTreeMap<String, VersionTrustMetadata>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VersionTrustMetadata {
+    #[serde(default)]
+    pub approver: Option<serde_json::Value>,
+    #[serde(default, rename = "_npmUser", deserialize_with = "npm_user_tolerant")]
+    pub npm_user: Option<NpmUser>,
+    #[serde(default)]
+    pub dist: Option<VersionTrustDist>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct VersionTrustDist {
+    #[serde(default)]
+    pub attestations: Option<Attestations>,
+}
+
 /// Metadata for a specific version of a package.
 ///
 /// Deserializes via `VersionMetadataRaw` (`#[serde(from = ...)]`) so

--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -16,7 +16,7 @@
 //! sibling-dedupe → lockfile-reuse → fetch-and-pick) is staged for a
 //! later refactor.
 
-use super::fetch::FetchScheduler;
+use super::fetch::{FetchScheduler, TrustHistory};
 use super::seed::seed_direct_deps;
 use super::vulnerable::{is_vulnerable, prefer_non_vulnerable_pick};
 use crate::local_source::{
@@ -95,6 +95,7 @@ pub(crate) struct ResolveDriver<'a> {
     /// doesn't crash the wrong task. Checked after the fetch-wait loop
     /// to decide skip (optional) vs propagate (required).
     failed_fetches: FxHashMap<String, Error>,
+    trust_histories: FxHashMap<String, TrustHistory>,
     /// Catalog picks gathered as the BFS rewrites `catalog:` task
     /// ranges. Outer key: catalog name. Inner: package name → spec.
     catalog_picks: BTreeMap<String, BTreeMap<String, String>>,
@@ -235,6 +236,7 @@ impl<'a> ResolveDriver<'a> {
             resolved_times: BTreeMap::new(),
             skipped_optional_dependencies: BTreeMap::new(),
             failed_fetches: FxHashMap::default(),
+            trust_histories: FxHashMap::default(),
             catalog_picks: BTreeMap::new(),
             deferred_transitives: Vec::new(),
             published_by,
@@ -305,6 +307,21 @@ impl<'a> ResolveDriver<'a> {
     /// popped.
     fn seed_initial_prefetches(&mut self) {
         for task in self.queue.iter() {
+            // Time-aware resolution needs publish times and trust evidence
+            // from package history. Exact optionals use the compact-history
+            // path so every platform variant can stay in the lockfile without
+            // retaining every release's dependency metadata.
+            if self.needs_time
+                && task.dep_type == DepType::Optional
+                && node_semver::Version::parse(&task.range).is_ok()
+            {
+                self.fetcher.ensure_exact_optional_fetch(
+                    task.name.as_str(),
+                    task.range.as_str(),
+                    self.published_by.as_deref(),
+                );
+                continue;
+            }
             if !self.resolver.is_prefetchable(
                 task.name.as_str(),
                 task.range.as_str(),
@@ -465,10 +482,13 @@ impl<'a> ResolveDriver<'a> {
         {
             self.ensure_fetch(&fetch_name);
             match self.fetcher.join_next().await {
-                Some(Ok(Ok((name, packument, from_primer)))) => {
+                Some(Ok(Ok((name, packument, from_primer, trust_history)))) => {
                     self.fetcher.release_in_flight(&name);
                     if from_primer {
                         self.fetcher.note_primer_seeded(name.clone());
+                    }
+                    if let Some(history) = trust_history {
+                        self.trust_histories.insert(name.clone(), history);
                     }
                     self.resolver.cache.insert(name, packument);
                     self.packument_fetch_count += 1;
@@ -715,14 +735,24 @@ impl<'a> ResolveDriver<'a> {
         // map and all version metadata, both of which are still
         // in scope here from L1191.
         if self.resolver.dependency_policy.trust_policy == crate::TrustPolicy::NoDowngrade {
-            crate::trust::check_no_downgrade(
-                packument,
-                &picked_ref.version,
-                picked_ref,
-                &self.resolver.dependency_policy.trust_policy_exclude,
-                self.resolver.dependency_policy.trust_policy_ignore_after,
-            )
-            .map_err(|e| match e {
+            let result = match self.trust_histories.get(&registry_name) {
+                Some(history) => crate::trust::check_no_downgrade_compact(
+                    packument,
+                    &picked_ref.version,
+                    picked_ref,
+                    history,
+                    &self.resolver.dependency_policy.trust_policy_exclude,
+                    self.resolver.dependency_policy.trust_policy_ignore_after,
+                ),
+                None => crate::trust::check_no_downgrade(
+                    packument,
+                    &picked_ref.version,
+                    picked_ref,
+                    &self.resolver.dependency_policy.trust_policy_exclude,
+                    self.resolver.dependency_policy.trust_policy_ignore_after,
+                ),
+            };
+            result.map_err(|e| match e {
                 crate::trust::TrustCheckError::Downgrade(d) => Error::TrustDowngrade(Box::new(d)),
                 crate::trust::TrustCheckError::MissingTime(d) => {
                     Error::TrustCheckMissingTime(Box::new(d))
@@ -1211,7 +1241,13 @@ impl<'a> ResolveDriver<'a> {
                 );
                 continue;
             }
-            if !self.existing_names.contains(dep_name.as_str())
+            if self.needs_time && node_semver::Version::parse(dep_range).is_ok() {
+                self.fetcher.ensure_exact_optional_fetch(
+                    dep_name,
+                    dep_range,
+                    self.published_by.as_deref(),
+                );
+            } else if !self.existing_names.contains(dep_name.as_str())
                 && self.resolver.is_prefetchable(
                     dep_name.as_str(),
                     dep_range.as_str(),

--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -543,8 +543,8 @@ impl<'a> ResolveDriver<'a> {
                 self.ensure_fetch(&fetch_name);
             }
             match self.fetcher.join_next().await {
-                Some(Ok((_, Ok((name, packument, from_primer, trust_history))))) => {
-                    if from_primer {
+                Some(Ok((_, Ok((name, packument, source, trust_history))))) => {
+                    if source == super::fetch::FetchSource::Primer {
                         self.fetcher.note_primer_seeded(name.clone());
                     }
                     self.record_fetch_result(name, packument, trust_history);
@@ -2220,6 +2220,26 @@ fn merge_fetch_result(
     trust_history: Option<TrustHistory>,
 ) {
     let Some(history) = trust_history else {
+        if trust_histories.contains_key(&name)
+            && let Some(existing) = cache.get(&name)
+        {
+            let missing_versions = existing
+                .versions
+                .iter()
+                .filter(|(version, _)| !packument.versions.contains_key(*version))
+                .map(|(version, metadata)| (version.clone(), metadata.clone()))
+                .collect::<Vec<_>>();
+            if !missing_versions.is_empty() {
+                for (version, metadata) in missing_versions {
+                    packument.versions.insert(version.clone(), metadata);
+                    if let Some(time) = existing.time.get(&version) {
+                        packument.time.insert(version, time.clone());
+                    }
+                }
+                cache.insert(name, packument);
+                return;
+            }
+        }
         cache.insert(name.clone(), packument);
         trust_histories.remove(&name);
         return;
@@ -2356,6 +2376,37 @@ mod tests {
 
         assert_eq!(cache["shared"].versions.len(), 2);
         assert!(!histories.contains_key("shared"));
+    }
+
+    #[test]
+    fn stale_full_fetch_preserves_compact_version_when_it_finishes_last() {
+        let mut cache = FxHashMap::default();
+        let mut histories = FxHashMap::default();
+
+        merge_fetch_result(
+            &mut cache,
+            &mut histories,
+            "shared".to_string(),
+            test_packument(&["2.0.0"]),
+            Some(test_history()),
+        );
+        merge_fetch_result(
+            &mut cache,
+            &mut histories,
+            "shared".to_string(),
+            test_packument(&["1.0.0"]),
+            None,
+        );
+
+        assert_eq!(
+            cache["shared"]
+                .versions
+                .keys()
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+            ["1.0.0", "2.0.0"]
+        );
+        assert!(histories.contains_key("shared"));
     }
 
     #[test]

--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -315,11 +315,18 @@ impl<'a> ResolveDriver<'a> {
                 && task.dep_type == DepType::Optional
                 && node_semver::Version::parse(&task.range).is_ok()
             {
-                self.fetcher.ensure_exact_optional_fetch(
-                    task.name.as_str(),
-                    task.range.as_str(),
-                    self.published_by.as_deref(),
-                );
+                let ready = self
+                    .resolver
+                    .cache
+                    .get(task.name.as_str())
+                    .is_some_and(|packument| packument.versions.contains_key(&task.range));
+                if !ready {
+                    self.fetcher.ensure_exact_optional_fetch(
+                        task.name.as_str(),
+                        task.range.as_str(),
+                        self.published_by.as_deref(),
+                    );
+                }
                 continue;
             }
             if !self.resolver.is_prefetchable(
@@ -355,10 +362,49 @@ impl<'a> ResolveDriver<'a> {
     /// prefetching names already covered by the lockfile check
     /// `existing_names` explicitly before invoking this.
     fn ensure_fetch(&mut self, name: &str) {
-        if !self.resolver.cache.contains_key(name) && !self.failed_fetches.contains_key(name) {
+        let needs_full =
+            !self.resolver.cache.contains_key(name) || self.trust_histories.contains_key(name);
+        if needs_full && !self.failed_fetches.contains_key(name) {
             self.fetcher
                 .ensure_fetch(name, self.published_by.as_deref());
         }
+    }
+
+    fn ensure_exact_optional_fetch(&mut self, name: &str, version: &str) {
+        let ready = self
+            .resolver
+            .cache
+            .get(name)
+            .is_some_and(|packument| packument.versions.contains_key(version));
+        if !ready && !self.failed_fetches.contains_key(name) {
+            self.fetcher
+                .ensure_exact_optional_fetch(name, version, self.published_by.as_deref());
+        }
+    }
+
+    fn cache_satisfies(&self, name: &str, exact_optional_version: Option<&str>) -> bool {
+        let Some(packument) = self.resolver.cache.get(name) else {
+            return false;
+        };
+        if !self.trust_histories.contains_key(name) {
+            return true;
+        }
+        exact_optional_version.is_some_and(|version| packument.versions.contains_key(version))
+    }
+
+    fn record_fetch_result(
+        &mut self,
+        name: String,
+        packument: aube_registry::Packument,
+        trust_history: Option<TrustHistory>,
+    ) {
+        merge_fetch_result(
+            &mut self.resolver.cache,
+            &mut self.trust_histories,
+            name,
+            packument,
+            trust_history,
+        );
     }
 
     /// Outer BFS loop. Pops tasks until the queue drains, with a
@@ -477,20 +523,24 @@ impl<'a> ResolveDriver<'a> {
         let _diag_task_wait =
             aube_util::diag::Span::new(aube_util::diag::Category::Resolver, "task_wait_packument")
                 .with_meta_fn(|| format!(r#"{{"name":{}}}"#, aube_util::diag::jstr(&fetch_name)));
-        while !self.resolver.cache.contains_key(&fetch_name)
+        let exact_optional_version = (self.needs_time
+            && task.dep_type == DepType::Optional
+            && node_semver::Version::parse(&task.range).is_ok())
+        .then_some(task.range.as_str());
+        while !self.cache_satisfies(&fetch_name, exact_optional_version)
             && !self.failed_fetches.contains_key(&fetch_name)
         {
-            self.ensure_fetch(&fetch_name);
+            if let Some(version) = exact_optional_version {
+                self.ensure_exact_optional_fetch(&fetch_name, version);
+            } else {
+                self.ensure_fetch(&fetch_name);
+            }
             match self.fetcher.join_next().await {
                 Some(Ok(Ok((name, packument, from_primer, trust_history)))) => {
-                    self.fetcher.release_in_flight(&name);
                     if from_primer {
                         self.fetcher.note_primer_seeded(name.clone());
                     }
-                    if let Some(history) = trust_history {
-                        self.trust_histories.insert(name.clone(), history);
-                    }
-                    self.resolver.cache.insert(name, packument);
+                    self.record_fetch_result(name, packument, trust_history);
                     self.packument_fetch_count += 1;
                 }
                 Some(Ok(Err(e))) => {
@@ -500,7 +550,6 @@ impl<'a> ResolveDriver<'a> {
                         crate::Error::Registry(n, _) => n.clone(),
                         _ => return Err(e),
                     };
-                    self.fetcher.release_in_flight(&name);
                     self.failed_fetches.insert(name, e);
                 }
                 Some(Err(join_err)) => {
@@ -685,6 +734,7 @@ impl<'a> ResolveDriver<'a> {
                     self.packument_fetch_time += fetch_start.elapsed();
                     self.packument_fetch_count += 1;
                     self.resolver.cache.insert(registry_name.clone(), live);
+                    self.trust_histories.remove(&registry_name);
                 }
                 // Only surface `AgeGate` when the cutoff actually
                 // came from `minimumReleaseAge`. When it came from
@@ -1242,11 +1292,7 @@ impl<'a> ResolveDriver<'a> {
                 continue;
             }
             if self.needs_time && node_semver::Version::parse(dep_range).is_ok() {
-                self.fetcher.ensure_exact_optional_fetch(
-                    dep_name,
-                    dep_range,
-                    self.published_by.as_deref(),
-                );
+                self.ensure_exact_optional_fetch(dep_name, dep_range);
             } else if !self.existing_names.contains(dep_name.as_str())
                 && self.resolver.is_prefetchable(
                     dep_name.as_str(),
@@ -2152,6 +2198,34 @@ impl<'a> ResolveDriver<'a> {
     }
 }
 
+fn merge_fetch_result(
+    cache: &mut FxHashMap<String, aube_registry::Packument>,
+    trust_histories: &mut FxHashMap<String, TrustHistory>,
+    name: String,
+    mut packument: aube_registry::Packument,
+    trust_history: Option<TrustHistory>,
+) {
+    let Some(history) = trust_history else {
+        cache.insert(name.clone(), packument);
+        trust_histories.remove(&name);
+        return;
+    };
+
+    // A full result is authoritative. If it won the race, a later compact
+    // result must not replace it with a one-version packument.
+    if cache.contains_key(&name) && !trust_histories.contains_key(&name) {
+        return;
+    }
+
+    if let Some(existing) = cache.get_mut(&name) {
+        existing.versions.append(&mut packument.versions);
+        existing.time.append(&mut packument.time);
+    } else {
+        cache.insert(name.clone(), packument);
+    }
+    trust_histories.entry(name).or_default().extend(history);
+}
+
 fn attach_integrity_to_git_source(local: &mut LocalSource, integrity: Option<&str>) {
     if let LocalSource::Git(git) = local
         && git.integrity.is_none()
@@ -2164,6 +2238,97 @@ fn attach_integrity_to_git_source(local: &mut LocalSource, integrity: Option<&st
 mod tests {
     use super::*;
     use aube_lockfile::GitSource;
+
+    fn test_packument(versions: &[&str]) -> aube_registry::Packument {
+        aube_registry::Packument {
+            name: "shared".to_string(),
+            modified: None,
+            versions: versions
+                .iter()
+                .map(|version| {
+                    (
+                        (*version).to_string(),
+                        serde_json::from_value(serde_json::json!({
+                            "name": "shared",
+                            "version": version,
+                        }))
+                        .unwrap(),
+                    )
+                })
+                .collect(),
+            dist_tags: BTreeMap::new(),
+            time: versions
+                .iter()
+                .map(|version| {
+                    (
+                        (*version).to_string(),
+                        "2024-01-01T00:00:00.000Z".to_string(),
+                    )
+                })
+                .collect(),
+        }
+    }
+
+    fn test_history() -> TrustHistory {
+        [(
+            "0.9.0".to_string(),
+            aube_registry::VersionTrustMetadata {
+                approver: None,
+                npm_user: None,
+                dist: None,
+            },
+        )]
+        .into_iter()
+        .collect()
+    }
+
+    #[test]
+    fn full_fetch_remains_authoritative_when_it_finishes_first() {
+        let mut cache = FxHashMap::default();
+        let mut histories = FxHashMap::default();
+
+        merge_fetch_result(
+            &mut cache,
+            &mut histories,
+            "shared".to_string(),
+            test_packument(&["1.0.0", "2.0.0"]),
+            None,
+        );
+        merge_fetch_result(
+            &mut cache,
+            &mut histories,
+            "shared".to_string(),
+            test_packument(&["1.0.0"]),
+            Some(test_history()),
+        );
+
+        assert_eq!(cache["shared"].versions.len(), 2);
+        assert!(!histories.contains_key("shared"));
+    }
+
+    #[test]
+    fn full_fetch_replaces_compact_result_when_it_finishes_last() {
+        let mut cache = FxHashMap::default();
+        let mut histories = FxHashMap::default();
+
+        merge_fetch_result(
+            &mut cache,
+            &mut histories,
+            "shared".to_string(),
+            test_packument(&["1.0.0"]),
+            Some(test_history()),
+        );
+        merge_fetch_result(
+            &mut cache,
+            &mut histories,
+            "shared".to_string(),
+            test_packument(&["1.0.0", "2.0.0"]),
+            None,
+        );
+
+        assert_eq!(cache["shared"].versions.len(), 2);
+        assert!(!histories.contains_key("shared"));
+    }
 
     #[test]
     fn attach_integrity_to_git_source_fills_missing_git_integrity() {

--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -542,7 +542,9 @@ impl<'a> ResolveDriver<'a> {
             self.failed_fetches.remove(&fetch_key);
         }
         while !self.cache_satisfies(&fetch_name, exact_optional_version)
-            && !self.failed_fetches.contains_key(&fetch_key)
+            && (!self.failed_fetches.contains_key(&fetch_key)
+                || (exact_optional_version.is_none()
+                    && self.fetcher.has_active_exact_fetch(&fetch_name)))
         {
             if let Some(version) = exact_optional_version {
                 self.ensure_exact_optional_fetch(&fetch_name, version);
@@ -550,7 +552,11 @@ impl<'a> ResolveDriver<'a> {
                 self.ensure_fetch(&fetch_name);
             }
             match self.fetcher.join_next().await {
-                Some(Ok((_, Ok((name, packument, source, trust_history))))) => {
+                Some(Ok((key, Ok((name, packument, source, trust_history))))) => {
+                    if let FetchKey::Exact(exact_name, _) = &key {
+                        self.failed_fetches
+                            .remove(&FetchKey::Full(exact_name.clone()));
+                    }
                     if source == super::fetch::FetchSource::Primer {
                         self.fetcher.note_primer_seeded(name.clone());
                     }

--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -534,6 +534,13 @@ impl<'a> ResolveDriver<'a> {
             || FetchKey::Full(fetch_name.clone()),
             |version| FetchKey::Exact(fetch_name.clone(), version.to_string()),
         );
+        // A compact exact result that landed after an optional full-fetch
+        // failure proves the package is reachable and leaves a trust-history
+        // marker requiring authoritative full metadata. Discard the stale
+        // prefetch failure so this range task can perform that refresh.
+        if exact_optional_version.is_none() && self.trust_histories.contains_key(&fetch_name) {
+            self.failed_fetches.remove(&fetch_key);
+        }
         while !self.cache_satisfies(&fetch_name, exact_optional_version)
             && !self.failed_fetches.contains_key(&fetch_key)
         {
@@ -2231,10 +2238,16 @@ fn merge_fetch_result(
                 .collect::<Vec<_>>();
             if !missing_versions.is_empty() {
                 for (version, metadata) in missing_versions {
-                    packument.versions.insert(version.clone(), metadata);
-                    if let Some(time) = existing.time.get(&version) {
-                        packument.time.insert(version, time.clone());
-                    }
+                    packument.versions.insert(version, metadata);
+                }
+                // Compact history contains publish times for every historical
+                // release used by no-downgrade checks, not only the selected
+                // version retained in `versions`.
+                for (version, time) in &existing.time {
+                    packument
+                        .time
+                        .entry(version.clone())
+                        .or_insert_with(|| time.clone());
                 }
                 cache.insert(name, packument);
                 return;
@@ -2383,11 +2396,15 @@ mod tests {
         let mut cache = FxHashMap::default();
         let mut histories = FxHashMap::default();
 
+        let mut compact = test_packument(&["2.0.0"]);
+        compact
+            .time
+            .insert("0.9.0".to_string(), "2023-01-01T00:00:00.000Z".to_string());
         merge_fetch_result(
             &mut cache,
             &mut histories,
             "shared".to_string(),
-            test_packument(&["2.0.0"]),
+            compact,
             Some(test_history()),
         );
         merge_fetch_result(
@@ -2407,6 +2424,7 @@ mod tests {
             ["1.0.0", "2.0.0"]
         );
         assert!(histories.contains_key("shared"));
+        assert_eq!(cache["shared"].time["0.9.0"], "2023-01-01T00:00:00.000Z");
     }
 
     #[test]

--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -386,10 +386,10 @@ impl<'a> ResolveDriver<'a> {
         let Some(packument) = self.resolver.cache.get(name) else {
             return false;
         };
-        if !self.trust_histories.contains_key(name) {
-            return true;
+        if let Some(version) = exact_optional_version {
+            return packument.versions.contains_key(version);
         }
-        exact_optional_version.is_some_and(|version| packument.versions.contains_key(version))
+        !self.trust_histories.contains_key(name)
     }
 
     fn record_fetch_result(
@@ -2211,9 +2211,23 @@ fn merge_fetch_result(
         return;
     };
 
-    // A full result is authoritative. If it won the race, a later compact
-    // result must not replace it with a one-version packument.
-    if cache.contains_key(&name) && !trust_histories.contains_key(&name) {
+    // A full result is normally authoritative. It can be stale, though: a
+    // later exact endpoint response may contain a newly published version
+    // that the cached full packument lacks. Preserve the full data while
+    // merging that missing exact version and its fresher compact history.
+    if !trust_histories.contains_key(&name)
+        && let Some(existing) = cache.get_mut(&name)
+    {
+        let has_missing_version = packument
+            .versions
+            .keys()
+            .any(|version| !existing.versions.contains_key(version));
+        if !has_missing_version {
+            return;
+        }
+        existing.versions.append(&mut packument.versions);
+        existing.time.append(&mut packument.time);
+        trust_histories.insert(name, history);
         return;
     }
 
@@ -2328,6 +2342,37 @@ mod tests {
 
         assert_eq!(cache["shared"].versions.len(), 2);
         assert!(!histories.contains_key("shared"));
+    }
+
+    #[test]
+    fn compact_fetch_adds_exact_version_missing_from_stale_full_result() {
+        let mut cache = FxHashMap::default();
+        let mut histories = FxHashMap::default();
+
+        merge_fetch_result(
+            &mut cache,
+            &mut histories,
+            "shared".to_string(),
+            test_packument(&["1.0.0"]),
+            None,
+        );
+        merge_fetch_result(
+            &mut cache,
+            &mut histories,
+            "shared".to_string(),
+            test_packument(&["2.0.0"]),
+            Some(test_history()),
+        );
+
+        assert_eq!(
+            cache["shared"]
+                .versions
+                .keys()
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+            ["1.0.0", "2.0.0"]
+        );
+        assert!(histories.contains_key("shared"));
     }
 
     #[test]

--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -16,7 +16,7 @@
 //! sibling-dedupe → lockfile-reuse → fetch-and-pick) is staged for a
 //! later refactor.
 
-use super::fetch::{FetchScheduler, TrustHistory};
+use super::fetch::{FetchKey, FetchScheduler, TrustHistory};
 use super::seed::seed_direct_deps;
 use super::vulnerable::{is_vulnerable, prefer_non_vulnerable_pick};
 use crate::local_source::{
@@ -90,11 +90,12 @@ pub(crate) struct ResolveDriver<'a> {
     /// mismatch or `pnpm.ignoredOptionalDependencies`).
     skipped_optional_dependencies: BTreeMap<String, BTreeMap<String, String>>,
     /// Packument fetches that failed (registry 404, network error, etc.),
-    /// keyed by package name. Errors are stored here instead of
+    /// keyed by request identity. Errors are stored here instead of
     /// propagated from `join_next` so a failed fetch for one package
-    /// doesn't crash the wrong task. Checked after the fetch-wait loop
-    /// to decide skip (optional) vs propagate (required).
-    failed_fetches: FxHashMap<String, Error>,
+    /// doesn't crash the wrong task or suppress another exact version.
+    /// Checked after the fetch-wait loop to decide skip (optional) vs
+    /// propagate (required).
+    failed_fetches: FxHashMap<FetchKey, Error>,
     trust_histories: FxHashMap<String, TrustHistory>,
     /// Catalog picks gathered as the BFS rewrites `catalog:` task
     /// ranges. Outer key: catalog name. Inner: package name → spec.
@@ -341,7 +342,7 @@ impl<'a> ResolveDriver<'a> {
             }
             if !self.resolver.cache.contains_key(task.name.as_str()) {
                 self.fetcher
-                    .ensure_fetch(task.name.as_str(), self.published_by.as_deref());
+                    .ensure_fetch(task.name.as_str(), self.published_by.as_deref(), false);
             }
         }
     }
@@ -362,11 +363,12 @@ impl<'a> ResolveDriver<'a> {
     /// prefetching names already covered by the lockfile check
     /// `existing_names` explicitly before invoking this.
     fn ensure_fetch(&mut self, name: &str) {
-        let needs_full =
-            !self.resolver.cache.contains_key(name) || self.trust_histories.contains_key(name);
-        if needs_full && !self.failed_fetches.contains_key(name) {
+        let force_refresh = self.trust_histories.contains_key(name);
+        let needs_full = !self.resolver.cache.contains_key(name) || force_refresh;
+        let key = FetchKey::Full(name.to_string());
+        if needs_full && !self.failed_fetches.contains_key(&key) {
             self.fetcher
-                .ensure_fetch(name, self.published_by.as_deref());
+                .ensure_fetch(name, self.published_by.as_deref(), force_refresh);
         }
     }
 
@@ -376,7 +378,8 @@ impl<'a> ResolveDriver<'a> {
             .cache
             .get(name)
             .is_some_and(|packument| packument.versions.contains_key(version));
-        if !ready && !self.failed_fetches.contains_key(name) {
+        let key = FetchKey::Exact(name.to_string(), version.to_string());
+        if !ready && !self.failed_fetches.contains_key(&key) {
             self.fetcher
                 .ensure_exact_optional_fetch(name, version, self.published_by.as_deref());
         }
@@ -527,8 +530,12 @@ impl<'a> ResolveDriver<'a> {
             && task.dep_type == DepType::Optional
             && node_semver::Version::parse(&task.range).is_ok())
         .then_some(task.range.as_str());
+        let fetch_key = exact_optional_version.map_or_else(
+            || FetchKey::Full(fetch_name.clone()),
+            |version| FetchKey::Exact(fetch_name.clone(), version.to_string()),
+        );
         while !self.cache_satisfies(&fetch_name, exact_optional_version)
-            && !self.failed_fetches.contains_key(&fetch_name)
+            && !self.failed_fetches.contains_key(&fetch_key)
         {
             if let Some(version) = exact_optional_version {
                 self.ensure_exact_optional_fetch(&fetch_name, version);
@@ -536,21 +543,21 @@ impl<'a> ResolveDriver<'a> {
                 self.ensure_fetch(&fetch_name);
             }
             match self.fetcher.join_next().await {
-                Some(Ok(Ok((name, packument, from_primer, trust_history)))) => {
+                Some(Ok((_, Ok((name, packument, from_primer, trust_history))))) => {
                     if from_primer {
                         self.fetcher.note_primer_seeded(name.clone());
                     }
                     self.record_fetch_result(name, packument, trust_history);
                     self.packument_fetch_count += 1;
                 }
-                Some(Ok(Err(e))) => {
+                Some(Ok((key, Err(e)))) => {
                     // Store failed fetches in the side table instead
                     // of propagating immediately. pnpm parity.
-                    let name = match &e {
-                        crate::Error::Registry(n, _) => n.clone(),
+                    match &e {
+                        crate::Error::Registry(_, _) => {}
                         _ => return Err(e),
-                    };
-                    self.failed_fetches.insert(name, e);
+                    }
+                    self.failed_fetches.insert(key, e);
                 }
                 Some(Err(join_err)) => {
                     return Err(Error::Registry("(join)".to_string(), join_err.to_string()));
@@ -570,12 +577,19 @@ impl<'a> ResolveDriver<'a> {
         }
         self.packument_fetch_time += wait_start.elapsed();
 
+        // A different request shape may have populated this task's data while
+        // its own request failed (for example, a full fetch satisfying an
+        // exact optional). In that case the usable cache entry wins.
+        if self.cache_satisfies(&fetch_name, exact_optional_version) {
+            self.failed_fetches.remove(&fetch_key);
+        }
+
         // Post-loop: if this task's packument fetch failed, decide
         // whether to skip (optional) or propagate (required).
         // For optional deps the error stays in `failed_fetches` so
         // sibling tasks that share the same transitive optional dep
         // don't re-fetch and re-fail for each importer.
-        if task.dep_type == DepType::Optional && self.failed_fetches.contains_key(&fetch_name) {
+        if task.dep_type == DepType::Optional && self.failed_fetches.contains_key(&fetch_key) {
             tracing::debug!(
                 "skipping optional dep {}@{}: registry fetch failed",
                 task.name,
@@ -586,7 +600,7 @@ impl<'a> ResolveDriver<'a> {
             }
             return Ok(());
         }
-        if let Some(e) = self.failed_fetches.remove(&fetch_name) {
+        if let Some(e) = self.failed_fetches.remove(&fetch_key) {
             return Err(e);
         }
 

--- a/crates/aube-resolver/src/resolve/fetch.rs
+++ b/crates/aube-resolver/src/resolve/fetch.rs
@@ -1,4 +1,4 @@
-use crate::{Error, FxHashSet, Resolver};
+use crate::{Error, FxHashMap, FxHashSet, Resolver};
 use aube_registry::client::RegistryClient;
 use aube_registry::{Packument, VersionTrustMetadata};
 use aube_util::adaptive::AdaptiveLimit;
@@ -22,6 +22,7 @@ use tokio::task::JoinSet;
 pub(super) struct FetchScheduler {
     in_flight: JoinSet<(FetchKey, Result<FetchResult, Error>)>,
     active_fetches: FxHashSet<FetchKey>,
+    task_keys: FxHashMap<tokio::task::Id, FetchKey>,
     primer_seeded_names: FxHashSet<String>,
     sem: Arc<AdaptiveLimit>,
     client: Arc<RegistryClient>,
@@ -48,6 +49,7 @@ impl FetchScheduler {
         Self {
             in_flight: JoinSet::new(),
             active_fetches: FxHashSet::default(),
+            task_keys: FxHashMap::default(),
             primer_seeded_names: FxHashSet::default(),
             sem,
             client: resolver.client.clone(),
@@ -98,10 +100,12 @@ impl FetchScheduler {
             needs_time: self.needs_time,
             force_refresh,
         };
-        self.in_flight.spawn(async move {
+        let task_key = key.clone();
+        let handle = self.in_flight.spawn(async move {
             let result = fetch_one_packument(inputs).await;
-            (key, result)
+            (task_key, result)
         });
+        self.task_keys.insert(handle.id(), key);
     }
 
     /// Fetch an exact optional dependency without retaining every historical
@@ -131,19 +135,30 @@ impl FetchScheduler {
             force_refresh: false,
         };
         let version = version.to_string();
-        self.in_flight.spawn(async move {
+        let task_key = key.clone();
+        let handle = self.in_flight.spawn(async move {
             let result = fetch_exact_optional_packument(inputs, version).await;
-            (key, result)
+            (task_key, result)
         });
+        self.task_keys.insert(handle.id(), key);
     }
 
     /// Wait for the next in-flight fetch to complete.
     pub(super) async fn join_next(&mut self) -> FetchOutcome {
-        let outcome = self.in_flight.join_next().await;
-        if let Some(Ok((key, _))) = &outcome {
-            self.active_fetches.remove(key);
+        match self.in_flight.join_next_with_id().await {
+            Some(Ok((id, outcome))) => {
+                self.task_keys.remove(&id);
+                self.active_fetches.remove(&outcome.0);
+                Some(Ok(outcome))
+            }
+            Some(Err(error)) => {
+                if let Some(key) = self.task_keys.remove(&error.id()) {
+                    self.active_fetches.remove(&key);
+                }
+                Some(Err(error))
+            }
+            None => None,
         }
-        outcome
     }
 
     pub(super) fn note_primer_seeded(&mut self, name: String) {
@@ -156,7 +171,7 @@ impl FetchScheduler {
     }
 
     pub(super) async fn drain(&mut self) {
-        while self.in_flight.join_next().await.is_some() {}
+        while self.join_next().await.is_some() {}
     }
 }
 
@@ -254,8 +269,8 @@ async fn fetch_one_packument(inputs: FetchInputs) -> Result<FetchResult, Error> 
         permit.record_cancelled();
         return Ok((name, packument, false, None));
     }
-    let use_metadata_primer = (force_metadata_primer
-        || client.uses_default_npm_registry_for(&name))
+    let use_metadata_primer = !force_refresh
+        && (force_metadata_primer || client.uses_default_npm_registry_for(&name))
         && primer_covers_cutoff;
     if use_metadata_primer
         && !cached.stale
@@ -383,7 +398,15 @@ async fn fetch_exact_optional_packument(
                 "compact exact metadata fetch failed for optional dep {name}@{version}; falling back to full packument: {err}"
             );
             permit.record_cancelled();
-            fetch_one_packument(inputs).await
+            let fallback = fetch_one_packument(inputs).await?;
+            if fallback.1.versions.contains_key(&version) {
+                Ok(fallback)
+            } else {
+                Err(Error::Registry(
+                    name,
+                    format!("version {version} is missing from the full packument"),
+                ))
+            }
         }
     }
 }
@@ -391,37 +414,12 @@ async fn fetch_exact_optional_packument(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::BTreeMap;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-    fn test_packument(versions: &[&str]) -> Packument {
-        Packument {
-            name: "shared".to_string(),
-            modified: None,
-            versions: versions
-                .iter()
-                .map(|version| {
-                    (
-                        (*version).to_string(),
-                        serde_json::from_value(serde_json::json!({
-                            "name": "shared",
-                            "version": version,
-                        }))
-                        .unwrap(),
-                    )
-                })
-                .collect(),
-            dist_tags: BTreeMap::new(),
-            time: BTreeMap::new(),
-        }
-    }
-
-    #[tokio::test]
-    async fn completed_full_fetch_can_force_refresh_a_fresh_disk_entry() {
-        let stale = test_packument(&["1.0.0"]);
-        let fresh = test_packument(&["1.0.0", "2.0.0"]);
-        let body = serde_json::to_vec(&fresh).unwrap();
+    async fn serve_registry(
+        body: Vec<u8>,
+    ) -> (String, Arc<AtomicUsize>, tokio::task::JoinHandle<()>) {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let registry = format!("http://{}/", listener.local_addr().unwrap());
         let requests = Arc::new(AtomicUsize::new(0));
@@ -447,29 +445,98 @@ mod tests {
                 }
             })
         };
+        (registry, requests, server)
+    }
+
+    #[tokio::test]
+    async fn completed_full_fetch_can_force_refresh_a_fresh_disk_entry() {
+        let Some(name) = crate::primer::popular_package_names()
+            .lines()
+            .find(|name| crate::primer::get(name).is_some())
+        else {
+            return;
+        };
+        let stale = crate::primer::get(name).unwrap().packument();
+        let Some(mut new_metadata) = stale.versions.values().next().cloned() else {
+            return;
+        };
+        let new_version = "9999.0.0";
+        new_metadata.version = new_version.to_string();
+        let mut fresh = stale.clone();
+        fresh.versions.insert(new_version.to_string(), new_metadata);
+        let stale_len = stale.versions.len();
+        let (registry, requests, server) =
+            serve_registry(serde_json::to_vec(&fresh).unwrap()).await;
 
         let cache = tempfile::tempdir().unwrap();
         let client = Arc::new(RegistryClient::new(&registry));
-        client.seed_full_packument_cache("shared", cache.path(), &stale, None, None, true);
+        client.seed_full_packument_cache(name, cache.path(), &stale, None, None, true);
         let resolver = Resolver::new(Arc::clone(&client))
-            .with_packument_full_cache(cache.path().to_path_buf());
+            .with_packument_full_cache(cache.path().to_path_buf())
+            .with_force_metadata_primer(true);
         let mut scheduler = FetchScheduler::new(&resolver, AdaptiveLimit::new(1, 1, 1), true);
 
-        scheduler.ensure_fetch("shared", None, false);
+        scheduler.ensure_fetch(name, None, false);
         let Some(Ok((FetchKey::Full(_), Ok((_, first, _, _))))) = scheduler.join_next().await
         else {
             panic!("cached full fetch did not complete");
         };
-        assert_eq!(first.versions.len(), 1);
+        assert_eq!(first.versions.len(), stale_len);
         assert_eq!(requests.load(Ordering::Relaxed), 0);
 
-        scheduler.ensure_fetch("shared", None, true);
+        scheduler.ensure_fetch(name, None, true);
         let Some(Ok((FetchKey::Full(_), Ok((_, refreshed, _, _))))) = scheduler.join_next().await
         else {
             panic!("forced full refresh did not restart");
         };
-        assert_eq!(refreshed.versions.len(), 2);
+        assert!(refreshed.versions.contains_key(new_version));
         assert_eq!(requests.load(Ordering::Relaxed), 1);
         server.abort();
+    }
+
+    #[tokio::test]
+    async fn missing_exact_version_fallback_returns_a_terminal_error() {
+        let body = serde_json::to_vec(&serde_json::json!({
+            "name": "shared",
+            "versions": {
+                "1.0.0": { "name": "shared", "version": "1.0.0" }
+            },
+            "dist-tags": { "latest": "1.0.0" },
+            "time": { "1.0.0": "2024-01-01T00:00:00.000Z" }
+        }))
+        .unwrap();
+        let (registry, requests, server) = serve_registry(body).await;
+        let resolver = Resolver::new(Arc::new(RegistryClient::new(&registry)));
+        let mut scheduler = FetchScheduler::new(&resolver, AdaptiveLimit::new(1, 1, 1), true);
+
+        scheduler.ensure_exact_optional_fetch("shared", "2.0.0", None);
+        let Some(Ok((FetchKey::Exact(_, version), Err(Error::Registry(_, message))))) =
+            scheduler.join_next().await
+        else {
+            panic!("missing exact version did not return a terminal registry error");
+        };
+        assert_eq!(version, "2.0.0");
+        assert!(message.contains("version 2.0.0 is missing"));
+        assert_eq!(requests.load(Ordering::Relaxed), 2);
+        server.abort();
+    }
+
+    async fn panic_fetch(key: FetchKey) -> (FetchKey, Result<FetchResult, Error>) {
+        let _ = key;
+        panic!("simulated fetch panic");
+    }
+
+    #[tokio::test]
+    async fn join_error_releases_the_active_fetch_key() {
+        let resolver = Resolver::new(Arc::new(RegistryClient::new("http://127.0.0.1:0")));
+        let mut scheduler = FetchScheduler::new(&resolver, AdaptiveLimit::new(1, 1, 1), false);
+        let key = FetchKey::Full("shared".to_string());
+        scheduler.active_fetches.insert(key.clone());
+        let handle = scheduler.in_flight.spawn(panic_fetch(key.clone()));
+        scheduler.task_keys.insert(handle.id(), key.clone());
+
+        assert!(matches!(scheduler.join_next().await, Some(Err(_))));
+        assert!(!scheduler.active_fetches.contains(&key));
+        assert!(scheduler.task_keys.is_empty());
     }
 }

--- a/crates/aube-resolver/src/resolve/fetch.rs
+++ b/crates/aube-resolver/src/resolve/fetch.rs
@@ -9,7 +9,7 @@ use tokio::task::JoinSet;
 /// Spawns and tracks in-flight packument fetches.
 ///
 /// Owns the `JoinSet` of running fetch tasks plus the bookkeeping the
-/// resolver needs to dedupe spawns (`scheduled_fetches`) and to know
+/// resolver needs to dedupe spawns (`active_fetches`) and to know
 /// which packuments came from the bundled primer
 /// (`primer_seeded_names`, so range misses against the primer's
 /// capped history can trigger a live refetch before reporting
@@ -20,8 +20,8 @@ use tokio::task::JoinSet;
 /// keeping it compatible with the BFS loop's `&mut self.resolver.cache`
 /// access pattern.
 pub(super) struct FetchScheduler {
-    in_flight: JoinSet<Result<FetchResult, Error>>,
-    scheduled_fetches: FxHashSet<FetchKey>,
+    in_flight: JoinSet<(FetchKey, Result<FetchResult, Error>)>,
+    active_fetches: FxHashSet<FetchKey>,
     primer_seeded_names: FxHashSet<String>,
     sem: Arc<AdaptiveLimit>,
     client: Arc<RegistryClient>,
@@ -34,10 +34,11 @@ pub(super) struct FetchScheduler {
 
 pub(super) type TrustHistory = std::collections::BTreeMap<String, VersionTrustMetadata>;
 pub(super) type FetchResult = (String, Packument, bool, Option<TrustHistory>);
-pub(super) type FetchOutcome = Option<Result<Result<FetchResult, Error>, tokio::task::JoinError>>;
+pub(super) type FetchOutcome =
+    Option<Result<(FetchKey, Result<FetchResult, Error>), tokio::task::JoinError>>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-enum FetchKey {
+pub(super) enum FetchKey {
     Full(String),
     Exact(String, String),
 }
@@ -46,7 +47,7 @@ impl FetchScheduler {
     pub(super) fn new(resolver: &Resolver, sem: Arc<AdaptiveLimit>, needs_time: bool) -> Self {
         Self {
             in_flight: JoinSet::new(),
-            scheduled_fetches: FxHashSet::default(),
+            active_fetches: FxHashSet::default(),
             primer_seeded_names: FxHashSet::default(),
             sem,
             client: resolver.client.clone(),
@@ -71,11 +72,14 @@ impl FetchScheduler {
     /// The caller is responsible for the resolver-cache gate — passing
     /// a name that's already in the cache wastes a spawn but is
     /// otherwise harmless.
-    pub(super) fn ensure_fetch(&mut self, name: &str, published_by: Option<&str>) {
-        if !self
-            .scheduled_fetches
-            .insert(FetchKey::Full(name.to_string()))
-        {
+    pub(super) fn ensure_fetch(
+        &mut self,
+        name: &str,
+        published_by: Option<&str>,
+        force_refresh: bool,
+    ) {
+        let key = FetchKey::Full(name.to_string());
+        if !self.active_fetches.insert(key.clone()) {
             return;
         }
         // Only a name-only exclude lets us skip the cutoff sight-unseen;
@@ -83,7 +87,7 @@ impl FetchScheduler {
         // versions are exempt, so it falls through to the cutoff check.
         let primer_covers_cutoff = self.mra_exclude.matches_name_only(name)
             || published_by.is_none_or(crate::primer::covers_cutoff);
-        self.in_flight.spawn(fetch_one_packument(FetchInputs {
+        let inputs = FetchInputs {
             name: name.to_string(),
             client: self.client.clone(),
             cache_dir: self.cache_dir.clone(),
@@ -92,7 +96,12 @@ impl FetchScheduler {
             force_metadata_primer: self.force_metadata_primer,
             sem: self.sem.clone(),
             needs_time: self.needs_time,
-        }));
+            force_refresh,
+        };
+        self.in_flight.spawn(async move {
+            let result = fetch_one_packument(inputs).await;
+            (key, result)
+        });
     }
 
     /// Fetch an exact optional dependency without retaining every historical
@@ -104,32 +113,37 @@ impl FetchScheduler {
         version: &str,
         published_by: Option<&str>,
     ) {
-        if !self
-            .scheduled_fetches
-            .insert(FetchKey::Exact(name.to_string(), version.to_string()))
-        {
+        let key = FetchKey::Exact(name.to_string(), version.to_string());
+        if !self.active_fetches.insert(key.clone()) {
             return;
         }
         let primer_covers_cutoff = self.mra_exclude.matches_name_only(name)
             || published_by.is_none_or(crate::primer::covers_cutoff);
-        self.in_flight.spawn(fetch_exact_optional_packument(
-            FetchInputs {
-                name: name.to_string(),
-                client: self.client.clone(),
-                cache_dir: self.cache_dir.clone(),
-                full_cache_dir: self.full_cache_dir.clone(),
-                primer_covers_cutoff,
-                force_metadata_primer: self.force_metadata_primer,
-                sem: self.sem.clone(),
-                needs_time: self.needs_time,
-            },
-            version.to_string(),
-        ));
+        let inputs = FetchInputs {
+            name: name.to_string(),
+            client: self.client.clone(),
+            cache_dir: self.cache_dir.clone(),
+            full_cache_dir: self.full_cache_dir.clone(),
+            primer_covers_cutoff,
+            force_metadata_primer: self.force_metadata_primer,
+            sem: self.sem.clone(),
+            needs_time: self.needs_time,
+            force_refresh: false,
+        };
+        let version = version.to_string();
+        self.in_flight.spawn(async move {
+            let result = fetch_exact_optional_packument(inputs, version).await;
+            (key, result)
+        });
     }
 
     /// Wait for the next in-flight fetch to complete.
     pub(super) async fn join_next(&mut self) -> FetchOutcome {
-        self.in_flight.join_next().await
+        let outcome = self.in_flight.join_next().await;
+        if let Some(Ok((key, _))) = &outcome {
+            self.active_fetches.remove(key);
+        }
+        outcome
     }
 
     pub(super) fn note_primer_seeded(&mut self, name: String) {
@@ -168,6 +182,9 @@ struct FetchInputs {
     /// True when the caller needs the packument's `time:` map and
     /// must therefore use the full-packument path.
     needs_time: bool,
+    /// Ignore an apparently fresh full-packument disk entry because a newer
+    /// compact response proved that it is incomplete.
+    force_refresh: bool,
 }
 
 /// Body of the per-packument fetch task spawned by the resolver.
@@ -187,6 +204,7 @@ async fn fetch_one_packument(inputs: FetchInputs) -> Result<FetchResult, Error> 
         force_metadata_primer,
         sem,
         needs_time,
+        force_refresh,
     } = inputs;
     let _diag_span =
         aube_util::diag::Span::new(aube_util::diag::Category::Resolver, "packument_fetch")
@@ -205,6 +223,12 @@ async fn fetch_one_packument(inputs: FetchInputs) -> Result<FetchResult, Error> 
     }
     aube_util::diag::attribute_wait(aube_util::diag::Slot::Pack, &name, permit_wait_ms);
     let _holder_guard = aube_util::diag::register_holder(aube_util::diag::Slot::Pack, &name);
+    if force_refresh
+        && needs_time
+        && let Some(dir) = full_cache_dir.as_ref()
+    {
+        client.invalidate_full_packument_cache(&name, dir);
+    }
     let mut cached = if needs_time {
         match full_cache_dir.as_ref() {
             Some(dir) => client.cached_full_packument_lookup(&name, dir),
@@ -361,5 +385,91 @@ async fn fetch_exact_optional_packument(
             permit.record_cancelled();
             fetch_one_packument(inputs).await
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    fn test_packument(versions: &[&str]) -> Packument {
+        Packument {
+            name: "shared".to_string(),
+            modified: None,
+            versions: versions
+                .iter()
+                .map(|version| {
+                    (
+                        (*version).to_string(),
+                        serde_json::from_value(serde_json::json!({
+                            "name": "shared",
+                            "version": version,
+                        }))
+                        .unwrap(),
+                    )
+                })
+                .collect(),
+            dist_tags: BTreeMap::new(),
+            time: BTreeMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn completed_full_fetch_can_force_refresh_a_fresh_disk_entry() {
+        let stale = test_packument(&["1.0.0"]);
+        let fresh = test_packument(&["1.0.0", "2.0.0"]);
+        let body = serde_json::to_vec(&fresh).unwrap();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let registry = format!("http://{}/", listener.local_addr().unwrap());
+        let requests = Arc::new(AtomicUsize::new(0));
+        let server = {
+            let requests = Arc::clone(&requests);
+            tokio::spawn(async move {
+                loop {
+                    let Ok((mut socket, _)) = listener.accept().await else {
+                        break;
+                    };
+                    requests.fetch_add(1, Ordering::Relaxed);
+                    let body = body.clone();
+                    tokio::spawn(async move {
+                        let mut buf = [0_u8; 2048];
+                        let _ = socket.read(&mut buf).await;
+                        let response = format!(
+                            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                            body.len()
+                        );
+                        socket.write_all(response.as_bytes()).await.unwrap();
+                        socket.write_all(&body).await.unwrap();
+                    });
+                }
+            })
+        };
+
+        let cache = tempfile::tempdir().unwrap();
+        let client = Arc::new(RegistryClient::new(&registry));
+        client.seed_full_packument_cache("shared", cache.path(), &stale, None, None, true);
+        let resolver = Resolver::new(Arc::clone(&client))
+            .with_packument_full_cache(cache.path().to_path_buf());
+        let mut scheduler = FetchScheduler::new(&resolver, AdaptiveLimit::new(1, 1, 1), true);
+
+        scheduler.ensure_fetch("shared", None, false);
+        let Some(Ok((FetchKey::Full(_), Ok((_, first, _, _))))) = scheduler.join_next().await
+        else {
+            panic!("cached full fetch did not complete");
+        };
+        assert_eq!(first.versions.len(), 1);
+        assert_eq!(requests.load(Ordering::Relaxed), 0);
+
+        scheduler.ensure_fetch("shared", None, true);
+        let Some(Ok((FetchKey::Full(_), Ok((_, refreshed, _, _))))) = scheduler.join_next().await
+        else {
+            panic!("forced full refresh did not restart");
+        };
+        assert_eq!(refreshed.versions.len(), 2);
+        assert_eq!(requests.load(Ordering::Relaxed), 1);
+        server.abort();
     }
 }

--- a/crates/aube-resolver/src/resolve/fetch.rs
+++ b/crates/aube-resolver/src/resolve/fetch.rs
@@ -9,7 +9,7 @@ use tokio::task::JoinSet;
 /// Spawns and tracks in-flight packument fetches.
 ///
 /// Owns the `JoinSet` of running fetch tasks plus the bookkeeping the
-/// resolver needs to dedupe spawns (`in_flight_names`) and to know
+/// resolver needs to dedupe spawns (`scheduled_fetches`) and to know
 /// which packuments came from the bundled primer
 /// (`primer_seeded_names`, so range misses against the primer's
 /// capped history can trigger a live refetch before reporting
@@ -21,7 +21,7 @@ use tokio::task::JoinSet;
 /// access pattern.
 pub(super) struct FetchScheduler {
     in_flight: JoinSet<Result<FetchResult, Error>>,
-    in_flight_names: FxHashSet<String>,
+    scheduled_fetches: FxHashSet<FetchKey>,
     primer_seeded_names: FxHashSet<String>,
     sem: Arc<AdaptiveLimit>,
     client: Arc<RegistryClient>,
@@ -36,11 +36,17 @@ pub(super) type TrustHistory = std::collections::BTreeMap<String, VersionTrustMe
 pub(super) type FetchResult = (String, Packument, bool, Option<TrustHistory>);
 pub(super) type FetchOutcome = Option<Result<Result<FetchResult, Error>, tokio::task::JoinError>>;
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum FetchKey {
+    Full(String),
+    Exact(String, String),
+}
+
 impl FetchScheduler {
     pub(super) fn new(resolver: &Resolver, sem: Arc<AdaptiveLimit>, needs_time: bool) -> Self {
         Self {
             in_flight: JoinSet::new(),
-            in_flight_names: FxHashSet::default(),
+            scheduled_fetches: FxHashSet::default(),
             primer_seeded_names: FxHashSet::default(),
             sem,
             client: resolver.client.clone(),
@@ -60,16 +66,18 @@ impl FetchScheduler {
         self.in_flight.len()
     }
 
-    /// Spawn a fetch for `name` unless one is already running for it.
+    /// Spawn a full fetch for `name` unless one was already scheduled.
     ///
     /// The caller is responsible for the resolver-cache gate — passing
     /// a name that's already in the cache wastes a spawn but is
     /// otherwise harmless.
     pub(super) fn ensure_fetch(&mut self, name: &str, published_by: Option<&str>) {
-        if self.in_flight_names.contains(name) {
+        if !self
+            .scheduled_fetches
+            .insert(FetchKey::Full(name.to_string()))
+        {
             return;
         }
-        self.in_flight_names.insert(name.to_string());
         // Only a name-only exclude lets us skip the cutoff sight-unseen;
         // a version-specific rule still needs publish times to tell which
         // versions are exempt, so it falls through to the cutoff check.
@@ -96,10 +104,12 @@ impl FetchScheduler {
         version: &str,
         published_by: Option<&str>,
     ) {
-        if self.in_flight_names.contains(name) {
+        if !self
+            .scheduled_fetches
+            .insert(FetchKey::Exact(name.to_string(), version.to_string()))
+        {
             return;
         }
-        self.in_flight_names.insert(name.to_string());
         let primer_covers_cutoff = self.mra_exclude.matches_name_only(name)
             || published_by.is_none_or(crate::primer::covers_cutoff);
         self.in_flight.spawn(fetch_exact_optional_packument(
@@ -120,10 +130,6 @@ impl FetchScheduler {
     /// Wait for the next in-flight fetch to complete.
     pub(super) async fn join_next(&mut self) -> FetchOutcome {
         self.in_flight.join_next().await
-    }
-
-    pub(super) fn release_in_flight(&mut self, name: &str) {
-        self.in_flight_names.remove(name);
     }
 
     pub(super) fn note_primer_seeded(&mut self, name: String) {

--- a/crates/aube-resolver/src/resolve/fetch.rs
+++ b/crates/aube-resolver/src/resolve/fetch.rs
@@ -326,15 +326,15 @@ async fn fetch_exact_optional_packument(
 ) -> Result<FetchResult, Error> {
     let permit = inputs.sem.acquire().await;
     let name = inputs.name.clone();
-    let fetched = tokio::try_join!(
-        inputs.client.fetch_single_version_metadata(&name, &version),
-        inputs.client.fetch_packument_trust_history(&name),
-    );
+    let fetched = inputs
+        .client
+        .fetch_exact_version_packument(&name, &version)
+        .await;
     match fetched {
-        Ok((metadata, history)) => {
+        Ok(exact) => {
             permit.record_success();
             let mut versions = std::collections::BTreeMap::new();
-            versions.insert(version, metadata);
+            versions.insert(version, exact.metadata);
             Ok((
                 name.clone(),
                 Packument {
@@ -342,10 +342,10 @@ async fn fetch_exact_optional_packument(
                     modified: None,
                     versions,
                     dist_tags: std::collections::BTreeMap::new(),
-                    time: history.time,
+                    time: exact.history.time,
                 },
                 false,
-                Some(history.versions),
+                Some(exact.history.versions),
             ))
         }
         Err(err) => {

--- a/crates/aube-resolver/src/resolve/fetch.rs
+++ b/crates/aube-resolver/src/resolve/fetch.rs
@@ -34,7 +34,7 @@ pub(super) struct FetchScheduler {
 }
 
 pub(super) type TrustHistory = std::collections::BTreeMap<String, VersionTrustMetadata>;
-pub(super) type FetchResult = (String, Packument, bool, Option<TrustHistory>);
+pub(super) type FetchResult = (String, Packument, FetchSource, Option<TrustHistory>);
 pub(super) type FetchOutcome =
     Option<Result<(FetchKey, Result<FetchResult, Error>), tokio::task::JoinError>>;
 
@@ -42,6 +42,14 @@ pub(super) type FetchOutcome =
 pub(super) enum FetchKey {
     Full(String),
     Exact(String, String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum FetchSource {
+    Disk,
+    Primer,
+    Network,
+    Exact,
 }
 
 impl FetchScheduler {
@@ -204,11 +212,8 @@ struct FetchInputs {
 
 /// Body of the per-packument fetch task spawned by the resolver.
 ///
-/// Returns `(name, packument, from_primer)` — `from_primer` is true
-/// when the result came from the bundled metadata primer (only its
-/// capped slice of high-traffic histories), so the caller knows a
-/// range miss must trigger a live registry refetch before reporting
-/// `ERR_AUBE_NO_MATCHING_VERSION`.
+/// Returns the result source so callers can distinguish incomplete local
+/// metadata from a live registry response.
 async fn fetch_one_packument(inputs: FetchInputs) -> Result<FetchResult, Error> {
     let FetchInputs {
         name,
@@ -267,7 +272,7 @@ async fn fetch_one_packument(inputs: FetchInputs) -> Result<FetchResult, Error> 
             },
         );
         permit.record_cancelled();
-        return Ok((name, packument, false, None));
+        return Ok((name, packument, FetchSource::Disk, None));
     }
     let use_metadata_primer = !force_refresh
         && (force_metadata_primer || client.uses_default_npm_registry_for(&name))
@@ -319,7 +324,7 @@ async fn fetch_one_packument(inputs: FetchInputs) -> Result<FetchResult, Error> 
             },
         );
         permit.record_cancelled();
-        return Ok((name, packument, true, None));
+        return Ok((name, packument, FetchSource::Primer, None));
     }
     let fetch_outcome = if needs_time {
         match full_cache_dir.as_ref() {
@@ -362,7 +367,7 @@ async fn fetch_one_packument(inputs: FetchInputs) -> Result<FetchResult, Error> 
             )
         },
     );
-    Ok((name, packument, false, None))
+    Ok((name, packument, FetchSource::Network, None))
 }
 
 async fn fetch_exact_optional_packument(
@@ -389,7 +394,7 @@ async fn fetch_exact_optional_packument(
                     dist_tags: std::collections::BTreeMap::new(),
                     time: exact.history.time,
                 },
-                false,
+                FetchSource::Exact,
                 Some(exact.history.versions),
             ))
         }
@@ -398,9 +403,22 @@ async fn fetch_exact_optional_packument(
                 "compact exact metadata fetch failed for optional dep {name}@{version}; falling back to full packument: {err}"
             );
             permit.record_cancelled();
+            let fallback_inputs = inputs.clone();
             let fallback = fetch_one_packument(inputs).await?;
             if fallback.1.versions.contains_key(&version) {
                 Ok(fallback)
+            } else if matches!(fallback.2, FetchSource::Disk | FetchSource::Primer) {
+                let mut refresh_inputs = fallback_inputs;
+                refresh_inputs.force_refresh = true;
+                let refreshed = fetch_one_packument(refresh_inputs).await?;
+                if refreshed.1.versions.contains_key(&version) {
+                    Ok(refreshed)
+                } else {
+                    Err(Error::Registry(
+                        name,
+                        format!("version {version} is missing from the full packument"),
+                    ))
+                }
             } else {
                 Err(Error::Registry(
                     name,
@@ -417,8 +435,8 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-    async fn serve_registry(
-        body: Vec<u8>,
+    async fn serve_registry_responses(
+        bodies: Vec<Vec<u8>>,
     ) -> (String, Arc<AtomicUsize>, tokio::task::JoinHandle<()>) {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let registry = format!("http://{}/", listener.local_addr().unwrap());
@@ -430,8 +448,8 @@ mod tests {
                     let Ok((mut socket, _)) = listener.accept().await else {
                         break;
                     };
-                    requests.fetch_add(1, Ordering::Relaxed);
-                    let body = body.clone();
+                    let request = requests.fetch_add(1, Ordering::Relaxed);
+                    let body = bodies[request.min(bodies.len() - 1)].clone();
                     tokio::spawn(async move {
                         let mut buf = [0_u8; 2048];
                         let _ = socket.read(&mut buf).await;
@@ -446,6 +464,12 @@ mod tests {
             })
         };
         (registry, requests, server)
+    }
+
+    async fn serve_registry(
+        body: Vec<u8>,
+    ) -> (String, Arc<AtomicUsize>, tokio::task::JoinHandle<()>) {
+        serve_registry_responses(vec![body]).await
     }
 
     #[tokio::test]
@@ -517,6 +541,51 @@ mod tests {
         };
         assert_eq!(version, "2.0.0");
         assert!(message.contains("version 2.0.0 is missing"));
+        assert_eq!(requests.load(Ordering::Relaxed), 2);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn exact_fallback_refreshes_an_incomplete_disk_entry() {
+        let incomplete = serde_json::from_value(serde_json::json!({
+            "name": "shared",
+            "versions": {
+                "1.0.0": { "name": "shared", "version": "1.0.0" }
+            },
+            "dist-tags": { "latest": "1.0.0" },
+            "time": { "1.0.0": "2024-01-01T00:00:00.000Z" }
+        }))
+        .unwrap();
+        let refreshed = serde_json::to_vec(&serde_json::json!({
+            "name": "shared",
+            "versions": {
+                "1.0.0": { "name": "shared", "version": "1.0.0" },
+                "2.0.0": { "name": "shared", "version": "2.0.0" }
+            },
+            "dist-tags": { "latest": "2.0.0" },
+            "time": {
+                "1.0.0": "2024-01-01T00:00:00.000Z",
+                "2.0.0": "2024-02-01T00:00:00.000Z"
+            }
+        }))
+        .unwrap();
+        let compact_miss = serde_json::to_vec(&incomplete).unwrap();
+        let (registry, requests, server) =
+            serve_registry_responses(vec![compact_miss, refreshed]).await;
+        let cache = tempfile::tempdir().unwrap();
+        let client = Arc::new(RegistryClient::new(&registry));
+        client.seed_full_packument_cache("shared", cache.path(), &incomplete, None, None, true);
+        let resolver = Resolver::new(client).with_packument_full_cache(cache.path().to_path_buf());
+        let mut scheduler = FetchScheduler::new(&resolver, AdaptiveLimit::new(1, 1, 1), true);
+
+        scheduler.ensure_exact_optional_fetch("shared", "2.0.0", None);
+        let Some(Ok((FetchKey::Exact(_, _), Ok((_, packument, source, _))))) =
+            scheduler.join_next().await
+        else {
+            panic!("forced exact fallback refresh did not complete");
+        };
+        assert!(packument.versions.contains_key("2.0.0"));
+        assert_eq!(source, FetchSource::Network);
         assert_eq!(requests.load(Ordering::Relaxed), 2);
         server.abort();
     }

--- a/crates/aube-resolver/src/resolve/fetch.rs
+++ b/crates/aube-resolver/src/resolve/fetch.rs
@@ -77,6 +77,15 @@ impl FetchScheduler {
         self.in_flight.len()
     }
 
+    /// Whether an exact request for any version of `name` is still running.
+    /// A successful exact response can supersede a retained full-fetch error
+    /// by proving the package is reachable and requiring a fresh full fetch.
+    pub(super) fn has_active_exact_fetch(&self, name: &str) -> bool {
+        self.active_fetches
+            .iter()
+            .any(|key| matches!(key, FetchKey::Exact(active_name, _) if active_name == name))
+    }
+
     /// Spawn a full fetch for `name` unless one was already scheduled.
     ///
     /// The caller is responsible for the resolver-cache gate — passing
@@ -607,5 +616,17 @@ mod tests {
         assert!(matches!(scheduler.join_next().await, Some(Err(_))));
         assert!(!scheduler.active_fetches.contains(&key));
         assert!(scheduler.task_keys.is_empty());
+    }
+
+    #[test]
+    fn active_exact_fetch_is_reported_by_package_name() {
+        let resolver = Resolver::new(Arc::new(RegistryClient::new("http://127.0.0.1:0")));
+        let mut scheduler = FetchScheduler::new(&resolver, AdaptiveLimit::new(1, 1, 1), false);
+        scheduler
+            .active_fetches
+            .insert(FetchKey::Exact("shared".to_string(), "1.0.0".to_string()));
+
+        assert!(scheduler.has_active_exact_fetch("shared"));
+        assert!(!scheduler.has_active_exact_fetch("other"));
     }
 }

--- a/crates/aube-resolver/src/resolve/fetch.rs
+++ b/crates/aube-resolver/src/resolve/fetch.rs
@@ -1,6 +1,6 @@
 use crate::{Error, FxHashSet, Resolver};
-use aube_registry::Packument;
 use aube_registry::client::RegistryClient;
+use aube_registry::{Packument, VersionTrustMetadata};
 use aube_util::adaptive::AdaptiveLimit;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -20,7 +20,7 @@ use tokio::task::JoinSet;
 /// keeping it compatible with the BFS loop's `&mut self.resolver.cache`
 /// access pattern.
 pub(super) struct FetchScheduler {
-    in_flight: JoinSet<Result<(String, Packument, bool), Error>>,
+    in_flight: JoinSet<Result<FetchResult, Error>>,
     in_flight_names: FxHashSet<String>,
     primer_seeded_names: FxHashSet<String>,
     sem: Arc<AdaptiveLimit>,
@@ -32,8 +32,9 @@ pub(super) struct FetchScheduler {
     needs_time: bool,
 }
 
-pub(super) type FetchOutcome =
-    Option<Result<Result<(String, Packument, bool), Error>, tokio::task::JoinError>>;
+pub(super) type TrustHistory = std::collections::BTreeMap<String, VersionTrustMetadata>;
+pub(super) type FetchResult = (String, Packument, bool, Option<TrustHistory>);
+pub(super) type FetchOutcome = Option<Result<Result<FetchResult, Error>, tokio::task::JoinError>>;
 
 impl FetchScheduler {
     pub(super) fn new(resolver: &Resolver, sem: Arc<AdaptiveLimit>, needs_time: bool) -> Self {
@@ -86,6 +87,36 @@ impl FetchScheduler {
         }));
     }
 
+    /// Fetch an exact optional dependency without retaining every historical
+    /// version's dependency metadata. The full document is decoded into its
+    /// publish-time/trust subset so policy checks keep their semantics.
+    pub(super) fn ensure_exact_optional_fetch(
+        &mut self,
+        name: &str,
+        version: &str,
+        published_by: Option<&str>,
+    ) {
+        if self.in_flight_names.contains(name) {
+            return;
+        }
+        self.in_flight_names.insert(name.to_string());
+        let primer_covers_cutoff = self.mra_exclude.matches_name_only(name)
+            || published_by.is_none_or(crate::primer::covers_cutoff);
+        self.in_flight.spawn(fetch_exact_optional_packument(
+            FetchInputs {
+                name: name.to_string(),
+                client: self.client.clone(),
+                cache_dir: self.cache_dir.clone(),
+                full_cache_dir: self.full_cache_dir.clone(),
+                primer_covers_cutoff,
+                force_metadata_primer: self.force_metadata_primer,
+                sem: self.sem.clone(),
+                needs_time: self.needs_time,
+            },
+            version.to_string(),
+        ));
+    }
+
     /// Wait for the next in-flight fetch to complete.
     pub(super) async fn join_next(&mut self) -> FetchOutcome {
         self.in_flight.join_next().await
@@ -113,6 +144,7 @@ impl FetchScheduler {
 ///
 /// All fields are owned/`Arc`-cloned so the future can be moved into
 /// the resolver's `JoinSet` without borrowing the outer scope.
+#[derive(Clone)]
 struct FetchInputs {
     name: String,
     client: Arc<RegistryClient>,
@@ -139,7 +171,7 @@ struct FetchInputs {
 /// capped slice of high-traffic histories), so the caller knows a
 /// range miss must trigger a live registry refetch before reporting
 /// `ERR_AUBE_NO_MATCHING_VERSION`.
-async fn fetch_one_packument(inputs: FetchInputs) -> Result<(String, Packument, bool), Error> {
+async fn fetch_one_packument(inputs: FetchInputs) -> Result<FetchResult, Error> {
     let FetchInputs {
         name,
         client,
@@ -190,7 +222,7 @@ async fn fetch_one_packument(inputs: FetchInputs) -> Result<(String, Packument, 
             },
         );
         permit.record_cancelled();
-        return Ok((name, packument, false));
+        return Ok((name, packument, false, None));
     }
     let use_metadata_primer = (force_metadata_primer
         || client.uses_default_npm_registry_for(&name))
@@ -242,7 +274,7 @@ async fn fetch_one_packument(inputs: FetchInputs) -> Result<(String, Packument, 
             },
         );
         permit.record_cancelled();
-        return Ok((name, packument, true));
+        return Ok((name, packument, true, None));
     }
     let fetch_outcome = if needs_time {
         match full_cache_dir.as_ref() {
@@ -285,5 +317,43 @@ async fn fetch_one_packument(inputs: FetchInputs) -> Result<(String, Packument, 
             )
         },
     );
-    Ok((name, packument, false))
+    Ok((name, packument, false, None))
+}
+
+async fn fetch_exact_optional_packument(
+    inputs: FetchInputs,
+    version: String,
+) -> Result<FetchResult, Error> {
+    let permit = inputs.sem.acquire().await;
+    let name = inputs.name.clone();
+    let fetched = tokio::try_join!(
+        inputs.client.fetch_single_version_metadata(&name, &version),
+        inputs.client.fetch_packument_trust_history(&name),
+    );
+    match fetched {
+        Ok((metadata, history)) => {
+            permit.record_success();
+            let mut versions = std::collections::BTreeMap::new();
+            versions.insert(version, metadata);
+            Ok((
+                name.clone(),
+                Packument {
+                    name,
+                    modified: None,
+                    versions,
+                    dist_tags: std::collections::BTreeMap::new(),
+                    time: history.time,
+                },
+                false,
+                Some(history.versions),
+            ))
+        }
+        Err(err) => {
+            tracing::debug!(
+                "compact exact metadata fetch failed for optional dep {name}@{version}; falling back to full packument: {err}"
+            );
+            permit.record_cancelled();
+            fetch_one_packument(inputs).await
+        }
+    }
 }

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -1265,10 +1265,13 @@ async fn minimum_release_age_compacts_exact_optional_platform_history() {
         .time
         .insert("1.0.0".to_string(), "2024-01-01T00:00:00.000Z".to_string());
     let mut exact = packument.versions["1.0.0"].clone();
-    exact.os = vec!["darwin".to_string()];
-    packument
-        .versions
-        .insert("1.0.0".to_string(), exact.clone());
+    let unsupported_os = if cfg!(target_os = "macos") {
+        "linux"
+    } else {
+        "darwin"
+    };
+    exact.os = vec![unsupported_os.to_string()];
+    packument.versions.insert("1.0.0".to_string(), exact);
     let full_body = serde_json::to_vec(&packument).unwrap();
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -1356,6 +1359,133 @@ async fn minimum_release_age_compacts_exact_optional_platform_history() {
 
     server.abort();
     let _ = std::fs::remove_dir_all(base);
+}
+
+async fn resolve_compact_same_name_collision(
+    second_is_optional_exact: bool,
+) -> (LockfileGraph, usize) {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let mut compact_parent = make_packument("compact-parent", &["1.0.0"], "1.0.0");
+    compact_parent
+        .versions
+        .get_mut("1.0.0")
+        .unwrap()
+        .optional_dependencies
+        .insert("shared-child".to_string(), "1.0.0".to_string());
+
+    let mut other_parent = make_packument("other-parent", &["1.0.0"], "1.0.0");
+    let other = other_parent.versions.get_mut("1.0.0").unwrap();
+    if second_is_optional_exact {
+        other
+            .optional_dependencies
+            .insert("shared-child".to_string(), "2.0.0".to_string());
+    } else {
+        other
+            .dependencies
+            .insert("shared-child".to_string(), "^2.0.0".to_string());
+    }
+
+    let mut shared = make_packument("shared-child", &["1.0.0", "2.0.0"], "2.0.0");
+    for packument in [&mut compact_parent, &mut other_parent, &mut shared] {
+        for version in packument.versions.keys() {
+            packument
+                .time
+                .insert(version.clone(), "2024-01-01T00:00:00.000Z".to_string());
+        }
+    }
+
+    let bodies = Arc::new(std::collections::HashMap::from([
+        (
+            "compact-parent".to_string(),
+            serde_json::to_vec(&compact_parent).unwrap(),
+        ),
+        (
+            "other-parent".to_string(),
+            serde_json::to_vec(&other_parent).unwrap(),
+        ),
+        (
+            "shared-child".to_string(),
+            serde_json::to_vec(&shared).unwrap(),
+        ),
+    ]));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let registry = format!("http://{}/", listener.local_addr().unwrap());
+    let shared_requests = Arc::new(AtomicUsize::new(0));
+    let server = {
+        let shared_requests = shared_requests.clone();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
+                let bodies = bodies.clone();
+                let shared_requests = shared_requests.clone();
+                tokio::spawn(async move {
+                    let mut buf = [0_u8; 4096];
+                    let n = socket.read(&mut buf).await.unwrap_or(0);
+                    let path = std::str::from_utf8(&buf[..n])
+                        .ok()
+                        .and_then(|request| request.split_whitespace().nth(1))
+                        .unwrap_or("/");
+                    let name = path.trim_start_matches('/').split('/').next().unwrap_or("");
+                    let Some(body) = bodies.get(name) else {
+                        socket
+                            .write_all(b"HTTP/1.1 404 Not Found\r\ncontent-length: 0\r\n\r\n")
+                            .await
+                            .unwrap();
+                        return;
+                    };
+                    if name == "shared-child" {
+                        shared_requests.fetch_add(1, Ordering::Relaxed);
+                    }
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                        body.len()
+                    );
+                    socket.write_all(response.as_bytes()).await.unwrap();
+                    socket.write_all(body).await.unwrap();
+                });
+            }
+        })
+    };
+
+    let client = Arc::new(aube_registry::client::RegistryClient::new(&registry));
+    let mut resolver = Resolver::new(client).with_minimum_release_age(Some(MinimumReleaseAge {
+        minutes: 60,
+        ..Default::default()
+    }));
+    let mut manifest = PackageJson::default();
+    manifest
+        .dependencies
+        .insert("compact-parent".to_string(), "1.0.0".to_string());
+    manifest
+        .dependencies
+        .insert("other-parent".to_string(), "1.0.0".to_string());
+
+    let graph = resolver.resolve(&manifest, None).await.unwrap();
+    let request_count = shared_requests.load(Ordering::Relaxed);
+    server.abort();
+    (graph, request_count)
+}
+
+#[tokio::test]
+async fn compact_fetch_keeps_two_exact_optional_versions_for_one_name() {
+    let (graph, requests) = resolve_compact_same_name_collision(true).await;
+
+    assert!(graph_has_package(&graph, "shared-child", "1.0.0"));
+    assert!(graph_has_package(&graph, "shared-child", "2.0.0"));
+    assert_eq!(requests, 2, "each exact version needs one compact fetch");
+}
+
+#[tokio::test]
+async fn compact_fetch_does_not_suppress_same_name_range_fetch() {
+    let (graph, requests) = resolve_compact_same_name_collision(false).await;
+
+    assert!(graph_has_package(&graph, "shared-child", "1.0.0"));
+    assert!(graph_has_package(&graph, "shared-child", "2.0.0"));
+    assert_eq!(requests, 2, "the exact and full fetches must both run");
 }
 
 /// Regression: when both `minimumReleaseAge` and `trustPolicy=NoDowngrade`

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -1269,7 +1269,6 @@ async fn minimum_release_age_compacts_exact_optional_platform_history() {
     packument
         .versions
         .insert("1.0.0".to_string(), exact.clone());
-    let exact_body = serde_json::to_vec(&exact).unwrap();
     let full_body = serde_json::to_vec(&packument).unwrap();
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -1284,7 +1283,6 @@ async fn minimum_release_age_compacts_exact_optional_platform_history() {
                 let Ok((mut socket, _)) = listener.accept().await else {
                     break;
                 };
-                let exact_body = exact_body.clone();
                 let full_body = full_body.clone();
                 let exact_requests = exact_requests.clone();
                 let full_requests = full_requests.clone();
@@ -1297,7 +1295,7 @@ async fn minimum_release_age_compacts_exact_optional_platform_history() {
                         .unwrap_or("/");
                     let body = if path.ends_with("/1.0.0") {
                         exact_requests.fetch_add(1, Ordering::Relaxed);
-                        exact_body
+                        full_body.clone()
                     } else {
                         full_requests.fetch_add(1, Ordering::Relaxed);
                         full_body
@@ -1340,7 +1338,11 @@ async fn minimum_release_age_compacts_exact_optional_platform_history() {
     let graph = resolver.resolve(&manifest, None).await.unwrap();
 
     assert!(!graph_has_package(&graph, "darwin-only", "1.0.0"));
-    assert_eq!(exact_requests.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        exact_requests.load(Ordering::Relaxed),
+        0,
+        "the compact path must not make a second exact-version request"
+    );
     assert_eq!(full_requests.load(Ordering::Relaxed), 1);
     assert_eq!(
         resolver.cache["darwin-only"].versions.len(),

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -1361,6 +1361,67 @@ async fn minimum_release_age_compacts_exact_optional_platform_history() {
     let _ = std::fs::remove_dir_all(base);
 }
 
+#[tokio::test]
+async fn compact_fetch_augments_stale_full_cache_with_exact_optional_version() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let mut stale = make_packument("fresh-optional", &["1.0.0"], "1.0.0");
+    stale
+        .time
+        .insert("1.0.0".to_string(), "2024-01-01T00:00:00.000Z".to_string());
+    let mut fresh = make_packument("fresh-optional", &["1.0.0", "2.0.0"], "2.0.0");
+    for version in fresh.versions.keys() {
+        fresh
+            .time
+            .insert(version.clone(), "2024-01-01T00:00:00.000Z".to_string());
+    }
+    let body = serde_json::to_vec(&fresh).unwrap();
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let registry = format!("http://{}/", listener.local_addr().unwrap());
+    let requests = Arc::new(AtomicUsize::new(0));
+    let server = {
+        let requests = requests.clone();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
+                let body = body.clone();
+                requests.fetch_add(1, Ordering::Relaxed);
+                tokio::spawn(async move {
+                    let mut buf = [0_u8; 2048];
+                    let _ = socket.read(&mut buf).await;
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                        body.len()
+                    );
+                    socket.write_all(response.as_bytes()).await.unwrap();
+                    socket.write_all(&body).await.unwrap();
+                });
+            }
+        })
+    };
+
+    let client = Arc::new(aube_registry::client::RegistryClient::new(&registry));
+    let mut resolver = Resolver::new(client).with_minimum_release_age(Some(MinimumReleaseAge {
+        minutes: 60,
+        ..Default::default()
+    }));
+    resolver.cache.insert("fresh-optional".to_string(), stale);
+    let mut manifest = PackageJson::default();
+    manifest
+        .optional_dependencies
+        .insert("fresh-optional".to_string(), "2.0.0".to_string());
+
+    let graph = resolver.resolve(&manifest, None).await.unwrap();
+
+    assert!(graph_has_package(&graph, "fresh-optional", "2.0.0"));
+    assert_eq!(requests.load(Ordering::Relaxed), 1);
+    server.abort();
+}
+
 async fn resolve_compact_same_name_collision(
     second_is_optional_exact: bool,
 ) -> (LockfileGraph, usize) {

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -1255,6 +1255,107 @@ async fn minimum_release_age_fetches_full_packument_directly() {
     let _ = std::fs::remove_dir_all(base);
 }
 
+#[tokio::test]
+async fn minimum_release_age_compacts_exact_optional_platform_history() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let mut packument = make_packument("darwin-only", &["1.0.0"], "1.0.0");
+    packument
+        .time
+        .insert("1.0.0".to_string(), "2024-01-01T00:00:00.000Z".to_string());
+    let mut exact = packument.versions["1.0.0"].clone();
+    exact.os = vec!["darwin".to_string()];
+    packument
+        .versions
+        .insert("1.0.0".to_string(), exact.clone());
+    let exact_body = serde_json::to_vec(&exact).unwrap();
+    let full_body = serde_json::to_vec(&packument).unwrap();
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let registry = format!("http://{}/", listener.local_addr().unwrap());
+    let exact_requests = Arc::new(AtomicUsize::new(0));
+    let full_requests = Arc::new(AtomicUsize::new(0));
+    let server = {
+        let exact_requests = exact_requests.clone();
+        let full_requests = full_requests.clone();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
+                let exact_body = exact_body.clone();
+                let full_body = full_body.clone();
+                let exact_requests = exact_requests.clone();
+                let full_requests = full_requests.clone();
+                tokio::spawn(async move {
+                    let mut buf = [0_u8; 2048];
+                    let n = socket.read(&mut buf).await.unwrap_or(0);
+                    let path = std::str::from_utf8(&buf[..n])
+                        .ok()
+                        .and_then(|request| request.split_whitespace().nth(1))
+                        .unwrap_or("/");
+                    let body = if path.ends_with("/1.0.0") {
+                        exact_requests.fetch_add(1, Ordering::Relaxed);
+                        exact_body
+                    } else {
+                        full_requests.fetch_add(1, Ordering::Relaxed);
+                        full_body
+                    };
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                        body.len()
+                    );
+                    socket.write_all(response.as_bytes()).await.unwrap();
+                    socket.write_all(&body).await.unwrap();
+                });
+            }
+        })
+    };
+
+    let base = std::env::temp_dir().join(format!(
+        "aube-resolver-exact-optional-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(base.join("packuments")).unwrap();
+    std::fs::create_dir_all(base.join("packuments-full")).unwrap();
+
+    let client = Arc::new(aube_registry::client::RegistryClient::new(&registry));
+    let mut resolver = Resolver::new(client)
+        .with_packument_cache(base.join("packuments"))
+        .with_packument_full_cache(base.join("packuments-full"))
+        .with_minimum_release_age(Some(MinimumReleaseAge {
+            minutes: 60,
+            ..Default::default()
+        }));
+    let mut manifest = PackageJson::default();
+    manifest
+        .optional_dependencies
+        .insert("darwin-only".to_string(), "1.0.0".to_string());
+
+    let graph = resolver.resolve(&manifest, None).await.unwrap();
+
+    assert!(!graph_has_package(&graph, "darwin-only", "1.0.0"));
+    assert_eq!(exact_requests.load(Ordering::Relaxed), 1);
+    assert_eq!(full_requests.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        resolver.cache["darwin-only"].versions.len(),
+        1,
+        "the full history must not be retained in the resolver cache"
+    );
+    assert_eq!(
+        graph.skipped_optional_dependencies["."]["darwin-only"],
+        "1.0.0"
+    );
+
+    server.abort();
+    let _ = std::fs::remove_dir_all(base);
+}
+
 /// Regression: when both `minimumReleaseAge` and `trustPolicy=NoDowngrade`
 /// are active, the resolver must use a full packument with `time`;
 /// using an abbreviated corgi packument would make the trust check fail

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -1549,6 +1549,137 @@ async fn compact_fetch_does_not_suppress_same_name_range_fetch() {
     assert_eq!(requests, 2, "the exact and full fetches must both run");
 }
 
+#[tokio::test]
+async fn failed_exact_optional_version_does_not_suppress_sibling_version() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let mut first_parent = make_packument("first-parent", &["1.0.0"], "1.0.0");
+    first_parent
+        .versions
+        .get_mut("1.0.0")
+        .unwrap()
+        .optional_dependencies
+        .insert("shared-child".to_string(), "1.0.0".to_string());
+    let mut second_parent = make_packument("second-parent", &["1.0.0"], "1.0.0");
+    second_parent
+        .versions
+        .get_mut("1.0.0")
+        .unwrap()
+        .optional_dependencies
+        .insert("shared-child".to_string(), "2.0.0".to_string());
+    let mut shared = make_packument("shared-child", &["1.0.0", "2.0.0"], "2.0.0");
+    for packument in [&mut first_parent, &mut second_parent, &mut shared] {
+        for version in packument.versions.keys() {
+            packument
+                .time
+                .insert(version.clone(), "2024-01-01T00:00:00.000Z".to_string());
+        }
+    }
+
+    let bodies = Arc::new(std::collections::HashMap::from([
+        (
+            "first-parent".to_string(),
+            serde_json::to_vec(&first_parent).unwrap(),
+        ),
+        (
+            "second-parent".to_string(),
+            serde_json::to_vec(&second_parent).unwrap(),
+        ),
+    ]));
+    let shared_body = serde_json::to_vec(&shared).unwrap();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let registry = format!("http://{}/", listener.local_addr().unwrap());
+    let shared_requests = Arc::new(AtomicUsize::new(0));
+    let server = {
+        let shared_requests = Arc::clone(&shared_requests);
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
+                let bodies = Arc::clone(&bodies);
+                let shared_body = shared_body.clone();
+                let shared_requests = Arc::clone(&shared_requests);
+                tokio::spawn(async move {
+                    let mut buf = [0_u8; 4096];
+                    let n = socket.read(&mut buf).await.unwrap_or(0);
+                    let path = std::str::from_utf8(&buf[..n])
+                        .ok()
+                        .and_then(|request| request.split_whitespace().nth(1))
+                        .unwrap_or("/");
+                    let name = path.trim_start_matches('/').split('/').next().unwrap_or("");
+                    if name == "shared-child" {
+                        let request = shared_requests.fetch_add(1, Ordering::Relaxed) + 1;
+                        if request <= 2 {
+                            socket
+                                .write_all(
+                                    b"HTTP/1.1 404 Not Found\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+                                )
+                                .await
+                                .unwrap();
+                            return;
+                        }
+                        let response = format!(
+                            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                            shared_body.len()
+                        );
+                        socket.write_all(response.as_bytes()).await.unwrap();
+                        socket.write_all(&shared_body).await.unwrap();
+                        return;
+                    }
+                    let Some(body) = bodies.get(name) else {
+                        socket
+                            .write_all(b"HTTP/1.1 404 Not Found\r\ncontent-length: 0\r\n\r\n")
+                            .await
+                            .unwrap();
+                        return;
+                    };
+                    if name == "second-parent" {
+                        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+                            while shared_requests.load(Ordering::Relaxed) < 2 {
+                                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+                            }
+                        })
+                        .await;
+                    }
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                        body.len()
+                    );
+                    socket.write_all(response.as_bytes()).await.unwrap();
+                    socket.write_all(body).await.unwrap();
+                });
+            }
+        })
+    };
+
+    let client = Arc::new(aube_registry::client::RegistryClient::new(&registry));
+    let mut resolver = Resolver::new(client).with_minimum_release_age(Some(MinimumReleaseAge {
+        minutes: 60,
+        ..Default::default()
+    }));
+    let mut manifest = PackageJson::default();
+    manifest
+        .dependencies
+        .insert("first-parent".to_string(), "1.0.0".to_string());
+    manifest
+        .dependencies
+        .insert("second-parent".to_string(), "1.0.0".to_string());
+
+    let graph = resolver.resolve(&manifest, None).await.unwrap();
+
+    assert!(
+        !graph_has_package(&graph, "shared-child", "1.0.0"),
+        "unexpected packages after {} shared requests: {:?}",
+        shared_requests.load(Ordering::Relaxed),
+        graph.packages.keys().collect::<Vec<_>>()
+    );
+    assert!(graph_has_package(&graph, "shared-child", "2.0.0"));
+    assert_eq!(shared_requests.load(Ordering::Relaxed), 3);
+    server.abort();
+}
+
 /// Regression: when both `minimumReleaseAge` and `trustPolicy=NoDowngrade`
 /// are active, the resolver must use a full packument with `time`;
 /// using an abbreviated corgi packument would make the trust check fail

--- a/crates/aube-resolver/src/trust.rs
+++ b/crates/aube-resolver/src/trust.rs
@@ -73,6 +73,30 @@ pub fn evidence_for(meta: &VersionMetadata) -> Option<TrustEvidence> {
     None
 }
 
+fn compact_evidence_for(meta: &aube_registry::VersionTrustMetadata) -> Option<TrustEvidence> {
+    if meta.approver.as_ref().is_some_and(is_approver) {
+        return Some(TrustEvidence::StagedPublish);
+    }
+    if meta
+        .npm_user
+        .as_ref()
+        .and_then(|user| user.trusted_publisher.as_ref())
+        .is_some_and(is_trusted_publisher)
+    {
+        return Some(TrustEvidence::TrustedPublisher);
+    }
+    if meta
+        .dist
+        .as_ref()
+        .and_then(|dist| dist.attestations.as_ref())
+        .and_then(|attestations| attestations.provenance.as_ref())
+        .is_some_and(is_provenance)
+    {
+        return Some(TrustEvidence::Provenance);
+    }
+    None
+}
+
 fn is_approver(v: &serde_json::Value) -> bool {
     match v {
         serde_json::Value::Null => false,
@@ -260,6 +284,98 @@ pub fn check_no_downgrade(
     let current = evidence_for(picked_meta);
     let current_rank = current.map_or(0, TrustEvidence::rank);
     if current_rank < prior.evidence.rank() {
+        return Err(TrustCheckError::Downgrade(TrustDowngradeDetails {
+            name: packument.name.clone(),
+            picked_version: picked_version.to_string(),
+            current_evidence: current,
+            prior_evidence: prior.evidence,
+            prior_version: prior.version,
+        }));
+    }
+    Ok(())
+}
+
+/// Trust-policy check using the compact history fetched for an exact
+/// dependency. The selected release remains full [`VersionMetadata`]; only
+/// historical releases use the evidence-only representation.
+pub fn check_no_downgrade_compact(
+    packument: &Packument,
+    picked_version: &str,
+    picked_meta: &VersionMetadata,
+    history: &std::collections::BTreeMap<String, aube_registry::VersionTrustMetadata>,
+    exclude: &TrustExcludeRules,
+    ignore_after_minutes: Option<u64>,
+) -> Result<(), TrustCheckError> {
+    let picked_parsed = node_semver::Version::parse(picked_version).ok();
+    if let Some(ref version) = picked_parsed {
+        if exclude.matches(&packument.name, version) {
+            return Ok(());
+        }
+    } else if exclude.matches_name_only(&packument.name) {
+        return Ok(());
+    }
+    if packument.time.is_empty() {
+        return Ok(());
+    }
+    let Some(picked_time) = packument.time.get(picked_version) else {
+        return Err(TrustCheckError::MissingTime(MissingTimeDetails {
+            name: packument.name.clone(),
+            version: picked_version.to_string(),
+        }));
+    };
+    if let Some(minutes) = ignore_after_minutes
+        && minutes > 0
+        && let Some(cutoff) = cutoff_iso8601(minutes)
+        && picked_time.as_str() < cutoff.as_str()
+    {
+        return Ok(());
+    }
+
+    let exclude_prereleases = picked_parsed
+        .as_ref()
+        .map(|version| version.pre_release.is_empty())
+        .unwrap_or(false);
+    let mut strongest: Option<PriorTrustEvidence> = None;
+    for (version, meta) in history {
+        if version == picked_version {
+            continue;
+        }
+        let Some(published_at) = packument.time.get(version) else {
+            continue;
+        };
+        if published_at >= picked_time {
+            continue;
+        }
+        if exclude_prereleases
+            && let Ok(parsed) = node_semver::Version::parse(version)
+            && !parsed.pre_release.is_empty()
+        {
+            continue;
+        }
+        let Some(evidence) = compact_evidence_for(meta) else {
+            continue;
+        };
+        if strongest
+            .as_ref()
+            .is_none_or(|current| evidence.rank() > current.evidence.rank())
+        {
+            strongest = Some(PriorTrustEvidence {
+                version: version.clone(),
+                evidence,
+            });
+        }
+        if strongest
+            .as_ref()
+            .is_some_and(|prior| prior.evidence == TrustEvidence::StagedPublish)
+        {
+            break;
+        }
+    }
+    let Some(prior) = strongest else {
+        return Ok(());
+    };
+    let current = evidence_for(picked_meta);
+    if current.map_or(0, TrustEvidence::rank) < prior.evidence.rank() {
         return Err(TrustCheckError::Downgrade(TrustDowngradeDetails {
             name: packument.name.clone(),
             picked_version: picked_version.to_string(),
@@ -872,6 +988,57 @@ mod tests {
             }
             _ => panic!("expected Downgrade"),
         }
+    }
+
+    #[test]
+    fn compact_history_preserves_downgrade_detection() {
+        let p = packument(
+            "foo",
+            vec![("3.0.0", "2025-03-01T00:00:00.000Z", version("foo", "3.0.0"))],
+        );
+        let history = BTreeMap::from([
+            (
+                "2.0.0".to_string(),
+                aube_registry::VersionTrustMetadata {
+                    approver: None,
+                    npm_user: None,
+                    dist: Some(aube_registry::VersionTrustDist {
+                        attestations: Some(Attestations {
+                            provenance: Some(serde_json::json!({
+                                "predicateType": "https://slsa.dev/provenance/v1"
+                            })),
+                        }),
+                    }),
+                },
+            ),
+            (
+                "3.0.0".to_string(),
+                aube_registry::VersionTrustMetadata {
+                    approver: None,
+                    npm_user: None,
+                    dist: None,
+                },
+            ),
+        ]);
+        let mut p = p;
+        p.time
+            .insert("2.0.0".to_string(), "2025-02-01T00:00:00.000Z".to_string());
+        let picked = &p.versions["3.0.0"];
+
+        let err = check_no_downgrade_compact(
+            &p,
+            "3.0.0",
+            picked,
+            &history,
+            &TrustExcludeRules::default(),
+            None,
+        )
+        .expect_err("compact prior provenance must still block a downgrade");
+        let TrustCheckError::Downgrade(details) = err else {
+            panic!("expected Downgrade");
+        };
+        assert_eq!(details.prior_version, "2.0.0");
+        assert_eq!(details.prior_evidence, TrustEvidence::Provenance);
     }
 
     #[test]

--- a/crates/aube-scripts/src/lib.rs
+++ b/crates/aube-scripts/src/lib.rs
@@ -1336,6 +1336,10 @@ pub async fn run_script(
     cmd.current_dir(script_dir)
         .stderr(child_stderr())
         .env("PATH", &new_path)
+        // The lazy node-gyp shim needs the outer project for registry/auth
+        // settings and bootstrap locking. Dependency scripts run from the
+        // virtual store, so falling back to their cwd would lose that context.
+        .env("AUBE_NODE_GYP_PROJECT_DIR", project_root)
         .env("npm_lifecycle_event", script_name);
 
     // Pass INIT_CWD the way npm/pnpm do — the directory the user

--- a/crates/aube-scripts/src/lib.rs
+++ b/crates/aube-scripts/src/lib.rs
@@ -1342,10 +1342,6 @@ pub async fn run_script(
     cmd.current_dir(script_dir)
         .stderr(child_stderr())
         .env("PATH", &new_path)
-        // The lazy node-gyp shim needs the outer project for registry/auth
-        // settings and bootstrap locking. Dependency scripts run from the
-        // virtual store, so falling back to their cwd would lose that context.
-        .env("AUBE_NODE_GYP_PROJECT_DIR", project_root)
         .env("npm_lifecycle_event", script_name);
 
     // Pass INIT_CWD the way npm/pnpm do — the directory the user
@@ -1369,6 +1365,11 @@ pub async fn run_script(
             &jail.env,
         );
         apply_script_settings_env(&mut cmd, settings);
+    } else {
+        // The lazy node-gyp shim needs the outer project for registry/auth
+        // settings and bootstrap locking. The jailed branch restores this in
+        // `apply_jail_env` after clearing the environment.
+        cmd.env("AUBE_NODE_GYP_PROJECT_DIR", project_root);
     }
 
     // npm-compat manifest env, applied last so it survives the jail's

--- a/crates/aube-scripts/src/lib.rs
+++ b/crates/aube-scripts/src/lib.rs
@@ -937,6 +937,12 @@ fn apply_jail_env(
         .env("TMPDIR", home)
         .env("TMP", home)
         .env("TEMP", home)
+        // `run_script` stamps this before entering the jail, but `env_clear`
+        // removes it. Restore the outer project so the lazy node-gyp shim
+        // inherits the right registry/auth and bootstrap-lock context.
+        // `apply_script_settings_env` runs after this and intentionally lets
+        // an embedder's `extra_env` override the default.
+        .env("AUBE_NODE_GYP_PROJECT_DIR", project_root)
         .env("npm_lifecycle_event", script_name);
     if std::env::var_os("INIT_CWD").is_none() {
         cmd.env("INIT_CWD", project_root);
@@ -1700,9 +1706,41 @@ mod jail_tests {
         assert_eq!(env("NODE_OPTIONS"), Some("--conditions=aube"));
         assert_eq!(env("npm_config_unsafe_perm"), Some("false"));
         assert_eq!(env("npm_config_shell_emulator"), Some("true"));
+        assert_eq!(env("AUBE_NODE_GYP_PROJECT_DIR"), Some("/tmp/project"));
         assert_eq!(env("npm_lifecycle_event"), Some("postinstall"));
         assert_eq!(env("npm_package_name"), Some("pkg"));
         assert_eq!(env("npm_package_version"), Some("1.2.3"));
+    }
+
+    #[test]
+    fn embedder_env_overrides_jailed_node_gyp_project_default() {
+        let mut cmd = tokio::process::Command::new("node");
+        let settings = ScriptSettings {
+            extra_env: vec![(
+                "AUBE_NODE_GYP_PROJECT_DIR".into(),
+                "/tmp/embedder-project".into(),
+            )],
+            ..Default::default()
+        };
+
+        apply_jail_env(
+            &mut cmd,
+            std::ffi::OsStr::new("/bin"),
+            Path::new("/tmp/aube-jail/home"),
+            Path::new("/tmp/project"),
+            &PackageJson::default(),
+            "postinstall",
+            &[],
+        );
+        apply_script_settings_env(&mut cmd, &settings);
+
+        let project_dir = cmd
+            .as_std()
+            .get_envs()
+            .find(|(key, _)| *key == std::ffi::OsStr::new("AUBE_NODE_GYP_PROJECT_DIR"))
+            .and_then(|(_, value)| value)
+            .and_then(|value| value.to_str());
+        assert_eq!(project_dir, Some("/tmp/embedder-project"));
     }
 
     fn proxy_env(settings: ScriptSettings) -> impl Fn(&str) -> Option<String> {

--- a/crates/aube/src/commands/install/lifecycle.rs
+++ b/crates/aube/src/commands/install/lifecycle.rs
@@ -582,15 +582,6 @@ pub(crate) async fn run_dep_lifecycle_scripts(
         return Ok(0);
     }
 
-    // Bootstrap node-gyp once before the fan-out when the ambient
-    // `PATH` doesn't already provide one. At least one job is about
-    // to run a lifecycle script, and we can't cheaply predict which
-    // ones will end up shelling out to `node-gyp` (explicit,
-    // implicit via binding.gyp, or transitive via node-gyp-build).
-    // If the user already has node-gyp (system install, nvm, a test
-    // shim), `ensure` returns `None` and we leave their copy alone.
-    let node_gyp_bin_dir = std::sync::Arc::new(node_gyp_bootstrap::ensure(project_dir).await?);
-
     // Pass 2 (parallel, bounded): fan out across `child_concurrency`
     // concurrent workers. Inside one job the three hooks
     // (preinstall → install → postinstall) still run sequentially —
@@ -619,7 +610,6 @@ pub(crate) async fn run_dep_lifecycle_scripts(
         let sem = semaphore.clone();
         let project_dir = project_dir.clone();
         let modules_dir_name = modules_dir_name.clone();
-        let node_gyp_bin_dir = node_gyp_bin_dir.clone();
         let jail_policy = jail_policy.clone();
         let task = crate::dep_chain::scope_current(async move {
             let _permit = sem.acquire().await.unwrap();
@@ -644,8 +634,14 @@ pub(crate) async fn run_dep_lifecycle_scripts(
                     SideEffectsCacheRestore::Miss => {}
                 }
             }
+            // Put a cheap lazy node-gyp shim behind the dep's own `.bin`.
+            // Most lifecycle scripts never invoke node-gyp, so eagerly
+            // installing its dependency tree here adds avoidable network and
+            // linking work. The shim bootstraps on first execution and still
+            // covers indirect calls from JS build helpers.
+            let dep_bin_dir = job.dep_modules_dir.join(".bin");
+            let node_gyp_bin_dir = node_gyp_bootstrap::lazy_shim_bin_dir(&dep_bin_dir)?;
             let tool_dirs: Vec<&std::path::Path> = node_gyp_bin_dir
-                .as_ref()
                 .as_deref()
                 .map(|p| vec![p])
                 .unwrap_or_default();

--- a/crates/aube/src/commands/install/node_gyp_bootstrap.rs
+++ b/crates/aube/src/commands/install/node_gyp_bootstrap.rs
@@ -9,13 +9,11 @@
 //! and npm solve this by bundling node-gyp with themselves; aube (a
 //! Rust binary) bootstraps it lazily on first need.
 //!
-//! User precedence: if `node-gyp` is already resolvable on the
-//! ambient `PATH` (system install, nvm, a shim in a test fixture),
-//! [`ensure`] returns `None` and we stay out of the way — the user's
-//! copy wins. Otherwise node-gyp is installed under
-//! `<cache_dir>/tools/node-gyp/<bucket>/` and the returned `.bin`
-//! dir is prepended to the lifecycle script's `PATH` *after* the
-//! dep's own `.bin`.
+//! User precedence: if `node-gyp` is already resolvable from the
+//! package's own `.bin` or ambient `PATH` (system install, nvm, a shim
+//! in a test fixture), [`lazy_shim_bin_dir`] stays out of the way — the
+//! user's copy wins. Otherwise it prepends a cheap shim that installs
+//! node-gyp under `<cache_dir>/tools/node-gyp/<bucket>/` only if invoked.
 //!
 //! The install runs in-process against a freshly-written
 //! `package.json` that pins node-gyp, via
@@ -79,21 +77,6 @@ fn tool_root() -> miette::Result<PathBuf> {
     let cache = aube_store::dirs::cache_dir()
         .ok_or_else(|| miette!("could not resolve cache dir for node-gyp bootstrap"))?;
     Ok(cache.join("tools").join("node-gyp"))
-}
-
-/// Returns `Some(bin_dir)` containing a freshly-bootstrapped `node-gyp`
-/// when the ambient `PATH` doesn't already provide one, or `None` when
-/// the user already has a copy on `PATH` — in which case we don't
-/// touch their setup.
-///
-/// `project_dir` is the outer install's project root; its `.npmrc`
-/// (if any) is propagated to the tool dir so the bootstrap inherits
-/// the same registry/auth configuration.
-pub async fn ensure(project_dir: &Path) -> miette::Result<Option<PathBuf>> {
-    if node_gyp_on_path() {
-        return Ok(None);
-    }
-    ensure_cached(project_dir).await.map(Some)
 }
 
 pub async fn ensure_cached(project_dir: &Path) -> miette::Result<PathBuf> {

--- a/test/node_gyp_bootstrap.bats
+++ b/test/node_gyp_bootstrap.bats
@@ -73,6 +73,31 @@ JSON
 	assert_file_exists "$XDG_CACHE_HOME/aube/tools/node-gyp/v12/node_modules/.bin/node-gyp"
 }
 
+@test "dep lifecycle does not bootstrap node-gyp unless invoked" {
+	if [ -z "${AUBE_TEST_REGISTRY:-}" ]; then
+		skip "AUBE_TEST_REGISTRY not set (Verdaccio not running)"
+	fi
+	cat >package.json <<'JSON'
+{
+  "name": "node-gyp-lazy-dep-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "aube-test-builds-marker": "^1.0.0"
+  },
+  "pnpm": {
+    "allowBuilds": {
+      "aube-test-builds-marker": true
+    }
+  }
+}
+JSON
+
+	run aube install
+	assert_success
+	assert_file_exists aube-builds-marker.txt
+	assert_dir_not_exists "$XDG_CACHE_HOME/aube/tools/node-gyp/v12"
+}
+
 @test "aube test adds bootstrapped node-gyp to PATH" {
 	# Ported from pnpm/test/install/lifecycleScripts.ts:128
 	# ('node-gyp is in the PATH'). The setup scrubbed ambient node-gyp,

--- a/test/node_gyp_rebuild.bats
+++ b/test/node_gyp_rebuild.bats
@@ -193,8 +193,8 @@ JSON
 
 @test "bootstrap is skipped when node-gyp is already on PATH" {
 	# The shim installed in `setup()` is a `node-gyp` on PATH, so
-	# `node_gyp_bootstrap::ensure()` must return `None` and leave the
-	# cache untouched. If we ever regress to bootstrapping
+	# the lazy bootstrap must stay out of the way and leave the cache
+	# untouched. If we ever regress to bootstrapping
 	# unconditionally this test will start hitting the real npm
 	# registry and fail in the hermetic CI environment.
 	cat >package.json <<'JSON'


### PR DESCRIPTION
## Summary

Fixes the resolver-side memory amplification reproduced in Discussion #1301.

With time-aware resolution enabled, exact optional platform packages were retaining every historical version's full dependency and distribution metadata before aube wrote all platform variants to the lockfile. `opencode-ai@1.18.18` retained 136,110 version records across its 12 platform packages.

This change:

- decodes each exact optional dependency from one full-packument response
- retains the selected version's complete metadata and only publish-time/trust evidence for historical versions
- preserves cross-platform lockfile output, `minimumReleaseAge`, and default trust-downgrade semantics
- falls back to the existing full-packument path for incompatible registries
- defers the bundled `node-gyp` bootstrap until a lifecycle script actually invokes it

## Reproduction

Five cold, isolated global adds of `opencode-ai@1.18.18` for each build, with tool order rotated so every build occupied each run position once. All runs used optimized/published binaries, the same pre-populated local Verdaccio with no uplink, and the repository throttle proxy at 500 Mbit/s with 50ms fixed latency. Each run received a fresh HOME, cache, store, global directory, and project with `minimumReleaseAge=1440` and `trustPolicy=no-downgrade`. Peak RSS was sampled from `/proc` every 5ms.

| build | peak RSS | elapsed |
|---|---:|---:|
| aube `main` (`8cd44019`) | 1,604 MiB (1,055–1,708) | 4.09s (3.98–10.88) |
| aube this PR (`6c5496af`) | 850 MiB (802–988) | 3.28s (2.89–5.20) |
| aube stacked PR #1318 (`194dc820`) | 364 MiB (345–396) | 3.10s (2.65–3.83) |
| pnpm 11.22.0 | 1,725 MiB (1,684–1,787) | 6.66s (6.30–11.01) |
| pnpm 12.0.0-rc.6 | 1,249 MiB (1,115–1,364) | 2.96s (2.74–4.18) |

Against current aube `main`, this PR reduces median peak RSS by 47% and median wall time by 20%. The separate large-entry streaming follow-up in #1318 takes the combined reduction to 77% while also improving wall time by 24%.
Follow-up profiling found a separate deterministic cost: aube eagerly installed its `node-gyp` toolchain before every approved dependency lifecycle, even when the script never invoked it. The bootstrap is now lazy. In five alternating cold pairs against the repository’s local Verdaccio through its shared 500 Mbit/s, 50ms-latency proxy, the pre-change commit measured 6.59s median (6.57–6.67s) and this commit measured 6.07s (6.01–6.31s): 0.52s / 7.9% faster. Median peak RSS was 703 MB before and 727 MB after; that small difference is within the per-run scatter. The phase trace independently shows dependency lifecycle falling from 831ms to 448ms by removing a 416ms nested node-gyp resolve/install.

All four lockfiles contain all 13 platform variants and only materialize the three Linux/x64-applicable packages. Retained platform version records drop from 136,110 to 11,890. The remaining aube peak is later in the fetch phase while the two matching 184 MB Linux binaries are extracted concurrently; the non-host platform histories are no longer retained.

## Validation

- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `mise run test:bats test/node_gyp_bootstrap.bats`
- regression coverage for lazy dependency `node-gyp` bootstrap, one-request selective decoding, compact exact optional history, and compact trust-downgrade detection

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches resolver fetch deduplication, trust-policy checks, and packument cache merging—core dependency resolution paths—with substantial new concurrency edge cases; install script env changes are narrower but affect native builds.
> 
> **Overview**
> **Resolver memory and fetch behavior** for time-aware installs (`minimumReleaseAge`, trust no-downgrade, time-based mode). Exact **optional** dependencies pinned to a semver now use a **single full-packument decode** that keeps full metadata only for the selected version and **trust/publish evidence** for other releases, cutting retained version metadata (e.g. multi-platform optional graphs) without changing lockfile platform coverage or policy semantics.
> 
> The registry client adds **`fetch_exact_version_packument`** and seed-based JSON parsing; the resolver tracks fetches by **`FetchKey`** (full vs exact), merges compact and full results when caches race or go stale, and runs **`check_no_downgrade_compact`** when only compact history is available.
> 
> **Install lifecycle:** **`node-gyp` is no longer bootstrapped before every approved lifecycle**—a per-dep **lazy shim** installs it on first invocation. Jailed scripts restore **`AUBE_NODE_GYP_PROJECT_DIR`** after `env_clear`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de386c8580ed6c0c129c20dcf88db74bcf7d04a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added trust-history awareness to dependency resolution.
  * Exact-version optional dependencies now use compact release metadata while retaining trust evidence.
  * Added protection against selecting releases with downgraded provenance.
  * Added lazy `node-gyp` bootstrapping, installing it only when required by a lifecycle script.
  * Lifecycle scripts now receive the project directory environment variable.

* **Bug Fixes**
  * Improved handling of offline, unavailable, oversized, and authenticated registry responses.
  * Improved release-age and trust checks for optional platform dependencies.

* **Tests**
  * Added coverage for trust history, optional dependencies, provenance checks, and lazy bootstrapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
