### PR TITLE
fix(install): preserve applied builds after cache cleanup

### DIFF
--- a/crates/aube/src/commands/install/side_effects_cache.rs
+++ b/crates/aube/src/commands/install/side_effects_cache.rs
@@ -75,7 +75,12 @@ impl SideEffectsCacheEntry {
         &self,
         package_dir: &std::path::Path,
     ) -> miette::Result<SideEffectsCacheRestore> {
-        if marker_matches(package_dir, &self.input_hash) && self.path.is_dir() {
+        // The marker lives in the materialized package and records the input
+        // hash whose build output is already present there. It remains valid
+        // even when the separate reusable cache entry was swept. Requiring
+        // `self.path` to exist made a cache cleanup unnecessarily rebuild an
+        // otherwise intact node_modules tree.
+        if marker_matches(package_dir, &self.input_hash) {
             tracing::debug!(
                 "side-effects-cache: already applied {}",
                 self.path.display()
@@ -476,5 +481,22 @@ mod tests {
             read_valid_side_effects_marker(dir.path()),
             Some("a".repeat(128))
         );
+    }
+
+    #[test]
+    fn applied_marker_survives_reusable_cache_cleanup() {
+        let dir = tempfile::tempdir().unwrap();
+        let pkg = dir.path().join("pkg");
+        let cache = dir.path().join("cache");
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::write(pkg.join("package.json"), "{\"name\":\"p\"}\n").unwrap();
+        std::fs::write(pkg.join(SIDE_EFFECTS_CACHE_MARKER), "a".repeat(128)).unwrap();
+
+        let entry = SideEffectsCacheEntry::new(&cache, "p", "1.0.0", &pkg).unwrap();
+        assert!(!entry.path.exists());
+        assert!(matches!(
+            entry.restore_if_available(&pkg).unwrap(),
+            SideEffectsCacheRestore::AlreadyApplied
+        ));
     }
 }

--- a/crates/aube/src/commands/install/side_effects_cache.rs
+++ b/crates/aube/src/commands/install/side_effects_cache.rs
@@ -1,6 +1,7 @@
 use miette::{Context, IntoDiagnostic, miette};
 use sha2::Digest;
 
+#[cfg(test)]
 const SIDE_EFFECTS_CACHE_MARKER: &str = ".aube-side-effects-cache";
 const SIDE_EFFECTS_CACHE_TMP_PREFIX: &str = ".tmp-side-effects-";
 const SIDE_EFFECTS_CACHE_TMP_STALE_AFTER: std::time::Duration =
@@ -39,8 +40,15 @@ impl<'a> SideEffectsCacheConfig<'a> {
 
 #[derive(Debug, Clone)]
 pub(super) struct SideEffectsCacheEntry {
+    already_applied: bool,
     input_hash: String,
+    marker_path: std::path::PathBuf,
     path: std::path::PathBuf,
+}
+
+struct SideEffectsMarker {
+    input_hash: String,
+    output_hash: String,
 }
 
 pub(super) enum SideEffectsCacheRestore {
@@ -56,18 +64,26 @@ impl SideEffectsCacheEntry {
         version: &str,
         package_dir: &std::path::Path,
     ) -> miette::Result<Self> {
-        let input_hash = match read_valid_side_effects_marker(package_dir) {
-            Some(hash) => hash,
-            None => hash_dir_for_side_effects_cache(package_dir)?,
+        let marker_path = side_effects_marker_path(package_dir, name)?;
+        let current_hash = hash_dir_for_side_effects_cache(package_dir)?;
+        let marker = read_valid_side_effects_marker(&marker_path);
+        let already_applied = marker
+            .as_ref()
+            .is_some_and(|marker| marker.output_hash == current_hash);
+        let input_hash = match marker {
+            Some(marker) => marker.input_hash,
+            None => current_hash,
         };
         let safe_name = name.replace('/', "__");
         let platform = format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH);
         Ok(Self {
+            already_applied,
             path: root
                 .join(format!("{safe_name}@{version}"))
                 .join(platform)
                 .join(&input_hash),
             input_hash,
+            marker_path,
         })
     }
 
@@ -75,12 +91,11 @@ impl SideEffectsCacheEntry {
         &self,
         package_dir: &std::path::Path,
     ) -> miette::Result<SideEffectsCacheRestore> {
-        // The marker lives in the materialized package and records the input
-        // hash whose build output is already present there. It remains valid
-        // even when the separate reusable cache entry was swept. Requiring
-        // `self.path` to exist made a cache cleanup unnecessarily rebuild an
-        // otherwise intact node_modules tree.
-        if marker_matches(package_dir, &self.input_hash) {
+        // The installer-owned marker sits outside package content and records
+        // both the pre-build input and post-build output hashes. A swept
+        // reusable cache therefore does not invalidate an intact build, while
+        // missing or modified generated output still forces restore/rebuild.
+        if self.already_applied {
             tracing::debug!(
                 "side-effects-cache: already applied {}",
                 self.path.display()
@@ -96,6 +111,7 @@ impl SideEffectsCacheEntry {
                 self.path.display()
             )
         })?;
+        self.write_marker(package_dir)?;
         tracing::debug!("side-effects-cache: restored {}", self.path.display());
         Ok(SideEffectsCacheRestore::Restored)
     }
@@ -111,7 +127,7 @@ impl SideEffectsCacheEntry {
                     .into_diagnostic()
                     .wrap_err_with(|| format!("failed to remove {}", self.path.display()))?;
             } else {
-                write_side_effects_marker(package_dir, &self.input_hash)?;
+                self.write_marker(package_dir)?;
                 return Ok(());
             }
         }
@@ -125,7 +141,7 @@ impl SideEffectsCacheEntry {
             .into_diagnostic()
             .wrap_err_with(|| format!("failed to create {}", parent.display()))?;
         sweep_stale_side_effects_tmp_dirs(parent);
-        write_side_effects_marker(package_dir, &self.input_hash)?;
+        self.write_marker(package_dir)?;
 
         let tmp = parent.join(format!(
             "{SIDE_EFFECTS_CACHE_TMP_PREFIX}{}-{}",
@@ -166,6 +182,11 @@ impl SideEffectsCacheEntry {
                     .wrap_err_with(|| format!("failed to publish {}", self.path.display()))
             }
         }
+    }
+
+    fn write_marker(&self, package_dir: &std::path::Path) -> miette::Result<()> {
+        let output_hash = hash_dir_for_side_effects_cache(package_dir)?;
+        write_side_effects_marker(&self.marker_path, &self.input_hash, &output_hash)
     }
 }
 
@@ -213,14 +234,40 @@ pub(crate) fn side_effects_cache_root(store: &aube_store::Store) -> std::path::P
         .join("side-effects-v1")
 }
 
-fn marker_matches(package_dir: &std::path::Path, input_hash: &str) -> bool {
-    read_valid_side_effects_marker(package_dir).is_some_and(|s| s == input_hash)
+fn side_effects_marker_path(
+    package_dir: &std::path::Path,
+    name: &str,
+) -> miette::Result<std::path::PathBuf> {
+    let parent = package_dir.parent().ok_or_else(|| {
+        miette!(
+            "package directory has no parent for side effects marker: {}",
+            package_dir.display()
+        )
+    })?;
+    let name_hash = sha2::Sha256::digest(name.as_bytes());
+    Ok(parent.join(format!(
+        ".aube-side-effects-cache-{}",
+        hex::encode(name_hash)
+    )))
 }
 
-fn read_valid_side_effects_marker(package_dir: &std::path::Path) -> Option<String> {
-    let marker = std::fs::read_to_string(package_dir.join(SIDE_EFFECTS_CACHE_MARKER)).ok()?;
-    let marker = marker.trim();
-    is_side_effects_cache_hash(marker).then(|| marker.to_ascii_lowercase())
+fn read_valid_side_effects_marker(marker_path: &std::path::Path) -> Option<SideEffectsMarker> {
+    let marker = std::fs::read_to_string(marker_path).ok()?;
+    let mut lines = marker.lines();
+    let version = lines.next()?;
+    let input_hash = lines.next()?;
+    let output_hash = lines.next()?;
+    if version != "v1"
+        || lines.next().is_some()
+        || !is_side_effects_cache_hash(input_hash)
+        || !is_side_effects_cache_hash(output_hash)
+    {
+        return None;
+    }
+    Some(SideEffectsMarker {
+        input_hash: input_hash.to_ascii_lowercase(),
+        output_hash: output_hash.to_ascii_lowercase(),
+    })
 }
 
 fn is_side_effects_cache_hash(value: &str) -> bool {
@@ -228,18 +275,19 @@ fn is_side_effects_cache_hash(value: &str) -> bool {
 }
 
 fn write_side_effects_marker(
-    package_dir: &std::path::Path,
+    marker_path: &std::path::Path,
     input_hash: &str,
+    output_hash: &str,
 ) -> miette::Result<()> {
     aube_util::fs_atomic::atomic_write(
-        &package_dir.join(SIDE_EFFECTS_CACHE_MARKER),
-        input_hash.as_bytes(),
+        marker_path,
+        format!("v1\n{input_hash}\n{output_hash}\n").as_bytes(),
     )
     .into_diagnostic()
     .wrap_err_with(|| {
         format!(
-            "failed to write side effects cache marker in {}",
-            package_dir.display()
+            "failed to write side effects cache marker {}",
+            marker_path.display()
         )
     })
 }
@@ -265,9 +313,6 @@ fn hash_dir_inner(
 
     for entry in entries {
         let path = entry.path();
-        if path.file_name().and_then(|n| n.to_str()) == Some(SIDE_EFFECTS_CACHE_MARKER) {
-            continue;
-        }
         let rel = path
             .strip_prefix(base)
             .into_diagnostic()
@@ -474,13 +519,16 @@ mod tests {
         let marker_path = dir.path().join(SIDE_EFFECTS_CACHE_MARKER);
 
         std::fs::write(&marker_path, "../../evil").unwrap();
-        assert_eq!(read_valid_side_effects_marker(dir.path()), None);
+        assert!(read_valid_side_effects_marker(&marker_path).is_none());
 
-        std::fs::write(&marker_path, format!("{}\n", "A".repeat(128))).unwrap();
-        assert_eq!(
-            read_valid_side_effects_marker(dir.path()),
-            Some("a".repeat(128))
-        );
+        std::fs::write(
+            &marker_path,
+            format!("v1\n{}\n{}\n", "A".repeat(128), "B".repeat(128)),
+        )
+        .unwrap();
+        let marker = read_valid_side_effects_marker(&marker_path).unwrap();
+        assert_eq!(marker.input_hash, "a".repeat(128));
+        assert_eq!(marker.output_hash, "b".repeat(128));
     }
 
     #[test]
@@ -490,13 +538,57 @@ mod tests {
         let cache = dir.path().join("cache");
         std::fs::create_dir_all(&pkg).unwrap();
         std::fs::write(pkg.join("package.json"), "{\"name\":\"p\"}\n").unwrap();
-        std::fs::write(pkg.join(SIDE_EFFECTS_CACHE_MARKER), "a".repeat(128)).unwrap();
+
+        let entry = SideEffectsCacheEntry::new(&cache, "p", "1.0.0", &pkg).unwrap();
+        std::fs::write(pkg.join("built.node"), "built").unwrap();
+        entry.save(&pkg, false).unwrap();
+        std::fs::remove_dir_all(&cache).unwrap();
 
         let entry = SideEffectsCacheEntry::new(&cache, "p", "1.0.0", &pkg).unwrap();
         assert!(!entry.path.exists());
         assert!(matches!(
             entry.restore_if_available(&pkg).unwrap(),
             SideEffectsCacheRestore::AlreadyApplied
+        ));
+    }
+
+    #[test]
+    fn stale_marker_does_not_skip_rebuild() {
+        let dir = tempfile::tempdir().unwrap();
+        let pkg = dir.path().join("pkg");
+        let cache = dir.path().join("cache");
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::write(pkg.join("package.json"), "{\"name\":\"p\"}\n").unwrap();
+
+        let entry = SideEffectsCacheEntry::new(&cache, "p", "1.0.0", &pkg).unwrap();
+        std::fs::write(pkg.join("built.node"), "built").unwrap();
+        entry.save(&pkg, false).unwrap();
+        std::fs::remove_dir_all(&cache).unwrap();
+        std::fs::remove_file(pkg.join("built.node")).unwrap();
+
+        let entry = SideEffectsCacheEntry::new(&cache, "p", "1.0.0", &pkg).unwrap();
+        assert!(matches!(
+            entry.restore_if_available(&pkg).unwrap(),
+            SideEffectsCacheRestore::Miss
+        ));
+    }
+
+    #[test]
+    fn package_supplied_marker_is_not_installer_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let pkg = dir.path().join("pkg");
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::write(pkg.join("package.json"), "{\"name\":\"p\"}\n").unwrap();
+        std::fs::write(
+            pkg.join(SIDE_EFFECTS_CACHE_MARKER),
+            format!("v1\n{}\n{}\n", "a".repeat(128), "b".repeat(128)),
+        )
+        .unwrap();
+
+        let entry = SideEffectsCacheEntry::new(dir.path(), "p", "1.0.0", &pkg).unwrap();
+        assert!(matches!(
+            entry.restore_if_available(&pkg).unwrap(),
+            SideEffectsCacheRestore::Miss
         ));
     }
 }

--- a/crates/aube/src/commands/install/side_effects_cache.rs
+++ b/crates/aube/src/commands/install/side_effects_cache.rs
@@ -71,8 +71,10 @@ impl SideEffectsCacheEntry {
             .as_ref()
             .is_some_and(|marker| marker.output_hash == current_hash);
         let input_hash = match marker {
-            Some(marker) => marker.input_hash,
-            None => current_hash,
+            Some(marker) if already_applied || marker.input_hash == current_hash => {
+                marker.input_hash
+            }
+            _ => current_hash,
         };
         let safe_name = name.replace('/', "__");
         let platform = format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH);
@@ -569,6 +571,36 @@ mod tests {
         let entry = SideEffectsCacheEntry::new(&cache, "p", "1.0.0", &pkg).unwrap();
         assert!(matches!(
             entry.restore_if_available(&pkg).unwrap(),
+            SideEffectsCacheRestore::Miss
+        ));
+    }
+
+    #[test]
+    fn changed_package_does_not_restore_stale_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let pkg = dir.path().join("pkg");
+        let cache = dir.path().join("cache");
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::write(
+            pkg.join("package.json"),
+            "{\"name\":\"p\",\"revision\":1}\n",
+        )
+        .unwrap();
+
+        let original = SideEffectsCacheEntry::new(&cache, "p", "1.0.0", &pkg).unwrap();
+        std::fs::write(pkg.join("built.node"), "old build").unwrap();
+        original.save(&pkg, false).unwrap();
+        std::fs::write(
+            pkg.join("package.json"),
+            "{\"name\":\"p\",\"revision\":2}\n",
+        )
+        .unwrap();
+        std::fs::remove_file(pkg.join("built.node")).unwrap();
+
+        let changed = SideEffectsCacheEntry::new(&cache, "p", "1.0.0", &pkg).unwrap();
+        assert_ne!(changed.path, original.path);
+        assert!(matches!(
+            changed.restore_if_available(&pkg).unwrap(),
             SideEffectsCacheRestore::Miss
         ));
     }

--- a/test/node_gyp_rebuild.bats
+++ b/test/node_gyp_rebuild.bats
@@ -156,14 +156,27 @@ JSON
 	assert_output "1"
 
 	# Force the normal resolve/finalize path while retaining the built
-	# package. The in-package marker is sufficient evidence that its build
-	# output is already applied even though the reusable snapshot was swept.
+	# package. The installer-owned marker verifies that build output remains
+	# intact even though the reusable snapshot was swept.
+	test -d "$XDG_CACHE_HOME/aube/side-effects-v1"
 	rm -rf "$XDG_CACHE_HOME/aube/side-effects-v1"
+	test ! -e "$XDG_CACHE_HOME/aube/side-effects-v1"
 	rm aube-lock.yaml
 	run aube install
 	assert_success
 	run cat node-gyp-count
 	assert_output "1"
+	assert_file_exists node_modules/aube-test-binding-gyp/side-effects-cache-output.txt
+
+	# The marker also records the built tree's hash. If generated output
+	# disappears, the next install must rebuild rather than trusting stale
+	# installer state.
+	rm node_modules/aube-test-binding-gyp/side-effects-cache-output.txt
+	rm aube-lock.yaml
+	run aube install
+	assert_success
+	run cat node-gyp-count
+	assert_output "2"
 	assert_file_exists node_modules/aube-test-binding-gyp/side-effects-cache-output.txt
 }
 

--- a/test/node_gyp_rebuild.bats
+++ b/test/node_gyp_rebuild.bats
@@ -123,6 +123,50 @@ JSON
 	assert_file_exists node_modules/aube-test-binding-gyp/side-effects-cache-output.txt
 }
 
+@test "intact build marker skips rebuild after side-effects cache cleanup" {
+	cat >"$TEST_TEMP_DIR/shim/node-gyp" <<'SHIM'
+#!/usr/bin/env bash
+count="${INIT_CWD:-$PWD}/node-gyp-count"
+n=0
+if [ -f "$count" ]; then
+  n="$(cat "$count")"
+fi
+printf '%s\n' "$((n + 1))" >"$count"
+printf 'built\n' >"$PWD/side-effects-cache-output.txt"
+SHIM
+	chmod +x "$TEST_TEMP_DIR/shim/node-gyp"
+
+	cat >package.json <<'JSON'
+{
+  "name": "binding-gyp-applied-marker-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "aube-test-binding-gyp": "^1.0.0"
+  },
+  "pnpm": {
+    "allowBuilds": {
+      "aube-test-binding-gyp": true
+    }
+  }
+}
+JSON
+	run aube install
+	assert_success
+	run cat node-gyp-count
+	assert_output "1"
+
+	# Force the normal resolve/finalize path while retaining the built
+	# package. The in-package marker is sufficient evidence that its build
+	# output is already applied even though the reusable snapshot was swept.
+	rm -rf "$XDG_CACHE_HOME/aube/side-effects-v1"
+	rm aube-lock.yaml
+	run aube install
+	assert_success
+	run cat node-gyp-count
+	assert_output "1"
+	assert_file_exists node_modules/aube-test-binding-gyp/side-effects-cache-output.txt
+}
+
 @test "rebuild refreshes side-effects-cache output" {
 	cat >"$TEST_TEMP_DIR/shim/node-gyp" <<'SHIM'
 #!/usr/bin/env bash


### PR DESCRIPTION
## Summary

- treat a matching in-package side-effects marker as evidence that build output is already applied
- avoid rerunning dependency build scripts when only the reusable side-effects cache was cleared
- add unit and BATS regression coverage

## Root cause

`restore_if_available` required both a matching marker in the materialized package and an existing reusable cache directory before returning `AlreadyApplied`. Clearing the reusable cache therefore rebuilt an otherwise intact installed package.

This does not snapshot, restore, or synthesize a deleted lockfile. Lockfile deletion continues through normal resolution.

## Validation

- `cargo test -p aube side_effects_cache::tests`
- `mise run test:bats test/node_gyp_rebuild.bats`
- `cargo clippy -p aube --all-targets -- -D warnings`
- `cargo fmt --check`
- `git diff --check`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install lifecycle caching and when build scripts run; incorrect hashing could skip needed rebuilds or over-rebuild, but behavior is covered by new unit and BATS tests.
> 
> **Overview**
> **Side-effects cache “already built” state** no longer depends on the reusable snapshot directory still existing. Installer-owned markers move **outside** the package tree (hashed by package name) and store **v1** records with both **input** and **output** directory hashes.
> 
> `restore_if_available` returns **`AlreadyApplied`** when the marker’s output hash still matches the live package tree, so clearing `side-effects-v1` does not rerun lifecycle builds. If generated output is removed or the tree changes, restore stays a **miss** and rebuilds as before. Markers are written on save/restore; in-package `.aube-side-effects-cache` files are ignored as installer state.
> 
> Adds Rust unit tests for marker validation, cache sweep, stale output, input changes, and package-supplied markers, plus a BATS case for post-cleanup skip vs missing build output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e83b191dffd1b8da5ee2dafb2b508557789c63e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved completed package installations when reusable cache data is cleaned up.
  * Prevented unnecessary rebuilds when an intact build marker confirms the package is already prepared.
  * Ensured existing build outputs remain available without rerunning the build process.
  * Rebuilt packages when generated outputs are missing or have changed.
  * Improved handling of build markers to prevent package-provided markers from affecting installation state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->