### PR TITLE
fix(release-plz): preserve major-only requirements on patch bumps

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -353,11 +353,18 @@ jobs:
               .split('\n')
               .map((line) => {
                 if (!line.startsWith(`${name} = {`) || !line.includes('path = ')) return line;
-                const updated = line.replace(`version = "${oldVersion}"`, `version = "${newVersion}"`);
-                if (updated === line) {
-                  throw new Error(`path dependency ${name} did not contain version ${oldVersion}`);
+                const exact = `version = "${oldVersion}"`;
+                if (line.includes(exact)) {
+                  return line.replace(exact, `version = "${newVersion}"`);
                 }
-                return updated;
+                const oldMajor = oldVersion.split('.')[0];
+                const newMajor = newVersion.split('.')[0];
+                if (oldMajor === newMajor && line.includes(`version = "${oldMajor}"`)) {
+                  return line;
+                }
+                throw new Error(
+                  `path dependency ${name} did not contain version ${oldVersion} or compatible major ${oldMajor}`,
+                );
               })
               .join('\n');
           }


### PR DESCRIPTION
Fix the repo-only force-patch path so it preserves compatible major-only workspace dependency requirements such as `version = "2"` when moving from 2.0.1 to 2.0.2. Exact internal versions are still rewritten, and unexpected requirements still fail closed.

Validated with `actionlint`, `git diff --check`, and a check against every current workspace `aube*` path requirement.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, fail-closed change to release-PR Cargo.toml rewriting only. Does not alter publish, auth, or crate contents.
> 
> **Overview**
> Stops the repo-only force-patch path in `release-plz.yml` from failing (or rewriting) workspace path deps that use a **major-only** requirement such as `version = "2"` when bumping `2.0.1` → `2.0.2`.
> 
> Exact internal versions are still rewritten. Anything that is neither the old exact version nor a compatible major is still a hard error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99ffe964442c4a47c20c29cb6a62e8ee1a1140e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release version handling for compatible path dependencies.
  * Prevented unnecessary release failures when dependencies already use another version within the same major version.
  * Preserved validation when dependency versions are incompatible or unexpected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->