### PR TITLE
fix(lockfile): resolve catalog overrides in pnpm output

### DIFF
--- a/crates/aube-lockfile/src/drift.rs
+++ b/crates/aube-lockfile/src/drift.rs
@@ -1341,12 +1341,14 @@ mod drift_tests {
                 "parent/@scope/pkg@>1.0.0".to_string(),
                 "catalog:".to_string(),
             ),
+            ("parent@^1>123numeric".to_string(), "catalog:".to_string()),
         ]);
         let catalogs = BTreeMap::from([(
             "default".to_string(),
             BTreeMap::from([
                 ("lodash".to_string(), "4.17.21".to_string()),
                 ("@scope/pkg".to_string(), "2.0.0".to_string()),
+                ("123numeric".to_string(), "1.0.0".to_string()),
             ]),
         )]);
 
@@ -1355,6 +1357,7 @@ mod drift_tests {
             BTreeMap::from([
                 ("parent/lodash@>=4.0.0".to_string(), "4.17.21".to_string(),),
                 ("parent/@scope/pkg@>1.0.0".to_string(), "2.0.0".to_string(),),
+                ("parent@^1>123numeric".to_string(), "1.0.0".to_string()),
             ])
         );
     }

--- a/crates/aube-lockfile/src/drift.rs
+++ b/crates/aube-lockfile/src/drift.rs
@@ -618,33 +618,15 @@ fn resolve_catalog_refs_in_overrides(
                 .strip_prefix("catalog:")
                 .map(|tail| if tail.is_empty() { "default" } else { tail })
                 .and_then(|cat_name| workspace_catalogs.get(cat_name))
-                .and_then(|cat| cat.get(override_key_package_name(k)))
+                .and_then(|cat| {
+                    override_match::target_package_name(k)
+                        .and_then(|package_name| cat.get(&package_name))
+                })
                 .cloned()
                 .unwrap_or_else(|| v.clone());
             (k.clone(), resolved)
         })
         .collect()
-}
-
-/// Extract the package name from an override selector key so the catalog
-/// can be looked up by pkg name. Handles bare (`lodash`), scoped
-/// (`@babel/core`), ranged (`lodash@<5`), ancestor-chained
-/// (`parent>lodash`), and combinations. Unparseable keys return the
-/// input unchanged; the catalog lookup will then miss and leave the
-/// value as-is.
-fn override_key_package_name(key: &str) -> &str {
-    let last = key.rsplit('>').next().unwrap_or(key);
-    if let Some(after_scope) = last.strip_prefix('@') {
-        match after_scope.find('@') {
-            Some(idx) => &last[..idx + 1],
-            None => last,
-        }
-    } else {
-        match last.find('@') {
-            Some(idx) => &last[..idx],
-            None => last,
-        }
-    }
 }
 
 /// Compare two override maps and return a human-readable reason
@@ -1326,6 +1308,25 @@ mod drift_tests {
         let mut evens = BTreeMap::new();
         evens.insert("lodash".into(), "4.17.21".into());
         catalogs.insert("evens".into(), evens);
+        assert_eq!(
+            graph.check_drift(&manifest, &ws_overrides, &[], &catalogs),
+            DriftStatus::Fresh,
+        );
+    }
+
+    #[test]
+    fn fresh_when_yarn_ancestor_override_catalog_ref_matches_lockfile() {
+        let manifest = make_manifest(&[("lodash", "^4.17.0")]);
+        let mut graph = make_graph(&[("lodash", "^4.17.0", "lodash@4.17.21")]);
+        graph
+            .overrides
+            .insert("parent/lodash".into(), "4.17.21".into());
+        let ws_overrides = BTreeMap::from([("parent/lodash".to_string(), "catalog:".to_string())]);
+        let catalogs = BTreeMap::from([(
+            "default".to_string(),
+            BTreeMap::from([("lodash".to_string(), "4.17.21".to_string())]),
+        )]);
+
         assert_eq!(
             graph.check_drift(&manifest, &ws_overrides, &[], &catalogs),
             DriftStatus::Fresh,

--- a/crates/aube-lockfile/src/drift.rs
+++ b/crates/aube-lockfile/src/drift.rs
@@ -1334,6 +1334,32 @@ mod drift_tests {
     }
 
     #[test]
+    fn catalog_overrides_resolve_slash_targets_with_comparators() {
+        let overrides = BTreeMap::from([
+            ("parent/lodash@>=4.0.0".to_string(), "catalog:".to_string()),
+            (
+                "parent/@scope/pkg@>1.0.0".to_string(),
+                "catalog:".to_string(),
+            ),
+        ]);
+        let catalogs = BTreeMap::from([(
+            "default".to_string(),
+            BTreeMap::from([
+                ("lodash".to_string(), "4.17.21".to_string()),
+                ("@scope/pkg".to_string(), "2.0.0".to_string()),
+            ]),
+        )]);
+
+        assert_eq!(
+            resolve_catalog_refs_in_overrides(&overrides, &catalogs),
+            BTreeMap::from([
+                ("parent/lodash@>=4.0.0".to_string(), "4.17.21".to_string(),),
+                ("parent/@scope/pkg@>1.0.0".to_string(), "2.0.0".to_string(),),
+            ])
+        );
+    }
+
+    #[test]
     fn stale_when_override_catalog_ref_diverges_from_lockfile() {
         // If the catalog moves to a new version, the resolved override
         // no longer matches the lockfile — drift must fire, not silently

--- a/crates/aube-lockfile/src/override_match.rs
+++ b/crates/aube-lockfile/src/override_match.rs
@@ -79,6 +79,14 @@ pub(crate) fn apply<'a>(
     })
 }
 
