### PR TITLE
fix(pack): resolve catalog dependencies before archiving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1935,9 +1935,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/crates/aube/src/commands/pack.rs
+++ b/crates/aube/src/commands/pack.rs
@@ -261,10 +261,36 @@ fn catalog_rewritten_package_json(project_dir: &Path) -> miette::Result<Option<V
     let mut rewritten = aube_manifest::serialize_json_with_indent(&manifest_json, indent)
         .into_diagnostic()
         .wrap_err("failed to serialize packed package.json")?;
-    if raw.ends_with('\n') {
-        rewritten.push('\n');
+    let line_ending = raw
+        .find('\n')
+        .map(|index| {
+            if index > 0 && raw.as_bytes()[index - 1] == b'\r' {
+                "\r\n"
+            } else {
+                "\n"
+            }
+        })
+        .unwrap_or("\n");
+    if line_ending == "\r\n" {
+        rewritten = rewritten.replace('\n', "\r\n");
+    }
+    if raw.ends_with(line_ending) {
+        rewritten.push_str(line_ending);
     }
     Ok(Some(rewritten.into_bytes()))
+}
+
+/// Apply the archive's catalog rewrite to a typed manifest before it becomes
+/// registry version metadata. Keeping this adapter beside the value-level
+/// transformer ensures the tarball and registry document use identical
+/// catalog resolution rules.
+pub(crate) fn rewrite_catalog_dependencies_in_manifest(
+    project_dir: &Path,
+    manifest: PackageJson,
+) -> miette::Result<PackageJson> {
+    let mut manifest_json = serde_json::to_value(manifest).into_diagnostic()?;
+    rewrite_catalog_dependencies(project_dir, &mut manifest_json)?;
+    serde_json::from_value(manifest_json).into_diagnostic()
 }
 
 /// Rewrite `catalog:` / `catalog:<name>` references in every dependency field
