### PR TITLE
perf(release): broaden offline PGO training

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -293,7 +293,7 @@ jobs:
   # PGO-optimized targets: x86_64 Linux GNU/musl (cross-built on amd64)
   # plus native aarch64 Linux GNU and native macOS arm64. Each builds
   # via benchmarks/pgo.bash — instrument under release-pgo, train against
-  # the hermetic Verdaccio registry, rebuild with -Cprofile-use. The
+  # the committed offline registry, rebuild with -Cprofile-use. The
   # x86_64 Linux targets use build-tool=cross so the resulting binary
   # preserves the current glibc baseline; the cross-built instrumented
   # binary runs on the host for training (cross's older glibc is
@@ -444,9 +444,8 @@ jobs:
           echo "/usr/lib/llvm-18/bin" >> "$GITHUB_PATH"
           /usr/lib/llvm-18/bin/llvm-bolt --version | head -2
           /usr/lib/llvm-18/bin/merge-fdata --help | head -2 || true
-      # verdaccio is installed lazily by hermetic.bash's
-      # _hermetic_ensure_verdaccio (called from pgo.bash via hermetic_start),
-      # so no explicit install step is needed here.
+      # PGO training is served from test/registry/storage by a dependency-free
+      # local Node server. Release builds never contact npmjs.org.
       - name: Import codesign certs
         if: startsWith(matrix.os, 'macos')
         uses: apple-actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7.0.0

--- a/benchmarks/offline-registry.mts
+++ b/benchmarks/offline-registry.mts
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+
+import { createReadStream, readFileSync, statSync } from "node:fs";
+import { createServer } from "node:http";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const storageDir = join(scriptDir, "..", "test", "registry", "storage");
+const portArg = process.argv.indexOf("--port");
+const port = portArg === -1 ? 4876 : Number(process.argv[portArg + 1]);
+
+if (!Number.isInteger(port) || port < 1 || port > 65535) {
+  console.error("offline-registry: --port must be an integer from 1 to 65535");
+  process.exit(2);
+}
+
+const packagePattern = /^(?:@[a-zA-Z0-9._~-]+\/)?[a-zA-Z0-9._~-]+$/;
+
+createServer((request, response) => {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    response.writeHead(405).end();
+    return;
+  }
+
+  const requestUrl = new URL(
+    request.url ?? "/",
+    "http://" + request.headers.host,
+  );
+  let pathname: string;
+  try {
+    pathname = decodeURIComponent(requestUrl.pathname);
+  } catch {
+    response.writeHead(400).end();
+    return;
+  }
+
+  if (pathname === "/") {
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end('{"name":"aube-offline-registry"}');
+    return;
+  }
+
+  const tarballMarker = "/-/";
+  const markerIndex = pathname.indexOf(tarballMarker);
+  const packageName =
+    markerIndex === -1 ? pathname.slice(1) : pathname.slice(1, markerIndex);
+  if (!packagePattern.test(packageName)) {
+    response.writeHead(404).end();
+    return;
+  }
+
+  try {
+    if (markerIndex !== -1) {
+      const tarballName = pathname.slice(markerIndex + tarballMarker.length);
+      if (!/^[a-zA-Z0-9._~-]+\.tgz$/.test(tarballName)) {
+        response.writeHead(404).end();
+        return;
+      }
+      const tarballPath = join(storageDir, ...packageName.split("/"), tarballName);
+      const size = statSync(tarballPath).size;
+      response.writeHead(200, {
+        "content-length": size,
+        "content-type": "application/octet-stream",
+      });
+      if (request.method === "HEAD") {
+        response.end();
+      } else {
+        createReadStream(tarballPath).pipe(response);
+      }
+      return;
+    }
+
+    const packumentPath = join(
+      storageDir,
+      ...packageName.split("/"),
+      "package.json",
+    );
+    const packument = JSON.parse(readFileSync(packumentPath, "utf8"));
+    const origin = "http://127.0.0.1:" + port;
+    for (const [version, manifest] of Object.entries(
+      packument.versions ?? {},
+    ) as Array<[string, { dist?: { tarball?: string } }]>) {
+      if (manifest.dist?.tarball) {
+        const tarballName = manifest.dist.tarball.split("/").at(-1);
+        const tarballPath = join(
+          storageDir,
+          ...packageName.split("/"),
+          tarballName ?? "",
+        );
+        try {
+          statSync(tarballPath);
+        } catch {
+          delete packument.versions[version];
+          continue;
+        }
+        manifest.dist.tarball =
+          origin + "/" + packageName + "/-/" + tarballName;
+      }
+    }
+    for (const [tag, version] of Object.entries(packument["dist-tags"] ?? {})) {
+      if (!((version as string) in packument.versions)) {
+        delete packument["dist-tags"][tag];
+      }
+    }
+    const body = JSON.stringify(packument);
+    response.writeHead(200, {
+      "content-length": Buffer.byteLength(body),
+      "content-type": "application/json",
+    });
+    response.end(request.method === "HEAD" ? undefined : body);
+  } catch {
+    response.writeHead(404).end();
+  }
+}).listen(port, "127.0.0.1", () => {
+  console.log("offline registry ready on http://127.0.0.1:" + port);
+});

