### PR TITLE
ci: run docs workflow for mise changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,8 @@ on:
       - "aube.usage.kdl"
       - "crates/**"
       - "Cargo.lock"
+      - "mise.toml"
+      - "mise.lock"
       - "benchmarks/results.json"
       - ".github/workflows/docs.yml"
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- run the docs workflow when `mise.toml` changes
- run the docs workflow when `mise.lock` changes
- ensure docs toolchain updates such as the `usage` CLI fix are validated and deploy the site

## Validation

- `mise exec -- actionlint .github/workflows/docs.yml`
- `mise exec -- usage --version` (`usage 6.1.0`)
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI path-filter only; no application, auth, or deploy-step logic changes.
> 
> **Overview**
> The docs GitHub Pages workflow now also runs on pushes that change `mise.toml` or `mise.lock`. That picks up toolchain updates (for example the `usage` CLI used to generate CLI docs) instead of skipping the site rebuild.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7af86c43f548c65aa49040b9dca6e0d56bd0905. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Documentation workflows now run when configuration lockfiles or tool configuration changes are pushed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->