@@ -749,18 +775,22 @@ fn file_mode(path: &Path) -> u32 {
 mod tests {
     use super::*;
 
-    fn archived_package_json(archive: &BuiltArchive) -> serde_json::Value {
+    fn archived_package_json_bytes(archive: &BuiltArchive) -> Vec<u8> {
         let gz = flate2::read::GzDecoder::new(archive.tarball.as_slice());
         let mut tar = tar::Archive::new(gz);
         for entry in tar.entries().unwrap() {
             let mut entry = entry.unwrap();
             if entry.path().unwrap() == Path::new("package/package.json") {
-                let mut contents = String::new();
-                std::io::Read::read_to_string(&mut entry, &mut contents).unwrap();
-                return serde_json::from_str(&contents).unwrap();
+                let mut contents = Vec::new();
+                std::io::Read::read_to_end(&mut entry, &mut contents).unwrap();
+                return contents;
             }
         }
         panic!("package.json missing from archive");
+    }
+
+    fn archived_package_json(archive: &BuiltArchive) -> serde_json::Value {
+        serde_json::from_slice(&archived_package_json_bytes(archive)).unwrap()
     }
 
     #[test]
@@ -818,6 +848,28 @@ mod tests {
 
         let on_disk = std::fs::read_to_string(dir.path().join("package.json")).unwrap();
         assert!(on_disk.contains("catalog:peers"));
+    }
+
+    #[test]
+    fn pack_archive_preserves_crlf_in_rewritten_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            "{\r\n  \"name\": \"catalog-pack\",\r\n  \"version\": \"1.0.0\",\r\n  \"dependencies\": {\"foo\": \"catalog:\"}\r\n}\r\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("pnpm-workspace.yaml"),
+            "catalog:\n  foo: ^1.2.3\n",
+        )
+        .unwrap();
+
+        let archive = build_archive(dir.path()).unwrap();
+        let packed = String::from_utf8(archived_package_json_bytes(&archive)).unwrap();
+
+        assert!(packed.ends_with("\r\n"));
+        assert!(packed.contains("\r\n  \"dependencies\""));
+        assert!(!packed.replace("\r\n", "").contains('\n'));
     }
 
     fn write_tree(root: &Path, files: &[&str]) {

--- a/crates/aube/src/commands/pack.rs
+++ b/crates/aube/src/commands/pack.rs
@@ -284,6 +284,7 @@ fn catalog_rewritten_package_json(project_dir: &Path) -> miette::Result<Option<V
 /// registry version metadata. Keeping this adapter beside the value-level
 /// transformer ensures the tarball and registry document use identical
 /// catalog resolution rules.
+#[cfg(feature = "publish")]
 pub(crate) fn rewrite_catalog_dependencies_in_manifest(
     project_dir: &Path,
     manifest: PackageJson,

--- a/crates/aube/src/commands/pack.rs
+++ b/crates/aube/src/commands/pack.rs
@@ -238,7 +238,113 @@ pub(crate) struct BuiltArchive {
 /// `aube pack` (writes the bytes to disk) and the forthcoming
 /// `aube publish` (hashes and uploads them).
 pub(crate) fn build_archive(project_dir: &Path) -> miette::Result<BuiltArchive> {
-    build_archive_with_package_json(project_dir, None)
+    let package_json = catalog_rewritten_package_json(project_dir)?;
+    build_archive_with_package_json(project_dir, package_json)
+}
+
+/// Return an in-memory `package.json` with publish-time catalog protocol
+/// references replaced by their concrete catalog ranges. The source manifest
+/// stays untouched. `None` means no catalog references were present, so the
+/// archive can copy the original bytes without reformatting them.
+fn catalog_rewritten_package_json(project_dir: &Path) -> miette::Result<Option<Vec<u8>>> {
+    let manifest_path = project_dir.join("package.json");
+    let raw = std::fs::read_to_string(&manifest_path)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to read {}", manifest_path.display()))?;
+    let mut manifest_json: serde_json::Value =
+        aube_manifest::parse_json(&manifest_path, raw.clone()).map_err(miette::Report::new)?;
+    if !rewrite_catalog_dependencies(project_dir, &mut manifest_json)? {
+        return Ok(None);
+    }
+
+    let indent = aube_manifest::detect_json_indent(&raw);
+    let mut rewritten = aube_manifest::serialize_json_with_indent(&manifest_json, indent)
+        .into_diagnostic()
+        .wrap_err("failed to serialize packed package.json")?;
+    if raw.ends_with('\n') {
+        rewritten.push('\n');
+    }
+    Ok(Some(rewritten.into_bytes()))
+}
+
+/// Rewrite `catalog:` / `catalog:<name>` references in every dependency field
+/// pnpm exports. Shared with directory-based publish so the two archive paths
+/// cannot drift. Catalog discovery is deliberately lazy: packages without
+/// catalog references keep packing even if an unrelated ancestor workspace
+/// manifest is malformed.
+pub(crate) fn rewrite_catalog_dependencies(
+    project_dir: &Path,
+    manifest_json: &mut serde_json::Value,
+) -> miette::Result<bool> {
+    const DEP_FIELDS: &[&str] = &[
+        "dependencies",
+        "devDependencies",
+        "optionalDependencies",
+        "peerDependencies",
+    ];
+
+    let Some(root) = manifest_json.as_object() else {
+        return Ok(false);
+    };
+    let has_catalog_refs = DEP_FIELDS.iter().any(|field| {
+        root.get(*field)
+            .and_then(serde_json::Value::as_object)
+            .is_some_and(|deps| {
+                deps.values()
+                    .any(|spec| spec.as_str().is_some_and(aube_util::pkg::is_catalog_spec))
+            })
+    });
+    if !has_catalog_refs {
+        return Ok(false);
+    }
+
+    let catalogs = super::catalog_discovery::discover_catalogs(project_dir)?;
+    let manifest_path = project_dir.join("package.json");
+    let root = manifest_json
+        .as_object_mut()
+        .ok_or_else(|| miette!("{} is not a JSON object", manifest_path.display()))?;
+    for field in DEP_FIELDS {
+        let Some(deps) = root
+            .get_mut(*field)
+            .and_then(serde_json::Value::as_object_mut)
+        else {
+            continue;
+        };
+        for (package, spec_value) in deps {
+            let Some(spec) = spec_value.as_str() else {
+                continue;
+            };
+            let Some(catalog_name) = spec
+                .strip_prefix("catalog:")
+                .map(|name| if name.is_empty() { "default" } else { name })
+            else {
+                continue;
+            };
+            let Some(catalog) = catalogs.get(catalog_name) else {
+                return Err(miette!(
+                    code = aube_codes::errors::ERR_AUBE_UNKNOWN_CATALOG,
+                    help = "define the catalog in `pnpm-workspace.yaml` or under `pnpm.catalog` / `workspaces.catalog` in `package.json`",
+                    "{} declares `{package}: {spec}` but catalog `{catalog_name}` is not defined",
+                    manifest_path.display(),
+                ));
+            };
+            let Some(resolved) = catalog.get(package) else {
+                return Err(miette!(
+                    code = aube_codes::errors::ERR_AUBE_UNKNOWN_CATALOG_ENTRY,
+                    "{} declares `{package}: {spec}` but catalog `{catalog_name}` has no entry for {package:?}",
+                    manifest_path.display(),
+                ));
+            };
+            if aube_util::pkg::is_catalog_spec(resolved) {
+                return Err(miette!(
+                    code = aube_codes::errors::ERR_AUBE_UNKNOWN_CATALOG_ENTRY,
+                    "catalog `{catalog_name}` entry for {package:?} is itself a catalog reference ({resolved:?}); catalogs cannot chain",
+                ));
+            }
+            *spec_value = serde_json::Value::String(resolved.clone());
+        }
+    }
+    Ok(true)
 }
 
 pub(crate) fn build_archive_with_package_json(
@@ -643,6 +749,20 @@ fn file_mode(path: &Path) -> u32 {
 mod tests {
     use super::*;
 
+    fn archived_package_json(archive: &BuiltArchive) -> serde_json::Value {
+        let gz = flate2::read::GzDecoder::new(archive.tarball.as_slice());
+        let mut tar = tar::Archive::new(gz);
+        for entry in tar.entries().unwrap() {
+            let mut entry = entry.unwrap();
+            if entry.path().unwrap() == Path::new("package/package.json") {
+                let mut contents = String::new();
+                std::io::Read::read_to_string(&mut entry, &mut contents).unwrap();
+                return serde_json::from_str(&contents).unwrap();
+            }
+        }
+        panic!("package.json missing from archive");
+    }
+
     #[test]
     fn tarball_filename_unscoped() {
         assert_eq!(tarball_filename("lodash", "4.17.21"), "lodash-4.17.21.tgz");
@@ -664,6 +784,40 @@ mod tests {
         assert!(is_npm_ignored("aube-lock.yaml"));
         assert!(is_npm_ignored("some-package-1.0.0.tgz"));
         assert!(!is_npm_ignored("src"));
+    }
+
+    #[test]
+    fn pack_archive_rewrites_default_and_named_catalog_dependencies() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            r#"{
+  "name": "catalog-pack",
+  "version": "1.0.0",
+  "dependencies": {"regular": "catalog:"},
+  "devDependencies": {"development": "catalog:"},
+  "optionalDependencies": {"optional": "catalog:tools"},
+  "peerDependencies": {"peer": "catalog:peers"}
+}
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("pnpm-workspace.yaml"),
+            "catalog:\n  regular: ^1.2.3\n  development: 4.5.6\ncatalogs:\n  tools:\n    optional: ~7.8.9\n  peers:\n    peer: '>=10'\n",
+        )
+        .unwrap();
+
+        let archive = build_archive(dir.path()).unwrap();
+        let package_json = archived_package_json(&archive);
+
+        assert_eq!(package_json["dependencies"]["regular"], "^1.2.3");
+        assert_eq!(package_json["devDependencies"]["development"], "4.5.6");
+        assert_eq!(package_json["optionalDependencies"]["optional"], "~7.8.9");
+        assert_eq!(package_json["peerDependencies"]["peer"], ">=10");
+
+        let on_disk = std::fs::read_to_string(dir.path().join("package.json")).unwrap();
+        assert!(on_disk.contains("catalog:peers"));
     }
 
     fn write_tree(root: &Path, files: &[&str]) {

--- a/crates/aube/src/commands/pack.rs
+++ b/crates/aube/src/commands/pack.rs
@@ -280,20 +280,6 @@ fn catalog_rewritten_package_json(project_dir: &Path) -> miette::Result<Option<V
     Ok(Some(rewritten.into_bytes()))
 }
 
-/// Apply the archive's catalog rewrite to a typed manifest before it becomes
-/// registry version metadata. Keeping this adapter beside the value-level
-/// transformer ensures the tarball and registry document use identical
-/// catalog resolution rules.
-#[cfg(feature = "publish")]
-pub(crate) fn rewrite_catalog_dependencies_in_manifest(
-    project_dir: &Path,
-    manifest: PackageJson,
-) -> miette::Result<PackageJson> {
-    let mut manifest_json = serde_json::to_value(manifest).into_diagnostic()?;
-    rewrite_catalog_dependencies(project_dir, &mut manifest_json)?;
-    serde_json::from_value(manifest_json).into_diagnostic()
-}
-
 /// Rewrite `catalog:` / `catalog:<name>` references in every dependency field
 /// pnpm exports. Shared with directory-based publish so the two archive paths
 /// cannot drift. Catalog discovery is deliberately lazy: packages without

--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -521,6 +521,7 @@ async fn publish_one(
     // must agree with it or consumers get a mismatch between
     // `npm info` output and the tarball they actually download.
     let manifest = super::pack::read_root_manifest(pkg_dir)?;
+    let manifest = super::pack::rewrite_catalog_dependencies_in_manifest(pkg_dir, manifest)?;
 
     publish_archive(archive, manifest, target, client, args, Some(pkg_dir)).await
 }
@@ -1900,6 +1901,21 @@ mod tests {
             serde_json::from_str(&package_json.expect("package.json in tarball")).unwrap();
 
         assert_eq!(package_json["dependencies"]["foo"], "^2.3.4");
+
+        let manifest = PackageJson::from_path(&tmp.path().join("package.json")).unwrap();
+        let manifest =
+            super::super::pack::rewrite_catalog_dependencies_in_manifest(tmp.path(), manifest)
+                .unwrap();
+        let body = build_publish_body(
+            &archive,
+            &manifest,
+            "https://registry.example.test/",
+            "latest",
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(body["versions"]["1.0.0"]["dependencies"]["foo"], "^2.3.4");
     }
 
     #[test]

--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -862,6 +862,7 @@ fn build_archive_for_publish(pkg_dir: &Path) -> miette::Result<BuiltArchive> {
         .wrap_err_with(|| format!("publish: invalid {}", manifest_path.display()))?;
     let mut manifest_json: serde_json::Value =
         serde_json::from_slice(&manifest_bytes).into_diagnostic()?;
+    super::pack::rewrite_catalog_dependencies(pkg_dir, &mut manifest_json)?;
     if let Some(obj) = manifest_json.as_object_mut() {
         obj.insert("name".into(), name.clone().into());
     }
@@ -1866,6 +1867,39 @@ mod tests {
         assert_eq!(archive.version, "2026.5.16");
         assert_eq!(archive.filename, "jdxcode-mise-linux-x64-2026.5.16.tgz");
         assert_eq!(package_json["version"], "2026.5.16");
+    }
+
+    #[test]
+    fn publish_archive_rewrites_catalog_dependencies() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("package.json"),
+            r#"{"name":"catalog-publish","version":"1.0.0","dependencies":{"foo":"catalog:"}}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            tmp.path().join("pnpm-workspace.yaml"),
+            "catalog:\n  foo: ^2.3.4\n",
+        )
+        .unwrap();
+
+        let archive = build_archive_for_publish(tmp.path()).unwrap();
+        let gz = flate2::read::GzDecoder::new(archive.tarball.as_slice());
+        let mut tar = tar::Archive::new(gz);
+        let mut package_json = None;
+        for entry in tar.entries().unwrap() {
+            let mut entry = entry.unwrap();
+            if entry.path().unwrap() == std::path::Path::new("package/package.json") {
+                let mut contents = String::new();
+                std::io::Read::read_to_string(&mut entry, &mut contents).unwrap();
+                package_json = Some(contents);
+                break;
+            }
+        }
+        let package_json: serde_json::Value =
+            serde_json::from_str(&package_json.expect("package.json in tarball")).unwrap();
+
+        assert_eq!(package_json["dependencies"]["foo"], "^2.3.4");
     }
 
     #[test]

--- a/crates/aube/src/commands/publish.rs
+++ b/crates/aube/src/commands/publish.rs
@@ -508,20 +508,8 @@ async fn publish_one(
     // The tarball build only happens now that we know we're actually
     // going to PUT. A recursive no-op publish still avoids file
     // collection, gzip, and body hashing.
-    let archive = build_archive_for_publish(pkg_dir)?;
+    let (archive, manifest) = build_archive_for_publish(pkg_dir)?;
     super::pack::run_pack_lifecycle_post(pkg_dir, args.ignore_scripts).await?;
-
-    // Re-read the manifest *after* the pre-pack chain. Publish-time
-    // hooks often rewrite `package.json` on the fly — `clean-package`
-    // strips `devDependencies`, build tools inject `exports`, a
-    // `prepublishOnly` might stamp a git SHA into the version. The
-    // tarball always reflects the on-disk state (`build_archive`
-    // reads it fresh), so the registry-visible metadata at
-    // `versions.<v>.*` and the env seen by `publish` / `postpublish`
-    // must agree with it or consumers get a mismatch between
-    // `npm info` output and the tarball they actually download.
-    let manifest = super::pack::read_root_manifest(pkg_dir)?;
-    let manifest = super::pack::rewrite_catalog_dependencies_in_manifest(pkg_dir, manifest)?;
 
     publish_archive(archive, manifest, target, client, args, Some(pkg_dir)).await
 }
@@ -851,7 +839,7 @@ fn read_publish_tarball(path: &Path) -> miette::Result<(BuiltArchive, PackageJso
     ))
 }
 
-fn build_archive_for_publish(pkg_dir: &Path) -> miette::Result<BuiltArchive> {
+fn build_archive_for_publish(pkg_dir: &Path) -> miette::Result<(BuiltArchive, PackageJson)> {
     let manifest_path = pkg_dir.join("package.json");
     let manifest_bytes = std::fs::read(&manifest_path)
         .into_diagnostic()
@@ -868,25 +856,27 @@ fn build_archive_for_publish(pkg_dir: &Path) -> miette::Result<BuiltArchive> {
         obj.insert("name".into(), name.clone().into());
     }
     let Some(raw_version) = manifest_json.get("version").and_then(|v| v.as_str()) else {
+        let rewritten_manifest = serde_json::from_value(manifest_json.clone()).into_diagnostic()?;
         let mut archive = build_archive_with_package_json(
             pkg_dir,
             Some(serde_json::to_vec_pretty(&manifest_json).into_diagnostic()?),
         )?;
         archive.name = name;
         archive.filename = tarball_filename(&archive.name, &archive.version);
-        return Ok(archive);
+        return Ok((archive, rewritten_manifest));
     };
     let version = normalize_publish_version(raw_version);
     if let Some(obj) = manifest_json.as_object_mut() {
         obj.insert("version".into(), version.into());
     }
+    let rewritten_manifest = serde_json::from_value(manifest_json.clone()).into_diagnostic()?;
     let mut package_json = serde_json::to_vec_pretty(&manifest_json).into_diagnostic()?;
     package_json.push(b'\n');
 
     let mut archive = build_archive_with_package_json(pkg_dir, Some(package_json))?;
     archive.name = name;
     normalize_archive_for_publish(&mut archive);
-    Ok(archive)
+    Ok((archive, rewritten_manifest))
 }
 
 fn normalize_publish_version(version: &str) -> String {
@@ -1849,7 +1839,7 @@ mod tests {
         .unwrap();
         std::fs::write(tmp.path().join("README.md"), "mise").unwrap();
 
-        let archive = build_archive_for_publish(tmp.path()).unwrap();
+        let (archive, _) = build_archive_for_publish(tmp.path()).unwrap();
         let gz = flate2::read::GzDecoder::new(archive.tarball.as_slice());
         let mut tar = tar::Archive::new(gz);
         let mut package_json = None;
@@ -1884,7 +1874,7 @@ mod tests {
         )
         .unwrap();
 
-        let archive = build_archive_for_publish(tmp.path()).unwrap();
+        let (archive, manifest) = build_archive_for_publish(tmp.path()).unwrap();
         let gz = flate2::read::GzDecoder::new(archive.tarball.as_slice());
         let mut tar = tar::Archive::new(gz);
         let mut package_json = None;
@@ -1902,10 +1892,6 @@ mod tests {
 
         assert_eq!(package_json["dependencies"]["foo"], "^2.3.4");
 
-        let manifest = PackageJson::from_path(&tmp.path().join("package.json")).unwrap();
-        let manifest =
-            super::super::pack::rewrite_catalog_dependencies_in_manifest(tmp.path(), manifest)
-                .unwrap();
         let body = build_publish_body(
             &archive,
             &manifest,
@@ -1928,7 +1914,7 @@ mod tests {
         .unwrap();
         std::fs::write(tmp.path().join("index.js"), "module.exports = 1").unwrap();
 
-        let packed = build_archive_for_publish(tmp.path()).unwrap();
+        let (packed, _) = build_archive_for_publish(tmp.path()).unwrap();
         let tarball_path = tmp.path().join("prebuilt-1.2.3.tgz");
         std::fs::write(&tarball_path, &packed.tarball).unwrap();
         let (loaded, manifest) = read_publish_tarball(&tarball_path).unwrap();
@@ -2002,7 +1988,7 @@ mod tests {
         assert_eq!(manifest.name.as_deref(), Some("workspace-name"));
         assert_eq!(published_name(&manifest).unwrap(), "@scope/published-name");
 
-        let archive = build_archive_for_publish(tmp.path()).unwrap();
+        let (archive, _) = build_archive_for_publish(tmp.path()).unwrap();
         let gz = flate2::read::GzDecoder::new(archive.tarball.as_slice());
         let mut tar = tar::Archive::new(gz);
         let mut package_json = None;

--- a/test/pack.bats
+++ b/test/pack.bats
@@ -61,6 +61,47 @@ _write_pkg_with_files() {
 	refute_line "package/NOPE.md"
 }
 
+@test "aube pack resolves catalog dependencies in the packed manifest" {
+	mkdir -p packages/app artifacts
+	cat >pnpm-workspace.yaml <<-'EOF'
+		packages:
+		  - packages/*
+		catalog:
+		  regular: ^1.2.3
+		  development: 4.5.6
+		catalogs:
+		  tools:
+		    optional: ~7.8.9
+		  peers:
+		    peer: '>=10'
+	EOF
+	cat >packages/app/package.json <<-'EOF'
+		{
+		  "name": "catalog-pack",
+		  "version": "1.0.0",
+		  "dependencies": {"regular": "catalog:"},
+		  "devDependencies": {"development": "catalog:"},
+		  "optionalDependencies": {"optional": "catalog:tools"},
+		  "peerDependencies": {"peer": "catalog:peers"}
+		}
+	EOF
+
+	run aube --dir packages/app pack --pack-destination "$TEST_TEMP_DIR/artifacts"
+	assert_success
+	assert_file_exists artifacts/catalog-pack-1.0.0.tgz
+
+	run tar -xOzf artifacts/catalog-pack-1.0.0.tgz package/package.json
+	assert_success
+	assert_output --partial '"regular": "^1.2.3"'
+	assert_output --partial '"development": "4.5.6"'
+	assert_output --partial '"optional": "~7.8.9"'
+	assert_output --partial '"peer": ">=10"'
+	refute_output --partial 'catalog:'
+
+	run grep -F '"regular": "catalog:"' packages/app/package.json
+	assert_success
+}
+
 @test "aube pack --json emits a machine-readable report" {
 	_write_pkg_with_files
 

--- a/test/publish.bats
+++ b/test/publish.bats
@@ -642,34 +642,46 @@ NODE
 	assert_failure
 }
 
-@test "aube publish re-reads package.json after pre-pack hooks so registry metadata matches tarball" {
+@test "aube publish uses the archive manifest snapshot for registry metadata" {
 	# Regression test for Cursor Bugbot issue: if a `prepublishOnly`
 	# script mutates package.json (e.g. stamping a git SHA into the
 	# version, stripping devDependencies), `build_publish_body` must
-	# see the post-hook manifest so `versions.<v>` metadata agrees
-	# with what's in the tarball. Previously we serialized the
-	# pre-hook snapshot and consumers saw a mismatch.
+	# see the archive-time manifest so `versions.<v>` metadata agrees
+	# with what's in the tarball. A later `postpack` mutation must not
+	# alter that snapshot.
 	cat >package.json <<-'EOF'
 		{
 		  "name": "publish-mutated",
 		  "version": "0.1.0",
 		  "main": "index.js",
 		  "files": ["index.js"],
+		  "dependencies": {
+		    "foo": "catalog:"
+		  },
 		  "devDependencies": {
 		    "should-be-stripped": "1.0.0"
 		  },
 		  "scripts": {
-		    "prepublishOnly": "node ./rewrite.mjs"
+		    "prepublishOnly": "node ./rewrite.mjs",
+		    "postpack": "node ./rewrite-postpack.mjs"
 		  }
 		}
 	EOF
 	echo "module.exports = 1" >index.js
+	cat >pnpm-workspace.yaml <<-'EOF'
+		catalog:
+		  foo: ^1.2.3
+	EOF
 	cat >rewrite.mjs <<'NODE'
 import fs from 'node:fs';
 const m = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 delete m.devDependencies;
 m.publishedBy = 'prepublishOnly';
 fs.writeFileSync('package.json', JSON.stringify(m, null, 2));
+NODE
+	cat >rewrite-postpack.mjs <<'NODE'
+import fs from 'node:fs';
+fs.writeFileSync('pnpm-workspace.yaml', 'catalog:\n  foo: ^9.9.9\n');
 NODE
 
 	cat >record-server.mjs <<'NODE'
@@ -724,6 +736,12 @@ NODE
 	run jq '.versions."0.1.0".devDependencies' put-body.json
 	assert_success
 	assert_output "null"
+
+	# postpack runs after the archive snapshot and must not change the
+	# catalog value used for registry metadata.
+	run jq -r '.versions."0.1.0".dependencies.foo' put-body.json
+	assert_success
+	assert_output "^1.2.3"
 }
 
 @test "aube publish --dry-run --json reports post-hook version when prepublishOnly bumps version" {


### PR DESCRIPTION
## Summary

- resolve default and named `catalog:` dependencies in packed manifests
- share the rewrite between `aube pack` and directory-based `aube publish`
- preserve the source `package.json` and its indentation/newline style
- cover dependencies, devDependencies, optionalDependencies, and peerDependencies

## Root cause

The pack path copied `package.json` directly from disk. Catalog discovery and rewriting existed for install and deploy, but the publishable archive never received an export-time manifest transformation, leaving catalog protocol specifiers for downstream consumers.

Catalog discovery is lazy so packages without catalog references do not start depending on ancestor workspace parsing.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `mise run test:bats test/pack.bats`

Fixes the behavior reported in [Discussion #1333](https://github.com/jdx/aube/discussions/1333).

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes publish tarball contents and registry metadata assembly; incorrect catalog resolution would ship wrong dependency ranges to consumers, though behavior is covered by new tests and mirrors existing install-time catalog rules.
> 
> **Overview**
> **Pack and publish archives** now replace `catalog:` / `catalog:<name>` in `dependencies`, `devDependencies`, `optionalDependencies`, and `peerDependencies` with resolved semver ranges from workspace catalogs before writing `package/package.json`. The on-disk `package.json` is not modified; when no catalog refs exist, the original bytes are embedded unchanged.
> 
> **Shared logic** lives in `rewrite_catalog_dependencies` (lazy catalog discovery, errors for unknown catalogs/entries/chained catalog refs). `aube pack` uses it via `catalog_rewritten_package_json` with preserved indent and line endings. Directory **`aube publish`** applies the same rewrite when building the tarball and returns an **archive-time `PackageJson` snapshot** for `build_publish_body`, so registry `versions.*` metadata matches the tarball even if `postpack` or later hooks change disk state.
> 
> Tests cover Rust pack/publish paths and Bats for `aube pack` / publish metadata regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d8bab81b3355fdddeeb653bcbb07231d03ba115. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Catalog-based dependencies are now resolved when packaging and publishing projects.
  * Resolution applies to regular, development, optional, and peer dependencies.
  * Packaged manifests and publishing metadata use resolved versions, while source manifests remain unchanged.
  * Clear errors are reported for unknown catalogs, missing entries, and chained catalog references.
  * Packaging preserves manifest formatting, including indentation, line endings, and trailing newlines.
  * Publishing metadata consistently reflects the manifest used to create the archive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->