### PR TITLE
perf(resolver): cache compact policy histories

### DIFF
--- a/crates/aube-registry/src/client/cache.rs
+++ b/crates/aube-registry/src/client/cache.rs
@@ -1,4 +1,4 @@
-use crate::Packument;
+use crate::{ExactVersionPackument, Packument};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
@@ -26,6 +26,16 @@ pub(super) struct CachedFullPackument {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) max_age_secs: Option<u64>,
     pub(super) packument: serde_json::Value,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct CachedExactVersionPackument {
+    pub(super) etag: Option<String>,
+    pub(super) last_modified: Option<String>,
+    pub(super) fetched_at: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) max_age_secs: Option<u64>,
+    pub(super) packument: ExactVersionPackument,
 }
 
 #[derive(Debug, Default)]
@@ -161,6 +171,36 @@ pub(super) fn packument_full_cache_path(
     let safe_name = aube_store::validate_and_encode_name(name)?;
     let origin = registry_origin_segment(registry_url);
     Some(cache_dir.join(origin).join(format!("{safe_name}.json")))
+}
+
+pub(super) fn exact_version_packument_cache_path(
+    cache_dir: &Path,
+    name: &str,
+    version: &str,
+    registry_url: &str,
+) -> Option<PathBuf> {
+    let safe_name = aube_store::validate_and_encode_name(name)?;
+    let origin = registry_origin_segment(registry_url);
+    let version_digest = blake3::hash(version.as_bytes()).to_hex();
+    Some(cache_dir.join(origin).join(format!(
+        "{safe_name}@{}.json",
+        &version_digest.as_str()[..16]
+    )))
+}
+
+pub(super) fn read_cached_exact_version_packument(
+    path: &Path,
+) -> Option<CachedExactVersionPackument> {
+    let content = std::fs::read(path).ok()?;
+    sonic_rs::from_slice(&content).ok()
+}
+
+pub(super) fn write_cached_exact_version_packument(
+    path: &Path,
+    cached: &CachedExactVersionPackument,
+) -> std::io::Result<()> {
+    let json = sonic_rs::to_vec(cached).map_err(std::io::Error::other)?;
+    aube_util::fs_atomic::atomic_write(path, &json)
 }
 
 pub(super) fn read_cached_full_packument(path: &Path) -> Option<CachedFullPackument> {

--- a/crates/aube-registry/src/client/endpoints.rs
+++ b/crates/aube-registry/src/client/endpoints.rs
@@ -1,5 +1,9 @@
 use super::body::{check_body_cap, read_body_capped};
-use super::cache::packument_full_cache_path;
+use super::cache::{
+    CachedExactVersionPackument, cached_is_fresh, exact_version_packument_cache_path,
+    extract_cache_headers, now_secs, packument_full_cache_path, parse_cache_control_max_age,
+    read_cached_exact_version_packument, write_cached_exact_version_packument,
+};
 use super::{
     AUDIT_BODY_CAP, PACKUMENT_FULL_ACCEPT, RegistryClient, check_dist_tag_status,
     dist_tag_root_url, dist_tag_url, parse_full_response, parse_full_response_seed,
@@ -191,6 +195,94 @@ impl RegistryClient {
             "packument-trust-history",
         )?;
         parse_full_response_seed(resp, crate::ExactVersionPackumentSeed { version }).await
+    }
+
+    /// Fetch one exact release plus compact policy history through a
+    /// disk-backed cache. Entries use the same TTL, registry-origin
+    /// partitioning, and conditional revalidation rules as other packuments.
+    pub async fn fetch_exact_version_packument_cached(
+        &self,
+        name: &str,
+        version: &str,
+        cache_dir: Option<&Path>,
+    ) -> Result<crate::ExactVersionPackument, Error> {
+        let Some(cache_dir) = cache_dir else {
+            return self.fetch_exact_version_packument(name, version).await;
+        };
+        let registry_url = self.registry_url_for(name);
+        let cache_path = exact_version_packument_cache_path(cache_dir, name, version, registry_url)
+            .ok_or_else(|| Error::InvalidName(name.to_string()))?;
+        let mut cached = read_cached_exact_version_packument(&cache_path);
+        if let Some(entry) = cached.take() {
+            if self.force_cache() || cached_is_fresh(entry.fetched_at, entry.max_age_secs) {
+                return Ok(entry.packument);
+            }
+            cached = Some(entry);
+        }
+        if self.network_mode == NetworkMode::Offline {
+            return Err(Error::Offline(format!("trust history for {name}")));
+        }
+
+        let (url, registry_url) = self.packument_url(name);
+        let resp = self
+            .send_metadata_with_retry(&format!("trust history {name}"), || {
+                let mut req = self
+                    .authed_get_for_package(&url, registry_url, name)
+                    .header("Accept", PACKUMENT_FULL_ACCEPT);
+                if let Some(entry) = cached.as_ref() {
+                    if let Some(etag) = entry.etag.as_ref() {
+                        req = req.header("If-None-Match", etag);
+                    }
+                    if let Some(last_modified) = entry.last_modified.as_ref() {
+                        req = req.header("If-Modified-Since", last_modified);
+                    }
+                }
+                req
+            })
+            .await?;
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(Error::NotFound(name.to_string()));
+        }
+        if resp.status() == reqwest::StatusCode::NOT_MODIFIED
+            && let Some(mut entry) = cached
+        {
+            entry.fetched_at = now_secs();
+            entry.max_age_secs = parse_cache_control_max_age(&resp).or(entry.max_age_secs);
+            if let Err(err) = write_cached_exact_version_packument(&cache_path, &entry) {
+                tracing::warn!(
+                    code = aube_codes::warnings::WARN_AUBE_PACKUMENT_CACHE_WRITE,
+                    "failed to write packument cache {}: {err}",
+                    cache_path.display()
+                );
+            }
+            return Ok(entry.packument);
+        }
+
+        let (etag, last_modified) = extract_cache_headers(&resp);
+        let max_age_secs = parse_cache_control_max_age(&resp);
+        let resp = resp.error_for_status()?;
+        check_body_cap(
+            &resp,
+            self.fetch_policy.packument_max_bytes,
+            "packument-trust-history",
+        )?;
+        let packument =
+            parse_full_response_seed(resp, crate::ExactVersionPackumentSeed { version }).await?;
+        let entry = CachedExactVersionPackument {
+            etag,
+            last_modified,
+            fetched_at: now_secs(),
+            max_age_secs,
+            packument,
+        };
+        if let Err(err) = write_cached_exact_version_packument(&cache_path, &entry) {
+            tracing::warn!(
+                code = aube_codes::warnings::WARN_AUBE_PACKUMENT_CACHE_WRITE,
+                "failed to write packument cache {}: {err}",
+                cache_path.display()
+            );
+        }
+        Ok(entry.packument)
     }
 
     /// Fetch the *full* (non-corgi) packument as raw JSON, bypassing the

