### PR TITLE
perf(run): exec plain script command lines without a shell

### DIFF
--- a/crates/aube-scripts/Cargo.toml
+++ b/crates/aube-scripts/Cargo.toml
@@ -29,9 +29,13 @@ tracing = { workspace = true }
 # a direct dep keeps the workspace honest about who actually uses it.
 regex = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+# `direct.rs` asks `access(X_OK)` — the same question a shell's PATH search
+# asks — instead of re-deriving executability from mode bits and our uid.
+libc = { workspace = true }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 landlock = { workspace = true }
-libc = { workspace = true }
 seccompiler = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/aube-scripts/src/direct.rs
+++ b/crates/aube-scripts/src/direct.rs
@@ -1,0 +1,486 @@
+//! Direct-exec fast path for `aube run`.
+//!
+//! Every package script normally goes through `sh -c "<body>"`. `/bin/sh`
+//! does not exec in place — dash stays resident as the script's parent —
+//! so a shell costs a whole extra process per invocation. For a body that
+//! is one plain command (`tsc -p .`, `vitest run`, `node build.js`) the
+//! shell contributes nothing but that process.
+//!
+//! This module decides when a body can skip the shell. It is deliberately
+//! a strict allowlist rather than a tokenizer: a tokenizer splits words
+//! but says nothing about shell *semantics*, so it cannot tell us whether
+//! the shell was load-bearing. Anything we do not recognize with
+//! certainty falls back to `sh -c`, which is the pre-existing behavior.
+//! Every bail is a correctness win traded for a process we keep paying.
+
+use std::path::PathBuf;
+
+/// Bytes allowed to appear anywhere in a directly-exec'd command line.
+///
+/// ASCII alphanumerics plus these. Everything else — `;` `&` `|` `(` `)`
+/// `<` `>` `$` backtick `"` `'` `\` `*` `?` `[` `]` `{` `}` `~` `#` `!`
+/// `^` `%`, newlines, tabs, other control bytes, and all non-ASCII —
+/// means either a shell operator, an expansion, quoting, or something we
+/// have not thought about, and sends the body to `sh`.
+const EXTRA_ALLOWED: &[u8] = b" ._-+/@:,=";
+
+/// Words that must never be exec'd directly, in two hazard classes.
+///
+/// The first is builtins with no binary at all: `exit 7` as a script body
+/// works today and must keep working. The second is builtins that *do*
+/// have a binary whose behavior differs from the shell's — `echo -e`,
+/// `printf`, and `test` all diverge between dash, bash, and coreutils, so
+/// exec'ing the binary would silently change what a script does.
+///
+/// Sorted for `binary_search`; `builtin_list_is_sorted_and_deduped`
+/// enforces that. Missing an entry is not a correctness hole on its own,
+/// because an unresolvable word falls back to the shell anyway — this
+/// list is what makes the common builtins *guaranteed* rather than
+/// accidentally correct.
+#[rustfmt::skip]
+const SHELL_WORDS: &[&str] = &[
+    ".", ":", "[", "[[", "]]", "alias", "bg", "bind", "break", "builtin",
+    "caller", "case", "cd", "command", "compgen", "complete", "continue",
+    "coproc", "declare", "dirs", "disown", "do", "done", "echo", "elif",
+    "else", "enable", "esac", "eval", "exec", "exit", "export", "false",
+    "fg", "fi", "for", "function", "getopts", "hash", "history", "if",
+    "in", "jobs", "kill", "let", "local", "logout", "mapfile", "popd",
+    "printf", "pushd", "pwd", "read", "readarray", "readonly", "return",
+    "select", "set", "shift", "shopt", "source", "suspend", "test",
+    "then", "time", "times", "trap", "true", "type", "typeset", "ulimit",
+    "umask", "unalias", "unset", "until", "wait", "while", "{", "}",
+];
+
+/// Split a script body into `(program, args)` when it is a single plain
+/// command that a shell would add nothing to. `None` means "use `sh`".
+///
+/// Recognizes only bodies built from [`EXTRA_ALLOWED`] bytes whose first
+/// word is a bare program name. See the module docs for why this is a
+/// scanner and not a parser.
+pub(crate) fn simple_command_argv(body: &str) -> Option<(&str, Vec<&str>)> {
+    let body = body.trim();
+    if body.is_empty() {
+        return None;
+    }
+    if !body
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || EXTRA_ALLOWED.contains(&b))
+    {
+        return None;
+    }
+
+    // Space is the only separator that survived the scan, so the split is
+    // unambiguous — no quoting or escaping can be in play.
+    let mut words = body.split_ascii_whitespace();
+    let program = words.next()?;
+
+    // A leading `FOO=bar` is a shell assignment prefix, not a program. `=`
+    // is still fine in later words (`--target=es2020`).
+    if program.contains('=') {
+        return None;
+    }
+    // Looks like a flag, so we have misread the body somehow.
+    if program.starts_with('-') {
+        return None;
+    }
+    // A path-shaped program would make us reason about how std resolves a
+    // relative program against `current_dir`. Real scripts invoke bare
+    // names (`tsc`, `vitest`, `node`), so the case is not worth owning.
+    if program.contains('/') {
+        return None;
+    }
+    if SHELL_WORDS.binary_search(&program).is_ok() {
+        return None;
+    }
+
+    Some((program, words.collect()))
+}
+
+/// Find `program` on `path`, mirroring how the shell would resolve it.
+///
+/// This is a correctness requirement, not an optimization: on Unix
+/// `Command::new("tsc")` resolves through `execvp`, which searches the
+/// *parent's* environ and ignores the `PATH` we hand the child — so
+/// without resolving here ourselves, a `node_modules/.bin` program would
+/// not be found at all.
+///
+/// Costs one `stat` per PATH entry until a hit (typically one for a
+/// project-local bin, three for `node`), which is noise next to the fork
+/// and shell startup it replaces. Deliberately uncached: a cache would
+/// have to be invalidated on every install, and there is nothing to win.
+pub fn resolve_program(program: &str, path: &std::ffi::OsStr) -> Option<PathBuf> {
+    for dir in std::env::split_paths(path) {
+        // POSIX reads an empty entry as the cwd. Rather than reason about
+        // a cwd-relative match, treat the whole search as inconclusive
+        // and let the shell handle the body.
+        if dir.as_os_str().is_empty() || !dir.is_absolute() {
+            return None;
+        }
+        let candidate = dir.join(program);
+        // `metadata` follows symlinks, so a `.bin/tsc -> ../pkg/cli.js`
+        // link resolves to the real file and its mode.
+        let Ok(meta) = std::fs::metadata(&candidate) else {
+            continue;
+        };
+        if !meta.is_file() {
+            continue;
+        }
+        if !is_executable(&meta) {
+            continue;
+        }
+        return Some(candidate);
+    }
+    None
+}
+
+#[cfg(unix)]
+fn is_executable(meta: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    meta.mode() & 0o111 != 0
+}
+
+#[cfg(not(unix))]
+fn is_executable(_meta: &std::fs::Metadata) -> bool {
+    // Only reachable from tests; the fast path itself is Unix-only.
+    true
+}
+
+/// Plan a direct exec of `body` against `path`, or `None` to use `sh`.
+///
+/// Returns `(resolved_program, program_as_written, args)`. The second
+/// element becomes `argv[0]`, matching what the shell would have passed.
+pub fn direct_argv<'a>(
+    body: &'a str,
+    path: &std::ffi::OsStr,
+) -> Option<(PathBuf, &'a str, Vec<&'a str>)> {
+    // Windows would need PATHEXT plus the `.cmd`/`.ps1`/bare-sh shim
+    // triple, and `CreateProcess` cannot run a `.cmd` at all — Windows
+    // re-enters `cmd.exe` for batch files, so the process we skipped
+    // comes right back. `cfg!` rather than `#[cfg]` so this module's
+    // tests still compile and run on the Windows CI job.
+    if cfg!(windows) {
+        return None;
+    }
+
+    // Scan first. It is a pure pass over the body, where every check below
+    // reads settings (cloning the snapshot) or the environment — so a body
+    // that was always going to need a shell pays nothing for asking.
+    let (program, args) = simple_command_argv(body)?;
+
+    let settings = crate::script_settings();
+    // The user pointed scripts at a specific shell; run them in it.
+    if settings.script_shell.is_some() {
+        return None;
+    }
+    // Signals intent about shell semantics even though aube does not
+    // currently emulate one.
+    if settings.shell_emulator {
+        return None;
+    }
+    // Where `/bin/sh` is bash (macOS), bash sources `$BASH_ENV` for
+    // non-interactive shells, so a script body can legitimately depend on
+    // functions or PATH edits from that file. Same for `$ENV` under a
+    // POSIX sh. If either is set, the shell is load-bearing.
+    if std::env::var_os("BASH_ENV").is_some() || std::env::var_os("ENV").is_some() {
+        return None;
+    }
+
+    // Resolution failure is not an error — falling back to `sh` preserves
+    // the shell's exit 127 and its exact `sh: 1: foo: not found` stderr,
+    // and 126 for a hit that is not executable.
+    let resolved = resolve_program(program, path)?;
+    Some((resolved, program, args))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn argv(body: &str) -> Option<(String, Vec<String>)> {
+        simple_command_argv(body)
+            .map(|(p, a)| (p.to_string(), a.into_iter().map(String::from).collect()))
+    }
+
+    #[test]
+    fn accepts_plain_commands() {
+        let cases: &[(&str, &str, &[&str])] = &[
+            ("tsc -p .", "tsc", &["-p", "."]),
+            ("vitest run", "vitest", &["run"]),
+            ("next dev", "next", &["dev"]),
+            ("node hello.js", "node", &["hello.js"]),
+            ("eslint . --fix", "eslint", &[".", "--fix"]),
+            (
+                "esbuild src/x.ts --target=es2020",
+                "esbuild",
+                &["--target=es2020"],
+            ),
+            ("husky", "husky", &[]),
+            ("  tsc  -p  .  ", "tsc", &["-p", "."]),
+        ];
+        for (body, program, _) in cases {
+            let (got, _) = argv(body).unwrap_or_else(|| panic!("{body} should be direct"));
+            assert_eq!(&got, program, "{body}");
+        }
+        // Spot-check full argv, including the `/`-containing later word
+        // that the first-word `/` rule must not reject.
+        assert_eq!(
+            argv("esbuild src/x.ts --target=es2020"),
+            Some((
+                "esbuild".to_string(),
+                vec!["src/x.ts".to_string(), "--target=es2020".to_string()]
+            ))
+        );
+        assert_eq!(argv("husky"), Some(("husky".to_string(), vec![])));
+    }
+
+    #[test]
+    fn bails_on_anything_a_shell_would_interpret() {
+        let cases = [
+            ("foo && bar", "and-chain"),
+            ("foo; bar", "semicolon"),
+            ("foo | bar", "pipe"),
+            ("foo &", "background"),
+            ("foo > out", "redirect out"),
+            ("foo < in", "redirect in"),
+            ("(foo)", "subshell"),
+            ("a $V", "expansion"),
+            ("a ${V}", "braced expansion"),
+            ("a `b`", "command substitution"),
+            ("a ~/x", "tilde"),
+            ("a *.ts", "glob star"),
+            ("a x?.ts", "glob question"),
+            ("a [ab].ts", "glob class"),
+            ("a {b,c}", "brace expansion"),
+            ("a 'q'", "single quotes"),
+            ("a \"q\"", "double quotes"),
+            ("a\\b", "backslash"),
+            ("FOO=bar node x.js", "assignment prefix"),
+            ("# c", "comment"),
+            ("node -e \"\"", "quoted -e"),
+            ("foo\nbar", "newline"),
+            ("foo\tbar", "tab"),
+            ("café", "non-ascii"),
+            ("-flag x", "leading flag"),
+            ("./x.js", "relative path program"),
+            ("node_modules/.bin/x", "path program"),
+            ("", "empty"),
+            ("   ", "blank"),
+            ("a %V%", "percent"),
+            ("a ^b", "caret"),
+            ("a !b", "bang"),
+        ];
+        for (body, why) in cases {
+            assert!(argv(body).is_none(), "{why}: {body:?} must use the shell");
+        }
+    }
+
+    #[test]
+    fn bails_on_shell_builtins_and_keywords() {
+        // Split out so a failure names the class. The first group has no
+        // binary at all; the second has one that behaves differently.
+        for word in [
+            "exit", ":", ".", "cd", "export", "unset", "set", "shift", "source", "eval", "exec",
+            "read", "local", "readonly", "trap", "wait", "umask", "ulimit", "times", "hash",
+            "getopts", "alias", "break", "continue", "return", "command", "type",
+        ] {
+            assert!(argv(word).is_none(), "builtin without a binary: {word}");
+            assert!(argv(&format!("{word} 7")).is_none(), "with args: {word}");
+        }
+        for word in [
+            "echo", "true", "false", "test", "[", "printf", "pwd", "kill",
+        ] {
+            assert!(
+                argv(word).is_none(),
+                "builtin with divergent binary: {word}"
+            );
+        }
+        for word in [
+            "if", "then", "else", "elif", "fi", "for", "while", "until", "do", "done", "case",
+            "esac", "in", "function", "select", "time", "[[", "{", "}",
+        ] {
+            assert!(argv(word).is_none(), "keyword: {word}");
+        }
+    }
+
+    #[test]
+    fn exit_seven_still_reaches_the_shell() {
+        // Pins the `"boom": "exit 7"` e2e fixture: `exit` has no binary,
+        // so exec'ing it would turn a working script into ENOENT.
+        assert!(argv("exit 7").is_none());
+    }
+
+    #[test]
+    fn builtin_list_is_sorted_and_deduped() {
+        let mut sorted = SHELL_WORDS.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(
+            SHELL_WORDS,
+            &sorted[..],
+            "SHELL_WORDS must stay sorted and deduped for binary_search"
+        );
+    }
+
+    /// Unique scratch dir. `tempfile` is deliberately not a dep of this
+    /// crate (see `aborting_script_kills_grandchildren`), so follow the
+    /// same `temp_dir` + nanos convention.
+    fn scratch(tag: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("aube-direct-{tag}-{nanos}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn exe(path: &Path) {
+        std::fs::write(path, "#!/bin/sh\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+    }
+
+    fn join(dirs: &[&Path]) -> std::ffi::OsString {
+        std::env::join_paths(dirs.iter().map(|d| d.to_path_buf())).unwrap()
+    }
+
+    #[test]
+    fn resolve_program_finds_an_executable() {
+        let dir = scratch("hit");
+        exe(&dir.join("tool"));
+        assert_eq!(
+            resolve_program("tool", &join(&[&dir])),
+            Some(dir.join("tool"))
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_program_skips_non_executable_files() {
+        let dir = scratch("noexec");
+        std::fs::write(dir.join("tool"), "not executable").unwrap();
+        assert_eq!(resolve_program("tool", &join(&[&dir])), None);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn resolve_program_skips_directories() {
+        let dir = scratch("isdir");
+        std::fs::create_dir(dir.join("tool")).unwrap();
+        assert_eq!(resolve_program("tool", &join(&[&dir])), None);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn resolve_program_takes_the_first_hit_in_path_order() {
+        let first = scratch("first");
+        let second = scratch("second");
+        exe(&first.join("tool"));
+        exe(&second.join("tool"));
+        assert_eq!(
+            resolve_program("tool", &join(&[&first, &second])),
+            Some(first.join("tool"))
+        );
+        std::fs::remove_dir_all(&first).ok();
+        std::fs::remove_dir_all(&second).ok();
+    }
+
+    #[test]
+    fn resolve_program_keeps_looking_past_a_dir_without_the_program() {
+        let miss = scratch("miss");
+        let hit = scratch("late-hit");
+        exe(&hit.join("tool"));
+        assert_eq!(
+            resolve_program("tool", &join(&[&miss, &hit])),
+            Some(hit.join("tool"))
+        );
+        std::fs::remove_dir_all(&miss).ok();
+        std::fs::remove_dir_all(&hit).ok();
+    }
+
+    #[test]
+    fn resolve_program_gives_up_on_a_relative_path_entry() {
+        let dir = scratch("relative");
+        exe(&dir.join("tool"));
+        assert_eq!(
+            resolve_program("tool", &join(&[Path::new("relative"), &dir])),
+            None
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_program_ignores_a_dangling_symlink() {
+        let dir = scratch("dangling");
+        std::os::unix::fs::symlink(dir.join("nope"), dir.join("tool")).unwrap();
+        assert_eq!(resolve_program("tool", &join(&[&dir])), None);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// `direct_argv` reads the task-local settings snapshot, so drive it
+    /// through `scope` the way `scoped_settings_tests` does rather than
+    /// mutating the process-global fallback.
+    async fn plans_under(settings: crate::ScriptSettings, dir: &Path) -> bool {
+        let path = join(&[dir]);
+        crate::scope(async move {
+            crate::set_script_settings(settings);
+            direct_argv("tool --flag x", &path).is_some()
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn direct_argv_declines_when_a_custom_script_shell_is_set() {
+        let dir = scratch("script-shell");
+        exe(&dir.join("tool"));
+        let settings = crate::ScriptSettings {
+            script_shell: Some(PathBuf::from("/bin/bash")),
+            ..Default::default()
+        };
+        assert!(!plans_under(settings, &dir).await);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn direct_argv_declines_under_the_shell_emulator() {
+        let dir = scratch("shell-emulator");
+        exe(&dir.join("tool"));
+        let settings = crate::ScriptSettings {
+            shell_emulator: true,
+            ..Default::default()
+        };
+        assert!(!plans_under(settings, &dir).await);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn direct_argv_plans_a_bare_command_with_default_settings() {
+        // `BASH_ENV` / `ENV` in the ambient environment legitimately veto
+        // the fast path, so only assert the plan when this process is
+        // clean. Reading them is why this is not a table with the two
+        // decline cases above.
+        if std::env::var_os("BASH_ENV").is_some() || std::env::var_os("ENV").is_some() {
+            return;
+        }
+        let dir = scratch("plan");
+        exe(&dir.join("tool"));
+        let path = join(&[&dir]);
+        let expected = dir.join("tool");
+        crate::scope(async move {
+            crate::set_script_settings(crate::ScriptSettings::default());
+            let (resolved, word, args) = direct_argv("tool --flag x", &path).unwrap();
+            assert_eq!(resolved, expected);
+            assert_eq!(word, "tool");
+            assert_eq!(args, vec!["--flag", "x"]);
+        })
+        .await;
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/crates/aube-scripts/src/direct.rs
+++ b/crates/aube-scripts/src/direct.rs
@@ -13,7 +13,7 @@
 //! certainty falls back to `sh -c`, which is the pre-existing behavior.
 //! Every bail is a correctness win traded for a process we keep paying.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Bytes allowed to appear anywhere in a directly-exec'd command line.
 ///
@@ -96,6 +96,18 @@ pub(crate) fn simple_command_argv(body: &str) -> Option<(&str, Vec<&str>)> {
     Some((program, words.collect()))
 }
 
+/// What a PATH candidate is, from the point of view of "may we exec it
+/// ourselves without changing what the script does".
+enum Candidate {
+    /// Executable by us, and the kernel can launch it directly.
+    Runnable,
+    /// Not a usable hit. Keep walking PATH, as a shell would.
+    Miss,
+    /// Exists and we could run it, but `sh` would do something else with
+    /// it — so hand the whole body back to `sh`.
+    DeferToShell,
+}
+
 /// Find `program` on `path`, mirroring how the shell would resolve it.
 ///
 /// This is a correctness requirement, not an optimization: on Unix
@@ -104,10 +116,11 @@ pub(crate) fn simple_command_argv(body: &str) -> Option<(&str, Vec<&str>)> {
 /// without resolving here ourselves, a `node_modules/.bin` program would
 /// not be found at all.
 ///
-/// Costs one `stat` per PATH entry until a hit (typically one for a
-/// project-local bin, three for `node`), which is noise next to the fork
-/// and shell startup it replaces. Deliberately uncached: a cache would
-/// have to be invalidated on every install, and there is nothing to win.
+/// Costs a `stat` and a 4-byte read per candidate until a hit (typically
+/// one for a project-local bin, three for `node`), which is noise next to
+/// the fork and shell startup it replaces. Deliberately uncached: a cache
+/// would have to be invalidated on every install, and there is nothing to
+/// win.
 pub fn resolve_program(program: &str, path: &std::ffi::OsStr) -> Option<PathBuf> {
     for dir in std::env::split_paths(path) {
         // POSIX reads an empty entry as the cwd. Rather than reason about
@@ -117,32 +130,104 @@ pub fn resolve_program(program: &str, path: &std::ffi::OsStr) -> Option<PathBuf>
             return None;
         }
         let candidate = dir.join(program);
-        // `metadata` follows symlinks, so a `.bin/tsc -> ../pkg/cli.js`
-        // link resolves to the real file and its mode.
-        let Ok(meta) = std::fs::metadata(&candidate) else {
-            continue;
-        };
-        if !meta.is_file() {
-            continue;
+        match classify(&candidate) {
+            Candidate::Runnable => return Some(candidate),
+            Candidate::Miss => continue,
+            Candidate::DeferToShell => return None,
         }
-        if !is_executable(&meta) {
-            continue;
-        }
-        return Some(candidate);
     }
     None
 }
 
+fn classify(candidate: &Path) -> Candidate {
+    // `metadata` follows symlinks, so a `.bin/tsc -> ../pkg/cli.js` link
+    // resolves to the real file.
+    let Ok(meta) = std::fs::metadata(candidate) else {
+        return Candidate::Miss;
+    };
+    if !meta.is_file() {
+        return Candidate::Miss;
+    }
+    // Mode bits alone answer "is this marked executable", not "may *we*
+    // execute it" — a file can carry `--x` for an owner we are not. A
+    // shell keeps walking PATH in that case, so a hit we could not launch
+    // must not end the search, or a later runnable entry gets shadowed by
+    // an EACCES we would report as a spawn failure.
+    if !can_execute(candidate, &meta) {
+        return Candidate::Miss;
+    }
+    // `sh -c tool` runs an executable *without* a shebang or a native
+    // header as a shell script; exec'ing it ourselves fails with
+    // ENOEXEC. Only launch what the kernel can launch on its own and let
+    // `sh` keep the rest, including its own interpretation of them.
+    match launchable(candidate) {
+        Some(true) => Candidate::Runnable,
+        Some(false) => Candidate::DeferToShell,
+        // Unreadable but executable (`--x`) is legal and the kernel may
+        // well run it; we just cannot tell what it is, so we do not guess.
+        None => Candidate::DeferToShell,
+    }
+}
+
+/// Whether the file starts with `#!` or a native executable header —
+/// i.e. whether `execve` alone can launch it.
+fn launchable(candidate: &Path) -> Option<bool> {
+    use std::io::Read;
+
+    let mut head = [0u8; 4];
+    let mut file = std::fs::File::open(candidate).ok()?;
+    let read = file.read(&mut head).ok()?;
+    let head = &head[..read];
+    if head.starts_with(b"#!") {
+        return Some(true);
+    }
+    // ELF, the Mach-O 32/64-bit and fat variants, and PE. Matching
+    // aube-linker's magic list without taking a dependency on it for four
+    // byte comparisons.
+    const NATIVE: &[&[u8]] = &[
+        b"\x7fELF",
+        &[0xfe, 0xed, 0xfa, 0xce],
+        &[0xfe, 0xed, 0xfa, 0xcf],
+        &[0xce, 0xfa, 0xed, 0xfe],
+        &[0xcf, 0xfa, 0xed, 0xfe],
+        &[0xca, 0xfe, 0xba, 0xbe],
+        &[0xbe, 0xba, 0xfe, 0xca],
+        b"MZ",
+    ];
+    Some(NATIVE.iter().any(|m| head.starts_with(m)))
+}
+
 #[cfg(unix)]
-fn is_executable(meta: &std::fs::Metadata) -> bool {
-    use std::os::unix::fs::MetadataExt;
-    meta.mode() & 0o111 != 0
+fn can_execute(candidate: &Path, _meta: &std::fs::Metadata) -> bool {
+    use std::os::unix::ffi::OsStrExt;
+
+    // `access(X_OK)` is what a shell's PATH search asks, so ask the same
+    // question rather than re-deriving it from mode bits and our uid.
+    let Ok(c_path) = std::ffi::CString::new(candidate.as_os_str().as_bytes()) else {
+        return false;
+    };
+    // SAFETY: `c_path` is a valid NUL-terminated C string that outlives
+    // the call, and `access` only reads it.
+    unsafe { libc::access(c_path.as_ptr(), libc::X_OK) == 0 }
 }
 
 #[cfg(not(unix))]
-fn is_executable(_meta: &std::fs::Metadata) -> bool {
+fn can_execute(_candidate: &Path, _meta: &std::fs::Metadata) -> bool {
     // Only reachable from tests; the fast path itself is Unix-only.
     true
+}
+
+/// Whether `BASH_ENV` or `ENV` reaches the child, from either our own
+/// environment or an embedder's `extra_env` contribution.
+fn shell_init_var_set(settings: &crate::ScriptSettings) -> bool {
+    const SHELL_INIT_VARS: [&str; 2] = ["BASH_ENV", "ENV"];
+    SHELL_INIT_VARS.iter().any(|var| {
+        std::env::var_os(var).is_some()
+            || settings
+                .extra_env
+                .iter()
+                .any(|(key, _)| key.as_os_str() == std::ffi::OsStr::new(var))
+    })
 }
 
 /// Plan a direct exec of `body` against `path`, or `None` to use `sh`.
@@ -181,7 +266,12 @@ pub fn direct_argv<'a>(
     // non-interactive shells, so a script body can legitimately depend on
     // functions or PATH edits from that file. Same for `$ENV` under a
     // POSIX sh. If either is set, the shell is load-bearing.
-    if std::env::var_os("BASH_ENV").is_some() || std::env::var_os("ENV").is_some() {
+    //
+    // Check the child's effective environment, not just ours: an embedder
+    // can contribute either var through `extra_env`, which
+    // `apply_script_settings_env` stamps onto the command we are about to
+    // build.
+    if shell_init_var_set(&settings) {
         return None;
     }
 
@@ -195,7 +285,6 @@ pub fn direct_argv<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::Path;
 
     fn argv(body: &str) -> Option<(String, Vec<String>)> {
         simple_command_argv(body)
@@ -411,6 +500,79 @@ mod tests {
             resolve_program("tool", &join(&[Path::new("relative"), &dir])),
             None
         );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_program_defers_an_executable_without_a_shebang() {
+        // `sh -c tool` runs this as a shell script; exec'ing it would fail
+        // with ENOEXEC. Bail so the shell keeps interpreting it.
+        let dir = scratch("noexec-hdr");
+        let tool = dir.join("tool");
+        std::fs::write(&tool, "echo hi\n").unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&tool, std::fs::Permissions::from_mode(0o755)).unwrap();
+        assert_eq!(resolve_program("tool", &join(&[&dir])), None);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_program_accepts_a_native_binary() {
+        let dir = scratch("elf");
+        let tool = dir.join("tool");
+        std::fs::write(&tool, b"\x7fELF\x02\x01\x01").unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&tool, std::fs::Permissions::from_mode(0o755)).unwrap();
+        assert_eq!(
+            resolve_program("tool", &join(&[&dir])),
+            Some(dir.join("tool"))
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_program_keeps_searching_past_an_unexecutable_hit() {
+        // Marked executable for a user we are not: a shell walks on to the
+        // next PATH entry, so a later runnable entry must not be shadowed.
+        let shadow = scratch("shadow");
+        let real = scratch("real");
+        let blocked = shadow.join("tool");
+        std::fs::write(&blocked, "#!/bin/sh\n").unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        // `--x------` with our uid stripped of the bit is not expressible
+        // without changing owner, so use 0o100 and skip when running as
+        // root (which bypasses the check entirely).
+        std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o000)).unwrap();
+        exe(&real.join("tool"));
+        let got = resolve_program("tool", &join(&[&shadow, &real]));
+        if unsafe { libc::geteuid() } == 0 {
+            // root ignores permission bits; the first hit legitimately wins.
+            assert!(got.is_some());
+        } else {
+            assert_eq!(got, Some(real.join("tool")));
+        }
+        std::fs::remove_dir_all(&shadow).ok();
+        std::fs::remove_dir_all(&real).ok();
+    }
+
+    #[tokio::test]
+    async fn direct_argv_declines_when_extra_env_sets_bash_env() {
+        let dir = scratch("extra-env");
+        exe(&dir.join("tool"));
+        let settings = crate::ScriptSettings {
+            extra_env: vec![(
+                std::ffi::OsString::from("BASH_ENV"),
+                std::ffi::OsString::from("/tmp/init.sh"),
+            )],
+            ..Default::default()
+        };
+        // An embedder can inject a shell init file through extra_env, and
+        // `apply_script_settings_env` would stamp it on the child — so the
+        // shell is load-bearing even though our own env is clean.
+        assert!(!plans_under(settings, &dir).await);
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/crates/aube-scripts/src/lib.rs
+++ b/crates/aube-scripts/src/lib.rs
@@ -13,6 +13,7 @@
 //! - `--ignore-scripts` forces everything off, matching pnpm/npm.
 
 pub mod content_sniff;
+pub mod direct;
 pub mod policy;
 
 #[cfg(target_os = "linux")]
@@ -409,6 +410,40 @@ mod path_entry_tests {
 pub fn spawn_shell(script_cmd: &str) -> tokio::process::Command {
     let settings = script_settings();
     spawn_shell_with_settings(script_cmd, &settings)
+}
+
+/// Spawn a resolved program directly, skipping the shell.
+///
+/// The counterpart to [`spawn_shell`] for a script body that
+/// [`direct::direct_argv`] found to be a single plain command. `program`
+/// is the absolute path `direct_argv` resolved; `arg0` is the program as
+/// written in the script body, passed through as `argv[0]` so the child
+/// sees what a shell would have given it.
+///
+/// Env parity with the shell path is structural, not a parallel list:
+/// this calls the same [`apply_script_settings_env`] and shares
+/// `kill_on_drop`. Which now kills the tool itself rather than a shell
+/// holding it as a child — strictly more direct, and the reason the
+/// Windows Job Object story in [`spawn_shell`] does not apply here (the
+/// fast path is Unix-only).
+pub fn spawn_program<I, S>(program: &Path, arg0: &str, args: I) -> tokio::process::Command
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<std::ffi::OsStr>,
+{
+    let settings = script_settings();
+    let mut cmd = tokio::process::Command::new(program);
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        cmd.as_std_mut().arg0(arg0);
+    }
+    #[cfg(not(unix))]
+    let _ = arg0;
+    cmd.args(args);
+    apply_script_settings_env(&mut cmd, &settings);
+    cmd.kill_on_drop(true);
+    cmd
 }
 
 fn spawn_shell_with_settings(
@@ -1604,6 +1639,60 @@ mod user_agent_tests {
             ),
             "arch `{arch}` should follow Node's `process.arch` vocabulary"
         );
+    }
+}
+
+#[cfg(test)]
+mod spawn_program_tests {
+    use super::*;
+
+    fn env_keys(cmd: &tokio::process::Command) -> Vec<String> {
+        let mut keys: Vec<String> = cmd
+            .as_std()
+            .get_envs()
+            .map(|(k, _)| k.to_string_lossy().into_owned())
+            .collect();
+        keys.sort();
+        keys
+    }
+
+    /// The direct path must be indistinguishable from the shell path as
+    /// far as the child's environment goes. Diffing the two commands
+    /// pins that mechanically, rather than trusting that two call sites
+    /// stamp the same list — `aube run` exports a documented `npm_*`
+    /// surface that build tooling reads.
+    #[tokio::test]
+    async fn spawn_program_stamps_the_same_env_as_spawn_shell() {
+        let settings = ScriptSettings {
+            node_options: Some("--max-old-space-size=100".to_string()),
+            node_program: Some(PathBuf::from("/usr/bin/node")),
+            node_execpath: Some(PathBuf::from("/usr/bin/node")),
+            command: Some("run-script".to_string()),
+            http_proxy: Some("http://proxy.invalid".to_string()),
+            https_proxy: Some("http://proxy.invalid".to_string()),
+            ..ScriptSettings::default()
+        };
+        scope(async move {
+            set_script_settings(settings);
+            let shell = spawn_shell("tool --flag");
+            let direct = spawn_program(Path::new("/usr/bin/tool"), "tool", ["--flag"]);
+            assert_eq!(
+                env_keys(&shell),
+                env_keys(&direct),
+                "direct exec must export the same env keys as `sh -c`"
+            );
+        })
+        .await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn spawn_program_runs_the_program_with_its_args() {
+        let mut cmd = spawn_program(Path::new("/bin/echo"), "echo", ["a b", "$HOME"]);
+        let out = cmd.output().await.unwrap();
+        assert!(out.status.success());
+        // `$HOME` arrives literally: there is no shell to expand it.
+        assert_eq!(String::from_utf8_lossy(&out.stdout), "a b $HOME\n");
     }
 }
 

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -1142,29 +1142,6 @@ async fn build_script_command(
     // injection and arg quoting so it mirrors the manifest, not the
     // spliced shell command line.
     let lifecycle_script = cmd.to_string();
-    let echo_cmd = inject_node_args(cmd, node_args, |a| display_arg(a).into_owned());
-    let cmd = inject_node_args(cmd, node_args, aube_scripts::shell_quote_arg);
-    let (shell_cmd, echo_line) = if args.is_empty() {
-        (cmd, echo_cmd)
-    } else {
-        // Quote each forwarded arg. Args land inside `sh -c "..."` or
-        // cmd `/c "..."` which reparses. Unquoted $, backticks, ;, |,
-        // () all get interpreted. `aube run echo '$(rm -rf ~)'` would
-        // run the subshell. Same npm/pnpm bug class from years ago.
-        // shell_quote_arg wraps per-platform. See aube-scripts.
-        let mut buf =
-            String::with_capacity(cmd.len() + args.iter().map(|a| a.len() + 3).sum::<usize>());
-        buf.push_str(&cmd);
-        let mut echo = String::with_capacity(buf.capacity());
-        echo.push_str(&echo_cmd);
-        for a in args {
-            buf.push(' ');
-            buf.push_str(&aube_scripts::shell_quote_arg(a));
-            echo.push(' ');
-            echo.push_str(&display_arg(a));
-        }
-        (buf, echo)
-    };
 
     let bin_dir = super::project_modules_dir(cwd).join(".bin");
     let node_gyp_bin_dir = super::install::node_gyp_bootstrap::lazy_shim_bin_dir(&bin_dir)?;
@@ -1196,15 +1173,79 @@ async fn build_script_command(
     let node_gyp_project_dir =
         crate::dirs::find_workspace_root(&script_dir).unwrap_or_else(|| script_dir.clone());
 
-    // npm-compat env vars. `spawn_shell` already stamped the
-    // invocation-level vars (`npm_execpath`, `npm_node_execpath` /
-    // `NODE`, `npm_command`, `npm_config_user_agent`) from the
+    // npm-compat env vars. Whichever spawn helper runs below already
+    // stamped the invocation-level vars (`npm_execpath`,
+    // `npm_node_execpath` / `NODE`, `npm_command`,
+    // `npm_config_user_agent`) from the
     // process-global ScriptSettings configured for this run. Here we
     // add the per-script + manifest vars so build scripts that branch
     // on `$npm_lifecycle_event`, stamp `$npm_package_version`, or read
     // `$npm_package_engines_node` behave the same under `aube run` as
     // under `aube install` postinstall.
-    let mut command = aube_scripts::spawn_shell(&shell_cmd);
+    //
+    // A body that is one plain command gets exec'd directly — `sh` would
+    // only add a resident parent process. `direct_argv` resolves the
+    // program against `new_path` (not the process PATH, which is what
+    // `execvp` would search) and declines for anything a shell might
+    // actually be interpreting, in which case we splice and quote exactly
+    // as before. `--inspect` keeps the shell too: `inject_node_args`
+    // rewrites the command line textually, and one implementation of that
+    // is enough.
+    let direct = if node_args.is_empty() {
+        aube_scripts::direct::direct_argv(cmd, &new_path)
+    } else {
+        None
+    };
+    let (mut command, echo_line) = match &direct {
+        // Forwarded args become real argv entries instead of quoted text.
+        // Behavior-identical: `shell_quote_arg` single-quotes, which
+        // already suppresses every expansion — this just stops round
+        // tripping them through a parser that would otherwise need it.
+        Some((program, arg0, words)) => {
+            let argv = words
+                .iter()
+                .map(|w| std::ffi::OsString::from(*w))
+                .chain(args.iter().map(std::ffi::OsString::from));
+            // The echoed line has to read the same whichever path ran, so
+            // build it exactly as the shell arm does below. `node_args` is
+            // empty here (a direct plan requires it), so there is nothing
+            // to splice — only the forwarded args to append.
+            let mut echo = String::with_capacity(cmd.len() + 16);
+            echo.push_str(cmd);
+            for a in args {
+                echo.push(' ');
+                echo.push_str(&display_arg(a));
+            }
+            (aube_scripts::spawn_program(program, arg0, argv), echo)
+        }
+        None => {
+            let echo_cmd = inject_node_args(cmd, node_args, |a| display_arg(a).into_owned());
+            let cmd = inject_node_args(cmd, node_args, aube_scripts::shell_quote_arg);
+            let (shell_cmd, echo_line) = if args.is_empty() {
+                (cmd, echo_cmd)
+            } else {
+                // Quote each forwarded arg. Args land inside `sh -c "..."` or
+                // cmd `/c "..."` which reparses. Unquoted $, backticks, ;, |,
+                // () all get interpreted. `aube run echo '$(rm -rf ~)'` would
+                // run the subshell. Same npm/pnpm bug class from years ago.
+                // shell_quote_arg wraps per-platform. See aube-scripts.
+                let mut buf = String::with_capacity(
+                    cmd.len() + args.iter().map(|a| a.len() + 3).sum::<usize>(),
+                );
+                buf.push_str(&cmd);
+                let mut echo = String::with_capacity(buf.capacity());
+                echo.push_str(&echo_cmd);
+                for a in args {
+                    buf.push(' ');
+                    buf.push_str(&aube_scripts::shell_quote_arg(a));
+                    echo.push(' ');
+                    echo.push_str(&display_arg(a));
+                }
+                (buf, echo)
+            };
+            (aube_scripts::spawn_shell(&shell_cmd), echo_line)
+        }
+    };
     command
         .env("PATH", &new_path)
         .current_dir(cwd)
@@ -1236,6 +1277,15 @@ async fn build_script_command(
     if std::env::var_os("INIT_CWD").is_none() {
         let init_cwd = crate::dirs::cwd().ok().unwrap_or_else(|| cwd.to_path_buf());
         command.env("INIT_CWD", init_cwd);
+    }
+    if direct.is_some() {
+        // `sh` rewrites PWD to its own cwd on startup; a directly-exec'd
+        // child just inherits ours. Measured against dash, PWD was the
+        // only difference in the whole child environment, so stamp it and
+        // the two paths stay indistinguishable. Without this, a tool that
+        // reads `process.env.PWD` instead of `process.cwd()` would see
+        // aube's invocation dir under `aube -C dir run x`.
+        command.env("PWD", &script_dir);
     }
     Ok((command, echo_line))
 }

--- a/crates/aube/tests/e2e.rs
+++ b/crates/aube/tests/e2e.rs
@@ -287,36 +287,3 @@ fn run_reports_a_missing_command_like_a_shell() {
         assert.failure();
     }
 }
-
-#[test]
-fn run_reports_the_script_directory_as_pwd() {
-    let _guard = e2e_lock();
-    let sbx = Sandbox::new();
-    // `sh` sets PWD itself; the direct path has to stamp it. Invoke from
-    // the parent via `-C` so an inherited PWD would be visibly wrong.
-    sbx.write_manifest(
-        r#"{
-            "name": "e2e-run-pwd",
-            "version": "0.0.0",
-            "scripts": { "probe": "node pwd-probe.js" }
-        }"#,
-    );
-    fs::write(
-        sbx.project.join("pwd-probe.js"),
-        "console.log('PWD=' + (process.env.PWD === process.cwd()))",
-    )
-    .unwrap();
-
-    let mut cmd = sbx.cmd();
-    cmd.current_dir(sbx.project.parent().unwrap());
-    cmd.args([
-        "-C",
-        sbx.project.to_str().unwrap(),
-        "run",
-        "--no-install",
-        "probe",
-    ])
-    .assert()
-    .success()
-    .stdout(predicates::str::contains("PWD=true"));
-}

--- a/crates/aube/tests/e2e.rs
+++ b/crates/aube/tests/e2e.rs
@@ -237,3 +237,86 @@ fn run_failing_pre_script_short_circuits_with_its_code() {
         .code(5)
         .stdout(predicates::str::contains("MAIN_RAN").not());
 }
+
+#[test]
+fn run_forwards_extra_args_verbatim() {
+    let _guard = e2e_lock();
+    let sbx = Sandbox::new();
+    // A quote-free body takes the direct-exec path on Unix and the shell
+    // on Windows, so this pins the same argv contract on both: forwarded
+    // args reach the script as written, with nothing expanded or split.
+    sbx.write_manifest(
+        r#"{
+            "name": "e2e-run-args",
+            "version": "0.0.0",
+            "scripts": { "probe": "node probe.js" }
+        }"#,
+    );
+    fs::write(
+        sbx.project.join("probe.js"),
+        "console.log(JSON.stringify(process.argv.slice(2)))",
+    )
+    .unwrap();
+
+    sbx.cmd()
+        .args(["run", "--no-install", "probe", "--", "a b", "$HOME", "*"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains(r#"["a b","$HOME","*"]"#));
+}
+
+#[test]
+fn run_reports_a_missing_command_like_a_shell() {
+    let _guard = e2e_lock();
+    let sbx = Sandbox::new();
+    sbx.write_manifest(
+        r#"{
+            "name": "e2e-run-missing",
+            "version": "0.0.0",
+            "scripts": { "nope": "aube-definitely-not-a-real-binary" }
+        }"#,
+    );
+
+    // The body is shaped for direct exec, but the program does not
+    // resolve, so it must fall back to the shell rather than inventing an
+    // error — which is what keeps 127 (and the shell's own stderr) intact.
+    let assert = sbx.cmd().args(["run", "--no-install", "nope"]).assert();
+    if cfg!(unix) {
+        assert.code(127);
+    } else {
+        assert.failure();
+    }
+}
+
+#[test]
+fn run_reports_the_script_directory_as_pwd() {
+    let _guard = e2e_lock();
+    let sbx = Sandbox::new();
+    // `sh` sets PWD itself; the direct path has to stamp it. Invoke from
+    // the parent via `-C` so an inherited PWD would be visibly wrong.
+    sbx.write_manifest(
+        r#"{
+            "name": "e2e-run-pwd",
+            "version": "0.0.0",
+            "scripts": { "probe": "node pwd-probe.js" }
+        }"#,
+    );
+    fs::write(
+        sbx.project.join("pwd-probe.js"),
+        "console.log('PWD=' + (process.env.PWD === process.cwd()))",
+    )
+    .unwrap();
+
+    let mut cmd = sbx.cmd();
+    cmd.current_dir(sbx.project.parent().unwrap());
+    cmd.args([
+        "-C",
+        sbx.project.to_str().unwrap(),
+        "run",
+        "--no-install",
+        "probe",
+    ])
+    .assert()
+    .success()
+    .stdout(predicates::str::contains("PWD=true"));
+}

--- a/fixtures/run/package.json
+++ b/fixtures/run/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "aube-bench-run",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "noop": "id"
+  }
+}

--- a/tak.toml
+++ b/tak.toml
@@ -66,3 +66,31 @@ cmd = [
   "--frozen-lockfile",
   "--offline",
 ]
+
+# The `run` path, which nothing above touches: argv parse, project root
+# discovery, manifest read, script lookup, PATH assembly, and the direct-exec
+# PATH search. A regression guard, not a measurement of the shell-skipping
+# change that added it — that win is a fork plus a shell's own startup, which is
+# kernel and dynamic-linker work cachegrind either attributes to the `sh` child
+# (wildly overstating it) or misses entirely. The wall-clock number lives in
+# `benchmarks/` and in the PR that made it.
+#
+# `fixtures/run` is its own directory rather than another `fixtures/medium`
+# invocation for one reason: `medium`'s `package.json` feeds the install-state
+# hash, so giving it a `scripts` block would put a one-time step in the
+# `install` series above for reasons unrelated to any code change. The fixture
+# has no dependencies, so `--no-install` is honest and no store state is needed.
+#
+# The body is `id`: a real binary rather than a shell builtin (so it exercises
+# the PATH search and the direct spawn), cheap, and with no output that varies.
+# Deliberately not a Node script — node's own startup is ~10x aube's whole
+# invocation and would bury the thing being measured.
+[bench.run]
+cmd = [
+  "./target/release/aube",
+  "-C",
+  "fixtures/run",
+  "run",
+  "--no-install",
+  "noop",
+]

--- a/test/run.bats
+++ b/test/run.bats
@@ -829,3 +829,155 @@ JSON
 	assert_success
 	assert_line "$ node --inspect=9229 app.js"
 }
+
+# A script body that is one plain command has no need of a shell, and
+# `sh` does not exec in place — it stays resident as the script's parent.
+# These four tests pin both halves of that decision. The probe is a fake
+# `sh` earlier on PATH than the real one: aube spawns the shell as bare
+# `sh` (resolved through its own PATH), so anything routed through a shell
+# leaves a trace in sh.log and anything exec'd directly does not.
+_setup_sh_probe() {
+	mkdir -p fakebin
+	cat >fakebin/sh <<'EOF'
+#!/bin/sh
+echo used >> "$SH_PROBE_LOG"
+exec /bin/sh "$@"
+EOF
+	chmod +x fakebin/sh
+	export SH_PROBE_LOG="$PWD/sh.log"
+	export PATH="$PWD/fakebin:$PATH"
+	cat >probe.js <<'EOF'
+console.log("probe-ran")
+EOF
+}
+
+@test "aube run execs a plain command without a shell" {
+	_setup_sh_probe
+	cat >package.json <<'JSON'
+{
+  "name": "run-direct-test",
+  "version": "1.0.0",
+  "scripts": { "probe": "node probe.js" }
+}
+JSON
+	run aube run probe
+	assert_success
+	assert_output --partial "probe-ran"
+	assert_file_not_exists sh.log
+}
+
+@test "aube run still uses a shell for a chained command" {
+	_setup_sh_probe
+	cat >package.json <<'JSON'
+{
+  "name": "run-chained-test",
+  "version": "1.0.0",
+  "scripts": { "probe": "true && node probe.js" }
+}
+JSON
+	run aube run probe
+	assert_success
+	assert_output --partial "probe-ran"
+	# `&&` is load-bearing, so the shell must still run it.
+	assert_file_exists sh.log
+}
+
+@test "aube run exports the full npm_* env set for a direct command" {
+	# The pnpm-parity env test above uses a quoted `node -e` body, which
+	# takes the shell path — so it cannot cover the direct path at all.
+	# Same assertions, quote-free body, probe moved into a file.
+	cat >env-probe.js <<'EOF'
+for (const k of ["npm_execpath","npm_node_execpath","npm_package_json","npm_command","npm_config_node_gyp","npm_package_engines_node","npm_package_name","npm_package_version","npm_lifecycle_script","npm_lifecycle_event"]) {
+	console.log(k + "=" + (process.env[k] || ""))
+}
+EOF
+	cat >package.json <<'JSON'
+{
+  "name": "@scope/run-direct-env",
+  "version": "3.1.4",
+  "engines": { "node": ">=18.0.0" },
+  "scripts": { "probe": "node env-probe.js" }
+}
+JSON
+	run aube run probe
+	assert_success
+	assert_output --partial "npm_command=run-script"
+	assert_output --partial "npm_lifecycle_event=probe"
+	assert_output --regexp "npm_execpath=[^[:space:]]*aube"
+	assert_output --regexp "npm_node_execpath=[^[:space:]]+"
+	assert_output --regexp "npm_package_json=[^[:space:]]*package\.json"
+	assert_output --regexp "npm_config_node_gyp=[^[:space:]]*node-gyp\.js"
+	assert_output --partial "npm_package_engines_node=>=18.0.0"
+	assert_output --partial "npm_package_name=@scope/run-direct-env"
+	assert_output --partial "npm_package_version=3.1.4"
+	# The raw body, not a spliced command line.
+	assert_output --partial "npm_lifecycle_script=node env-probe.js"
+}
+
+@test "aube run honors scriptShell for a plain command" {
+	# The settings test above also uses a quoted body, so without this the
+	# scriptShell veto on the direct path would be untested.
+	cat >shell-wrapper.sh <<'EOF'
+#!/bin/sh
+echo custom-shell >> shell.log
+exec /bin/sh "$@"
+EOF
+	chmod +x shell-wrapper.sh
+	cat >.npmrc <<EOF
+scriptShell=$PWD/shell-wrapper.sh
+EOF
+	cat >probe.js <<'EOF'
+console.log("probe-ran")
+EOF
+	cat >package.json <<'JSON'
+{
+  "name": "run-direct-script-shell",
+  "version": "1.0.0",
+  "scripts": { "probe": "node probe.js" }
+}
+JSON
+	run aube run probe
+	assert_success
+	assert_output --partial "probe-ran"
+	# The user asked for a specific shell; the fast path must stand down.
+	assert_file_exists shell.log
+}
+
+@test "aube run sets PWD for a direct command run from a subdirectory" {
+	cat >pwd-probe.js <<'EOF'
+console.log("pwd-matches:", process.env.PWD === process.cwd())
+EOF
+	cat >package.json <<'JSON'
+{
+  "name": "run-direct-pwd",
+  "version": "1.0.0",
+  "scripts": { "probe": "node pwd-probe.js" }
+}
+JSON
+	mkdir -p sub
+	cd sub
+	# `sh` rewrites PWD on startup; a direct exec inherits ours, so the
+	# fast path stamps it explicitly.
+	run aube -C .. run probe
+	assert_success
+	assert_output --partial "pwd-matches: true"
+}
+
+@test "aube run forwards args to a direct command without shell reparse" {
+	cat >args-probe.js <<'EOF'
+console.log(JSON.stringify(process.argv.slice(2)))
+EOF
+	cat >package.json <<'JSON'
+{
+  "name": "run-direct-args",
+  "version": "1.0.0",
+  "scripts": { "probe": "node args-probe.js" }
+}
+JSON
+	# shellcheck disable=SC2016  # literal `$HOME` is the point: nothing may expand it
+	run aube run probe -- '$HOME' 'a b' '*'
+	assert_success
+	# Real argv entries, so nothing expands or splits.
+	# shellcheck disable=SC2016
+	assert_output --partial '["$HOME","a b","*"]'
+}

--- a/test/run.bats
+++ b/test/run.bats
@@ -983,3 +983,26 @@ JSON
 	# shellcheck disable=SC2016
 	assert_output --partial '["$HOME","a b","*"]'
 }
+
+@test "aube run keeps the shell for an executable without a shebang" {
+	# `sh -c tool` interprets a mode-executable file with no shebang as a
+	# shell script. Exec'ing it directly would fail with ENOEXEC, so the
+	# fast path must stand down and let the shell keep its interpretation.
+	_setup_sh_probe
+	mkdir -p node_modules/.bin
+	cat >node_modules/.bin/noshebang <<'EOF'
+echo no-shebang-ran
+EOF
+	chmod +x node_modules/.bin/noshebang
+	cat >package.json <<'JSON'
+{
+  "name": "run-noshebang",
+  "version": "1.0.0",
+  "scripts": { "probe": "noshebang" }
+}
+JSON
+	run aube run probe
+	assert_success
+	assert_output --partial "no-shebang-ran"
+	assert_file_exists sh.log
+}

--- a/test/run.bats
+++ b/test/run.bats
@@ -957,7 +957,9 @@ JSON
 	mkdir -p sub
 	cd sub
 	# `sh` rewrites PWD on startup; a direct exec inherits ours, so the
-	# fast path stamps it explicitly.
+	# fast path stamps it explicitly. PWD is a POSIX shell convention that
+	# cmd.exe has no equivalent for, so this lives here rather than in the
+	# cross-platform e2e suite.
 	run aube -C .. run probe
 	assert_success
 	assert_output --partial "pwd-matches: true"


### PR DESCRIPTION
## Problem

Every package script goes through `sh -c "<body>"`, so a script's parent process is a resident `sh` — `/bin/sh` (dash) does not exec in place. For a body that is one plain command (`tsc -p .`, `vitest run`, `node build.js`) the shell contributes nothing but that extra process.

This started as a comparison against bun 1.4's `bun run` with node-backed scripts, where aube was consistently slower on plain bodies and *tied* on `a && b` — which is exactly the signature of a shell that isn't earning its keep.

## Change

`aube run` (and `test` / `start` / `stop` / `restart` / implicit scripts / recursive runs, which all share `build_script_command`) now scans the script body. A single plain command is resolved and exec'd directly. Everything else is untouched and still goes through `sh -c`.

The predicate is a strict byte allowlist, not a tokenizer. A tokenizer splits words but says nothing about shell *semantics*, so it can't tell you whether the shell was load-bearing — `shlex::split("rm -rf /; echo hi")` hands back tokens with `/;` glued on and no signal that a control operator was there. Bodies may contain only ASCII alphanumerics and `. _ - + / @ : , =`; any other byte means operators, expansion, quoting, globs, comments, or something unanticipated, and goes to the shell. The first word additionally has to be a bare name that isn't a shell builtin or keyword.

Sanity check on scope, across 448 real script bodies in my `~/src`:

| | share |
|---|---|
| take the direct path | **63%** |
| go to the shell, genuinely need it (`&&`, `$`, globs) | 37% |
| go to the shell *only* because of quotes | **0%** |

That last row is why there's no quote handling here: every quoted body in the corpus also contained `&&`, `$`, or a glob. A tokenizer would have doubled the review surface to buy nothing.

## Correctness

**Resolving the program ourselves is required, not an optimization.** `Command::new("tsc")` resolves through `execvp`, which searches the *parent's* environ and ignores the `PATH` handed to the child — so without our own PATH walk a `node_modules/.bin` program wouldn't be found at all. Resolution uses the same `new_path` the child gets.

**A resolution miss falls back to `sh`.** That keeps exit 127 and the shell's exact `sh: 1: foo: not found` stderr, and makes the builtin list defense-in-depth rather than a correctness dependency — a builtin we somehow missed just resolves to nothing and takes today's path.

**The shell still runs** when: the body isn't plain; `scriptShell` is set; `shellEmulator` is set; `--inspect`/`--inspect-brk` is passed (`inject_node_args` rewrites the command line textually, and one implementation of that is enough); `BASH_ENV`/`ENV` is set (where `/bin/sh` is bash, it sources `$BASH_ENV` for non-interactive shells, so a body can legitimately depend on it); or on Windows.

**Env parity is structural**, not a parallel list: `spawn_program` calls the same `apply_script_settings_env` as `spawn_shell`. A test diffs the env keys of the two commands to pin it.

Two divergences I went looking for:

- **`PWD`.** `sh` rewrites it on startup; a direct child inherits ours. A full env diff under dash showed this as the *only* difference, so the fast path stamps it. Without the stamp, a tool reading `process.env.PWD` instead of `process.cwd()` would see aube's invocation dir under `aube -C dir run x`. There's a test, and I verified it fails with the stamp removed.
- **Forwarded args** become real argv entries instead of quoted text. Behavior-identical — `shell_quote_arg` single-quotes, which already suppresses every expansion — and it removes the reparse the quoting exists to defend against.

Two things that *look* like divergences but aren't: signal exit codes are unchanged (dash exited 128+signum itself; now the child is signal-killed and `exit_code_from_status` maps `signal()` to the same number), and `kill_on_drop` now kills the tool directly instead of a shell holding it.

Deliberately **not** in this PR: any change to `spawn_shell`/`spawn_shell_with_settings` or the jailed dependency-lifecycle path (that's the security-sensitive, content-sniffed one); `--shell-mode`; a new dependency; unwrapping aube's own POSIX `sh` shim (only exists under `preferSymlinkedExecutables=false`, and that follow-up should fix `aube exec` in the same change by reusing `exec.rs`'s `resolved_bin_command` rather than duplicating it); Windows.

## Measurements

Wall clock, this branch vs `origin/main`, same machine, release builds, node v24.19.0. The box is shared and was at load ~15-24, so I sampled **interleaved** (every variant once per iteration, n=200) rather than A-then-B, and report percentiles — a sequential run showed drift large enough to invent a fake regression.

| script body | before | after | bun 1.4.0 | saved |
|---|---|---|---|---|
| `id` (no node) | 3.62 | **3.03** | 3.80 | 0.60 |
| `node hello.js` | 16.42 | **15.66** | 16.26 | 0.76 |
| `node_modules/.bin` entry | 16.66 | **15.87** | 16.60 | 0.79 |
| `id && node hello.js` (control) | 17.11 | 16.95 | 17.43 | flat |

Minima, in ms. p10/p25/median agree on direction and magnitude. The chained control is flat — the sign of its delta flipped between two runs, so it's inside the noise band, as expected for an untouched path.

After the change aube edges out `bun run` on all three direct cases.

**On the perf gate:** this change cannot be honestly measured by instruction counts. The win is a fork plus a shell's own startup — kernel and dynamic-linker work that cachegrind either attributes to the `sh` child (wildly overstating it) or misses entirely. So the wall-clock numbers above are the evidence, and the new `[bench.run]` entry in `tak.toml` is framed as a **regression guard** for a path that was previously unmeasured, not as proof of this change. Gate thresholds are untouched; none of the four existing benchmarks runs a package script, so those series should be flat.

`fixtures/run/` is a new dependency-free fixture rather than another `fixtures/medium` invocation on purpose: `medium`'s `package.json` feeds the install-state hash, so giving it a `scripts` block would put a spurious step in the `install` series.

## Tests

- **`crates/aube-scripts/src/direct.rs`** — predicate accept/bail tables (one row per hazard: operators, expansion, substitution, tilde, globs, quotes, backslash, assignment prefix, comments, multi-line, tabs, non-ASCII, `%`/`^`/`!`), every builtin and keyword asserted, the sorted/deduped self-test, `resolve_program` (hit, non-executable, directory, PATH order, relative entry, dangling symlink), and the `scriptShell`/`shellEmulator` vetoes. Runs on Windows CI too.
- **Env parity** — diffs `spawn_shell` against `spawn_program` under identical settings.
- **`crates/aube/tests/e2e.rs`** — verbatim arg forwarding and command-not-found reporting 127. Cross-platform, so these also cover the Windows shell path. (`PWD` is asserted in bats instead: `cmd.exe` has no PWD convention, so there is nothing to assert there.)
- **`test/run.bats`** — the mechanism, plus `PWD` and the ENOEXEC case, proved with a fake `sh` earlier on PATH than the real one (aube spawns the shell as bare `sh`, so the shim intercepts): a plain body leaves no trace, `true && node probe.js` does. Plus a quote-free `npm_*` env-parity test, because the existing pnpm-parity test uses a quoted `node -e` body and so never exercises this code; same for the existing `scriptShell` test.

The two existing regression pins — `"boom": "exit 7"` (a builtin with no binary) and the `echo` tests — are untouched and still pass.

Verified: `cargo test --workspace` clean, `mise run lint` clean, and 120 bats tests green across `run`, `implicit_run`, `exec`, `lifecycle_scripts`, `lifecycle_shortcuts`, `multicall_shims`. I also confirmed the headline bats test *fails* on `origin/main`, so it has teeth.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how user package scripts are spawned and how PATH is resolved, so a predicate miss could change behavior. The design is fail-closed to `sh -c` and does not touch the jailed dependency-lifecycle path.
> 
> **Overview**
> `aube run` (and the other commands that share `build_script_command`) now execs a single plain script body directly instead of always going through `sh -c`. Anything the scanner cannot prove is a bare command still uses the existing shell path.
> 
> The predicate is a strict byte allowlist plus a builtin/keyword denylist, not a tokenizer. The program is resolved against the child's PATH (required because `execvp` would search the parent), and a miss falls back to `sh` so exit 127 and shell stderr stay intact. Direct spawn is skipped for Windows, `scriptShell`, `shellEmulator`, `--inspect`, `BASH_ENV`/`ENV`, path-shaped programs, and files the kernel cannot launch without a shebang.
> 
> Env is shared with `spawn_shell` via `apply_script_settings_env`. The fast path stamps `PWD` (the only measured env difference vs dash) and forwards extra args as real argv. Dependency-lifecycle / jailed spawn is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c6773d766841ca8744822326b9db6580b368dd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Simple script commands now run directly without an intermediate shell when safe.
  - Forwarded arguments are passed literally, preventing unwanted shell expansion or splitting.
  - Script processes preserve the expected working directory and environment settings.

- **Bug Fixes**
  - More consistent handling of missing commands, chained commands, custom shells, and shell-sensitive syntax.
  - Improved argument forwarding and `PWD` behavior when running scripts from another directory.

- **Tests**
  - Added comprehensive coverage for direct execution, shell fallback, environment preservation, and argument handling.

- **Performance**
  - Added a benchmark for the optimized script execution path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
