### PR TITLE
feat(resolver): skip lockfile reuse for extension-targeted packages on drift

### DIFF
--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -25,7 +25,8 @@ use crate::local_source::{
 };
 use crate::locked_index::LockedIndex;
 use crate::package_ext::{
-    apply_package_extensions, apply_package_extensions_to_deps, pick_override_spec,
+    apply_package_extensions, apply_package_extensions_to_deps, package_selector_matches,
+    pick_override_spec,
 };
 use crate::semver_util::{PickResult, pick_version, version_satisfies};
 use crate::{
@@ -2055,6 +2056,28 @@ impl<'a> ResolveDriver<'a> {
         }
         let version = locked_pkg.version.clone();
         let dep_path = dep_path_for(&task.name, &version);
+
+        // When the lockfile's packageExtensions checksum drifted (signaled via
+        // `dependency_policy.package_extensions_drifted`), an extension
+        // targeting this (name, version) can inject deps the locked entry
+        // doesn't carry. Reuse skips the packument fetch where extensions are
+        // applied (the apply_package_extensions call in the fresh-resolve
+        // path), so the injected dep would never be enqueued. Force a fresh
+        // fetch for extension-targeted packages only on drift; a fresh
+        // lockfile already reflects the extension, so reuse stays on the
+        // no-fetch path. No-op for standalone aube (the flag defaults to
+        // false); an embedder that enforces a packageExtensions checksum sets
+        // it when drift is detected.
+        if self.resolver.dependency_policy.package_extensions_drifted
+            && self
+                .resolver
+                .dependency_policy
+                .package_extensions
+                .iter()
+                .any(|ext| package_selector_matches(&ext.selector, task.registry_name(), &version))
+        {
+            return false;
+        }
 
         if task.is_root
             && let Some(deps) = self.importers.get_mut(&task.importer)

--- a/crates/aube-resolver/src/types.rs
+++ b/crates/aube-resolver/src/types.rs
@@ -57,13 +57,7 @@ impl Default for MinimumReleaseAge {
     }
 }
 
-/// `#[non_exhaustive]`: an external crate must construct this via
-/// `DependencyPolicy::default()` plus the `with_*` builders below, never a
-/// struct literal — so adding a field here (like
-/// `package_extensions_drifted`, below) never breaks a downstream crate the
-/// way it would on a plain struct.
 #[derive(Debug, Clone)]
