### PR TITLE
chore: manage usage cli with mise

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -413,40 +413,40 @@ checksum = "sha256:60cd368533d0ad73fa86d93d5bbf95ef40587245ce684ed138c1b31557b5f
 url = "https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_windows_amd64.exe"
 
 [[tools.usage]]
-version = "4.0.0"
+version = "6.1.0"
 backend = "aqua:jdx/usage"
 
 [tools.usage."platforms.linux-arm64"]
-checksum = "sha256:bb9556ad822852f1824d9fb6e4d4063d3bf2639929ec4b74750c1f419c2ef733"
-url = "https://github.com/jdx/usage/releases/download/v4.0.0/usage-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/489800370"
+checksum = "sha256:bb52c86367cabd59d455debdc8402434a7863cc5d24b506e9230409a187ceb57"
+url = "https://github.com/jdx/usage/releases/download/v6.1.0/usage-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/525532817"
 
 [tools.usage."platforms.linux-arm64-musl"]
-checksum = "sha256:bb9556ad822852f1824d9fb6e4d4063d3bf2639929ec4b74750c1f419c2ef733"
-url = "https://github.com/jdx/usage/releases/download/v4.0.0/usage-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/489800370"
+checksum = "sha256:bb52c86367cabd59d455debdc8402434a7863cc5d24b506e9230409a187ceb57"
+url = "https://github.com/jdx/usage/releases/download/v6.1.0/usage-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/525532817"
 
 [tools.usage."platforms.linux-x64"]
-checksum = "sha256:3ce4d8d30f27db44f0aa2fe8bd351229e36e8d38b09060b0cadb7e02be57c69e"
-url = "https://github.com/jdx/usage/releases/download/v4.0.0/usage-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/489800150"
+checksum = "sha256:2ceec78d071d66a5dcdcc6ad68a5ee79c64fc6c2fbe0050d4f013dfbc3308ba2"
+url = "https://github.com/jdx/usage/releases/download/v6.1.0/usage-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/525532821"
 
 [tools.usage."platforms.linux-x64-musl"]
-checksum = "sha256:3ce4d8d30f27db44f0aa2fe8bd351229e36e8d38b09060b0cadb7e02be57c69e"
-url = "https://github.com/jdx/usage/releases/download/v4.0.0/usage-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/489800150"
+checksum = "sha256:2ceec78d071d66a5dcdcc6ad68a5ee79c64fc6c2fbe0050d4f013dfbc3308ba2"
+url = "https://github.com/jdx/usage/releases/download/v6.1.0/usage-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/525532821"
 
 [tools.usage."platforms.macos-arm64"]
-checksum = "sha256:b86b3b96590c40156977906758b92238fab506edcbdc5331f9efb034207e2ab4"
-url = "https://github.com/jdx/usage/releases/download/v4.0.0/usage-universal-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/489800167"
+checksum = "sha256:317156bbd740ce95195e1016eb6800145944b4dbd2bd7e4f874684761b989524"
+url = "https://github.com/jdx/usage/releases/download/v6.1.0/usage-universal-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/525531450"
 
 [tools.usage."platforms.macos-x64"]
-checksum = "sha256:b86b3b96590c40156977906758b92238fab506edcbdc5331f9efb034207e2ab4"
-url = "https://github.com/jdx/usage/releases/download/v4.0.0/usage-universal-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/489800167"
+checksum = "sha256:317156bbd740ce95195e1016eb6800145944b4dbd2bd7e4f874684761b989524"
+url = "https://github.com/jdx/usage/releases/download/v6.1.0/usage-universal-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/525531450"
 
 [tools.usage."platforms.windows-x64"]
-checksum = "sha256:91a241e3abf4925855814ae8cab3e6e826736b9cfaddc55a12cf4c3fe03d0dc7"
-url = "https://github.com/jdx/usage/releases/download/v4.0.0/usage-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/489801502"
+checksum = "sha256:816843e71bf5ecc2d458b328b89edc771ca0a1f8b1777ff7be254007920a64bf"
+url = "https://github.com/jdx/usage/releases/download/v6.1.0/usage-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/525535418"

--- a/mise.toml
+++ b/mise.toml
@@ -7,6 +7,7 @@ cargo.binstall_native = true
 
 [tools]
 actionlint = "latest"
+usage = "6.1.0"
 communique = "latest"
 "github:bnjbvr/cargo-machete" = "latest"
 "github:foresterre/cargo-msrv" = "latest"
@@ -162,18 +163,13 @@ dir = "{{config_root}}"
 run = "bash benchmarks/pgo.bash"
 
 [tasks.render]
-depends = ["build", "build-usage"]
+depends = ["build"]
 run = [
   "./target/debug/aube usage > aube.usage.kdl",
   "rm -rf docs/cli && mkdir -p docs/cli",
-  "target/usage-cli/bin/usage g markdown -mf aube.usage.kdl --out-dir docs/cli --url-prefix /cli",
-  "target/usage-cli/bin/usage g json -f aube.usage.kdl > docs/cli/commands.json",
+  "usage g markdown -mf aube.usage.kdl --out-dir docs/cli --url-prefix /cli",
+  "usage g json -f aube.usage.kdl > docs/cli/commands.json",
   "node scripts/patch-generated-cli-docs.mjs",
   "cargo run -p aube-settings --bin generate-settings-docs",
   "cargo run -p aube-codes --bin generate-error-codes-docs",
 ]
-
-[tasks.build-usage]
-run = "cargo install --locked --root target/usage-cli --version 6.1.0 usage-cli"
-sources = ["Cargo.lock", "mise.toml"]
-outputs = ["target/usage-cli/bin/usage"]


### PR DESCRIPTION
## Summary

- pin the precompiled usage 6.1.0 release in mise.toml and mise.lock
- use the mise-managed usage executable during docs rendering
- remove the custom cargo install task and target-local binary path

## Verification

- MISE_LOCKED=1 mise install usage@6.1.0
- usage --version
- mise run render
- mise run lint
- mise run test

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added the Usage CLI tool at version 6.1.0.
  * Updated rendering to use the managed Usage CLI tool.
  * Removed the redundant Usage build task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->