### PR TITLE
perf(run): defer aubr install runtime startup

### DIFF
--- a/crates/aube/src/commands/auto_install.rs
+++ b/crates/aube/src/commands/auto_install.rs
@@ -1,6 +1,61 @@
-use miette::miette;
+use std::future::Future;
+
+use miette::{IntoDiagnostic, WrapErr, miette};
 
 use super::install;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct LazyInstallRuntime {
+    worker_threads: usize,
+    max_blocking_threads: usize,
+}
+
+impl LazyInstallRuntime {
+    pub(crate) fn new(worker_threads: usize, max_blocking_threads: usize) -> Self {
+        Self {
+            worker_threads,
+            max_blocking_threads,
+        }
+    }
+}
+
+tokio::task_local! {
+    static LAZY_INSTALL_RUNTIME: LazyInstallRuntime;
+}
+
+/// Allow an auto-install reached from a lightweight CLI runtime to create the
+/// full install runtime only after the freshness check misses. Task-local
+/// scoping keeps in-process embedding calls on their host's ambient runtime.
+pub(crate) async fn with_lazy_install_runtime<F: Future>(
+    config: LazyInstallRuntime,
+    future: F,
+) -> F::Output {
+    LAZY_INSTALL_RUNTIME.scope(config, future).await
+}
+
+async fn run_with_install_runtime<T, F, Fut>(operation: F) -> miette::Result<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: Future<Output = miette::Result<T>> + 'static,
+{
+    let Ok(config) = LAZY_INSTALL_RUNTIME.try_with(|config| *config) else {
+        return operation().await;
+    };
+    tokio::task::spawn_blocking(move || {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(config.worker_threads)
+            .max_blocking_threads(config.max_blocking_threads)
+            .enable_all()
+            .build()
+            .into_diagnostic()
+            .wrap_err("failed to build lazy install runtime")?;
+        runtime.block_on(operation())
+    })
+    .await
+    .into_diagnostic()
+    .wrap_err("lazy install runtime task failed")?
+}
 
 pub(crate) async fn ensure_installed(no_install: bool) -> miette::Result<()> {
     ensure_installed_in(no_install, None).await
@@ -102,7 +157,7 @@ pub(crate) async fn ensure_installed_in(
     // Anchor the auto-install at the resolved tree, not the process cwd,
     // so an embedding host installs the project it asked to run.
     opts.project_dir = Some(cwd);
-    install::run(opts).await?;
+    run_with_install_runtime(|| install::run(opts)).await?;
 
     Ok(())
 }
@@ -128,4 +183,34 @@ fn resolve_verify_deps_before_run(cwd: &std::path::Path) -> miette::Result<Verif
         "prompt" | "install" => VerifyDepsBeforeRun::Install,
         _ => VerifyDepsBeforeRun::Install,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lazy_install_switches_from_current_thread_to_multi_thread() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread test runtime should build");
+
+        let ambient = runtime
+            .block_on(run_with_install_runtime(|| async {
+                Ok(tokio::runtime::Handle::current().runtime_flavor())
+            }))
+            .expect("ambient operation should run");
+        assert_eq!(ambient, tokio::runtime::RuntimeFlavor::CurrentThread);
+
+        let lazy = runtime
+            .block_on(with_lazy_install_runtime(
+                LazyInstallRuntime::new(1, 2),
+                run_with_install_runtime(|| async {
+                    Ok(tokio::runtime::Handle::current().runtime_flavor())
+                }),
+            ))
+            .expect("lazy operation should run");
+        assert_eq!(lazy, tokio::runtime::RuntimeFlavor::MultiThread);
+    }
 }

--- a/crates/aube/src/commands/mod.rs
+++ b/crates/aube/src/commands/mod.rs
@@ -88,7 +88,9 @@ mod script_settings;
 mod settings_context;
 mod workspace_helpers;
 
-pub(crate) use auto_install::{ensure_installed, ensure_installed_in};
+pub(crate) use auto_install::{
+    LazyInstallRuntime, ensure_installed, ensure_installed_in, with_lazy_install_runtime,
+};
 
 /// Resolve the directory a completion probe should inspect without changing
 /// the process cwd. Invalid `-C` targets yield no completions, matching the