-#[non_exhaustive]
 pub struct DependencyPolicy {
     pub package_extensions: Vec<PackageExtension>,
     pub allowed_deprecated_versions: BTreeMap<String, String>,
@@ -78,9 +72,10 @@ pub struct DependencyPolicy {
     /// Defaults to `false`; an embedder that enforces a packageExtensions
     /// checksum (e.g. nub) sets this when drift is detected via
     /// [`Self::with_package_extensions_drifted`]. Standalone aube leaves it
-    /// `false`, so the reuse path is unchanged. Kept crate-private: with the
-    /// struct `#[non_exhaustive]`, an external crate can only reach it
-    /// through the builder method, never a struct literal.
+    /// `false`, so the reuse path is unchanged. Kept crate-private (not
+    /// `pub`) so adding it isn't a semver-breaking change: it never appears
+    /// in a downstream struct literal either way, since a caller reaches it
+    /// only through the builder method.
     pub(crate) package_extensions_drifted: bool,
 }
 
@@ -90,14 +85,6 @@ impl DependencyPolicy {
     /// resolver skips lockfile reuse for extension-targeted packages.
     pub fn with_package_extensions_drifted(mut self, drifted: bool) -> Self {
         self.package_extensions_drifted = drifted;
-        self
-    }
-
-    /// Set the trust policy. Needed because `#[non_exhaustive]` blocks a
-    /// struct literal (even `Foo { trust_policy: x, ..Default::default() }`)
-    /// from a downstream crate.
-    pub fn with_trust_policy(mut self, trust_policy: TrustPolicy) -> Self {
-        self.trust_policy = trust_policy;
         self
     }
 }

--- a/crates/aube-resolver/src/types.rs
+++ b/crates/aube-resolver/src/types.rs
@@ -71,8 +71,10 @@ pub struct DependencyPolicy {
     /// extension re-applied - otherwise an injected dep silently misses.
     /// Defaults to `false`; an embedder that enforces a packageExtensions
     /// checksum (e.g. nub) sets this when drift is detected. Standalone aube
-    /// leaves it `false`, so the reuse path is unchanged.
-    pub(crate) package_extensions_drifted: bool,
+    /// leaves it `false`, so the reuse path is unchanged. Must stay `pub` so
+    /// struct-update syntax outside this crate (crate aube's install command)
+    /// can construct the policy.
+    pub package_extensions_drifted: bool,
 }
 
 impl DependencyPolicy {

--- a/crates/aube-resolver/src/types.rs
+++ b/crates/aube-resolver/src/types.rs
@@ -57,7 +57,13 @@ impl Default for MinimumReleaseAge {
     }
 }
 
+/// `#[non_exhaustive]`: an external crate must construct this via
+/// `DependencyPolicy::default()` plus the `with_*` builders below, never a
+/// struct literal — so adding a field here (like
+/// `package_extensions_drifted`, below) never breaks a downstream crate the
+/// way it would on a plain struct.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct DependencyPolicy {
     pub package_extensions: Vec<PackageExtension>,
     pub allowed_deprecated_versions: BTreeMap<String, String>,
@@ -70,11 +76,12 @@ pub struct DependencyPolicy {
     /// for extension-targeted packages so the packument is re-fetched and the
     /// extension re-applied - otherwise an injected dep silently misses.
     /// Defaults to `false`; an embedder that enforces a packageExtensions
-    /// checksum (e.g. nub) sets this when drift is detected. Standalone aube
-    /// leaves it `false`, so the reuse path is unchanged. Must stay `pub` so
-    /// struct-update syntax outside this crate (crate aube's install command)
-    /// can construct the policy.
-    pub package_extensions_drifted: bool,
+    /// checksum (e.g. nub) sets this when drift is detected via
+    /// [`Self::with_package_extensions_drifted`]. Standalone aube leaves it
+    /// `false`, so the reuse path is unchanged. Kept crate-private: with the
+    /// struct `#[non_exhaustive]`, an external crate can only reach it
+    /// through the builder method, never a struct literal.
+    pub(crate) package_extensions_drifted: bool,
 }
 
 impl DependencyPolicy {
@@ -83,6 +90,14 @@ impl DependencyPolicy {
     /// resolver skips lockfile reuse for extension-targeted packages.
     pub fn with_package_extensions_drifted(mut self, drifted: bool) -> Self {
         self.package_extensions_drifted = drifted;
+        self
+    }
+
+    /// Set the trust policy. Needed because `#[non_exhaustive]` blocks a
+    /// struct literal (even `Foo { trust_policy: x, ..Default::default() }`)
+    /// from a downstream crate.
+    pub fn with_trust_policy(mut self, trust_policy: TrustPolicy) -> Self {
+        self.trust_policy = trust_policy;
         self
     }
 }

--- a/crates/aube-resolver/src/types.rs
+++ b/crates/aube-resolver/src/types.rs
@@ -65,6 +65,24 @@ pub struct DependencyPolicy {
     pub trust_policy_exclude: crate::trust::TrustExcludeRules,
     pub trust_policy_ignore_after: Option<u64>,
     pub block_exotic_subdeps: bool,
+    /// True when the lockfile's `packageExtensions` checksum drifted from the
+    /// project's current extensions. The resolver then skips lockfile reuse
+    /// for extension-targeted packages so the packument is re-fetched and the
+    /// extension re-applied - otherwise an injected dep silently misses.
+    /// Defaults to `false`; an embedder that enforces a packageExtensions
+    /// checksum (e.g. nub) sets this when drift is detected. Standalone aube
+    /// leaves it `false`, so the reuse path is unchanged.
+    pub(crate) package_extensions_drifted: bool,
+}
+
+impl DependencyPolicy {
+    /// Set the packageExtensions-drift signal. An embedder that enforces a
+    /// packageExtensions checksum calls this when drift is detected so the
+    /// resolver skips lockfile reuse for extension-targeted packages.
+    pub fn with_package_extensions_drifted(mut self, drifted: bool) -> Self {
+        self.package_extensions_drifted = drifted;
+        self
+    }
 }
 
 impl Default for DependencyPolicy {
@@ -76,6 +94,7 @@ impl Default for DependencyPolicy {
             trust_policy_exclude: crate::trust::TrustExcludeRules::default(),
             trust_policy_ignore_after: None,
             block_exotic_subdeps: true,
+            package_extensions_drifted: false,
         }
     }
 }

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -2686,8 +2686,13 @@ mod trust_policy_validation_cache_tests {
     }
 
     fn no_downgrade_policy() -> aube_resolver::DependencyPolicy {
-        aube_resolver::DependencyPolicy::default()
-            .with_trust_policy(aube_resolver::TrustPolicy::NoDowngrade)
+        // Field assignment, not struct-update syntax: `DependencyPolicy`
+        // carries a crate-private field, so `Foo { trust_policy: x,
+        // ..Default::default() }` doesn't compile from this crate. Setting
+        // an already-`pub` field directly on an existing instance does.
+        let mut policy = aube_resolver::DependencyPolicy::default();
+        policy.trust_policy = aube_resolver::TrustPolicy::NoDowngrade;
+        policy
     }
 
     #[test]

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -2686,10 +2686,8 @@ mod trust_policy_validation_cache_tests {
     }
 
     fn no_downgrade_policy() -> aube_resolver::DependencyPolicy {
-        aube_resolver::DependencyPolicy {
-            trust_policy: aube_resolver::TrustPolicy::NoDowngrade,
-            ..Default::default()
-        }
+        aube_resolver::DependencyPolicy::default()
+            .with_trust_policy(aube_resolver::TrustPolicy::NoDowngrade)
     }
 
     #[test]


### PR DESCRIPTION
Add a `package_extensions_drifted` flag to DependencyPolicy (defaults false). When an embedder sets it, try_lockfile_reuse skips extension-targeted packages so the packument is re-fetched and the extension re-applied — otherwise an edited extension's injected dep silently misses on a warm re-resolve that reuses the stale locked subgraph.

No-op for standalone aube (the flag defaults false); an embedder that enforces a packageExtensions checksum sets it when drift is detected. Motivated by nubjs/nub#766.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured package extensions are applied correctly after their checksums change.
  * Prevented outdated dependency results from being reused when relevant extensions are updated.
  * Improved dependency resolution accuracy and consistency after package-extension changes.

* **Enhancements**
  * Added tracking for package-extension changes so dependency results reflect the latest extension behavior.
  * Triggered fresh resolution when extension updates affect a package, ensuring the resulting environment stays current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->