+/// Extract the final package target from any supported pnpm/yarn override key.
+/// Unlike [`compile`], this accepts ancestor chains because catalog expansion
+/// needs the target name even when the override cannot apply to an importer.
+pub(crate) fn target_package_name(key: &str) -> Option<String> {
+    let target = split_segments(key)?.pop()?;
+    parse_segment(target).map(|(name, _)| name)
+}
+
 fn parse_key(key: &str) -> Option<(String, Option<String>)> {
     if key.is_empty() {
         return None;
@@ -294,6 +302,17 @@ mod tests {
             ("parent/foo", "1.0.0"),
         ]));
         assert!(rules.is_empty());
+    }
+
+    #[test]
+    fn target_name_supports_pnpm_and_yarn_ancestor_selectors() {
+        assert_eq!(target_package_name("parent>foo").as_deref(), Some("foo"));
+        assert_eq!(target_package_name("parent/foo").as_deref(), Some("foo"));
+        assert_eq!(target_package_name("**/foo").as_deref(), Some("foo"));
+        assert_eq!(
+            target_package_name("parent/@scope/foo@^1").as_deref(),
+            Some("@scope/foo")
+        );
     }
 
     #[test]

--- a/crates/aube-lockfile/src/override_match.rs
+++ b/crates/aube-lockfile/src/override_match.rs
@@ -105,49 +105,57 @@ fn parse_key(key: &str) -> Option<(String, Option<String>)> {
 /// (`>=`, `>1.0.0`, `> 1`) attached to the segment they qualify.
 /// Mirrors `aube-resolver::override_rule::split_segments`.
 fn split_segments(key: &str) -> Option<Vec<&str>> {
-    if key.contains('>') {
-        let bytes = key.as_bytes();
-        let mut parts: Vec<&str> = Vec::new();
-        let mut start = 0;
-        let mut i = 0;
-        let mut in_req = false;
-        while i < bytes.len() {
-            let c = bytes[i];
-            if c == b'@' && !in_req && i != start {
-                in_req = true;
-            } else if c == b'>' {
-                if in_req {
-                    let comparator_cont = bytes
-                        .get(i + 1)
-                        .is_some_and(|&n| matches!(n, b'=' | b' ' | b'v') || n.is_ascii_digit());
-                    if comparator_cont {
-                        i += 1;
-                        continue;
-                    }
-                }
-                if start == i {
-                    return None;
-                }
-                parts.push(&key[start..i]);
-                start = i + 1;
-                in_req = false;
-            }
-            i += 1;
-        }
-        if start >= bytes.len() {
-            return None;
-        }
-        parts.push(&key[start..]);
-        return Some(parts);
-    }
-    // Yarn slash form: split on `/` except the scope-introducing `/`.
     let bytes = key.as_bytes();
+    let mut pnpm_parts: Vec<&str> = Vec::new();
+    let mut start = 0;
+    let mut i = 0;
+    let mut in_req = false;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c == b'@' && !in_req && i != start {
+            in_req = true;
+        } else if c == b'>' {
+            if in_req {
+                let comparator_cont = bytes
+                    .get(i + 1)
+                    .is_some_and(|&n| matches!(n, b'=' | b' ' | b'v') || n.is_ascii_digit());
+                if comparator_cont {
+                    i += 1;
+                    continue;
+                }
+            }
+            if start == i {
+                return None;
+            }
+            pnpm_parts.push(&key[start..i]);
+            start = i + 1;
+            in_req = false;
+        }
+        i += 1;
+    }
+    if start >= bytes.len() {
+        return None;
+    }
+    pnpm_parts.push(&key[start..]);
+
+    // Split each pnpm segment on Yarn `/` ancestors except the
+    // scope-introducing slash. This second pass is required even when
+    // the key contains `>`: it may be a comparator in a slash-form
+    // selector such as `parent/lodash@>=4`.
     let mut out: Vec<&str> = Vec::new();
+    for part in pnpm_parts {
+        split_slash_segments(part, &mut out)?;
+    }
+    Some(out)
+}
+
+fn split_slash_segments<'a>(part: &'a str, out: &mut Vec<&'a str>) -> Option<()> {
+    let bytes = part.as_bytes();
     let mut start = 0;
     let mut i = 0;
     while i < bytes.len() {
         if bytes[i] == b'/' {
-            let current = &key[start..i];
+            let current = &part[start..i];
             let scope = current.starts_with('@') && !current[1..].contains('/');
             if !scope {
                 if current.is_empty() {
@@ -159,12 +167,12 @@ fn split_segments(key: &str) -> Option<Vec<&str>> {
         }
         i += 1;
     }
-    let tail = &key[start..];
+    let tail = &part[start..];
     if tail.is_empty() {
         return None;
     }
     out.push(tail);
-    Some(out)
+    Some(())
 }
 
 /// Parse a single segment `name[@range]` (scoped or unscoped) into its
@@ -311,6 +319,14 @@ mod tests {
         assert_eq!(target_package_name("**/foo").as_deref(), Some("foo"));
         assert_eq!(
             target_package_name("parent/@scope/foo@^1").as_deref(),
+            Some("@scope/foo")
+        );
+        assert_eq!(
+            target_package_name("parent/lodash@>=4.0.0").as_deref(),
+            Some("lodash")
+        );
+        assert_eq!(
+            target_package_name("parent/@scope/foo@>1.0.0").as_deref(),
             Some("@scope/foo")
         );
     }

--- a/crates/aube-lockfile/src/override_match.rs
+++ b/crates/aube-lockfile/src/override_match.rs
@@ -103,33 +103,24 @@ fn parse_key(key: &str) -> Option<(String, Option<String>)> {
 /// Split `key` on pnpm `>` chain separators (and yarn `/` ancestors),
 /// while keeping `>` characters that belong to a version comparator
 /// (`>=`, `>1.0.0`, `> 1`) attached to the segment they qualify.
+/// pnpm treats `>` as a parent delimiter unless the preceding byte is
+/// a space, `|`, or `@`; this matches its `/[^ |@]>/` boundary rule.
 /// Mirrors `aube-resolver::override_rule::split_segments`.
 fn split_segments(key: &str) -> Option<Vec<&str>> {
     let bytes = key.as_bytes();
     let mut pnpm_parts: Vec<&str> = Vec::new();
     let mut start = 0;
     let mut i = 0;
-    let mut in_req = false;
     while i < bytes.len() {
-        let c = bytes[i];
-        if c == b'@' && !in_req && i != start {
-            in_req = true;
-        } else if c == b'>' {
-            if in_req {
-                let comparator_cont = bytes
-                    .get(i + 1)
-                    .is_some_and(|&n| matches!(n, b'=' | b' ' | b'v') || n.is_ascii_digit());
-                if comparator_cont {
-                    i += 1;
-                    continue;
-                }
-            }
+        if bytes[i] == b'>' && i == 0 {
+            return None;
+        }
+        if bytes[i] == b'>' && !matches!(bytes[i - 1], b' ' | b'|' | b'@') {
             if start == i {
                 return None;
             }
             pnpm_parts.push(&key[start..i]);
             start = i + 1;
-            in_req = false;
         }
         i += 1;
     }
@@ -328,6 +319,10 @@ mod tests {
         assert_eq!(
             target_package_name("parent/@scope/foo@>1.0.0").as_deref(),
             Some("@scope/foo")
+        );
+        assert_eq!(
+            target_package_name("parent@^1>123numeric").as_deref(),
+            Some("123numeric")
         );
     }
 

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -257,8 +257,13 @@ pub(crate) struct ResolveTask {
     pub(crate) importer: String,
     /// The original specifier from package.json before any rewrites
     /// (e.g. `"npm:real-pkg@^2.0.0"` for an alias, or `"^4.17.0"` for a normal range).
-    /// Only set for root deps; recorded into the lockfile for drift detection.
+    /// Only set for root deps; retained for diagnostics and skipped-optional
+    /// drift metadata even when an override changes the lockfile specifier.
     pub(crate) original_specifier: Option<String>,
+    /// Override-applied specifier pnpm records on a direct importer dependency.
+    /// `None` when no override fired, so ordinary catalog dependencies continue
+    /// to emit their raw `catalog:` manifest specifier.
+    lockfile_override_specifier: Option<String>,
     /// Real registry package name for npm-alias tasks.
     ///
     /// When a task arrives with `range` like `"npm:h3@2.0.1-rc.20"`,
@@ -307,6 +312,12 @@ impl ResolveTask {
         self.real_name.as_deref().unwrap_or(&self.name)
     }
 
+    fn lockfile_specifier(&self) -> Option<String> {
+        self.lockfile_override_specifier
+            .clone()
+            .or_else(|| self.original_specifier.clone())
+    }
+
     /// Construct a root-importer task for `(name, range)` under
     /// `importer`, with the appropriate `dep_type` and no parent/ancestry.
     /// Every root-dep enqueue site uses this shape; the factory keeps
@@ -322,6 +333,7 @@ impl ResolveTask {
             parent: None,
             importer,
             original_specifier: Some(original),
+            lockfile_override_specifier: None,
             real_name: None,
             ancestors: Arc::from([]),
             range_from_override: false,
@@ -347,6 +359,7 @@ impl ResolveTask {
             parent: Some(parent),
             importer,
             original_specifier: None,
+            lockfile_override_specifier: None,
             real_name: None,
             ancestors,
             range_from_override: false,

--- a/crates/aube-resolver/src/override_rule.rs
+++ b/crates/aube-resolver/src/override_rule.rs
@@ -98,9 +98,9 @@ fn parse_key(key: &str) -> Option<(Vec<Segment>, Segment)> {
 
 /// Split a selector key into its segment strings. pnpm uses `>` as a
 /// hard separator between `name[@versionreq]` segments; yarn uses `/`
-/// and expects scoped names to count as a single segment. We
-/// auto-detect: `>` wins if present, otherwise fall back to yarn-style
-/// slash tokenization that respects scopes.
+/// and expects scoped names to count as a single segment. Both passes
+/// are applied because a yarn-style selector may contain `>` inside a
+/// version comparator.
 ///
 /// The `>` split isn't a blind `str::split('>')` because a `>`
 /// character is also legal *inside* a version req (`>=2`, `>1.0.0`).
@@ -112,61 +112,66 @@ fn parse_key(key: &str) -> Option<(Vec<Segment>, Segment)> {
 /// other `>` ends the current version req and introduces the next
 /// segment.
 fn split_segments(key: &str) -> Option<Vec<&str>> {
-    if key.contains('>') {
-        let mut parts: Vec<&str> = Vec::new();
-        let bytes = key.as_bytes();
-        let mut start = 0;
-        let mut i = 0;
-        // `in_req` flips true as soon as we see the `@` that
-        // introduces a segment's version req. It resets to false on
-        // every segment boundary.
-        let mut in_req = false;
-        while i < bytes.len() {
-            let c = bytes[i];
-            if c == b'@' && !in_req && i != start {
-                // A non-leading `@` inside a segment starts the
-                // version req. (A leading `@` is the scope prefix
-                // and is handled by `parse_segment`.)
-                in_req = true;
-            } else if c == b'>' {
-                if in_req {
-                    // Could be part of a semver comparator: `>=2`,
-                    // `>1.0`, `> 1` (whitespace), `>v2`. If so, keep
-                    // consuming as part of the version req.
-                    let looks_like_comparator_cont = bytes
-                        .get(i + 1)
-                        .is_some_and(|&n| matches!(n, b'=' | b' ' | b'v') || n.is_ascii_digit());
-                    if looks_like_comparator_cont {
-                        i += 1;
-                        continue;
-                    }
+    let mut pnpm_parts: Vec<&str> = Vec::new();
+    let bytes = key.as_bytes();
+    let mut start = 0;
+    let mut i = 0;
+    // `in_req` flips true as soon as we see the `@` that
+    // introduces a segment's version req. It resets to false on
+    // every segment boundary.
+    let mut in_req = false;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c == b'@' && !in_req && i != start {
+            // A non-leading `@` inside a segment starts the
+            // version req. (A leading `@` is the scope prefix
+            // and is handled by `parse_segment`.)
+            in_req = true;
+        } else if c == b'>' {
+            if in_req {
+                // Could be part of a semver comparator: `>=2`,
+                // `>1.0`, `> 1` (whitespace), `>v2`. If so, keep
+                // consuming as part of the version req.
+                let looks_like_comparator_cont = bytes
+                    .get(i + 1)
+                    .is_some_and(|&n| matches!(n, b'=' | b' ' | b'v') || n.is_ascii_digit());
+                if looks_like_comparator_cont {
+                    i += 1;
+                    continue;
                 }
-                // Segment boundary.
-                if start == i {
-                    return None; // empty segment, e.g. `>foo` or `foo>>bar`
-                }
-                parts.push(&key[start..i]);
-                start = i + 1;
-                in_req = false;
             }
-            i += 1;
+            // Segment boundary.
+            if start == i {
+                return None; // empty segment, e.g. `>foo` or `foo>>bar`
+            }
+            pnpm_parts.push(&key[start..i]);
+            start = i + 1;
+            in_req = false;
         }
-        if start >= bytes.len() {
-            return None; // key ended on `>`
-        }
-        parts.push(&key[start..]);
-        return Some(parts);
+        i += 1;
     }
+    if start >= bytes.len() {
+        return None; // key ended on `>`
+    }
+    pnpm_parts.push(&key[start..]);
+
+    let mut out: Vec<&str> = Vec::new();
+    for part in pnpm_parts {
+        split_slash_segments(part, &mut out)?;
+    }
+    Some(out)
+}
+
+fn split_slash_segments<'a>(part: &'a str, out: &mut Vec<&'a str>) -> Option<()> {
     // Yarn slash form. Walk byte-by-byte so we can tell scope `/` from
     // ancestor `/`: a `/` inside a segment that started with `@` and
     // hasn't seen a `/` yet is a scope separator.
-    let bytes = key.as_bytes();
-    let mut out: Vec<&str> = Vec::new();
+    let bytes = part.as_bytes();
     let mut start = 0;
     let mut i = 0;
     while i < bytes.len() {
         if bytes[i] == b'/' {
-            let current = &key[start..i];
+            let current = &part[start..i];
             let looks_like_scope = current.starts_with('@') && !current[1..].contains('/');
             if !looks_like_scope {
                 if current.is_empty() {
@@ -178,12 +183,12 @@ fn split_segments(key: &str) -> Option<Vec<&str>> {
         }
         i += 1;
     }
-    let tail = &key[start..];
+    let tail = &part[start..];
     if tail.is_empty() {
         return None;
     }
     out.push(tail);
-    Some(out)
+    Some(())
 }
 
 /// Parse one segment string into a `Segment`. Handles `**` (wildcard),
@@ -458,6 +463,19 @@ mod tests {
         assert_eq!(r.parents.len(), 1);
         assert_eq!(r.parents[0].name, "@scope/parent");
         assert_eq!(r.target.name, "foo");
+    }
+
+    #[test]
+    fn parses_yarn_ancestor_targets_with_comparators() {
+        let unscoped = rule("parent/lodash@>=4.0.0", "catalog:");
+        assert_eq!(unscoped.parents[0].name, "parent");
+        assert_eq!(unscoped.target.name, "lodash");
+        assert_eq!(unscoped.target.version_req.as_deref(), Some(">=4.0.0"));
+
+        let scoped = rule("parent/@scope/pkg@>1.0.0", "catalog:");
+        assert_eq!(scoped.parents[0].name, "parent");
+        assert_eq!(scoped.target.name, "@scope/pkg");
+        assert_eq!(scoped.target.version_req.as_deref(), Some(">1.0.0"));
     }
 
     #[test]

--- a/crates/aube-resolver/src/override_rule.rs
+++ b/crates/aube-resolver/src/override_rule.rs
@@ -102,51 +102,26 @@ fn parse_key(key: &str) -> Option<(Vec<Segment>, Segment)> {
 /// are applied because a yarn-style selector may contain `>` inside a
 /// version comparator.
 ///
-/// The `>` split isn't a blind `str::split('>')` because a `>`
-/// character is also legal *inside* a version req (`>=2`, `>1.0.0`).
-/// We walk the key instead, tracking whether we're sitting inside a
-/// version req (entered via an `@` that isn't the scope prefix) and
-/// only splitting on `>` that *starts a new segment* — i.e. isn't
-/// followed by something that looks like a semver comparator
-/// continuation (`=`, a digit, whitespace, or a leading `v`). Any
-/// other `>` ends the current version req and introduces the next
-/// segment.
+/// The `>` split isn't a blind `str::split('>')` because a `>` is also
+/// legal inside a version req (`>=2`, `>1.0.0`). pnpm recognizes a
+/// parent delimiter with `/[^ |@]>/`: a `>` preceded by a space, `|`,
+/// or `@` remains part of the range, and every other `>` is a boundary.
 fn split_segments(key: &str) -> Option<Vec<&str>> {
     let mut pnpm_parts: Vec<&str> = Vec::new();
     let bytes = key.as_bytes();
     let mut start = 0;
     let mut i = 0;
-    // `in_req` flips true as soon as we see the `@` that
-    // introduces a segment's version req. It resets to false on
-    // every segment boundary.
-    let mut in_req = false;
     while i < bytes.len() {
-        let c = bytes[i];
-        if c == b'@' && !in_req && i != start {
-            // A non-leading `@` inside a segment starts the
-            // version req. (A leading `@` is the scope prefix
-            // and is handled by `parse_segment`.)
-            in_req = true;
-        } else if c == b'>' {
-            if in_req {
-                // Could be part of a semver comparator: `>=2`,
-                // `>1.0`, `> 1` (whitespace), `>v2`. If so, keep
-                // consuming as part of the version req.
-                let looks_like_comparator_cont = bytes
-                    .get(i + 1)
-                    .is_some_and(|&n| matches!(n, b'=' | b' ' | b'v') || n.is_ascii_digit());
-                if looks_like_comparator_cont {
-                    i += 1;
-                    continue;
-                }
-            }
+        if bytes[i] == b'>' && i == 0 {
+            return None;
+        }
+        if bytes[i] == b'>' && !matches!(bytes[i - 1], b' ' | b'|' | b'@') {
             // Segment boundary.
             if start == i {
                 return None; // empty segment, e.g. `>foo` or `foo>>bar`
             }
             pnpm_parts.push(&key[start..i]);
             start = i + 1;
-            in_req = false;
         }
         i += 1;
     }
@@ -476,6 +451,14 @@ mod tests {
         assert_eq!(scoped.parents[0].name, "parent");
         assert_eq!(scoped.target.name, "@scope/pkg");
         assert_eq!(scoped.target.version_req.as_deref(), Some(">1.0.0"));
+    }
+
+    #[test]
+    fn parses_numeric_pnpm_chain_target() {
+        let rule = rule("parent@^1>123numeric", "catalog:");
+        assert_eq!(rule.parents[0].name, "parent");
+        assert_eq!(rule.parents[0].version_req.as_deref(), Some("^1"));
+        assert_eq!(rule.target.name, "123numeric");
     }
 
     #[test]

--- a/crates/aube-resolver/src/resolve.rs
+++ b/crates/aube-resolver/src/resolve.rs
@@ -113,6 +113,31 @@ impl Resolver {
     ) -> Result<LockfileGraph, Error> {
         let resolved_catalogs =
             catalog::materialize_catalog_picks(catalog_picks, resolved_versions);
+        // pnpm stores catalog-expanded override values in its lockfile header,
+        // not the raw `catalog:` references from pnpm-workspace.yaml. Resolve
+        // every valid selector against the configured catalogs here so even an
+        // override that did not happen to match this graph is serialized in the
+        // same canonical form. Invalid/missing catalog references stay raw; a
+        // matching task reports the existing catalog diagnostic during resolve.
+        let mut lockfile_overrides = self.overrides.clone();
+        for rule in &self.override_rules {
+            let Some(catalog_name) = rule
+                .replacement
+                .strip_prefix("catalog:")
+                .map(|name| if name.is_empty() { "default" } else { name })
+            else {
+                continue;
+            };
+            let Some(real_range) = self
+                .catalogs
+                .get(catalog_name)
+                .and_then(|catalog| catalog.get(&rule.target.name))
+                .filter(|range| !aube_util::pkg::is_catalog_spec(range))
+            else {
+                continue;
+            };
+            lockfile_overrides.insert(rule.raw_key.clone(), real_range.clone());
+        }
 
         let canonical = LockfileGraph {
             importers,
@@ -125,10 +150,9 @@ impl Resolver {
                 // on after the graph is built when the setting is active.
                 lockfile_include_tarball_url: false,
             },
-            // Stamp the resolver's overrides into the output graph so the
-            // lockfile writer can round-trip them and the next install's
-            // drift check can compare them against the manifest.
-            overrides: self.overrides.clone(),
+            // Stamp the pnpm-canonical override values into the output graph so
+            // the writer and the next install's drift check see the same shape.
+            overrides: lockfile_overrides,
             ignored_optional_dependencies: self.ignored_optional_dependencies.clone(),
             times: resolved_times,
             skipped_optional_dependencies,

--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -1797,6 +1797,13 @@ impl<'a> ResolveDriver<'a> {
                     }
                     None => (override_spec, None),
                 };
+                // pnpm records the override-applied specifier for direct
+                // importer dependencies. Keep ordinary `catalog:` dependencies
+                // verbatim, but once an override fires use its effective value
+                // (including catalog expansion) in the lockfile importer.
+                if task.is_root {
+                    task.original_specifier = Some(effective_spec.clone());
+                }
                 if task.range != effective_spec {
                     if let Some((catalog_name, real_range)) = pending_pick {
                         self.catalog_picks

--- a/crates/aube-resolver/src/resolve/driver.rs
+++ b/crates/aube-resolver/src/resolve/driver.rs
@@ -993,7 +993,7 @@ impl<'a> ResolveDriver<'a> {
                 name: task.name.clone(),
                 dep_path: dep_path.clone(),
                 dep_type: task.dep_type,
-                specifier: task.original_specifier.clone(),
+                specifier: task.lockfile_specifier(),
             });
         }
 
@@ -1626,7 +1626,7 @@ impl<'a> ResolveDriver<'a> {
                 name: task.name.clone(),
                 dep_path: dep_path.clone(),
                 dep_type: task.dep_type,
-                specifier: task.original_specifier.clone(),
+                specifier: task.lockfile_specifier(),
             });
         }
 
@@ -1749,8 +1749,8 @@ impl<'a> ResolveDriver<'a> {
         // Catalog protocol: rewrite `catalog:` / `catalog:<name>` to
         // the workspace catalog's actual range *before* the override
         // loop, so overrides can still target a catalog dep by bare
-        // name. The original `catalog:...` text stays in
-        // `original_specifier` for the lockfile importer.
+        // name. The raw `catalog:...` text stays in `original_specifier`;
+        // the separate lockfile field changes only if an override fires.
         if let Some((catalog_name, real_range)) = self
             .resolver
             .resolve_catalog_spec(&task.name, &task.range)?
@@ -1802,7 +1802,7 @@ impl<'a> ResolveDriver<'a> {
                 // verbatim, but once an override fires use its effective value
                 // (including catalog expansion) in the lockfile importer.
                 if task.is_root {
-                    task.original_specifier = Some(effective_spec.clone());
+                    task.lockfile_override_specifier = Some(effective_spec.clone());
                 }
                 if task.range != effective_spec {
                     if let Some((catalog_name, real_range)) = pending_pick {
@@ -1939,7 +1939,7 @@ impl<'a> ResolveDriver<'a> {
                 name: task.name.clone(),
                 dep_path: dep_path.clone(),
                 dep_type: task.dep_type,
-                specifier: task.original_specifier.clone(),
+                specifier: task.lockfile_specifier(),
             });
         }
         if let Some(ref parent_dp) = task.parent
@@ -2063,7 +2063,7 @@ impl<'a> ResolveDriver<'a> {
                 name: task.name.clone(),
                 dep_path: dep_path.clone(),
                 dep_type: task.dep_type,
-                specifier: task.original_specifier.clone(),
+                specifier: task.lockfile_specifier(),
             });
         }
         if let Some(ref parent_dp) = task.parent

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -4421,7 +4421,13 @@ async fn catalog_override_records_pnpm_resolved_lockfile_shape() {
         "default".to_string(),
         BTreeMap::from([("is-number".to_string(), "7.0.0".to_string())]),
     )]);
-    let overrides = BTreeMap::from([("is-number".to_string(), "catalog:".to_string())]);
+    let overrides = BTreeMap::from([
+        ("is-number".to_string(), "catalog:".to_string()),
+        (
+            "parent/is-number@>=7.0.0".to_string(),
+            "catalog:".to_string(),
+        ),
+    ]);
     let mut resolver = Resolver::new(client)
         .with_catalogs(catalogs)
         .with_overrides(overrides);
@@ -4438,6 +4444,7 @@ async fn catalog_override_records_pnpm_resolved_lockfile_shape() {
         .expect("catalog override should resolve");
 
     assert_eq!(graph.overrides["is-number"], "7.0.0");
+    assert_eq!(graph.overrides["parent/is-number@>=7.0.0"], "7.0.0");
     let dep = &graph.importers["."][0];
     assert_eq!(dep.name, "is-number");
     assert_eq!(dep.specifier.as_deref(), Some("7.0.0"));

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -4419,7 +4419,10 @@ async fn catalog_override_records_pnpm_resolved_lockfile_shape() {
     ));
     let catalogs = BTreeMap::from([(
         "default".to_string(),
-        BTreeMap::from([("is-number".to_string(), "7.0.0".to_string())]),
+        BTreeMap::from([
+            ("is-number".to_string(), "7.0.0".to_string()),
+            ("123numeric".to_string(), "1.0.0".to_string()),
+        ]),
     )]);
     let overrides = BTreeMap::from([
         ("is-number".to_string(), "catalog:".to_string()),
@@ -4427,6 +4430,7 @@ async fn catalog_override_records_pnpm_resolved_lockfile_shape() {
             "parent/is-number@>=7.0.0".to_string(),
             "catalog:".to_string(),
         ),
+        ("parent@^1>123numeric".to_string(), "catalog:".to_string()),
     ]);
     let mut resolver = Resolver::new(client)
         .with_catalogs(catalogs)
@@ -4445,6 +4449,7 @@ async fn catalog_override_records_pnpm_resolved_lockfile_shape() {
 
     assert_eq!(graph.overrides["is-number"], "7.0.0");
     assert_eq!(graph.overrides["parent/is-number@>=7.0.0"], "7.0.0");
+    assert_eq!(graph.overrides["parent@^1>123numeric"], "1.0.0");
     let dep = &graph.importers["."][0];
     assert_eq!(dep.name, "is-number");
     assert_eq!(dep.specifier.as_deref(), Some("7.0.0"));

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -4399,6 +4399,43 @@ async fn fresh_resolve_handles_versionless_scoped_npm_alias_from_catalog() {
     let entry = catalog.get("popper2").unwrap();
     assert_eq!(entry.specifier, "npm:@popperjs/core");
     assert_eq!(entry.version, "2.11.8");
+    assert_eq!(
+        graph.importers["."][0].specifier.as_deref(),
+        Some("catalog:"),
+        "an ordinary catalog dependency keeps its manifest specifier"
+    );
+}
+
+#[tokio::test]
+async fn catalog_override_records_pnpm_resolved_lockfile_shape() {
+    let is_number = make_packument("is-number", &["7.0.0"], "7.0.0");
+    let client = Arc::new(aube_registry::client::RegistryClient::new(
+        "http://127.0.0.1:0",
+    ));
+    let catalogs = BTreeMap::from([(
+        "default".to_string(),
+        BTreeMap::from([("is-number".to_string(), "7.0.0".to_string())]),
+    )]);
+    let overrides = BTreeMap::from([("is-number".to_string(), "catalog:".to_string())]);
+    let mut resolver = Resolver::new(client)
+        .with_catalogs(catalogs)
+        .with_overrides(overrides);
+    resolver.cache.insert("is-number".to_string(), is_number);
+
+    let mut manifest = PackageJson::default();
+    manifest
+        .dev_dependencies
+        .insert("is-number".to_string(), "catalog:".to_string());
+
+    let graph = resolver
+        .resolve(&manifest, None)
+        .await
+        .expect("catalog override should resolve");
+
+    assert_eq!(graph.overrides["is-number"], "7.0.0");
+    let dep = &graph.importers["."][0];
+    assert_eq!(dep.name, "is-number");
+    assert_eq!(dep.specifier.as_deref(), Some("7.0.0"));
 }
 
 // Catalog-aliased dep + selector override targeting the original
@@ -4457,6 +4494,11 @@ async fn override_with_bare_range_undoes_prior_catalog_alias() {
     );
     assert!(!graph.packages.contains_key("js-yaml@0.0.11"));
     assert!(!graph.packages.contains_key("@zkochan/js-yaml@0.0.11"));
+    assert_eq!(
+        graph.importers["."][0].specifier.as_deref(),
+        Some("^3.14.2"),
+        "version-keyed overrides rewrite direct importer specifiers"
+    );
 }
 
 #[tokio::test]

--- a/crates/aube-resolver/src/tests.rs
+++ b/crates/aube-resolver/src/tests.rs
@@ -68,6 +68,7 @@ fn build_age_gate_resolves_dist_tag_range() {
         parent: None,
         importer: ".".into(),
         original_specifier: None,
+        lockfile_override_specifier: None,
         real_name: None,
         ancestors: Arc::from([]),
         range_from_override: false,
@@ -92,6 +93,7 @@ fn build_no_match_falls_back_to_prereleases() {
         parent: None,
         importer: ".".into(),
         original_specifier: None,
+        lockfile_override_specifier: None,
         real_name: None,
         ancestors: Arc::from([]),
         range_from_override: false,
@@ -338,6 +340,7 @@ fn exotic_subdeps_from_local_parents_are_allowed() {
         parent: Some("pi-web-ui@file+abc123".to_string()),
         importer: ".".to_string(),
         original_specifier: None,
+        lockfile_override_specifier: None,
         real_name: None,
         ancestors: Arc::from([]),
         range_from_override: false,
@@ -367,6 +370,7 @@ fn exotic_subdeps_from_unknown_parents_stay_blocked() {
         parent: Some("pi-web-ui@file+missing".to_string()),
         importer: ".".to_string(),
         original_specifier: None,
+        lockfile_override_specifier: None,
         real_name: None,
         ancestors: Arc::from([]),
         range_from_override: false,
@@ -385,6 +389,7 @@ fn exotic_subdeps_from_registry_parents_stay_blocked() {
         parent: Some("pi-web-ui@0.68.1".to_string()),
         importer: ".".to_string(),
         original_specifier: None,
+        lockfile_override_specifier: None,
         real_name: None,
         ancestors: Arc::from([]),
         range_from_override: false,
@@ -4436,6 +4441,39 @@ async fn catalog_override_records_pnpm_resolved_lockfile_shape() {
     let dep = &graph.importers["."][0];
     assert_eq!(dep.name, "is-number");
     assert_eq!(dep.specifier.as_deref(), Some("7.0.0"));
+}
+
+#[tokio::test]
+async fn skipped_optional_override_keeps_raw_manifest_specifier() {
+    let mut optional = make_packument("platform-only", &["7.0.0"], "7.0.0");
+    let unsupported_os = if cfg!(target_os = "macos") {
+        "linux"
+    } else {
+        "darwin"
+    };
+    optional.versions.get_mut("7.0.0").unwrap().os = vec![unsupported_os.to_string()];
+
+    let client = Arc::new(aube_registry::client::RegistryClient::new(
+        "http://127.0.0.1:0",
+    ));
+    let overrides = BTreeMap::from([("platform-only".to_string(), "7.0.0".to_string())]);
+    let mut resolver = Resolver::new(client).with_overrides(overrides);
+    resolver.cache.insert("platform-only".to_string(), optional);
+
+    let mut manifest = PackageJson::default();
+    manifest
+        .optional_dependencies
+        .insert("platform-only".to_string(), "^6.0.0".to_string());
+
+    let graph = resolver
+        .resolve(&manifest, None)
+        .await
+        .expect("platform-skipped override should resolve");
+
+    assert_eq!(
+        graph.skipped_optional_dependencies["."]["platform-only"], "^6.0.0",
+        "skipped-optional drift metadata must keep the manifest value"
+    );
 }
 
 // Catalog-aliased dep + selector override targeting the original


### PR DESCRIPTION
## Summary

- expand `catalog:` references in lockfile override metadata
- record override-applied specifiers for direct importer dependencies
- preserve raw `catalog:` specifiers when no override fires

Fixes the pnpm interoperability failure reported in [Discussion #1343](https://github.com/jdx/aube/discussions/1343).

## Testing

- `cargo test -p aube-resolver`
- `cargo test -p aube-lockfile`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- reporter reproduction with pnpm 11.22.0

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches lockfile serialization, frozen-lockfile drift, and override selector parsing. Incorrect expansion or parsing could cause false drift or wrong catalog lookups, but this is interoperability rather than auth or data handling.
> 
> **Overview**
> Makes pnpm lockfile output match pnpm’s catalog-override format so frozen installs no longer disagree with pnpm-written lockfiles.
> 
> Catalog `overrides` are now expanded to concrete ranges in the lockfile header, including ancestor selectors that never matched this graph. Direct importer deps record the override-applied specifier when an override fires, while ordinary `catalog:` deps and skipped-optional metadata keep the raw manifest value.
> 
> Override key parsing now splits pnpm `>` and Yarn `/` in two passes using pnpm’s `/[^ |@]>/` boundary, so selectors like `parent/lodash@>=4` and `parent@^1>123numeric` resolve the correct target for catalog lookup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 836ca876efef4928659c86a9ad68ef5fe8800a40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Catalog-based dependency overrides now resolve to configured version ranges in lockfile data.
  * Root dependency records reflect effective override values, including expanded catalog references.
  * Ordinary catalog dependencies preserve their original `catalog:` specifiers.
  * Version-based overrides correctly replace catalog aliases with intended ranges.
  * Optional dependencies skipped on unsupported platforms retain their original manifest specifiers.
  * Nested package selectors, including mixed pnpm and Yarn syntax, resolve the correct target package.
  * Version-qualified selectors with numeric package names now resolve correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->