### PR TITLE
feat(run): echo the script command line before running it

### DIFF
--- a/crates/aube/src/commands/restart.rs
+++ b/crates/aube/src/commands/restart.rs
@@ -43,20 +43,24 @@ pub async fn run(
 
     ensure_installed(no_install).await?;
 
+    // `aube restart` has no `-s` of its own, so the echoed `$ <cmd>` line
+    // is gated on the global `--silent` / `--loglevel silent` alone.
+    let silent = super::global_output_flags().silent;
+
     if manifest.scripts.contains_key("restart") {
         // Propagate a non-zero `restart` exit up to the binary's single
         // `std::process::exit` rather than terminating in place.
-        if let Some(code) = exec_script(&cwd, &manifest, "restart", args).await? {
+        if let Some(code) = exec_script(&cwd, &manifest, "restart", args, silent).await? {
             return Ok(Some(code));
         }
     } else {
         // `stop` then `start`, each optional. A non-zero `stop` short-circuits
         // before `start` runs — matching the previous behavior where the inner
         // script runner terminated the process on the first failure.
-        if let Some(Some(code)) = exec_optional(&cwd, &manifest, "stop", &[]).await? {
+        if let Some(Some(code)) = exec_optional(&cwd, &manifest, "stop", &[], silent).await? {
             return Ok(Some(code));
         }
-        if let Some(Some(code)) = exec_optional(&cwd, &manifest, "start", args).await? {
+        if let Some(Some(code)) = exec_optional(&cwd, &manifest, "start", args, silent).await? {
             return Ok(Some(code));
         }
     }

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -662,6 +662,7 @@ pub(crate) async fn run_script_with(
         args,
         node_args,
         enable_pre_post_scripts,
+        silent,
     )
     .await
 }
@@ -771,6 +772,7 @@ async fn run_script_filtered(
             args,
             node_args,
             enable_pre_post_scripts,
+            silent,
         )
         .await?
         {
@@ -1017,6 +1019,7 @@ async fn run_filtered_parallel(
                     &args,
                     &node_args,
                     enable_pre_post_scripts,
+                    silent,
                     &output_mode,
                 )
                 .await
@@ -1089,11 +1092,14 @@ pub(crate) async fn exec_optional(
     manifest: &PackageJson,
     script: &str,
     args: &[String],
+    silent: bool,
 ) -> miette::Result<Option<Option<i32>>> {
     if !manifest.scripts.contains_key(script) {
         return Ok(None);
     }
-    Ok(Some(exec_script(cwd, manifest, script, args).await?))
+    Ok(Some(
+        exec_script(cwd, manifest, script, args, silent).await?,
+    ))
 }
 
 /// Run a single script. Returns `Ok(Some(code))` on a non-zero child exit
@@ -1104,8 +1110,9 @@ pub(crate) async fn exec_script(
     manifest: &PackageJson,
     script: &str,
     args: &[String],
+    silent: bool,
 ) -> miette::Result<Option<i32>> {
-    exec_script_with_node_args(cwd, manifest, script, args, &[]).await
+    exec_script_with_node_args(cwd, manifest, script, args, &[], silent).await
 }
 
 /// Build a fully-configured `tokio::process::Command` for running a
@@ -1115,6 +1122,13 @@ pub(crate) async fn exec_script(
 /// returns the raw status so the parallel path can collect all outcomes).
 /// Keeping one place to configure these means future security fixes land
 /// once, not twice.
+///
+/// Returns the command alongside the `$ <cmd>` line to echo for it. The
+/// echoed line is built here rather than at the call sites because this
+/// is where `cmd` has already been through node-arg injection — echoing
+/// the raw manifest body would hide the `--inspect` a user just asked
+/// for. See [`display_arg`] for why the echoed args are quoted more
+/// loosely than the executed ones.
 async fn build_script_command(
     cwd: &Path,
     manifest: &PackageJson,
@@ -1122,15 +1136,16 @@ async fn build_script_command(
     cmd: &str,
     args: &[String],
     node_args: &[String],
-) -> miette::Result<tokio::process::Command> {
+) -> miette::Result<(tokio::process::Command, String)> {
     // Raw script body as written in package.json, exported as
     // `npm_lifecycle_script` (pnpm parity). Captured before node-arg
     // injection and arg quoting so it mirrors the manifest, not the
     // spliced shell command line.
     let lifecycle_script = cmd.to_string();
     let cmd = inject_node_args(cmd, node_args);
-    let shell_cmd = if args.is_empty() {
-        cmd
+    let (shell_cmd, echo_line) = if args.is_empty() {
+        let echo_line = cmd.clone();
+        (cmd, echo_line)
     } else {
         // Quote each forwarded arg. Args land inside `sh -c "..."` or
         // cmd `/c "..."` which reparses. Unquoted $, backticks, ;, |,
@@ -1140,11 +1155,15 @@ async fn build_script_command(
         let mut buf =
             String::with_capacity(cmd.len() + args.iter().map(|a| a.len() + 3).sum::<usize>());
         buf.push_str(&cmd);
+        let mut echo = String::with_capacity(buf.capacity());
+        echo.push_str(&cmd);
         for a in args {
             buf.push(' ');
             buf.push_str(&aube_scripts::shell_quote_arg(a));
+            echo.push(' ');
+            echo.push_str(&display_arg(a));
         }
-        buf
+        (buf, echo)
     };
 
     let bin_dir = super::project_modules_dir(cwd).join(".bin");
@@ -1218,7 +1237,30 @@ async fn build_script_command(
         let init_cwd = crate::dirs::cwd().ok().unwrap_or_else(|| cwd.to_path_buf());
         command.env("INIT_CWD", init_cwd);
     }
-    Ok(command)
+    Ok((command, echo_line))
+}
+
+/// Quote `arg` for the echoed `$ <cmd>` line only — never for execution.
+///
+/// The executed command line quotes every arg unconditionally via
+/// `shell_quote_arg`, which is correct but turns `aube run test foo` into
+/// a displayed `... 'foo'`. npm, pnpm, and bun all echo shell-safe args
+/// bare, so do the same: pass through anything drawn from a conservative
+/// safe set, and fall back to the *exact* execution quoting for anything
+/// else. Routing the interesting cases through `shell_quote_arg` rather
+/// than a second quoting implementation means the echoed line can never
+/// disagree with what actually ran.
+fn display_arg(arg: &str) -> std::borrow::Cow<'_, str> {
+    let safe = !arg.is_empty()
+        && arg.chars().all(|c| {
+            c.is_ascii_alphanumeric()
+                || matches!(c, '_' | '-' | '.' | '/' | '=' | ':' | '@' | ',' | '+')
+        });
+    if safe {
+        std::borrow::Cow::Borrowed(arg)
+    } else {
+        std::borrow::Cow::Owned(aube_scripts::shell_quote_arg(arg))
+    }
 }
 
 fn inject_node_args(cmd: &str, node_args: &[String]) -> String {
@@ -1255,19 +1297,22 @@ pub(crate) async fn exec_script_chain(
     args: &[String],
     node_args: &[String],
     enable_pre_post_scripts: bool,
+    silent: bool,
 ) -> miette::Result<Option<i32>> {
     if enable_pre_post_scripts {
         let pre = format!("pre{script}");
-        if let Some(Some(code)) = exec_optional(cwd, manifest, &pre, &[]).await? {
+        if let Some(Some(code)) = exec_optional(cwd, manifest, &pre, &[], silent).await? {
             return Ok(Some(code));
         }
     }
-    if let Some(code) = exec_script_with_node_args(cwd, manifest, script, args, node_args).await? {
+    if let Some(code) =
+        exec_script_with_node_args(cwd, manifest, script, args, node_args, silent).await?
+    {
         return Ok(Some(code));
     }
     if enable_pre_post_scripts {
         let post = format!("post{script}");
-        if let Some(Some(code)) = exec_optional(cwd, manifest, &post, &[]).await? {
+        if let Some(Some(code)) = exec_optional(cwd, manifest, &post, &[], silent).await? {
             return Ok(Some(code));
         }
     }
@@ -1285,13 +1330,18 @@ async fn exec_script_with_node_args(
     script: &str,
     args: &[String],
     node_args: &[String],
+    silent: bool,
 ) -> miette::Result<Option<i32>> {
     let cmd = manifest
         .scripts
         .get(script)
         .ok_or_else(|| miette!("script not found: {script}"))?;
 
-    let mut command = build_script_command(cwd, manifest, script, cmd, args, node_args).await?;
+    let (mut command, echo_line) =
+        build_script_command(cwd, manifest, script, cmd, args, node_args).await?;
+    if !silent {
+        super::run_output::echo_script_command(&echo_line, None);
+    }
 
     let status = command
         .status()
@@ -1314,11 +1364,13 @@ pub(crate) async fn exec_script_status(
     manifest: &PackageJson,
     script: &str,
     args: &[String],
+    silent: bool,
     output_mode: &super::run_output::OutputMode,
 ) -> miette::Result<std::process::ExitStatus> {
-    exec_script_status_with_node_args(cwd, manifest, script, args, &[], output_mode).await
+    exec_script_status_with_node_args(cwd, manifest, script, args, &[], silent, output_mode).await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn exec_script_status_chain(
     cwd: &Path,
     manifest: &PackageJson,
@@ -1326,58 +1378,116 @@ pub(crate) async fn exec_script_status_chain(
     args: &[String],
     node_args: &[String],
     enable_pre_post_scripts: bool,
+    silent: bool,
     output_mode: &super::run_output::OutputMode,
 ) -> miette::Result<std::process::ExitStatus> {
     if enable_pre_post_scripts {
         let pre = format!("pre{script}");
         if manifest.scripts.contains_key(&pre) {
-            let status = exec_script_status(cwd, manifest, &pre, &[], output_mode).await?;
+            let status = exec_script_status(cwd, manifest, &pre, &[], silent, output_mode).await?;
             if !status.success() {
                 return Ok(status);
             }
         }
     }
-    let status =
-        exec_script_status_with_node_args(cwd, manifest, script, args, node_args, output_mode)
-            .await?;
+    let status = exec_script_status_with_node_args(
+        cwd,
+        manifest,
+        script,
+        args,
+        node_args,
+        silent,
+        output_mode,
+    )
+    .await?;
     if !status.success() {
         return Ok(status);
     }
     if enable_pre_post_scripts {
         let post = format!("post{script}");
         if manifest.scripts.contains_key(&post) {
-            return exec_script_status(cwd, manifest, &post, &[], output_mode).await;
+            return exec_script_status(cwd, manifest, &post, &[], silent, output_mode).await;
         }
     }
     Ok(status)
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn exec_script_status_with_node_args(
     cwd: &Path,
     manifest: &PackageJson,
     script: &str,
     args: &[String],
     node_args: &[String],
+    silent: bool,
     output_mode: &super::run_output::OutputMode,
 ) -> miette::Result<std::process::ExitStatus> {
     let cmd = manifest
         .scripts
         .get(script)
         .ok_or_else(|| miette!("script not found: {script}"))?;
-    let command = build_script_command(cwd, manifest, script, cmd, args, node_args).await?;
+    let (command, echo_line) =
+        build_script_command(cwd, manifest, script, cmd, args, node_args).await?;
+    if !silent {
+        super::run_output::echo_script_command(&echo_line, Some(output_mode));
+    }
     super::run_output::run_command(command, output_mode).await
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        RecursiveOpts, command_column_width, completion_line, effective_concurrency,
+        RecursiveOpts, command_column_width, completion_line, display_arg, effective_concurrency,
         inject_node_args, name_column_width, node_args_from_run_flags, order_matched_packages,
     };
     use aube_manifest::PackageJson;
     use aube_workspace::selector::SelectedPackage;
     use std::collections::BTreeMap;
     use std::path::PathBuf;
+
+    /// Shell-safe args echo bare, matching what npm, pnpm, and bun print.
+    /// Quoting these would make `aube run test --watch` echo as
+    /// `... '--watch'`, which is noise no other package manager emits.
+    #[test]
+    fn display_arg_leaves_shell_safe_args_bare() {
+        for arg in [
+            "build",
+            "--watch",
+            "-v",
+            "src/index.ts",
+            "--reporter=json",
+            "@scope/pkg",
+            "a,b",
+            "1.2.3",
+            "NODE_ENV=production",
+        ] {
+            assert_eq!(display_arg(arg), arg, "{arg} should echo unquoted");
+        }
+    }
+
+    /// Anything outside the safe set falls back to `shell_quote_arg` — the
+    /// same function that builds the executed command line. Asserting
+    /// equality against it (rather than a hardcoded string) is what keeps
+    /// the echoed line from ever drifting from what actually ran.
+    #[test]
+    fn display_arg_falls_back_to_exec_quoting() {
+        for arg in [
+            "",
+            "a b",
+            "$(rm -rf ~)",
+            "it's",
+            "a;b",
+            "*",
+            "a\nb",
+            "\u{e9}",
+        ] {
+            assert_eq!(
+                display_arg(arg),
+                aube_scripts::shell_quote_arg(arg),
+                "{arg:?} should reuse the execution quoting"
+            );
+        }
+    }
 
     fn pkg(name: &str, deps: &[&str]) -> SelectedPackage {
         let manifest = PackageJson {

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -1142,10 +1142,10 @@ async fn build_script_command(
     // injection and arg quoting so it mirrors the manifest, not the
     // spliced shell command line.
     let lifecycle_script = cmd.to_string();
-    let cmd = inject_node_args(cmd, node_args);
+    let echo_cmd = inject_node_args(cmd, node_args, |a| display_arg(a).into_owned());
+    let cmd = inject_node_args(cmd, node_args, aube_scripts::shell_quote_arg);
     let (shell_cmd, echo_line) = if args.is_empty() {
-        let echo_line = cmd.clone();
-        (cmd, echo_line)
+        (cmd, echo_cmd)
     } else {
         // Quote each forwarded arg. Args land inside `sh -c "..."` or
         // cmd `/c "..."` which reparses. Unquoted $, backticks, ;, |,
@@ -1156,7 +1156,7 @@ async fn build_script_command(
             String::with_capacity(cmd.len() + args.iter().map(|a| a.len() + 3).sum::<usize>());
         buf.push_str(&cmd);
         let mut echo = String::with_capacity(buf.capacity());
-        echo.push_str(&cmd);
+        echo.push_str(&echo_cmd);
         for a in args {
             buf.push(' ');
             buf.push_str(&aube_scripts::shell_quote_arg(a));
@@ -1263,7 +1263,12 @@ fn display_arg(arg: &str) -> std::borrow::Cow<'_, str> {
     }
 }
 
-fn inject_node_args(cmd: &str, node_args: &[String]) -> String {
+/// Splice `node_args` in after a leading bare `node`, quoting each with
+/// `quote`. Callers pass `shell_quote_arg` to build the line that is
+/// actually executed and [`display_arg`] to build the echoed one, so a
+/// CLI `--inspect` echoes exactly like the same flag written into the
+/// manifest body instead of picking up quotes the manifest form never has.
+fn inject_node_args(cmd: &str, node_args: &[String], quote: impl Fn(&str) -> String) -> String {
     if node_args.is_empty() {
         return cmd.to_string();
     }
@@ -1280,7 +1285,7 @@ fn inject_node_args(cmd: &str, node_args: &[String]) -> String {
     out.push_str(&cmd[..leading_len + 4]);
     for arg in node_args {
         out.push(' ');
-        out.push_str(&aube_scripts::shell_quote_arg(arg));
+        out.push_str(&quote(arg));
     }
     out.push_str(rest);
     out
@@ -1629,17 +1634,31 @@ mod tests {
     #[test]
     fn inject_node_args_only_touches_direct_node_commands() {
         let args = vec!["--inspect".to_string()];
+        let quote = aube_scripts::shell_quote_arg;
         assert_eq!(
-            inject_node_args("node test.js", &args),
+            inject_node_args("node test.js", &args, quote),
             format!(
                 "node {} test.js",
                 aube_scripts::shell_quote_arg("--inspect")
             )
         );
-        assert_eq!(inject_node_args("tsx test.ts", &args), "tsx test.ts");
+        assert_eq!(inject_node_args("tsx test.ts", &args, quote), "tsx test.ts");
         assert_eq!(
-            inject_node_args("node-gyp rebuild", &args),
+            inject_node_args("node-gyp rebuild", &args, quote),
             "node-gyp rebuild"
+        );
+    }
+
+    /// A CLI `--inspect` has to echo exactly like the same flag written
+    /// into the manifest body. Quoting only the injected one would put
+    /// the noise `display_arg` removes right back on the path this
+    /// feature newly exposes.
+    #[test]
+    fn injected_node_args_echo_unquoted_like_the_manifest_form() {
+        let args = vec!["--inspect=127.0.0.1:9229".to_string()];
+        assert_eq!(
+            inject_node_args("node app.js", &args, |a| display_arg(a).into_owned()),
+            "node --inspect=127.0.0.1:9229 app.js"
         );
     }
 

--- a/crates/aube/src/commands/run_output.rs
+++ b/crates/aube/src/commands/run_output.rs
@@ -1,4 +1,5 @@
-//! Per-package output prefixing for parallel recursive runs.
+//! Script-run output: the echoed `$ <cmd>` line every run emits, and
+//! per-package output prefixing for parallel recursive runs.
 //!
 //! `aube run -r --parallel` and `aube exec -r --parallel` (or any mode
 //! with `--workspace-concurrency`) need to keep the stdout/stderr from
@@ -131,6 +132,30 @@ pub(crate) async fn run_command(
         .map_err(|e| miette!("stderr pump task failed: {e}"))?
         .map_err(|e| miette!("stderr pump io error: {e}"))?;
     Ok(status)
+}
+
+/// Echo a script's command line to stderr as `$ <cmd>` just before it
+/// runs. npm, pnpm, and bun all do this, and it is the only thing that
+/// tells you *what* a script name actually expanded to — invaluable when
+/// a CI log shows `aube run build` failing and the manifest has since
+/// changed.
+///
+/// Stderr, not stdout, so `aube run print-json > out.json` stays clean.
+/// Under `--silent` the caller skips this entirely; the global
+/// `--loglevel silent` guard redirecting fd 2 to `/dev/null` is a second
+/// line of defense, not the primary gate.
+///
+/// `mode` is `Some` only on the parallel recursive path, where child
+/// output is already being multiplexed with a `<pkg>: ` prefix — the echo
+/// line has to carry the same prefix or it cannot be attributed to a
+/// package. Sequential runs pass `None` and get a bare `$ <cmd>`.
+pub(crate) fn echo_script_command(cmd: &str, mode: Option<&OutputMode>) {
+    let no_color = std::env::var_os("NO_COLOR").is_some();
+    let prefix = match mode {
+        Some(mode) => format_line_prefix(mode, std::io::stderr().is_terminal() && !no_color),
+        None => String::new(),
+    };
+    eprintln!("{prefix}$ {cmd}");
 }
 
 /// Build the per-line prefix string up front so we don't re-format it

--- a/docs/package-manager/scripts.md
+++ b/docs/package-manager/scripts.md
@@ -32,6 +32,30 @@ When no `package.json` script matches, `aube run <name>` falls back to a
 local binary with the same name in `node_modules/.bin`. Scripts still win over
 bins, so a project can override a tool command with its own script.
 
+### Echoed command lines
+
+Before running a script, aube prints its command line to **stderr**, prefixed
+with `$` — the same thing npm, pnpm, and bun do:
+
+```console
+$ aubr build
+$ tsc -p .
+```
+
+`pre`/`post` scripts each get their own line, and forwarded args are appended
+so the echoed line reproduces the run exactly. It goes to stderr, so
+`aube run print-json > out.json` still captures only the script's own output.
+
+Pass `--silent` (or `-s`, or `--loglevel silent`) to suppress the echo while
+keeping the script's own stdout and stderr:
+
+```sh
+aube run --silent build
+```
+
+In `--parallel` workspace runs the echoed line carries the same `<package>: `
+prefix as the rest of that package's output.
+
 ## Local binaries
 
 ```sh

--- a/test/hoisted.bats
+++ b/test/hoisted.bats
@@ -130,13 +130,16 @@ JSON
 	assert_dir_exists node_modules/is-number
 	assert_not_exists packages/app/node_modules/is-number
 
+	# `assert_line` rather than `assert_output`: `aube run` also echoes the
+	# `$ <cmd>` line. Using `-s` to get an exact match would mute the
+	# "Auto-installing" notice this test is here to refute.
 	run aube run ok
 	assert_success
-	assert_output "ok"
+	assert_line "ok"
 	refute_output --partial "Auto-installing"
 	run aube run ok
 	assert_success
-	assert_output "ok"
+	assert_line "ok"
 	refute_output --partial "Auto-installing"
 }
 

--- a/test/run.bats
+++ b/test/run.bats
@@ -1,5 +1,9 @@
 #!/usr/bin/env bats
 
+# `run --separate-stderr` is a 1.5.0 flag; declaring the floor turns the
+# BW02 warning it otherwise emits into a hard version check.
+bats_require_minimum_version 1.5.0
+
 setup() {
 	load 'test_helper/common_setup'
 	_common_setup
@@ -714,4 +718,91 @@ JSON
 	run aube run --complete
 	assert_success
 	assert_output "ok:echo ok"
+}
+
+@test "aube run echoes the script command line to stderr" {
+	# npm, pnpm, and bun all print `$ <cmd>` before running a script.
+	# It is the only thing that says what a script name expanded to,
+	# which is what makes a failing CI log readable.
+	printf '{ "name": "echo-cmd", "scripts": { "hello": "echo hi" } }' >package.json
+	run aube run --no-install hello
+	assert_success
+	assert_line "$ echo hi"
+	assert_line "hi"
+}
+
+@test "aube run echoes pre and post scripts separately" {
+	cat >package.json <<-'JSON'
+		{
+		  "name": "echo-chain",
+		  "scripts": {
+		    "prebuild": "echo before",
+		    "build": "echo main",
+		    "postbuild": "echo after"
+		  }
+		}
+	JSON
+	run aube run --no-install build
+	assert_success
+	assert_line "$ echo before"
+	assert_line "$ echo main"
+	assert_line "$ echo after"
+}
+
+@test "aube run echoes forwarded args, quoting only what needs it" {
+	# pnpm and bun echo shell-safe args bare; anything with whitespace or
+	# metacharacters is quoted so the line stays copy-pasteable.
+	printf '{ "name": "echo-args", "scripts": { "go": "echo" } }' >package.json
+	run aube run --no-install go --watch 'two words'
+	assert_success
+	assert_line "$ echo --watch 'two words'"
+}
+
+@test "aube run writes the echoed command to stderr, not stdout" {
+	# `aube run print-json > out.json` has to stay parseable.
+	printf '{ "name": "echo-stream", "scripts": { "hello": "echo hi" } }' >package.json
+	run --separate-stderr aube run --no-install hello
+	assert_success
+	assert_output "hi"
+	[[ "$stderr" == *'$ echo hi'* ]]
+}
+
+@test "aube run --silent suppresses the echoed command but not script output" {
+	printf '{ "name": "echo-silent", "scripts": { "hello": "echo hi" } }' >package.json
+	run aube run --no-install -s hello
+	assert_success
+	assert_output "hi"
+	refute_output --partial '$ echo hi'
+
+	run aube --silent run --no-install hello
+	assert_success
+	assert_output "hi"
+	refute_output --partial '$ echo hi'
+}
+
+@test "aube run does not echo for the node_modules/.bin fallback" {
+	# Matches bun: the `$ <cmd>` line reports a package.json script body.
+	# A bare binary name is already exactly what the user typed.
+	printf '{ "name": "echo-bin", "scripts": {} }' >package.json
+	mkdir -p node_modules/.bin
+	printf '#!/bin/sh\necho from-bin\n' >node_modules/.bin/mybin
+	chmod +x node_modules/.bin/mybin
+	run aube run --no-install mybin
+	assert_success
+	assert_output "from-bin"
+	refute_output --partial '$ '
+}
+
+@test "aube run -r --parallel prefixes the echoed command with the package" {
+	# Parallel output is multiplexed, so an unprefixed `$ <cmd>` line
+	# could not be attributed to a package.
+	printf '{ "name": "root", "private": true }' >package.json
+	printf 'packages:\n  - "packages/*"\n' >pnpm-workspace.yaml
+	mkdir -p packages/a packages/b
+	printf '{ "name": "pkg-a", "scripts": { "build": "echo a-done" } }' >packages/a/package.json
+	printf '{ "name": "pkg-b", "scripts": { "build": "echo b-done" } }' >packages/b/package.json
+	run aube run --no-install -r --parallel build
+	assert_success
+	assert_line "pkg-a: $ echo a-done"
+	assert_line "pkg-b: $ echo b-done"
 }

--- a/test/run.bats
+++ b/test/run.bats
@@ -806,3 +806,26 @@ JSON
 	assert_line "pkg-a: $ echo a-done"
 	assert_line "pkg-b: $ echo b-done"
 }
+
+@test "aube run echoes an injected --inspect like the manifest form" {
+	# The executed line quotes injected node args; the echoed one must not,
+	# or the same flag would render differently depending on whether it came
+	# from the CLI or from the script body.
+	cat >package.json <<-'JSON'
+		{
+		  "name": "echo-inspect",
+		  "scripts": {
+		    "cli": "node app.js",
+		    "manual": "node --inspect=9229 app.js"
+		  }
+		}
+	JSON
+	echo 'console.log("ran")' >app.js
+	run aube run --no-install --inspect=9229 cli
+	assert_success
+	assert_line "$ node --inspect=9229 app.js"
+
+	run aube run --no-install manual
+	assert_success
+	assert_line "$ node --inspect=9229 app.js"
+}

--- a/test/runtime.bats
+++ b/test/runtime.bats
@@ -310,7 +310,9 @@ _basic_project() {
 	assert_success
 	eval "$output"
 
-	run aube run --no-install nested-pnpm
+	# `-s` drops aube's wrapper output (the echoed `$ <cmd>` line) so the
+	# assertion stays an exact match on what the script itself printed.
+	run aube run --no-install -s nested-pnpm
 	assert_success
 	assert_output "$AUBE_SHIM_DIR/pnpm"
 }
@@ -337,7 +339,9 @@ SH
 	assert_success
 	eval "$output"
 
-	run aube run --no-install nested-pnpm
+	# `-s` drops aube's wrapper output (the echoed `$ <cmd>` line) so the
+	# assertion stays an exact match on what the script itself printed.
+	run aube run --no-install -s nested-pnpm
 	assert_success
 	assert_output "$AUBE_SHIM_DIR/pnpm"
 }


### PR DESCRIPTION
## What

`aube run` now prints the script's command line to stderr before running it, prefixed with `$` — the same thing npm, pnpm, and bun all do:

```console
$ aubr build
$ tsc -p .
```

## Why

aube was the only one of the four that ran silently. That matters most in the place you can't re-run: a CI log shows `aube run build` exiting non-zero with no record of what `build` actually expanded to, and the manifest may well have changed since.

Verified against the other three on the same fixture — the output is byte-identical to bun, and matches pnpm including its quoting of args that contain spaces:

| | echoes | stream | `--silent` |
|---|---|---|---|
| npm 11 | `> pkg@1.0.0 hello` + `> node hello.js` | stderr | suppressed |
| pnpm 11.22 | `$ node hello.js` | stderr | suppressed |
| bun 1.4.0 | `$ node hello.js` | stderr | suppressed |
| aube (before) | — | — | — |
| aube (this PR) | `$ node hello.js` | stderr | suppressed |

## Details

- **Stderr, not stdout**, so `aube run print-json > out.json` still captures only the script's own output.
- **Post-injection command line** is what gets echoed, so a forwarded `--inspect` shows up in the line rather than being hidden behind the raw manifest body.
- **`pre`/`post` scripts each get their own line**, matching bun.
- **Parallel recursive runs** carry the same `<package>: ` prefix as the rest of that package's multiplexed output — an unprefixed line couldn't be attributed to a package:
  ```
  pkg-a: $ echo a-done
  pkg-b: $ echo b-done
  ```
- **The `node_modules/.bin` fallback stays quiet**, matching bun. A bare binary name is already exactly what the user typed.
- **Suppressed by `--silent` / `-s` / `--loglevel silent`**, which leaves the script's own stdout and stderr untouched. The existing `-s` help text ("Suppress aube's wrapper output while still showing script stdout/stderr") already described this behavior.

### Arg quoting

The executed command line quotes every forwarded arg unconditionally via `shell_quote_arg`, which is correct but would echo `aube run test --watch` as `... '--watch'` — noise no other package manager emits. `display_arg` passes shell-safe args through bare and defers everything else to `shell_quote_arg` itself, so the echoed line can never disagree with what actually ran. A unit test asserts that fallback equality rather than hardcoding expected strings.

```console
$ aube run withargs a b 'c d'
$ node -e "console.log(process.argv.slice(1))" a b 'c d'
```

## Compatibility

This changes default output for every script run. `--silent` is the escape hatch, and it's the behavior users coming from npm/pnpm/bun already expect. Flagging it explicitly since anything parsing aube's stderr would see the new line.

## Testing

- 7 new bats tests in `test/run.bats` covering the echo, pre/post chain, arg quoting, stream routing (`--separate-stderr`), all three silent variants, the `.bin` fallback staying quiet, and the parallel prefix.
- 2 new unit tests for `display_arg`.
- `cargo test` (819 lib tests + integration) green; `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.
- Baselined `run.bats`, `exec.bats`, `filter.bats`, `color.bats`, `lifecycle_shortcuts.bats`, `implicit_run.bats`, `loglevel.bats`, and `lifecycle_scripts.bats` against an unmodified tree: the failing set is identical before and after, all from a broken `node` shim in my sandbox rather than this change.

Also added `bats_require_minimum_version 1.5.0` to `run.bats` — it already used the 1.5.0-only `run --separate-stderr` flag and was emitting a BW02 warning; this PR adds a second use.

_This PR was generated by Claude Code._

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Output-only change to script runs; quoting for display reuses execution quoting and does not alter how commands are spawned. Default stderr now includes an extra line, which can affect parsers that consume aube's stderr.
> 
> **Overview**
> `aube run` (and lifecycle shortcuts that share the same exec path) now prints the expanded script command to **stderr** as `$ <cmd>` before spawn, matching npm/pnpm/bun so CI logs show what a script name actually ran.
> 
> The echoed line is the post-injection command (so CLI `--inspect` appears), with `pre`/`post` each getting their own line. Shell-safe args stay unquoted via `display_arg`; everything else uses the same `shell_quote_arg` as execution. Parallel recursive runs prefix the echo with `<pkg>: `; the `.bin` fallback stays quiet. `--silent` / `-s` / `--loglevel silent` suppress the echo without muting script output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cea94c27b37fda3b629ef66890899e1da49cf6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Script commands are now echoed with a `$` prefix, including lifecycle scripts and forwarded arguments.
  * Parallel package output includes package-specific command prefixes.

* **Bug Fixes**
  * Silent mode now consistently suppresses command echoes across start, stop, restart, and run operations.
  * Command arguments are displayed with safer, execution-equivalent quoting.

* **Documentation**
  * Documented command echoing, stderr behavior, and silent-mode options.

* **Tests**
  * Added coverage for echoing, quoting, stderr routing, silent mode, and parallel execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->