--- a/crates/aube-registry/src/client/retry_tests.rs
+++ b/crates/aube-registry/src/client/retry_tests.rs
@@ -41,6 +41,94 @@ fn make_packument_json() -> serde_json::Value {
     })
 }
 
+fn make_exact_history_json() -> serde_json::Value {
+    serde_json::json!({
+        "name": "demo",
+        "versions": {
+            "1.0.0": {
+                "name": "demo",
+                "version": "1.0.0",
+                "dist": {
+                    "tarball": "https://registry.example/demo/-/demo-1.0.0.tgz",
+                    "integrity": "sha512-ZGVtbw=="
+                }
+            },
+            "0.9.0": {
+                "name": "demo",
+                "version": "0.9.0",
+                "_npmUser": {"trustedPublisher": {"id": "github"}}
+            }
+        },
+        "time": {
+            "0.9.0": "2024-01-01T00:00:00.000Z",
+            "1.0.0": "2024-02-01T00:00:00.000Z"
+        }
+    })
+}
+
+#[tokio::test]
+async fn exact_policy_history_uses_fresh_disk_cache() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/demo"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("cache-control", "max-age=3600")
+                .set_body_json(make_exact_history_json()),
+        )
+        .mount(&server)
+        .await;
+
+    let client = client_with(&server, FetchPolicy::default());
+    let temp = tempfile::tempdir().unwrap();
+    for _ in 0..2 {
+        let exact = client
+            .fetch_exact_version_packument_cached("demo", "1.0.0", Some(temp.path()))
+            .await
+            .expect("exact history fetch");
+        assert_eq!(exact.metadata.version, "1.0.0");
+        assert_eq!(exact.history.versions.len(), 1);
+    }
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1, "second read should use the disk cache");
+}
+
+#[tokio::test]
+async fn exact_policy_history_revalidates_stale_cache() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/demo"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("cache-control", "max-age=0")
+                .insert_header("etag", "\"history-v1\"")
+                .set_body_json(make_exact_history_json()),
+        )
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/demo"))
+        .and(header("if-none-match", "\"history-v1\""))
+        .respond_with(ResponseTemplate::new(304).insert_header("cache-control", "max-age=3600"))
+        .mount(&server)
+        .await;
+
+    let client = client_with(&server, FetchPolicy::default());
+    let temp = tempfile::tempdir().unwrap();
+    for _ in 0..3 {
+        let exact = client
+            .fetch_exact_version_packument_cached("demo", "1.0.0", Some(temp.path()))
+            .await
+            .expect("exact history fetch");
+        assert_eq!(exact.metadata.version, "1.0.0");
+    }
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 2, "third read should use revalidated cache");
+}
+
 #[tokio::test]
 async fn retries_on_503_then_succeeds() {
     let server = MockServer::start().await;

--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -214,7 +214,7 @@ pub struct Packument {
 /// trust-downgrade policies for an exact version. Deserializing this shape
 /// skips dependency maps and distribution metadata for every historical
 /// release, avoiding the large retained heap of a full [`Packument`].
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PackumentTrustHistory {
     #[serde(default, deserialize_with = "non_string_tolerant_map")]
     pub time: BTreeMap<String, String>,
@@ -226,7 +226,7 @@ pub struct PackumentTrustHistory {
 /// policy checks. The full registry document is decoded in a single pass:
 /// the selected release uses [`VersionMetadata`], while every other release
 /// uses [`VersionTrustMetadata`].
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ExactVersionPackument {
     pub metadata: VersionMetadata,
     pub history: PackumentTrustHistory,
@@ -359,7 +359,7 @@ struct TolerantStringMap(
     #[serde(deserialize_with = "non_string_tolerant_map")] BTreeMap<String, String>,
 );
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct VersionTrustMetadata {
     #[serde(default)]
@@ -370,7 +370,7 @@ pub struct VersionTrustMetadata {
     pub dist: Option<VersionTrustDist>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct VersionTrustDist {
     #[serde(default)]
     pub attestations: Option<Attestations>,

--- a/crates/aube-resolver/src/builder.rs
+++ b/crates/aube-resolver/src/builder.rs
@@ -30,6 +30,7 @@ impl Resolver {
             resolved_tx: None,
             packument_cache_dir: None,
             packument_full_cache_dir: None,
+            packument_policy_cache_dir: None,
             auto_install_peers: true,
             exclude_links_from_lockfile: false,
             supported_architectures: SupportedArchitectures::default(),
@@ -77,6 +78,7 @@ impl Resolver {
                 resolved_tx: Some(tx),
                 packument_cache_dir: None,
                 packument_full_cache_dir: None,
+                packument_policy_cache_dir: None,
                 auto_install_peers: true,
                 exclude_links_from_lockfile: false,
                 supported_architectures: SupportedArchitectures::default(),
@@ -120,6 +122,12 @@ impl Resolver {
     /// `ResolutionMode::TimeBased` so we can read the `time:` map.
     pub fn with_packument_full_cache(mut self, cache_dir: std::path::PathBuf) -> Self {
         self.packument_full_cache_dir = Some(cache_dir);
+        self
+    }
+
+    /// Disk cache for exact releases plus compact publish-time/trust history.
+    pub fn with_packument_policy_cache(mut self, cache_dir: std::path::PathBuf) -> Self {
+        self.packument_policy_cache_dir = Some(cache_dir);
         self
     }
 

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -111,6 +111,9 @@ pub struct Resolver {
     /// map). Defaults to the sibling `packuments-full-v1/` directory
     /// next to `packument_cache_dir`.
     packument_full_cache_dir: Option<std::path::PathBuf>,
+    /// Compact exact-version policy histories, isolated from both corgi and
+    /// complete full-packument cache schemas.
+    packument_policy_cache_dir: Option<std::path::PathBuf>,
     /// When true (pnpm's default), a package's declared `peerDependencies`
     /// are enqueued like regular transitives and — if not already
     /// satisfied by the importer — hoisted to the importer's direct deps.

--- a/crates/aube-resolver/src/resolve/fetch.rs
+++ b/crates/aube-resolver/src/resolve/fetch.rs
@@ -27,6 +27,7 @@ pub(super) struct FetchScheduler {
     client: Arc<RegistryClient>,
     cache_dir: Option<PathBuf>,
     full_cache_dir: Option<PathBuf>,
+    policy_cache_dir: Option<PathBuf>,
     mra_exclude: crate::trust::PackageVersionPolicy,
     force_metadata_primer: bool,
     needs_time: bool,
@@ -52,6 +53,7 @@ impl FetchScheduler {
             client: resolver.client.clone(),
             cache_dir: resolver.packument_cache_dir.clone(),
             full_cache_dir: resolver.packument_full_cache_dir.clone(),
+            policy_cache_dir: resolver.packument_policy_cache_dir.clone(),
             mra_exclude: resolver
                 .minimum_release_age
                 .as_ref()
@@ -88,6 +90,7 @@ impl FetchScheduler {
             client: self.client.clone(),
             cache_dir: self.cache_dir.clone(),
             full_cache_dir: self.full_cache_dir.clone(),
+            policy_cache_dir: self.policy_cache_dir.clone(),
             primer_covers_cutoff,
             force_metadata_primer: self.force_metadata_primer,
             sem: self.sem.clone(),
@@ -118,6 +121,7 @@ impl FetchScheduler {
                 client: self.client.clone(),
                 cache_dir: self.cache_dir.clone(),
                 full_cache_dir: self.full_cache_dir.clone(),
+                policy_cache_dir: self.policy_cache_dir.clone(),
                 primer_covers_cutoff,
                 force_metadata_primer: self.force_metadata_primer,
                 sem: self.sem.clone(),
@@ -156,6 +160,7 @@ struct FetchInputs {
     client: Arc<RegistryClient>,
     cache_dir: Option<PathBuf>,
     full_cache_dir: Option<PathBuf>,
+    policy_cache_dir: Option<PathBuf>,
     /// Precomputed from the resolver's `minimum_release_age` exclude
     /// list and `published_by` cutoff — if false, the primer is
     /// bypassed even when it would otherwise be eligible.
@@ -183,6 +188,7 @@ async fn fetch_one_packument(inputs: FetchInputs) -> Result<FetchResult, Error> 
         client,
         cache_dir,
         full_cache_dir,
+        policy_cache_dir: _,
         primer_covers_cutoff,
         force_metadata_primer,
         sem,
@@ -334,7 +340,7 @@ async fn fetch_exact_optional_packument(
     let name = inputs.name.clone();
     let fetched = inputs
         .client
-        .fetch_exact_version_packument(&name, &version)
+        .fetch_exact_version_packument_cached(&name, &version, inputs.policy_cache_dir.as_deref())
         .await;
     match fetched {
         Ok(exact) => {

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -2725,7 +2725,8 @@ its own name to; this setting takes a complete path instead, so
 
 The global virtual store (`<cacheDir>/virtual-store/`) and cached
 packument metadata (`<cacheDir>/packuments-v1/`,
-`<cacheDir>/packuments-full-v1/`) live under this directory. The
+`<cacheDir>/packuments-full-v1/`, and `<cacheDir>/packuments-policy-v1/`)
+live under this directory. The
 content-addressable store is *not* here — it is `storeDir`, which
 defaults under `$XDG_DATA_HOME` instead. A few smaller caches (the OSV
 advisory mirror, the bootstrapped `node-gyp`, git clones) still follow

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -55,6 +55,7 @@ pub const INDEX_SUBDIR: &str = "index";
 pub const VIRTUAL_STORE_SUBDIR: &str = "virtual-store";
 pub const PACKUMENT_CACHE_SUBDIR: &str = "packuments-v1";
 pub const PACKUMENT_FULL_CACHE_SUBDIR: &str = "packuments-full-v1";
+pub const PACKUMENT_POLICY_CACHE_SUBDIR: &str = "packuments-policy-v1";
 
 /// The global content-addressable store, owned by aube.
 ///
@@ -309,6 +310,13 @@ impl Store {
     /// corgi and full responses have different shapes.
     pub fn packument_full_cache_dir(&self) -> PathBuf {
         self.cache_dir.join(PACKUMENT_FULL_CACHE_SUBDIR)
+    }
+
+    /// Directory for compact publish-time/trust histories used by exact
+    /// optional dependencies. Kept separate because these entries retain one
+    /// exact release plus policy evidence, not a complete packument.
+    pub fn packument_policy_cache_dir(&self) -> PathBuf {
+        self.cache_dir.join(PACKUMENT_POLICY_CACHE_SUBDIR)
     }
 
     /// Check if a file with the given integrity hash exists in the store.

--- a/crates/aube/src/commands/install/settings.rs
+++ b/crates/aube/src/commands/install/settings.rs
@@ -1091,9 +1091,11 @@ pub(crate) fn configure_resolver(
     let cache_dir = crate::commands::resolved_cache_dir_with_ctx(cwd, settings_ctx);
     let mut resolver = resolver
         .with_packument_network_concurrency(packument_concurrency)
-        .with_packument_cache(cache_dir.join("packuments-v1"));
+        .with_packument_cache(cache_dir.join(aube_store::PACKUMENT_CACHE_SUBDIR))
+        .with_packument_policy_cache(cache_dir.join(aube_store::PACKUMENT_POLICY_CACHE_SUBDIR));
     if cache_full_packuments {
-        resolver = resolver.with_packument_full_cache(cache_dir.join("packuments-full-v1"));
+        resolver = resolver
+            .with_packument_full_cache(cache_dir.join(aube_store::PACKUMENT_FULL_CACHE_SUBDIR));
     }
     let mut resolver = resolver
         .with_auto_install_peers(auto_install_peers)

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -2737,7 +2737,8 @@ its own name to; this setting takes a complete path instead, so
 
 The global virtual store (`<cacheDir>/virtual-store/`) and cached
 packument metadata (`<cacheDir>/packuments-v1/`,
-`<cacheDir>/packuments-full-v1/`) live under this directory. The
+`<cacheDir>/packuments-full-v1/`, and `<cacheDir>/packuments-policy-v1/`)
+live under this directory. The
 content-addressable store is *not* here — it is `storeDir`, which
 defaults under `$XDG_DATA_HOME` instead. A few smaller caches (the OSV
 advisory mirror, the bootstrapped `node-gyp`, git clones) still follow
@@ -3197,4 +3198,3 @@ Examples:
 
 - `AUBE_NO_AUTO_INSTALL=1 aube run dev`
 - `echo 'aubeNoAutoInstall=true' >> .npmrc`
-


### PR DESCRIPTION
## Summary

Cache the compact exact-version policy histories introduced by #1315 so subsequent projects do not download and selectively decode the same large platform-package histories again.

The new `packuments-policy-v1` cache:

- is partitioned by registry origin and exact version
- stores only the selected release metadata plus compact publish-time/trust evidence
- follows the existing packument cache's response `max-age` or 30-minute default freshness policy
- conditionally revalidates stale entries with ETag/Last-Modified
- preserves authenticated requests and offline/prefer-offline behavior

Cold first installs are intentionally unchanged.

## Benchmark

Controlled lockfile-only installs into subsequent isolated projects, using the repository's local Verdaccio through the shared 500 Mbit/s, 50ms-latency proxy. Ordinary caches were warmed for both variants; five runs each:

| variant | runs | median |
|---|---|---:|
| #1315 without policy cache | 2.956s, 2.797s, 2.860s, 2.855s, 3.178s | 2.860s |
| this PR | 2.542s, 1.051s, 1.297s, 1.776s, 0.747s | 1.297s |

This is a 54.7% median reduction. The reproduction creates 12 cache entries totaling 26 MB for `opencode-ai@1.18.18`.

## Validation

- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- fresh-cache hit regression test
- stale-cache ETag/304 revalidation regression test

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*
