### PR TITLE
build(aubr): add reproducible lean binary target

### DIFF
--- a/crates/aube/Cargo.toml
+++ b/crates/aube/Cargo.toml
@@ -111,6 +111,11 @@ default = [
     "hickory-dns",
     "workspace-yaml-preserve",
 ]
+# Minimum feature set for an independently linked `aubr` experiment. The
+# runner can still auto-install, so it needs the production allocator, TLS,
+# and DNS cache; it does not expose publish, config TUI, or workspace YAML
+# mutation commands after multicall dispatch rewrites argv to `aube run`.
+aubr-lean = ["mimalloc", "rustls", "hickory-dns"]
 # Include the interactive `aube config tui` browser. Builds that want the
 # smallest dependency graph can disable default features and omit this.
 config-tui = ["dep:crossterm", "dep:ratatui"]

--- a/crates/aube/Cargo.toml
+++ b/crates/aube/Cargo.toml
@@ -111,11 +111,6 @@ default = [
     "hickory-dns",
     "workspace-yaml-preserve",
 ]
-# Minimum feature set for an independently linked `aubr` experiment. The
-# runner can still auto-install, so it needs the production allocator, TLS,
-# and DNS cache; it does not expose publish, config TUI, or workspace YAML
-# mutation commands after multicall dispatch rewrites argv to `aube run`.
-aubr-lean = ["mimalloc", "rustls", "hickory-dns"]
 # Include the interactive `aube config tui` browser. Builds that want the
 # smallest dependency graph can disable default features and omit this.
 config-tui = ["dep:crossterm", "dep:ratatui"]

--- a/mise.toml
+++ b/mise.toml
@@ -169,7 +169,7 @@ run = "bash benchmarks/pgo.bash"
 [tasks."build:aubr-lean"]
 dir = "{{config_root}}"
 env = { CARGO_TARGET_DIR = "{{config_root}}/target/aubr-lean" }
-run = "cargo build --release --locked -p aube --bin aubr --no-default-features --features aubr-lean"
+run = "cargo build --release --locked -p aube --bin aubr --no-default-features --features mimalloc,rustls,hickory-dns"
 
 [tasks.render]
 depends = ["build"]

--- a/mise.toml
+++ b/mise.toml
@@ -162,6 +162,15 @@ run = [
 dir = "{{config_root}}"
 run = "bash benchmarks/pgo.bash"
 
+# Build a separately linked runner with command-only features. Release
+# archives deliberately keep shipping `aubr` as a symlink to the PGO-trained
+# `aube`: this artifact is useful for measuring the standalone design, but it
+# adds a second ~40 MiB executable and has not beaten the multicall binary.
+[tasks."build:aubr-lean"]
+dir = "{{config_root}}"
+env = { CARGO_TARGET_DIR = "{{config_root}}/target/aubr-lean" }
+run = "cargo build --release --locked -p aube --bin aubr --no-default-features --features aubr-lean"
+
 [tasks.render]
 depends = ["build"]
 run = [


### PR DESCRIPTION
## Summary

- add `mise run build:aubr-lean` with an isolated target directory and a task-local minimal feature set
- provide a reproducible independently linked runner experiment without adding a permanent Cargo feature
- leave release archives on the PGO-trained `aube` multicall symlink

## Outcome

This is a reproducible negative experiment, not a proposal to ship the standalone artifact.

| artifact | size | warm Node script |
|---|---:|---:|
| regular non-PGO multicall | 44,288,768 B | 32.6 ± 2.0 ms |
| PGO multicall | 48,492,240 B | 31.3 ± 1.3 ms |
| lean standalone | 42,063,232 B | 56.2 ± 26.0 ms (30.1 ms minimum) |

The lean binary removes 2.2 MB (5.0%) from one executable, but shipping it would replace a near-zero-byte symlink with another 42 MB executable. Its minimum is effectively flat and its means were consistently noisier/slower in both benchmark orders. Automatic install necessarily retains most of the package-manager graph, so feature trimming alone cannot make this genuinely small.

The task keeps the experiment cheap to reproduce without a real-world release regression. It adds no registry access to release builds and does not alter release packaging.

## Verification

- `cargo fmt --check`
- `cargo check --locked --release --no-default-features --features mimalloc,rustls,hickory-dns -p aube --bin aube`
- release build of the identical feature set
- warm real-Node smoke and benchmark

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*