--- a/crates/aube/src/lib.rs
+++ b/crates/aube/src/lib.rs
@@ -723,6 +723,9 @@ fn report_exit_code(report: &miette::Report) -> i32 {
 
 fn inner_main() -> miette::Result<i32> {
     let mut argv: Vec<OsString> = std::env::args_os().collect();
+    let invoked_as_aubr = argv
+        .first()
+        .is_some_and(|arg| crate::tool_shims::stem_of_argv0(arg) == "aubr");
     if argv.get(1).and_then(|arg| arg.to_str()) == Some("__complete_word__") {
         let name = argv
             .first()
@@ -901,8 +904,18 @@ fn inner_main() -> miette::Result<i32> {
         .unwrap_or(4);
     let workers = parse_env("AUBE_TOKIO_WORKERS", cpu_count.min(8));
     let blocking = parse_env("AUBE_TOKIO_BLOCKING", 128);
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(workers)
+    // A non-installing aubr invocation only needs one async task to supervise
+    // the script process. Keep auto-install-capable runs on the multi-thread
+    // runtime: a stale tree can enter the full parallel install pipeline.
+    let current_thread_run = aubr_can_use_current_thread(invoked_as_aubr, &cli);
+    let mut runtime_builder = if current_thread_run {
+        tokio::runtime::Builder::new_current_thread()
+    } else {
+        let mut builder = tokio::runtime::Builder::new_multi_thread();
+        builder.worker_threads(workers);
+        builder
+    };
+    let runtime = runtime_builder
         .max_blocking_threads(blocking)
         .enable_all()
         .build()
@@ -917,6 +930,14 @@ fn inner_main() -> miette::Result<i32> {
     // embeds the command layer in-process. `None` means "no explicit
     // code" — the normal success exit of 0.
     Ok(exit_code.unwrap_or(0))
+}
+
+fn aubr_can_use_current_thread(invoked_as_aubr: bool, cli: &Cli) -> bool {
+    invoked_as_aubr
+        && matches!(
+            cli.command.as_ref(),
+            Some(Commands::Run(args)) if args.no_install
+        )
 }
 
 async fn async_main(cli: Cli) -> miette::Result<Option<i32>> {
@@ -1462,6 +1483,18 @@ async fn run_install_command(
 #[cfg(test)]
 mod cli_spec_tests {
     use super::*;
+
+    #[test]
+    fn only_non_installing_aubr_uses_current_thread_runtime() {
+        let aubr = Cli::try_parse_test_from(["aubr", "--no-install", "build"])
+            .expect("aubr --no-install should parse");
+        assert!(aubr_can_use_current_thread(true, &aubr));
+
+        let installing =
+            Cli::try_parse_test_from(["aubr", "build"]).expect("aubr script should parse");
+        assert!(!aubr_can_use_current_thread(true, &installing));
+        assert!(!aubr_can_use_current_thread(false, &aubr));
+    }
 
     #[test]
     fn install_accepts_subcommand_registry_flag() {

--- a/crates/aube/src/lib.rs
+++ b/crates/aube/src/lib.rs
@@ -904,10 +904,10 @@ fn inner_main() -> miette::Result<i32> {
         .unwrap_or(4);
     let workers = parse_env("AUBE_TOKIO_WORKERS", cpu_count.min(8));
     let blocking = parse_env("AUBE_TOKIO_BLOCKING", 128);
-    // A non-installing aubr invocation only needs one async task to supervise
-    // the script process. Keep auto-install-capable runs on the multi-thread
-    // runtime: a stale tree can enter the full parallel install pipeline.
-    let current_thread_run = aubr_can_use_current_thread(invoked_as_aubr, &cli);
+    // Every aubr invocation starts on the lightweight runtime. If its
+    // synchronous freshness probe finds that dependencies need installing,
+    // auto_install lazily creates a multi-thread runtime for that work only.
+    let current_thread_run = aubr_uses_current_thread(invoked_as_aubr, &cli);
     let mut runtime_builder = if current_thread_run {
         tokio::runtime::Builder::new_current_thread()
     } else {
@@ -921,7 +921,14 @@ fn inner_main() -> miette::Result<i32> {
         .build()
         .into_diagnostic()
         .wrap_err("failed to build tokio runtime")?;
-    let exit_code = runtime.block_on(async_main(cli))?;
+    let exit_code = if current_thread_run {
+        runtime.block_on(commands::with_lazy_install_runtime(
+            commands::LazyInstallRuntime::new(workers, blocking),
+            async_main(cli),
+        ))?
+    } else {
+        runtime.block_on(async_main(cli))?
+    };
     drop(runtime);
     // Return the command's exit code rather than terminating here: a
     // non-zero result (e.g. `run`/`exec` propagating a child's status)
@@ -932,12 +939,8 @@ fn inner_main() -> miette::Result<i32> {
     Ok(exit_code.unwrap_or(0))
 }
 
-fn aubr_can_use_current_thread(invoked_as_aubr: bool, cli: &Cli) -> bool {
-    invoked_as_aubr
-        && matches!(
-            cli.command.as_ref(),
-            Some(Commands::Run(args)) if args.no_install
-        )
+fn aubr_uses_current_thread(invoked_as_aubr: bool, cli: &Cli) -> bool {
+    invoked_as_aubr && matches!(cli.command.as_ref(), Some(Commands::Run(_)))
 }
 
 async fn async_main(cli: Cli) -> miette::Result<Option<i32>> {
@@ -1485,15 +1488,15 @@ mod cli_spec_tests {
     use super::*;
 
     #[test]
-    fn only_non_installing_aubr_uses_current_thread_runtime() {
+    fn every_aubr_run_uses_current_thread_runtime() {
         let aubr = Cli::try_parse_test_from(["aubr", "--no-install", "build"])
             .expect("aubr --no-install should parse");
-        assert!(aubr_can_use_current_thread(true, &aubr));
+        assert!(aubr_uses_current_thread(true, &aubr));
 
         let installing =
             Cli::try_parse_test_from(["aubr", "build"]).expect("aubr script should parse");
-        assert!(!aubr_can_use_current_thread(true, &installing));
-        assert!(!aubr_can_use_current_thread(false, &aubr));
+        assert!(aubr_uses_current_thread(true, &installing));
+        assert!(!aubr_uses_current_thread(false, &aubr));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- use a current-thread Tokio runtime for every `aubr` script invocation, including the default auto-install-capable path
- keep the existing synchronous freshness and policy checks on that lightweight runtime
- lazily create a configured multi-thread runtime only when a stale tree reaches the actual install
- scope the lazy-runtime policy with a Tokio task-local so embedded callers retain their host runtime behavior
- cover both the CLI selection boundary and the lazy runtime handoff with unit tests

## Outcome

Normal warm `aubr <script>` invocations now get the same lightweight startup path as `--no-install`. A stale invocation pays the one-time cost of creating a separate multi-thread runtime, then runs the full parallel install pipeline there before returning to the lightweight runtime to launch the script.

The original release benchmark still characterizes the size of the startup opportunity:

| Workload | Baseline | Current-thread | Result |
| --- | ---: | ---: | ---: |
| `aubr --no-install noop` | 3.4 ms | 3.2 ms | 6% faster |
| Node-backed semver script | 30.7 ms | 31.3 ms | flat / 2% slower |

Worker startup is measurable in isolation but remains hidden by real Node launch variance. The broader runtime selection means default warm runs can capture that native-process improvement without sacrificing cold-install concurrency.

## Validation

- `cargo fmt --check`
- `cargo clippy -p aube --all-targets -- -D warnings`
- `cargo test -p aube` (819 unit tests plus integration targets)
- focused runtime-flavor tests for ordinary `aubr` selection and stale-install handoff
- original release-mode benchmark against the same main commit

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches process-wide Tokio runtime construction and nested `block_on` for auto-install, which can deadlock or starve if install work assumes the ambient runtime. Scoped to CLI `aubr run`, not auth or data handling.
> 
> **Overview**
> Starts every `aubr` **run** on a current-thread Tokio runtime so the warm script path avoids multi-thread worker startup. Other binaries and commands still use the existing multi-thread pool.
> 
> If auto-install actually fires, `ensure_installed` now builds a nested multi-thread runtime on a blocking thread (task-local `LazyInstallRuntime`) so install work is not stuck on the lightweight runtime. In-process embedders without that task-local stay on the host runtime.
> 
> Adds tests for runtime selection and the current-thread → multi-thread switch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cceb752ec4253838976eb5346e518828a7a784e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->