### PR TITLE
perf(store): stream large tar entries into CAS

### DIFF
--- a/crates/aube-store/src/cas.rs
+++ b/crates/aube-store/src/cas.rs
@@ -466,18 +466,16 @@ impl Store {
         // holding this same shard lock. Hold it through publication and any
         // recovery so a streamed writer cannot unlink an in-progress file.
         #[cfg(target_os = "macos")]
-        let _shard_guard = if self.fast_path.load(Ordering::Acquire) {
-            hex_hash
-                .get(..2)
-                .and_then(|shard| u8::from_str_radix(shard, 16).ok())
-                .map(|shard| {
-                    FAST_PATH_SHARD_LOCKS[shard as usize]
-                        .lock()
-                        .unwrap_or_else(|poisoned| poisoned.into_inner())
-                })
-        } else {
-            None
-        };
+        let _shard_guard = hex_hash
+            .get(..2)
+            .and_then(|shard| u8::from_str_radix(shard, 16).ok())
+            .map(|shard| {
+                FAST_PATH_SHARD_LOCKS[shard as usize]
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+            });
+        #[cfg(target_os = "macos")]
+        let mut recovery_lock = None;
 
         let mut retried_missing_parent = false;
         let mut retried_torn_entry = false;
@@ -500,6 +498,34 @@ impl Store {
                     temp = e.file;
                     if !cas_file_matches_len(&store_path, len) {
                         wait_for_cas_file_len(&store_path, len);
+                    }
+                    // A slow-path process can observe a partial final file
+                    // owned by another process that holds the macOS install
+                    // lock and is writing directly. Wait for that process
+                    // before deciding the entry is torn. The in-process shard
+                    // mutex above separately serializes recovery threads in
+                    // this process.
+                    #[cfg(target_os = "macos")]
+                    if !self.fast_path.load(Ordering::Acquire)
+                        && !cas_file_matches_len(&store_path, len)
+                        && recovery_lock.is_none()
+                    {
+                        let lock_dir = self
+                            .root
+                            .parent()
+                            .map(Path::to_path_buf)
+                            .unwrap_or_else(|| self.root.clone());
+                        std::fs::create_dir_all(&lock_dir)
+                            .map_err(|e| Error::Io(lock_dir.clone(), e))?;
+                        let lock_path = lock_dir.join(".install.lock");
+                        let file = std::fs::OpenOptions::new()
+                            .create(true)
+                            .truncate(false)
+                            .write(true)
+                            .open(&lock_path)
+                            .map_err(|e| Error::Io(lock_path.clone(), e))?;
+                        file.lock().map_err(|e| Error::Io(lock_path.clone(), e))?;
+                        recovery_lock = Some(file);
                     }
                     if cas_file_matches_len(&store_path, len) {
                         break CasWriteOutcome::AlreadyExisted;

--- a/crates/aube-store/src/cas.rs
+++ b/crates/aube-store/src/cas.rs
@@ -437,6 +437,89 @@ impl Store {
         }
     }
 
+    /// Whether tar entries can bypass the in-memory compression gate and
+    /// stream straight into a CAS staging file. Store compression may unwrap
+    /// napi hybrids before hashing, which inherently needs the complete
+    /// entry, so keep that opt-in path on the byte-buffered importer.
+    pub(crate) fn permits_streaming_import(&self) -> bool {
+        store_compression_gate().is_none()
+    }
+
+    /// Publish a tempfile that was written and BLAKE3-hashed while its tar
+    /// entry was decoded. The tempfile lives under the CAS root, so
+    /// `persist_noclobber` is an atomic same-filesystem publish and does not
+    /// copy the entry a second time.
+    pub(crate) fn import_hashed_tempfile(
+        &self,
+        mut temp: tempfile::NamedTempFile,
+        hex_hash: String,
+        len: u64,
+        executable: bool,
+    ) -> Result<StoredFile, Error> {
+        let store_path = self.file_path_from_hex(&hex_hash);
+        let parent = store_path
+            .parent()
+            .ok_or_else(|| Error::Io(store_path.clone(), std::io::ErrorKind::NotFound.into()))?;
+        std::fs::create_dir_all(parent).map_err(|e| Error::Io(parent.to_path_buf(), e))?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            temp.as_file()
+                .set_permissions(std::fs::Permissions::from_mode(0o644))
+                .map_err(|e| Error::Io(store_path.clone(), e))?;
+        }
+
+        let outcome = match temp.persist_noclobber(&store_path) {
+            Ok(_) => CasWriteOutcome::Created,
+            Err(e) if e.error.kind() == std::io::ErrorKind::AlreadyExists => {
+                temp = e.file;
+                if !cas_file_matches_len(&store_path, len) {
+                    wait_for_cas_file_len(&store_path, len);
+                }
+                if cas_file_matches_len(&store_path, len) {
+                    CasWriteOutcome::AlreadyExisted
+                } else {
+                    // Match `import_bytes` recovery for a crashed predecessor:
+                    // retain our complete staging file, remove the torn CAS
+                    // entry, and retry the no-clobber publish once.
+                    let _ = xx::file::remove_file(&store_path);
+                    match temp.persist_noclobber(&store_path) {
+                        Ok(_) => CasWriteOutcome::Created,
+                        Err(e)
+                            if e.error.kind() == std::io::ErrorKind::AlreadyExists
+                                && cas_file_matches_len(&store_path, len) =>
+                        {
+                            CasWriteOutcome::AlreadyExisted
+                        }
+                        Err(e) => return Err(Error::Io(store_path.clone(), e.error)),
+                    }
+                }
+            }
+            Err(e) => return Err(Error::Io(store_path.clone(), e.error)),
+        };
+
+        if aube_util::diag::enabled() {
+            let name = match outcome {
+                CasWriteOutcome::Created => "cas_miss",
+                CasWriteOutcome::AlreadyExisted => "cas_hit",
+            };
+            aube_util::diag::instant_lazy(aube_util::diag::Category::Store, name, || {
+                format!(r#"{{"size":{len}}}"#)
+            });
+        }
+
+        if executable {
+            self.write_exec_marker(&store_path)?;
+        }
+        Ok(StoredFile {
+            hex_hash,
+            store_path,
+            executable,
+            size: Some(len),
+        })
+    }
+
     /// Import a single file's content into the store. Returns the stored file info.
     ///
     /// Hot path on cold installs: callers should invoke

--- a/crates/aube-store/src/cas.rs
+++ b/crates/aube-store/src/cas.rs
@@ -85,7 +85,7 @@ fn wait_for_cas_file_len(path: &Path, expected_len: u64) {
 ///
 /// A malformed size predicate disables compression (returns `None`)
 /// rather than silently widening the gate; the addon still lands plain.
-fn store_compression_gate() -> Option<&'static Gate> {
+pub(crate) fn store_compression_gate() -> Option<&'static Gate> {
     static GATE: std::sync::OnceLock<Option<Gate>> = std::sync::OnceLock::new();
     GATE.get_or_init(|| {
         let raw = aube_util::env::embedder_env("COMPRESS_STORE")?;
@@ -437,14 +437,6 @@ impl Store {
         }
     }
 
-    /// Whether tar entries can bypass the in-memory compression gate and
-    /// stream straight into a CAS staging file. Store compression may unwrap
-    /// napi hybrids before hashing, which inherently needs the complete
-    /// entry, so keep that opt-in path on the byte-buffered importer.
-    pub(crate) fn permits_streaming_import(&self) -> bool {
-        store_compression_gate().is_none()
-    }
-
     /// Publish a tempfile that was written and BLAKE3-hashed while its tar
     /// entry was decoded. The tempfile lives under the CAS root, so
     /// `persist_noclobber` is an atomic same-filesystem publish and does not
@@ -474,6 +466,23 @@ impl Store {
             Ok(_) => CasWriteOutcome::Created,
             Err(e) if e.error.kind() == std::io::ErrorKind::AlreadyExists => {
                 temp = e.file;
+                // The macOS byte importer publishes directly into the final
+                // path while holding this same shard lock. Wait for that
+                // writer before deciding an existing entry is torn; otherwise
+                // streamed publication could unlink its in-progress file.
+                #[cfg(target_os = "macos")]
+                let _shard_guard = if self.fast_path.load(Ordering::Acquire) {
+                    hex_hash
+                        .get(..2)
+                        .and_then(|shard| u8::from_str_radix(shard, 16).ok())
+                        .map(|shard| {
+                            FAST_PATH_SHARD_LOCKS[shard as usize]
+                                .lock()
+                                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                        })
+                } else {
+                    None
+                };
                 if !cas_file_matches_len(&store_path, len) {
                     wait_for_cas_file_len(&store_path, len);
                 }

--- a/crates/aube-store/src/cas.rs
+++ b/crates/aube-store/src/cas.rs
@@ -462,50 +462,59 @@ impl Store {
                 .map_err(|e| Error::Io(store_path.clone(), e))?;
         }
 
-        let outcome = match temp.persist_noclobber(&store_path) {
-            Ok(_) => CasWriteOutcome::Created,
-            Err(e) if e.error.kind() == std::io::ErrorKind::AlreadyExists => {
-                temp = e.file;
-                // The macOS byte importer publishes directly into the final
-                // path while holding this same shard lock. Wait for that
-                // writer before deciding an existing entry is torn; otherwise
-                // streamed publication could unlink its in-progress file.
-                #[cfg(target_os = "macos")]
-                let _shard_guard = if self.fast_path.load(Ordering::Acquire) {
-                    hex_hash
-                        .get(..2)
-                        .and_then(|shard| u8::from_str_radix(shard, 16).ok())
-                        .map(|shard| {
-                            FAST_PATH_SHARD_LOCKS[shard as usize]
-                                .lock()
-                                .unwrap_or_else(|poisoned| poisoned.into_inner())
-                        })
-                } else {
-                    None
-                };
-                if !cas_file_matches_len(&store_path, len) {
-                    wait_for_cas_file_len(&store_path, len);
+        // The macOS byte importer publishes directly into the final path while
+        // holding this same shard lock. Hold it through publication and any
+        // recovery so a streamed writer cannot unlink an in-progress file.
+        #[cfg(target_os = "macos")]
+        let _shard_guard = if self.fast_path.load(Ordering::Acquire) {
+            hex_hash
+                .get(..2)
+                .and_then(|shard| u8::from_str_radix(shard, 16).ok())
+                .map(|shard| {
+                    FAST_PATH_SHARD_LOCKS[shard as usize]
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner())
+                })
+        } else {
+            None
+        };
+
+        let mut retried_missing_parent = false;
+        let mut retried_torn_entry = false;
+        let outcome = loop {
+            match temp.persist_noclobber(&store_path) {
+                Ok(_) => break CasWriteOutcome::Created,
+                Err(e) if e.error.kind() == std::io::ErrorKind::NotFound => {
+                    temp = e.file;
+                    if retried_missing_parent {
+                        return Err(Error::Io(store_path.clone(), e.error));
+                    }
+                    // A concurrent prune may remove the shard after the
+                    // initial create. Match the buffered importer by
+                    // recreating it and retrying publication once.
+                    std::fs::create_dir_all(parent)
+                        .map_err(|e| Error::Io(parent.to_path_buf(), e))?;
+                    retried_missing_parent = true;
                 }
-                if cas_file_matches_len(&store_path, len) {
-                    CasWriteOutcome::AlreadyExisted
-                } else {
-                    // Match `import_bytes` recovery for a crashed predecessor:
-                    // retain our complete staging file, remove the torn CAS
-                    // entry, and retry the no-clobber publish once.
-                    let _ = xx::file::remove_file(&store_path);
-                    match temp.persist_noclobber(&store_path) {
-                        Ok(_) => CasWriteOutcome::Created,
-                        Err(e)
-                            if e.error.kind() == std::io::ErrorKind::AlreadyExists
-                                && cas_file_matches_len(&store_path, len) =>
-                        {
-                            CasWriteOutcome::AlreadyExisted
-                        }
-                        Err(e) => return Err(Error::Io(store_path.clone(), e.error)),
+                Err(e) if e.error.kind() == std::io::ErrorKind::AlreadyExists => {
+                    temp = e.file;
+                    if !cas_file_matches_len(&store_path, len) {
+                        wait_for_cas_file_len(&store_path, len);
+                    }
+                    if cas_file_matches_len(&store_path, len) {
+                        break CasWriteOutcome::AlreadyExisted;
+                    } else if retried_torn_entry {
+                        return Err(Error::Io(store_path.clone(), e.error));
+                    } else {
+                        // Match `import_bytes` recovery for a crashed predecessor:
+                        // retain our complete staging file, remove the torn CAS
+                        // entry, and retry the no-clobber publish once.
+                        let _ = xx::file::remove_file(&store_path);
+                        retried_torn_entry = true;
                     }
                 }
+                Err(e) => return Err(Error::Io(store_path.clone(), e.error)),
             }
-            Err(e) => return Err(Error::Io(store_path.clone(), e.error)),
         };
 
         if aube_util::diag::enabled() {

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -1885,6 +1885,31 @@ mod tests {
         assert!(index.contains_key("index.js"));
     }
 
+    #[test]
+    fn test_import_tarball_streams_large_entry_into_cas() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("files"));
+        store.ensure_shards_exist().unwrap();
+        let content: Vec<u8> = (0..(256 << 10)).map(|i| (i % 251) as u8).collect();
+        let tarball = build_tarball("package/bin/native", &content);
+
+        let index = store.import_tarball(&tarball).unwrap();
+        let stored = &index["bin/native"];
+
+        assert_eq!(stored.hex_hash, blake3_hex(&content));
+        assert_eq!(stored.size, Some(content.len() as u64));
+        assert_eq!(std::fs::read(&stored.store_path).unwrap(), content);
+        assert!(
+            std::fs::read_dir(dir.path().join("files"))
+                .unwrap()
+                .all(|entry| !entry
+                    .unwrap()
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with(".aube-stream-"))
+        );
+    }
+
     #[cfg(not(windows))]
     #[test]
     fn test_import_tarball_accepts_posix_colon_filename() {

--- a/crates/aube-store/src/tarball.rs
+++ b/crates/aube-store/src/tarball.rs
@@ -414,7 +414,12 @@ impl Store {
             let mode = entry.header().mode().unwrap_or(0o644);
             let executable = mode & 0o111 != 0;
 
-            if declared >= LARGE_ENTRY_STREAM_THRESHOLD && self.permits_streaming_import() {
+            // Store compression may unwrap napi hybrids before hashing, which
+            // inherently needs the complete entry. Keep that opt-in path on
+            // the byte-buffered importer.
+            if declared >= LARGE_ENTRY_STREAM_THRESHOLD
+                && crate::cas::store_compression_gate().is_none()
+            {
                 // Keep small files on the staged/rayon path, but never retain
                 // an existing chunk while decoding a large entry. Large files
                 // are written once into a same-filesystem CAS tempfile and

--- a/crates/aube-store/src/tarball.rs
+++ b/crates/aube-store/src/tarball.rs
@@ -249,7 +249,7 @@ impl Store {
         &self,
         compressed_reader: R,
     ) -> Result<PackageIndex, Error> {
-        use std::io::Read;
+        use std::io::{Read, Write};
 
         let _diag =
             aube_util::diag::Span::new(aube_util::diag::Category::Store, "import_tarball_reader");
@@ -411,6 +411,54 @@ impl Store {
                 continue;
             };
 
+            let mode = entry.header().mode().unwrap_or(0o644);
+            let executable = mode & 0o111 != 0;
+
+            if declared >= LARGE_ENTRY_STREAM_THRESHOLD && self.permits_streaming_import() {
+                // Keep small files on the staged/rayon path, but never retain
+                // an existing chunk while decoding a large entry. Large files
+                // are written once into a same-filesystem CAS tempfile and
+                // hashed during decompression, then atomically published.
+                if !staged.is_empty() {
+                    let chunk = std::mem::take(&mut staged);
+                    flush_chunk(chunk, &mut index, &mut cas_ns)?;
+                }
+
+                std::fs::create_dir_all(&self.root).map_err(|e| Error::Io(self.root.clone(), e))?;
+                let mut temp = tempfile::Builder::new()
+                    .prefix(".aube-stream-")
+                    .tempfile_in(&self.root)
+                    .map_err(|e| Error::Io(self.root.clone(), e))?;
+                let mut hasher = blake3::Hasher::new();
+                let mut limited = (&mut entry).take(MAX_TARBALL_ENTRY_BYTES);
+                let mut buffer = [0u8; STREAM_COPY_BUFFER_SIZE];
+                let read_t0 = std::time::Instant::now();
+                let mut actual_len = 0u64;
+                loop {
+                    let n = limited
+                        .read(&mut buffer)
+                        .map_err(|e| Error::Tar(e.to_string()))?;
+                    if n == 0 {
+                        break;
+                    }
+                    temp.write_all(&buffer[..n])
+                        .map_err(|e| Error::Io(self.root.clone(), e))?;
+                    hasher.update(&buffer[..n]);
+                    actual_len = actual_len.saturating_add(n as u64);
+                }
+                decode_ns += read_t0.elapsed().as_nanos();
+
+                let hex_hash = hasher.finalize().to_hex().to_string();
+                let cas_t0 = std::time::Instant::now();
+                let stored = self.import_hashed_tempfile(temp, hex_hash, actual_len, executable)?;
+                cas_ns += cas_t0.elapsed().as_nanos();
+                total_uncompressed = total_uncompressed.saturating_add(actual_len);
+                max_entry_bytes = max_entry_bytes.max(actual_len);
+                staged_count += 1;
+                index.insert(rel_path, stored);
+                continue;
+            }
+
             // Clamp upfront alloc so a lying header can't force a 512
             // MiB reservation before any byte has been read. read_to_end
             // grows the Vec for the rare entry that really is huge.
@@ -432,8 +480,6 @@ impl Store {
                 )));
             }
 
-            let mode = entry.header().mode().unwrap_or(0o644);
-            let executable = mode & 0o111 != 0;
             total_uncompressed = total_uncompressed.saturating_add(content.len() as u64);
             max_entry_bytes = max_entry_bytes.max(content.len() as u64);
             staged.push((rel_path, content, executable));
@@ -688,6 +734,16 @@ fn is_windows_reserved_name(name: &str) -> bool {
 /// header size, which an attacker controls. `read_to_end` grows
 /// past this ceiling when a legitimate larger file warrants it.
 const VEC_PREALLOC_CEILING: usize = 64 * 1024;
+
+/// Entries at least this large stream through a CAS tempfile instead of
+/// occupying a full growable `Vec`. Eight MiB keeps the hot path for normal
+/// npm files while bounding concurrent native-binary extraction memory.
+#[cfg(not(test))]
+const LARGE_ENTRY_STREAM_THRESHOLD: u64 = 8 << 20;
+#[cfg(test)]
+const LARGE_ENTRY_STREAM_THRESHOLD: u64 = 128 << 10;
+
+const STREAM_COPY_BUFFER_SIZE: usize = 256 * 1024;
 
 /// A `Read` wrapper that refuses to deliver more than `remaining`
 /// bytes. Unlike `std::io::Read::take`, exhaustion produces an

--- a/crates/aube/src/commands/store.rs
+++ b/crates/aube/src/commands/store.rs
@@ -288,6 +288,25 @@ fn prune(args: PruneArgs) -> miette::Result<()> {
     let mut removed_files = 0u64;
     let mut removed_bytes = 0u64;
 
+    // NamedTempFile removes these on every normal exit, but SIGKILL or a
+    // machine crash can strand a large streamed tar entry at the CAS root.
+    // They are never referenced by an index and are safe prune candidates.
+    for entry in std::fs::read_dir(&root).into_diagnostic()?.flatten() {
+        let path = entry.path();
+        let is_stream_temp = entry
+            .file_name()
+            .to_str()
+            .is_some_and(|name| name.starts_with(".aube-stream-"));
+        if !is_stream_temp || !path.is_file() {
+            continue;
+        }
+        let len = entry.metadata().map(|metadata| metadata.len()).unwrap_or(0);
+        if args.dry_run || std::fs::remove_file(&path).is_ok() {
+            removed_files += 1;
+            removed_bytes += len;
+        }
+    }
+
     // Walk every 2-char shard directory. Store layout is
     // <root>/<shard>/<rest-of-hash>[-exec].
     for shard in std::fs::read_dir(&root).into_diagnostic()?.flatten() {

--- a/test/store.bats
+++ b/test/store.bats
@@ -196,6 +196,23 @@ EOF
 	refute_output --partial "Pruned 0 files"
 }
 
+@test "aube store prune removes orphaned streamed-entry tempfiles" {
+	store_v1="$(aube store path)"
+	mkdir -p "$store_v1/files"
+	stream_temp="$store_v1/files/.aube-stream-orphan"
+	dd if=/dev/zero of="$stream_temp" bs=1024 count=4 2>/dev/null
+
+	run aube store prune --dry-run
+	assert_success
+	assert_file_exists "$stream_temp"
+	assert_output --partial "Would prune 1 file"
+
+	run aube store prune
+	assert_success
+	assert_file_not_exists "$stream_temp"
+	assert_output --partial "Pruned 1 file"
+}
+
 @test "aube store prune removes entries from deleted registered projects" {
 	mkdir project
 	cat >project/package.json <<'JSON'


### PR DESCRIPTION
## Summary

Stacked on #1315.

Large regular tar entries now stream into a same-filesystem CAS tempfile once they reach 8 MiB. Aube hashes each entry while decompressing it, then atomically publishes the tempfile at the content-addressed path. Small entries retain the staged/rayon importer, and opt-in store compression retains the buffered path because napi hybrid unwrapping requires complete bytes.

## Root cause

The HTTP and gzip layers already streamed, but the tar importer used `read_to_end` for every individual entry. Two concurrent ~184 MiB opencode binaries therefore occupied hundreds of MiB each after `Vec` growth and allocator retention.

## Benchmark

Five cold, isolated global adds of `opencode-ai@1.18.18` for each build, with tool order rotated so every build occupied each run position once. All runs used optimized/published binaries, the same pre-populated local Verdaccio with no uplink, and the repository throttle proxy at 500 Mbit/s with 50ms fixed latency. Each run received a fresh HOME, cache, store, global directory, and project with `minimumReleaseAge=1440` and `trustPolicy=no-downgrade`. Peak RSS was sampled from `/proc` every 5ms.

| build | peak RSS | elapsed |
|---|---:|---:|
| aube `main` (`8cd44019`) | 1,604 MiB (1,055–1,708) | 4.09s (3.98–10.88) |
| aube PR #1315 (`6c5496af`) | 850 MiB (802–988) | 3.28s (2.89–5.20) |
| aube this PR (`194dc820`) | 364 MiB (345–396) | 3.10s (2.65–3.83) |
| pnpm 11.22.0 | 1,725 MiB (1,684–1,787) | 6.66s (6.30–11.01) |
| pnpm 12.0.0-rc.6 | 1,249 MiB (1,115–1,364) | 2.96s (2.74–4.18) |

Against its #1315 parent, this PR reduces median peak RSS by 57% and median wall time by 5%. Against current `main`, it reduces median peak RSS by 77% and wall time by 24%. It uses 79% less memory than pnpm 11 and 71% less than pnpm 12 RC. pnpm 12 RC was 0.15s faster on median, but the ranges overlap substantially.

## Validation

- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- regression coverage verifies streamed content, hash, size, CAS placement, and staging-file cleanup

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the hot tarball→CAS path and adds concurrent publish logic on macOS; behavior is aligned with existing `import_bytes` recovery, but mistakes could corrupt or mis-dedupe CAS entries.
> 
> **Overview**
> **Large tarball entries** (≥8 MiB when store compression is off) no longer use `read_to_end` into a `Vec`. They flush any pending staged chunk, copy through a 256 KiB buffer into a `.aube-stream-*` tempfile under the CAS root while BLAKE3-hashing, then publish via new **`import_hashed_tempfile`** (atomic `persist_noclobber`, same torn-entry / missing-shard retries as buffered imports, macOS shard locking and install-lock wait). Entries at or above the threshold still use the staged/rayon path when **`AUBE_COMPRESS_STORE`** is enabled, because hybrid unwrapping needs full bytes.
> 
> **`store prune`** now deletes orphaned `.aube-stream-*` files at the CAS root (crash/SIGKILL leftovers). **`store_compression_gate`** is `pub(crate)` so the tarball path can gate streaming. Tests cover streamed import and prune behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef332d2dc847b67fd2a7808c40a35350e94dccb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