--- a/benchmarks/pgo.bash
+++ b/benchmarks/pgo.bash
@@ -5,10 +5,11 @@
 # Three-phase rustc PGO flow, plus an optional BOLT step:
 #
 #   1. Build aube with -Cprofile-generate (instrumented binary).
-#   2. Train against the hermetic Verdaccio registry — a mix of cold
-#      and warm installs of fixture.package.json — so the profile
-#      covers the resolver / registry / store / linker hot paths and
-#      the frozen-lockfile fast path.
+#   2. Train against the committed offline registry — cold and warm
+#      installs plus representative developer-loop commands against
+#      pgo.package.json — so the profile covers resolver / registry /
+#      store / linker hot paths, the frozen fast path, Node-backed script
+#      dispatch, dependency inspection, and add/remove.
 #   3. Merge .profraw via llvm-profdata, recompile with -Cprofile-use.
 #   4. (AUBE_PGO_BOLT=1) re-link phase 3b with `--emit-relocs`, build
 #      an instrumented variant via `llvm-bolt --instrument`, replay
@@ -25,10 +26,8 @@
 #
 # Local default: target/release-pgo/aube using profile=release-pgo.
 #
-# Holds /tmp/aube-bench.lock for the entire run because the hermetic
-# registry (port 4874), throttle proxy (port 4875), and warmed cache
-# (~/.cache/aube-bench/registry) are shared across worktrees,
-# terminals, and agents.
+# Holds /tmp/aube-bench.lock for the entire run because the offline
+# training registry uses a shared port across worktrees and agents.
 #
 # CI hooks (env vars):
 #   AUBE_PGO_NO_LOCK=1          skip /tmp/aube-bench.lock acquisition
@@ -60,6 +59,9 @@
 #                               `perf` needed), which works without
 #                               LBR/BRBE branch sampling and without
 #                               privileged kernel knobs.
+#   AUBE_PGO_WORKFLOW_RUNS=<n>  repetitions for each warm developer-loop
+#                               workflow (default: 20). Set to 0 for an
+#                               install-only comparison build.
 
 set -euo pipefail
 
@@ -73,6 +75,26 @@ PGO_PROFILE="${AUBE_PGO_PROFILE:-release-pgo}"
 PGO_TARGET="${AUBE_PGO_TARGET:-}"
 PGO_BUILD_TOOL="${AUBE_PGO_BUILD_TOOL:-cargo}"
 PGO_BOLT="${AUBE_PGO_BOLT:-}"
