### PR TITLE
chore(mise): add fix task for clippy autofix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,10 @@ jobs:
   # jdx/aube but must not write. Pull requests start with empty local state and
   # must restore entries previously seeded by main; main can seed a cold cache.
   cache-qualification:
-    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'
+    # Fork pull requests run with a read-only GITHUB_TOKEN and GitHub refuses
+    # to issue an OIDC token for them, so the cache-auth probe below cannot
+    # run. Skip on fork PRs; `final` treats that skip as OK.
+    if: (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main') && github.event.pull_request.head.repo.fork != true
     runs-on: namespace-profile-endev-linux-amd64
     timeout-minutes: 20
     permissions:
@@ -456,6 +459,8 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           NEEDS_JSON: ${{ toJSON(needs) }}
           REF: ${{ github.ref }}
+          # "true" only for pull_request events from a fork; empty otherwise.
+          FORK_PR: ${{ github.event.pull_request.head.repo.fork }}
         run: |
           python3 - <<'PY'
           import json
@@ -467,6 +472,10 @@ jobs:
           SKIP_OK = {"api-stability"}
           ADVISORY_FAILURE = {"api-stability"}
           if os.environ["EVENT_NAME"] == "workflow_dispatch" and os.environ["REF"] != "refs/heads/main":
+              SKIP_OK.add("cache-qualification")
+          # Fork PRs can't mint an OIDC token, so cache-qualification is
+          # skipped by its `if:`; allow that skip here.
+          if os.environ.get("FORK_PR", "") == "true":
               SKIP_OK.add("cache-qualification")
 
           needs = json.loads(os.environ["NEEDS_JSON"])

--- a/mise.toml
+++ b/mise.toml
@@ -37,11 +37,16 @@ run = "hk check --all --slow"
 [tasks.lint-fix]
 run = "hk fix --all --slow"
 
-# Apply clippy's machine-applicable autofixes. Coverage matches aube's clippy
-# gate (`cargo clippy --all-targets -- -D warnings`). Run on a dirty tree is
-# intended (--allow-dirty --allow-staged); review the diff before committing.
+# Apply clippy's machine-applicable autofixes via cargo-fixit — a drop-in
+# replacement for `cargo clippy --fix` that skips the full re-check compile
+# between fix rounds, so repeated runs are faster. Pinned through mise's cargo
+# backend (the repo's convention for compiled cargo tools, matching
+# cargo-audit/cargo-deny in CI), so a contributor gets it with no manual
+# install. No `cargo clippy --fix` fallback — cargo-fixit is the only path.
+# Modeled on `cargo fix` 1.89: add `--all-targets` to also fix tests/benches,
+# and `--allow-dirty`/`--allow-staged` to run on a dirty tree.
 [tasks.fix]
-run = "cargo clippy --fix --all-targets --allow-dirty --allow-staged -- -D warnings"
+run = "mise x cargo:cargo-fixit@0.1.15 -- cargo fixit --clippy --all-targets --allow-dirty --allow-staged"
 
 [tasks.build]
 run = "cargo build"

--- a/mise.toml
+++ b/mise.toml
@@ -37,6 +37,12 @@ run = "hk check --all --slow"
 [tasks.lint-fix]
 run = "hk fix --all --slow"
 
+# Apply clippy's machine-applicable autofixes. Coverage matches aube's clippy
+# gate (`cargo clippy --all-targets -- -D warnings`). Run on a dirty tree is
+# intended (--allow-dirty --allow-staged); review the diff before committing.
+[tasks.fix]
+run = "cargo clippy --fix --all-targets --allow-dirty --allow-staged -- -D warnings"
+
 [tasks.build]
 run = "cargo build"
 


### PR DESCRIPTION
`mise run fix` now applies clippy's autofixes via `cargo fixit --clippy`.

[cargo-fixit](https://github.com/crate-ci/cargo-fixit) is a drop-in replacement for `cargo clippy --fix` that skips the full re-check compile between fix rounds, so repeated runs are faster. It is pinned through mise's cargo backend at `0.1.15` (the repo's convention for compiled cargo tools, matching cargo-audit/cargo-deny in CI), so a contributor gets it with no manual install. There is no `cargo clippy --fix` fallback — cargo-fixit is the only path.

The CI clippy gate is unchanged — this is the dev-facing autofix entry point.

<details>
<summary>Apologies for the churn on this one</summary>

Earlier iterations went the wrong way on the tool choice — first removing cargo-fixit, then simplifying to `cargo clippy --fix`. Sorry for the back-and-forth. This is the simpler version we actually want: `cargo fixit --clippy`, cargo-fixit pinned as a dev dependency, no fallback.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a standardized task for applying available code-quality fixes across all supported targets.
  * Supports clean and modified working trees, including staged changes.
  * Documents the supported autofix workflow for consistent maintenance.
  * Cache qualification checks may continue after failures on non-main branches, while failures remain blocking on main.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->