### PR TITLE
fix(install): apply global virtual store flags in ci

### DIFF
--- a/crates/aube/src/commands/ci.rs
+++ b/crates/aube/src/commands/ci.rs
@@ -38,6 +38,11 @@ pub async fn run(args: CiArgs) -> miette::Result<()> {
     args.network.install_overrides();
     args.lockfile.install_overrides();
     args.virtual_store.install_overrides();
+    let mut cli_flags = args.virtual_store.flags().to_cli_flag_bag();
+    cli_flags.push((
+        "dangerously-allow-all-builds".to_string(),
+        "false".to_string(),
+    ));
     let CiArgs {
         ignore_scripts,
         no_optional,
@@ -79,10 +84,7 @@ pub async fn run(args: CiArgs) -> miette::Result<()> {
         minimum_release_age_override: None,
         strict_no_lockfile: true,
         force: false,
-        cli_flags: vec![(
-            "dangerously-allow-all-builds".to_string(),
-            "false".to_string(),
-        )],
+        cli_flags,
         env_snapshot: aube_settings::values::capture_env(),
         git_prepare_depth: 0,
         inherited_build_policy: None,

--- a/test/ci.bats
+++ b/test/ci.bats
@@ -64,6 +64,23 @@ teardown() {
 	assert_file_exists node_modules/is-odd/package.json
 }
 
+@test "aube ci --disable-global-virtual-store materializes packages per-project" {
+	_setup_basic_fixture
+	run aube --disable-global-virtual-store ci
+	assert_success
+	assert_dir_exists node_modules/.aube/is-odd@3.0.1
+	run test -L node_modules/.aube/is-odd@3.0.1
+	assert_failure
+}
+
+@test "aube clean-install --enable-global-virtual-store overrides the CI default" {
+	_setup_basic_fixture
+	run env CI=1 aube clean-install --enable-global-virtual-store
+	assert_success
+	run test -L node_modules/.aube/is-odd@3.0.1
+	assert_success
+}
+
 @test "aube ci removes a symlink node_modules without wiping its target" {
 	# If node_modules is a symlink to an unrelated directory (rare but
 	# legal), ci must unlink the symlink itself and NOT recursively delete


### PR DESCRIPTION
## Summary

- thread global virtual store CLI flags into `aube ci` install settings
- preserve the CI hard-disable for dependency builds
- cover disable/enable overrides, pre/post-subcommand placement, and the `clean-install` alias

Discussion: #1351

## Tests

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p aube --lib`
- `mise run test:bats test/ci.bats --filter global-virtual-store`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI flag-plumbing fix in the CI install path with bats coverage; no auth or lockfile-integrity changes.
> 
> **Overview**
> `aube ci` now forwards global virtual-store CLI flags into install settings instead of dropping them. `--disable-global-virtual-store` / `--enable-global-virtual-store` (including the `clean-install` alias) actually change whether packages are materialized locally or linked from the global store.
> 
> The CI hard-disable of `--dangerously-allow-all-builds` is unchanged; that flag is still appended after the virtual-store bag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59d6451920531cf0007a85a5bdf2ca2110490e4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CI installs now honor virtual store configuration flags while retaining secure build settings.
  * Per-project package materialization works correctly when the global virtual store is disabled.
  * Explicitly enabling the global virtual store now correctly overrides the default CI behavior.

* **Tests**
  * Added coverage for virtual store behavior during clean CI installs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->