### PR TITLE
ci: qualify cache with mise 2026.8.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
           persist-credentials: false
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
-          version: 2026.8.8
+          version: 2026.8.9
           install: false
           cache: false
       - name: Qualify production cache authorization


### PR DESCRIPTION
## Summary
- update the cache qualification job to install mise 2026.8.9
- keeps the production Rust action-cache qualification on the released build that includes the latest cache fixes

## Validation
- actionlint .github/workflows/ci.yml

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single version pin in a dedicated qualification job; no application or security logic changes.
> 
> **Overview**
> The **`cache-qualification`** job’s `jdx/mise-action` pin moves from **2026.8.8** to **2026.8.9**, so production Rust action-cache qualification runs against the release that includes the latest cache fixes. No other workflow jobs or steps change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 069b851fc0a347fb040ced92b7bd883c1365b5c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the cache qualification workflow to use the latest `mise` action version.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->