### PR TITLE
fix(resolver): allow deep peer-context chains to converge

### DIFF
--- a/crates/aube-resolver/src/peer_context.rs
+++ b/crates/aube-resolver/src/peer_context.rs
@@ -296,7 +296,9 @@ pub fn hoist_auto_installed_peers(mut graph: LockfileGraph) -> LockfileGraph {
 /// contextualized tails in every `pkg.dependencies` map, so when a
 /// descendant looks a peer up in ancestor scope it sees the full
 /// nested tail and serializes it as such. Most peer chains converge in
-/// 2–3 iterations; we cap at 16 as a safety belt.
+/// 2–3 iterations. The safety limit scales with the number of peer-bearing
+/// packages so deeper finite chains can converge, with a hard ceiling to
+/// bound work for pathological graphs.
 ///
 /// Limitations (documented as follow-ups in the README):
 ///   - No per-peer range satisfaction — we take whatever the ancestor has,
@@ -361,7 +363,20 @@ pub fn apply_peer_contexts(
     canonical: LockfileGraph,
     options: &PeerContextOptions,
 ) -> Result<LockfileGraph, crate::Error> {
-    const MAX_ITERATIONS: usize = 16;
+    const MIN_ITERATIONS: usize = 16;
+    const MAX_ITERATIONS: usize = 256;
+    // Each pass can propagate one more nested peer suffix through a chain.
+    // Allow one pass per peer-bearing package plus a final unchanged pass to
+    // confirm convergence. Keep the legacy 16-pass floor for small cyclic
+    // graphs, while retaining a hard ceiling for adversarial input.
+    let peer_package_count = canonical
+        .packages
+        .values()
+        .filter(|pkg| !pkg.peer_dependencies.is_empty())
+        .count();
+    let iteration_limit = peer_package_count
+        .saturating_add(1)
+        .clamp(MIN_ITERATIONS, MAX_ITERATIONS);
     let mut current = canonical;
     let mut converged = false;
     // Hash both keys and dependency tails. A peer-context iteration can
@@ -384,12 +399,12 @@ pub fn apply_peer_contexts(
         aube_util::hash::ordered_seq_hash(tokens.iter().copied())
     };
     // Carry the post-iteration hash forward as the next iteration's
-    // pre-hash. Saves one full graph walk per iteration (the loop runs
-    // up to 16 times; each `graph_hash` allocates a Vec<&str> sized
+    // pre-hash. Saves one full graph walk per iteration (each `graph_hash`
+    // allocates a Vec<&str> sized
     // to `pkgs * 3 + deps * 2` tokens — ~25k entries on a 1000-pkg
     // graph). One hash per iter instead of two.
     let mut before = graph_hash(&current);
-    for i in 0..MAX_ITERATIONS {
+    for i in 0..iteration_limit {
         let after_once = apply_peer_contexts_once(current, options);
         let next = if options.dedupe_peer_dependents {
             dedupe_peer_variants(after_once)
@@ -411,10 +426,10 @@ pub fn apply_peer_contexts(
         // broken node_modules. Now fatal.
         tracing::error!(
             code = aube_codes::errors::ERR_AUBE_PEER_CONTEXT_NOT_CONVERGED,
-            max_iterations = MAX_ITERATIONS,
-            "peer-context hit MAX_ITERATIONS={MAX_ITERATIONS} without convergence"
+            max_iterations = iteration_limit,
+            "peer-context hit iteration limit={iteration_limit} without convergence"
         );
-        return Err(crate::Error::PeerContextDivergence(MAX_ITERATIONS));
+        return Err(crate::Error::PeerContextDivergence(iteration_limit));
     }
     // Propagate each package's peer-suffix segments up through its
     // non-peer-declaring ancestors so a parent that pulls in a peer-

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -2805,6 +2805,61 @@ fn dedupe_peers_cycle_break_still_converges() {
     }
 }
 
+#[test]
+fn peer_chain_deeper_than_legacy_limit_converges() {
+    const CHAIN_LEN: usize = 20;
+    let package_name = |index: usize| format!("package-{index:02}");
+    let mut packages = BTreeMap::new();
+
+    for index in 0..CHAIN_LEN {
+        let name = package_name(index);
+        let next = (index + 1 < CHAIN_LEN).then(|| package_name(index + 1));
+        let dependencies = next
+            .as_deref()
+            .map(|next| vec![(next, "1.0.0")])
+            .unwrap_or_default();
+        let peer_dependencies = next
+            .as_deref()
+            .map(|next| vec![(next, "^1")])
+            .unwrap_or_default();
+        packages.insert(
+            format!("{name}@1.0.0"),
+            mk_locked(&name, "1.0.0", &dependencies, &peer_dependencies),
+        );
+    }
+
+    let root_name = package_name(0);
+    let mut importers = BTreeMap::new();
+    importers.insert(
+        ".".to_string(),
+        vec![DirectDep {
+            name: root_name.clone(),
+            dep_path: format!("{root_name}@1.0.0"),
+            dep_type: DepType::Production,
+            specifier: Some("^1".to_string()),
+        }],
+    );
+
+    let graph = LockfileGraph {
+        importers,
+        packages,
+        ..Default::default()
+    };
+    let out = apply_peer_contexts(graph, &PeerContextOptions::default())
+        .expect("peer chains deeper than 16 packages should converge");
+
+    for package in out.packages.values() {
+        for (child_name, child_tail) in &package.dependencies {
+            let child_key = format!("{child_name}@{child_tail}");
+            assert!(
+                out.packages.contains_key(&child_key),
+                "dangling dep_path {child_key} referenced from {}",
+                package.dep_path
+            );
+        }
+    }
+}
+
 // Regression: under `dedupe-peers=true`, a package whose canonical
 // version coincidentally matches a nested peer's version in an
 // unrelated subtree must NOT collide. Cycle detection runs against


### PR DESCRIPTION
## Summary

- scale the peer-context fixed-point limit with the number of peer-bearing packages
- retain the existing 16-pass floor and add a 256-pass hard ceiling for pathological graphs
- add a regression test covering a 20-package nested peer chain

## Root cause

The fixed-point pass propagated one nested peer suffix per iteration but always stopped after 16 iterations. `@deepseek-ai/dsh@0.1.0-rc.6` contains a peer chain that requires 18 passes, so resolution failed with `ERR_AUBE_PEER_CONTEXT_NOT_CONVERGED` even though the finite graph would converge.

Fixes the aube failure reported in [mise discussion #12085](https://github.com/jdx/mise/discussions/12085).

## Validation

- `cargo test -p aube-resolver`
- `cargo clippy -p aube-resolver --all-targets -- -D warnings`
- `cargo fmt --check`
- reproduced the original package with `target/debug/aube install --dir /tmp/aube-dsh-pr-repro --dry-run --verbose`; 582 packages resolved and peer contexts converged after 18 iterations

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches resolver peer-context convergence bounds; wrong limits could still fail installs or allow excessive work on pathological graphs, but behavior for shallow graphs stays at the 16-iteration floor.
> 
> **Overview**
> Fixes **`ERR_AUBE_PEER_CONTEXT_NOT_CONVERGED`** when nested peer suffixes need more than 16 fixed-point passes (e.g. `@deepseek-ai/dsh` needing ~18).
> 
> **`apply_peer_contexts`** no longer stops after a hard **16** iterations. The loop limit is **`peer_package_count + 1`**, clamped between **16** (unchanged floor for small/cyclic graphs) and **256** (ceiling). Convergence detection and **`PeerContextDivergence`** errors now report this computed limit instead of the old constant.
> 
> Adds **`peer_chain_deeper_than_legacy_limit_converges`**, a **20**-package linear peer chain regression test that would have failed under the fixed cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 653ede3dfbcfc49fd966236abc6ca4108c973236. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency resolution for larger peer-dependency chains.
  * Prevented dangling dependency references after peer-context processing.
  * Added clearer reporting when resolution does not converge.

* **Tests**
  * Added regression coverage for dependency chains exceeding 16 packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->