+PGO_WORKFLOW_RUNS="${AUBE_PGO_WORKFLOW_RUNS:-20}"
+PGO_REGISTRY_PORT="${AUBE_PGO_REGISTRY_PORT:-4876}"
+PGO_REGISTRY_URL="http://127.0.0.1:$PGO_REGISTRY_PORT"
+PGO_NODE_BIN="$(node -p 'process.execPath')"
+PGO_NODE_DIR="$(dirname "$PGO_NODE_BIN")"
+PGO_TRAIN_PATH="$PGO_NODE_DIR:$PATH"
+
+case "$PGO_WORKFLOW_RUNS" in
+'' | *[!0-9]*)
+	echo "ERROR: AUBE_PGO_WORKFLOW_RUNS must be a non-negative integer" >&2
+	exit 1
+	;;
+esac
+
+case "$PGO_REGISTRY_PORT" in
+'' | *[!0-9]*)
+	echo "ERROR: AUBE_PGO_REGISTRY_PORT must be an integer" >&2
+	exit 1
+	;;
+esac
 
 if [ -n "$PGO_BOLT" ]; then
 	# Prefer `/usr/lib/llvm-NN/bin/llvm-bolt` over the unversioned
@@ -124,16 +146,6 @@ if [ -n "$PGO_TARGET" ]; then
 	target_dir_part="$PGO_TARGET/"
 fi
 
-# Default to the same throttled hermetic registry the rest of aube's
-# bench harness uses, so PGO numbers and bench numbers stay comparable.
-export BENCH_HERMETIC="${BENCH_HERMETIC:-1}"
-export BENCH_BANDWIDTH="${BENCH_BANDWIDTH:-500mbit}"
-export BENCH_LATENCY="${BENCH_LATENCY:-50ms}"
-# Force the bundled metadata primer on for the hermetic Verdaccio
-# mirror — the primer is keyed to npmjs.org, so without this aube
-# would skip its own warm-cache fast path on the bench registry.
-export AUBE_FORCE_METADATA_PRIMER="${AUBE_FORCE_METADATA_PRIMER:-true}"
-
 if [ -z "${AUBE_PGO_NO_LOCK:-}" ] && command -v flock >/dev/null 2>&1; then
 	echo ">>> Acquiring /tmp/aube-bench.lock (30 min timeout)"
 	exec 9>/tmp/aube-bench.lock
@@ -145,6 +157,41 @@ if [ -z "${AUBE_PGO_NO_LOCK:-}" ] && command -v flock >/dev/null 2>&1; then
 else
 	echo ">>> Skipping /tmp/aube-bench.lock (AUBE_PGO_NO_LOCK or flock missing)"
 fi
+
+training_registry_start() {
+	if curl -fsS "$PGO_REGISTRY_URL/" >/dev/null 2>&1; then
+		echo "ERROR: port $PGO_REGISTRY_PORT is already in use" >&2
+		exit 1
+	fi
+
+	"$PGO_NODE_BIN" "$SCRIPT_DIR/offline-registry.mts" --port "$PGO_REGISTRY_PORT" \
+		>"$train_dir/offline-registry.log" 2>&1 &
+	PGO_REGISTRY_PID=$!
+
+	local retries=60
+	while ! curl -fsS "$PGO_REGISTRY_URL/" >/dev/null 2>&1; do
+		if ! kill -0 "$PGO_REGISTRY_PID" 2>/dev/null; then
+			echo "ERROR: offline training registry exited during startup" >&2
+			cat "$train_dir/offline-registry.log" >&2
+			exit 1
+		fi
+		retries=$((retries - 1))
+		if [ "$retries" -le 0 ]; then
+			echo "ERROR: offline training registry failed to start" >&2
+			exit 1
+		fi
+		sleep 0.1
+	done
+	echo "Offline training registry: $PGO_REGISTRY_URL"
+}
+
+training_registry_stop() {
+	if [ -n "${PGO_REGISTRY_PID:-}" ]; then
+		kill "$PGO_REGISTRY_PID" 2>/dev/null || true
+		wait "$PGO_REGISTRY_PID" 2>/dev/null || true
+		unset PGO_REGISTRY_PID
+	fi
+}
 
 RUSTC_HOST="$(rustc -vV | sed -n 's|^host: ||p')"
 RUSTC_SYSROOT="$(rustc --print sysroot)"
@@ -174,7 +221,7 @@ fi
 echo ">>> [1/3] Building instrumented binary ($PGO_BUILD_TOOL, profile=$PGO_PROFILE${PGO_TARGET:+, target=$PGO_TARGET})"
 # shellcheck disable=SC2086 # intentional word-splitting on $target_arg
 RUSTFLAGS="-Cprofile-generate=$PGO_PROFRAW_DIR" \
