### PR TITLE
chore: release v2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "aube-codes"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "aube-ffi"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "aube",
  "aube-codes",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "aube-node"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "aube",
  "aube-codes",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "aube-runtime"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "aube-util",
  "base64 0.23.1",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "aube-codes",
  "blake3",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "aube-codes",
  "aube-manifest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ inherits = "release"
 panic = "unwind"
 
 [workspace.package]
-version = "2.0.1"
+version = "2.1.0"
 edition = "2024"
 # Kept at the floor mise can build with (its distro packaging pins the
 # toolchain) so mise can embed the library crates. CI enforces this via

--- a/crates/aube-codes/CHANGELOG.md
+++ b/crates/aube-codes/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0](https://github.com/jdx/aube/compare/aube-codes-v2.0.1...aube-codes-v2.1.0) - 2026-08-23
+
+### Other
+
+- refresh benchmarks for v2.0.1 ([#1350](https://github.com/jdx/aube/pull/1350))
+
 ## [2.0.1](https://github.com/jdx/aube/compare/aube-codes-v2.0.0...aube-codes-v2.0.1) - 2026-08-23
 
 ### Added

--- a/crates/aube-linker/CHANGELOG.md
+++ b/crates/aube-linker/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0](https://github.com/jdx/aube/compare/aube-linker-v2.0.1...aube-linker-v2.1.0) - 2026-08-23
+
+### Other
+
+- refresh benchmarks for v2.0.1 ([#1350](https://github.com/jdx/aube/pull/1350))
+
 ## [2.0.1](https://github.com/jdx/aube/compare/aube-linker-v2.0.0...aube-linker-v2.0.1) - 2026-08-23
 
 ### Added

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0](https://github.com/jdx/aube/compare/aube-lockfile-v2.0.1...aube-lockfile-v2.1.0) - 2026-08-23
+
+### Other
+
+- refresh benchmarks for v2.0.1 ([#1350](https://github.com/jdx/aube/pull/1350))
+
 ## [2.0.1](https://github.com/jdx/aube/compare/aube-lockfile-v2.0.0...aube-lockfile-v2.0.1) - 2026-08-23
 
 ### Added

--- a/crates/aube-manifest/CHANGELOG.md
+++ b/crates/aube-manifest/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0](https://github.com/jdx/aube/compare/aube-manifest-v2.0.1...aube-manifest-v2.1.0) - 2026-08-23
+
+### Other
+
+- refresh benchmarks for v2.0.1 ([#1350](https://github.com/jdx/aube/pull/1350))
+
 ## [2.0.1](https://github.com/jdx/aube/compare/aube-manifest-v2.0.0...aube-manifest-v2.0.1) - 2026-08-23
 
 ### Added

--- a/crates/aube-registry/CHANGELOG.md
+++ b/crates/aube-registry/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0](https://github.com/jdx/aube/compare/aube-registry-v2.0.1...aube-registry-v2.1.0) - 2026-08-23
+
+### Other
+
+- refresh benchmarks for v2.0.1 ([#1350](https://github.com/jdx/aube/pull/1350))
+
 ## [1.41.0](https://github.com/jdx/aube/compare/aube-registry-v1.40.0...aube-registry-v1.41.0) - 2026-08-16
 
 ### Other

--- a/crates/aube-resolver/CHANGELOG.md
+++ b/crates/aube-resolver/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0](https://github.com/jdx/aube/compare/aube-resolver-v2.0.1...aube-resolver-v2.1.0) - 2026-08-23
+
+### Other
+
+- *(resolver)* bypass network limit for primer metadata ([#1353](https://github.com/jdx/aube/pull/1353))
+- *(resolver)* bypass network limit for disk metadata ([#1352](https://github.com/jdx/aube/pull/1352))
+- refresh benchmarks for v2.0.1 ([#1350](https://github.com/jdx/aube/pull/1350))
+
 ## [1.41.0](https://github.com/jdx/aube/compare/aube-resolver-v1.40.0...aube-resolver-v1.41.0) - 2026-08-16
 
 ### Fixed

--- a/crates/aube-runtime/CHANGELOG.md
+++ b/crates/aube-runtime/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0](https://github.com/jdx/aube/compare/aube-runtime-v2.0.1...aube-runtime-v2.1.0) - 2026-08-23
+
+### Other
+
+- refresh benchmarks for v2.0.1 ([#1350](https://github.com/jdx/aube/pull/1350))
+
 ## [1.41.0](https://github.com/jdx/aube/compare/aube-runtime-v1.40.0...aube-runtime-v1.41.0) - 2026-08-16
 
 ### Other

--- a/crates/aube-scripts/CHANGELOG.md
+++ b/crates/aube-scripts/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0](https://github.com/jdx/aube/compare/aube-scripts-v2.0.1...aube-scripts-v2.1.0) - 2026-08-23
+
+### Other
+
+- *(run)* exec plain script command lines without a shell ([#1363](https://github.com/jdx/aube/pull/1363))
+- refresh benchmarks for v2.0.1 ([#1350](https://github.com/jdx/aube/pull/1350))
+
 ## [1.41.0](https://github.com/jdx/aube/compare/aube-scripts-v1.40.0...aube-scripts-v1.41.0) - 2026-08-16
 
 ### Other

--- a/crates/aube-settings/CHANGELOG.md
+++ b/crates/aube-settings/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0](https://github.com/jdx/aube/compare/aube-settings-v2.0.1...aube-settings-v2.1.0) - 2026-08-23
+
+### Other
+
+- refresh benchmarks for v2.0.1 ([#1350](https://github.com/jdx/aube/pull/1350))
+
 ## [2.0.1](https://github.com/jdx/aube/compare/aube-settings-v2.0.0...aube-settings-v2.0.1) - 2026-08-23
 
 ### Added

--- a/crates/aube-store/CHANGELOG.md
+++ b/crates/aube-store/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0](https://github.com/jdx/aube/compare/aube-store-v2.0.1...aube-store-v2.1.0) - 2026-08-23
+
+### Other
+
+- refresh benchmarks for v2.0.1 ([#1350](https://github.com/jdx/aube/pull/1350))
+
 ## [2.0.1](https://github.com/jdx/aube/compare/aube-store-v2.0.0...aube-store-v2.0.1) - 2026-08-23
 
 ### Added

--- a/crates/aube-util/CHANGELOG.md
+++ b/crates/aube-util/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0](https://github.com/jdx/aube/compare/aube-util-v2.0.1...aube-util-v2.1.0) - 2026-08-23
+
+### Other
+
+- refresh benchmarks for v2.0.1 ([#1350](https://github.com/jdx/aube/pull/1350))
+
 ## [2.0.1](https://github.com/jdx/aube/compare/aube-util-v2.0.0...aube-util-v2.0.1) - 2026-08-23
 
 ### Added

--- a/crates/aube-workspace/CHANGELOG.md
+++ b/crates/aube-workspace/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0](https://github.com/jdx/aube/compare/aube-workspace-v2.0.1...aube-workspace-v2.1.0) - 2026-08-23
+
+### Other
+
+- refresh benchmarks for v2.0.1 ([#1350](https://github.com/jdx/aube/pull/1350))
+
 ## [1.41.0](https://github.com/jdx/aube/compare/aube-workspace-v1.40.0...aube-workspace-v1.41.0) - 2026-08-16
 
 ### Other

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0](https://github.com/jdx/aube/compare/v2.0.1...v2.1.0) - 2026-08-23
+
+### Added
+
+- *(run)* echo the script command line before running it ([#1358](https://github.com/jdx/aube/pull/1358))
+
+### Fixed
+
+- *(install)* apply global virtual store flags in ci ([#1355](https://github.com/jdx/aube/pull/1355))
+
+### Other
+
+- *(run)* exec final aubr script shell on unix ([#1360](https://github.com/jdx/aube/pull/1360))
+- *(run)* reuse manifest and settings contexts ([#1359](https://github.com/jdx/aube/pull/1359))
+- *(run)* exec plain script command lines without a shell ([#1363](https://github.com/jdx/aube/pull/1363))
+- *(run)* only rewrite node-gyp shims when they change ([#1361](https://github.com/jdx/aube/pull/1361))
+- *(run)* defer aubr install runtime startup ([#1357](https://github.com/jdx/aube/pull/1357))
+- refresh benchmarks for v2.0.1 ([#1350](https://github.com/jdx/aube/pull/1350))
+
 ## [2.0.1](https://github.com/jdx/aube/compare/v1.41.0...v2.0.1) - 2026-08-23
 
 ### Added

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "2.0.1",
-  "releasedAt": "2026-08-23T01:17:50Z"
+  "version": "2.1.0",
+  "releasedAt": "2026-08-23T21:42:52Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v2.1.0`

This PR bumps the workspace to `v2.1.0` and regenerates CHANGELOG entries, `aube.usage.kdl`, the CLI docs, and the benchmark results.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata only: version strings, changelogs, and release.json. No runtime or security logic changes.
> 
> **Overview**
> Cuts **v2.1.0** by bumping `[workspace.package]` / crate versions and `release.json`.
> 
> Changelogs record the post-2.0.1 work: `run` echo/exec/shim/startup tweaks, CI global virtual-store flags, resolver network-limit bypasses for primer/disk metadata, and a benchmark refresh. No product code is in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ede29f18fd1f176ac50aeb1dae6b9da89c1cde5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->