### PR TITLE
ci(cache-qualification): skip the OIDC probe for fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,10 @@ jobs:
   # jdx/aube but must not write. Pull requests start with empty local state and
   # must restore entries previously seeded by main; main can seed a cold cache.
   cache-qualification:
-    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'
+    # Fork pull requests run with a read-only GITHUB_TOKEN and GitHub refuses
+    # to issue an OIDC token for them, so the cache-auth probe below cannot
+    # run. Skip on fork PRs; `final` treats that skip as OK.
+    if: (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main') && github.event.pull_request.head.repo.fork != true
     runs-on: namespace-profile-endev-linux-amd64
     timeout-minutes: 20
     permissions:
@@ -456,6 +459,8 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           NEEDS_JSON: ${{ toJSON(needs) }}
           REF: ${{ github.ref }}
+          # "true" only for pull_request events from a fork; empty otherwise.
+          FORK_PR: ${{ github.event.pull_request.head.repo.fork }}
         run: |
           python3 - <<'PY'
           import json
@@ -467,6 +472,10 @@ jobs:
           SKIP_OK = {"api-stability"}
           ADVISORY_FAILURE = {"api-stability"}
           if os.environ["EVENT_NAME"] == "workflow_dispatch" and os.environ["REF"] != "refs/heads/main":
+              SKIP_OK.add("cache-qualification")
+          # Fork PRs can't mint an OIDC token, so cache-qualification is
+          # skipped by its `if:`; allow that skip here.
+          if os.environ.get("FORK_PR", "") == "true":
               SKIP_OK.add("cache-qualification")
 
           needs = json.loads(os.environ["NEEDS_JSON"])


### PR DESCRIPTION
## Root cause

Fork pull requests run with a **read-only `GITHUB_TOKEN`** and GitHub **refuses to issue an OIDC token** for them — `id-token: write` in `permissions:` is silently ignored for fork PRs. As a result `ACTIONS_ID_TOKEN_REQUEST_URL` is empty, and the `cache-qualification` cache-auth probe (a `curl` to that URL) exits with **curl error 3 ("URL malformed")**. The `final` gate then hard-errors on `cache-qualification: failure`, red-lining every fork PR even when the rest of CI is green.

This never reproduces on `main` or same-repo PRs because those contexts *do* get an OIDC token, so the probe runs normally.

## Fix

Two targeted changes in `.github/workflows/ci.yml`, both gating only on the fork condition:

1. **`cache-qualification` job** — append `&& github.event.pull_request.head.repo.fork != true` to its `if:`, so it **skips** (neutral, not failed) on fork PRs. Same-repo PRs and `main` pushes keep the existing `if:` behavior and still run the probe.
2. **`final` gate** — add a `FORK_PR: ${{ github.event.pull_request.head.repo.fork }}` env var and, when it is `"true"`, add `cache-qualification` to `SKIP_OK`. The gate already has this exact pattern for the `workflow_dispatch` non-main case, so this mirrors the proven shape.

Net behavior:

| Event | `cache-qualification` | `final` |
| --- | --- | --- |
| fork PR | skipped (allowed) | pass |
| same-repo PR | runs | pass only if probe succeeds |
| `main` push | runs | pass only if probe succeeds |

## Provenance

This is the **same `ci.yml` change** already applied inline on three feature PRs so they could pass CI from forks:
- [#1325](https://github.com/jdx/aube/pull/1325)
- [#1326](https://github.com/jdx/aube/pull/1326)
- [#1327](https://github.com/jdx/aube/pull/1327)

Landing it standalone on `main` means:
- Those three PRs can drop their inline copy and merge cleanly (no `ci.yml` conflict between them).
- Future fork PRs to `jdx/aube` pass CI without needing to re-apply the workaround.

The diff is `ci.yml`-only — no feature code, no `mise.toml`, no behavior change for non-fork events.