-	"$PGO_BUILD_TOOL" build --profile="$PGO_PROFILE" $target_arg -p aube
+	"$PGO_BUILD_TOOL" build --profile="$PGO_PROFILE" $target_arg -p aube --bin aube
 
 INSTRUMENTED_BIN="$REPO_ROOT/target/${target_dir_part}${PGO_PROFILE}/aube"
 if [ ! -x "$INSTRUMENTED_BIN" ]; then
@@ -183,26 +230,16 @@ if [ ! -x "$INSTRUMENTED_BIN" ]; then
 fi
 
 # ---------- Phase 2: training ----------
-echo ">>> [2/3] Training against hermetic registry"
-
-# shellcheck disable=SC1091
-source "$SCRIPT_DIR/hermetic.bash"
+echo ">>> [2/3] Training against committed offline registry"
 
 train_dir="$(mktemp -d "${TMPDIR:-/tmp}/aube-pgo-train.XXXXXX")"
 cleanup() {
-	hermetic_stop || true
+	training_registry_stop
 	rm -rf "$train_dir"
 }
 trap cleanup EXIT
 
-AUBE_BIN="$INSTRUMENTED_BIN" hermetic_start
-
-# hermetic_start runs _hermetic_warm on the first invocation against a
-# given cache dir, which executes the instrumented binary against npmjs
-# uplink. In CI that warm step fires every run (no persisted cache) and
-# would otherwise contribute non-representative profraw covering the
-# uplink path. Drop those before the real training runs land.
-rm -f "$PGO_PROFRAW_DIR"/*.profraw
+training_registry_start
 
 # Force the instrumented binary to write profraw to a host path we
 # control, regardless of what `-Cprofile-generate=<dir>` baked in at
@@ -214,31 +251,67 @@ rm -f "$PGO_PROFRAW_DIR"/*.profraw
 # silently produces no merged output. Setting LLVM_PROFILE_FILE at
 # runtime sidesteps the path-translation question entirely. %m
 # disambiguates per module signature; %p per process — together they
-# keep the 6 training runs from colliding on the same file.
+# keep the install and developer-workflow runs from colliding on the same file.
 PROFRAW_PATTERN="$PGO_PROFRAW_DIR/aube-%m-%p.profraw"
 
-# 3 cold + 3 warm. Cold runs each get a fresh dir so the resolver,
-# registry, store, and linker hot paths all run end-to-end. Warm runs
-# reuse the last cold dir so the frozen-lockfile fast path is also
-# represented in the profile. The binary is parameterized so phase 4
-# (BOLT) can replay the same workload against the BOLT-instrumented
+# 3 cold + 3 warm installs, followed by representative warm workflows.
+# Cold runs each get a fresh dir so the resolver, registry, store, and
+# linker hot paths all run end-to-end. Warm runs reuse the last cold dir
+# so the frozen-lockfile fast path is also represented in the profile.
+# The workflow pass runs a real installed Node binary via both aubr and
+# exec, reads the dependency graph via list/why, then removes and re-adds
+# a dependency. The binary is parameterized so
+# phase 4 (BOLT) can replay the same workload against the BOLT-instrumented
 # variant of the PGO-optimized binary.
 cold_run() {
 	local bin=$1 i=$2 tag=${3:-cold}
 	local run_dir="$train_dir/$tag.$i"
 	rm -rf "$run_dir"
 	mkdir -p "$run_dir/home"
-	cp "$SCRIPT_DIR/fixture.package.json" "$run_dir/package.json"
-	printf 'registry=%s\n' "$BENCH_REGISTRY_URL" >"$run_dir/.npmrc"
-	printf 'registry=%s\n' "$BENCH_REGISTRY_URL" >"$run_dir/home/.npmrc"
+	cp "$SCRIPT_DIR/pgo.package.json" "$run_dir/package.json"
+	{
+		printf 'registry=%s\n' "$PGO_REGISTRY_URL"
+		printf 'advisoryCheck=off\n'
+		printf 'advisoryCheckOnInstall=off\n'
+		printf 'lowDownloadThreshold=0\n'
+	} >"$run_dir/.npmrc"
+	cp "$run_dir/.npmrc" "$run_dir/home/.npmrc"
 	echo "  train: cold install ($i)"
-	(cd "$run_dir" && HOME="$run_dir/home" "$bin" install --ignore-scripts >/dev/null)
+	(cd "$run_dir" && HOME="$run_dir/home" PATH="$PGO_TRAIN_PATH" "$bin" install --ignore-scripts >/dev/null)
 }
 
 warm_run() {
 	local bin=$1 run_dir=$2 i=$3
 	echo "  train: warm install ($i)"
-	(cd "$run_dir" && HOME="$run_dir/home" "$bin" install --ignore-scripts >/dev/null)
+	(cd "$run_dir" && HOME="$run_dir/home" PATH="$PGO_TRAIN_PATH" "$bin" install --ignore-scripts >/dev/null)
+}
+
+train_workflows() {
+	local bin=$1 run_dir=$2
+	local shim_dir="$run_dir/bin"
+	local i
+
+	if [ "$PGO_WORKFLOW_RUNS" -eq 0 ]; then
+		echo "  train: developer workflows skipped (AUBE_PGO_WORKFLOW_RUNS=0)"
+		return
+	fi
+
+	mkdir -p "$shim_dir"
+	ln -sf "$bin" "$shim_dir/aubr"
+
+	echo "  train: developer workflows ($PGO_WORKFLOW_RUNS repetitions each)"
+	i=1
+	while [ "$i" -le "$PGO_WORKFLOW_RUNS" ]; do
+		(cd "$run_dir" && HOME="$run_dir/home" PATH="$PGO_TRAIN_PATH" "$shim_dir/aubr" check-version >/dev/null)
+		(cd "$run_dir" && HOME="$run_dir/home" PATH="$PGO_TRAIN_PATH" "$bin" exec --no-install semver 1.2.3 >/dev/null)
+		(cd "$run_dir" && HOME="$run_dir/home" PATH="$PGO_TRAIN_PATH" "$bin" list --depth 1 >/dev/null)
+		(cd "$run_dir" && HOME="$run_dir/home" PATH="$PGO_TRAIN_PATH" "$bin" why is-number --parseable >/dev/null)
+		i=$((i + 1))
+	done
+
+	echo "  train: remove + add"
+	(cd "$run_dir" && HOME="$run_dir/home" PATH="$PGO_TRAIN_PATH" "$bin" remove undici --ignore-scripts >/dev/null)
+	(cd "$run_dir" && HOME="$run_dir/home" PATH="$PGO_TRAIN_PATH" "$bin" add undici@6.25.0 --ignore-scripts --allow-low-downloads >/dev/null)
 }
 
 # LLVM_PROFILE_FILE only matters for the instrumented binary, so it's
@@ -250,9 +323,10 @@ done
 for i in 1 2 3; do
 	warm_run "$INSTRUMENTED_BIN" "$train_dir/cold.3" "$i"
 done
+train_workflows "$INSTRUMENTED_BIN" "$train_dir/cold.3"
 unset LLVM_PROFILE_FILE
 
-hermetic_stop
+training_registry_stop
 
 # Sanity check: confirm training actually wrote profraw. Without
 # LLVM_PROFILE_FILE this silently produced zero files on cross-built
@@ -311,7 +385,7 @@ if [ -n "$PGO_BOLT" ]; then
 fi
 # shellcheck disable=SC2086 # intentional word-splitting on $target_arg
 RUSTFLAGS="$phase3b_rustflags" \
-	"$PGO_BUILD_TOOL" build --profile="$PGO_PROFILE" $target_arg -p aube
+	"$PGO_BUILD_TOOL" build --profile="$PGO_PROFILE" $target_arg -p aube --bin aube
 
 # Phase 3b wrote to the same path as phase 1, so the file at
 # $INSTRUMENTED_BIN is now the PGO-optimized build, not the instrumented
@@ -353,17 +427,18 @@ echo ">>> [4a/4] Building instrumented binary"
 	--instrumentation-file-append-pid \
 	-o "$BOLT_INSTR_BIN"
 
-# Replay the same 3 cold + 3 warm training workload as phase 2, this
-# time against the instrumented PGO binary. Each invocation writes
-# bolt.<pid>.fdata on exit. The hermetic registry was stopped at end
-# of phase 2; restart it here.
-AUBE_BIN="$BOLT_INSTR_BIN" hermetic_start
+# Replay the same install + developer workflow mix as phase 2, this time
+# against the instrumented PGO binary. Each invocation writes
+# bolt.<pid>.fdata on exit. The offline registry was stopped at end of
+# phase 2; restart it here.
+training_registry_start
 
 echo ">>> [4b/4] Training instrumented binary"
 for i in 1 2 3; do cold_run "$BOLT_INSTR_BIN" "$i" bolt; done
 for i in 1 2 3; do warm_run "$BOLT_INSTR_BIN" "$train_dir/bolt.3" "$i"; done
+train_workflows "$BOLT_INSTR_BIN" "$train_dir/bolt.3"
 
-hermetic_stop
+training_registry_stop
 
 # Sanity check: instrumentation writes on `_exit`. If the binary
 # crashed mid-run, no fdata. Without this we'd fall through to

--- a/benchmarks/pgo.package.json
+++ b/benchmarks/pgo.package.json
@@ -1,0 +1,19 @@
+{
+  "name": "aube-pgo-training",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "@testing-library/react": "14.0.0",
+    "chalk": "4.1.2",
+    "is-odd": "3.0.1",
+    "node-gyp": "12.3.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "semver": "7.7.4",
+    "tinyglobby": "0.2.16",
+    "undici": "6.25.0"
+  },
+  "scripts": {
+    "check-version": "semver 1.2.3"
+  }
+}


### PR DESCRIPTION
## Summary

- replace release PGO training through Verdaccio with a dependency-free local server over the committed registry corpus, so release builds never contact npmjs.org
- train PGO and BOLT on a 113-package dependency graph plus real Node-backed run/exec, list, why, remove, and add workflows
- build only the multicall `aube` binary during PGO phases, avoiding a redundant `aubx` link

## Results

Compared workflow-trained PGO with install-only PGO using identical release builds and alternating AB/BA runs pinned to one CPU:

| Workflow | Change |
| --- | ---: |
| `aube list --depth 1` | 2.4% faster |
| `aube why is-number --parseable` | 3.9% faster |
| warm install | flat (+0.4%) |
| `aube exec` | flat (+0.2%) |
| Node-backed `aubr` | flat (within 1%) |

The workload improves common dependency-inspection commands without trading away install, exec, or trampoline performance. The `aubr` result is explicitly treated as noise rather than a claimed improvement.

## Validation

- full install-only PGO build
- full workflow-trained PGO build
- full workflow-trained PGO+BOLT build (3,991 profiled functions)
- `mise run lint`
- `mise run test`
- `node --check benchmarks/offline-registry.mts`
- `bash -n benchmarks/pgo.bash`
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how release binaries are profiled and optimized, so a bad training corpus or registry server can silently shift production performance. No auth or user-data paths are involved.
> 
> **Overview**
> Release PGO/BOLT training no longer uses Verdaccio or npmjs. It now serves the committed `test/registry/storage` corpus from a small local Node HTTP server (`offline-registry.mts`) so release builds stay fully offline.
> 
> Training is broader than install-only: cold/warm installs of `pgo.package.json`, then repeated `aubr`/exec/list/why plus remove/add. PGO cargo steps also build only `--bin aube`. Workflow count is tunable via `AUBE_PGO_WORKFLOW_RUNS`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c2da1950582dc1b5c61f0e667f142fa7de29522. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an offline package registry for local benchmark and release workflows.
  * Added a dedicated benchmark package with pinned dependencies and version-check tooling.
  * Added configurable workflow repetition and registry-port settings.

* **Bug Fixes**
  * Improved validation and error handling for registry requests and benchmark configuration.

* **Chores**
  * Updated release documentation to clarify that builds use local package sources and do not contact npmjs.org.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->