### PR TITLE
perf(run): persist install-generated script plans

### DIFF
--- a/crates/aube/src/commands/install/finalize.rs
+++ b/crates/aube/src/commands/install/finalize.rs
@@ -385,6 +385,7 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
             state::WriteStateInput {
                 section_filtered: dep_selection.prod_or_dev_axis(),
                 package_json_hashes,
+                manifests,
                 cli_flags,
                 package_content_hashes,
                 graph_lthash,

--- a/crates/aube/src/commands/install/finalize.rs
+++ b/crates/aube/src/commands/install/finalize.rs
@@ -278,7 +278,8 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
             delta::compute_subtree_hashes_from_leaf(graph, &package_content_hashes)
         });
         let graph_lthash = hex::encode(delta::lthash_of(&package_content_hashes).digest());
-        let package_json_hashes = state::collect_package_json_hashes_from_manifests(cwd, manifests);
+        let (package_json_hashes, run_manifests) =
+            state::collect_package_json_run_state(cwd, manifests);
         // Diff against the previous install. Logs delta counts at
         // debug so `-v` installs surface what actually moved. A
         // later pass feeds the plan into fetch and link as a
@@ -385,7 +386,7 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
             state::WriteStateInput {
                 section_filtered: dep_selection.prod_or_dev_axis(),
                 package_json_hashes,
-                manifests,
+                run_manifests,
                 cli_flags,
                 package_content_hashes,
                 graph_lthash,

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -627,9 +627,13 @@ pub(crate) async fn run_script_with(
     }
 
     let install_root = crate::dirs::find_workspace_root(&cwd).unwrap_or_else(|| cwd.clone());
-    let manifest = crate::state::read_run_manifest(&install_root, &cwd)
-        .map(Ok)
-        .unwrap_or_else(|| load_manifest(&cwd))?;
+    let plan_root = install_root.clone();
+    let plan_cwd = cwd.clone();
+    let plan =
+        tokio::task::spawn_blocking(move || crate::state::read_run_manifest(&plan_root, &plan_cwd))
+            .await
+            .into_diagnostic()?;
+    let manifest = plan.map(Ok).unwrap_or_else(|| load_manifest(&cwd))?;
     if !manifest.scripts.contains_key(script) {
         ensure_installed_in(no_install, Some(&cwd)).await?;
         let bin_path = super::project_modules_dir(&cwd).join(".bin").join(script);

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -626,7 +626,10 @@ pub(crate) async fn run_script_with(
         .await;
     }
 
-    let manifest = load_manifest(&cwd)?;
+    let install_root = crate::dirs::find_workspace_root(&cwd).unwrap_or_else(|| cwd.clone());
+    let manifest = crate::state::read_run_manifest(&install_root, &cwd)
+        .map(Ok)
+        .unwrap_or_else(|| load_manifest(&cwd))?;
     if !manifest.scripts.contains_key(script) {
         ensure_installed_in(no_install, Some(&cwd)).await?;
         let bin_path = super::project_modules_dir(&cwd).join(".bin").join(script);

--- a/crates/aube/src/commands/run.rs
+++ b/crates/aube/src/commands/run.rs
@@ -626,6 +626,9 @@ pub(crate) async fn run_script_with(
         .await;
     }
 
+    // Installation hooks may rewrite package.json. Resolve the launch plan
+    // only after auto-install so this invocation uses the post-hook manifest.
+    ensure_installed_in(no_install, Some(&cwd)).await?;
     let install_root = crate::dirs::find_workspace_root(&cwd).unwrap_or_else(|| cwd.clone());
     let plan_root = install_root.clone();
     let plan_cwd = cwd.clone();
@@ -635,7 +638,6 @@ pub(crate) async fn run_script_with(
             .into_diagnostic()?;
     let manifest = plan.map(Ok).unwrap_or_else(|| load_manifest(&cwd))?;
     if !manifest.scripts.contains_key(script) {
-        ensure_installed_in(no_install, Some(&cwd)).await?;
         let bin_path = super::project_modules_dir(&cwd).join(".bin").join(script);
         if bin_path.exists() {
             return super::exec::exec_bin_with_node_args(
@@ -661,7 +663,6 @@ pub(crate) async fn run_script_with(
         return Err(miette!("script not found: {script}\n  {hint}"));
     }
 
-    ensure_installed_in(no_install, Some(&cwd)).await?;
     exec_script_chain(
         &cwd,
         &manifest,

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -743,7 +743,7 @@ fn collect_gvs_nested_links(
 pub struct WriteStateInput<'a> {
     pub section_filtered: bool,
     pub package_json_hashes: BTreeMap<String, String>,
-    pub manifests: &'a [(String, aube_manifest::PackageJson)],
+    pub run_manifests: BTreeMap<String, aube_manifest::PackageJson>,
     pub cli_flags: &'a [(String, String)],
     pub package_content_hashes: BTreeMap<String, String>,
     pub graph_lthash: String,
@@ -756,7 +756,7 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
     let WriteStateInput {
         section_filtered,
         package_json_hashes,
-        manifests,
+        run_manifests,
         cli_flags,
         package_content_hashes,
         graph_lthash,
@@ -788,8 +788,6 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
             ))
         })
         .collect();
-    let run_manifests = collect_run_manifests(project_dir, manifests);
-
     // Capture (size, mtime) per manifest so the next freshness check
     // can skip the BLAKE3 hash on the warm path. See R1 docstring on
     // FreshnessState.package_json_meta.
@@ -1427,60 +1425,58 @@ fn read_installed_package_manifest(
     Ok(Some(parsed))
 }
 
-pub fn collect_package_json_hashes_from_manifests(
+pub fn collect_package_json_run_state(
     project_dir: &Path,
     manifests: &[(String, aube_manifest::PackageJson)],
-) -> BTreeMap<String, String> {
-    manifests
+) -> (
+    BTreeMap<String, String>,
+    BTreeMap<String, aube_manifest::PackageJson>,
+) {
+    let snapshots: Vec<_> = manifests
         .par_iter()
         .filter_map(|(rel, _)| {
-            let pkg_json = if rel == "." {
+            let manifest_path = if rel == "." {
                 project_dir.join("package.json")
             } else {
                 project_dir.join(rel).join("package.json")
             };
-            if !pkg_json.is_file() {
-                return None;
-            }
+            let content = std::fs::read_to_string(&manifest_path).ok()?;
             let key = if rel == "." {
                 ".".to_string()
             } else {
-                relative_path_or_original(&pkg_json, project_dir)
+                relative_path_or_original(&manifest_path, project_dir)
             };
-            Some((key, hash_file(&pkg_json)))
+            let hash = hash_bytes(content.as_bytes());
+            let plan = aube_manifest::PackageJson::parse(&manifest_path, content)
+                .ok()
+                .map(|manifest| {
+                    let mut extra = BTreeMap::new();
+                    for field in ["config", "bin"] {
+                        if let Some(value) = manifest.extra.get(field) {
+                            extra.insert(field.to_string(), value.clone());
+                        }
+                    }
+                    aube_manifest::PackageJson {
+                        name: manifest.name,
+                        version: manifest.version,
+                        scripts: manifest.scripts,
+                        engines: manifest.engines,
+                        extra,
+                        ..Default::default()
+                    }
+                });
+            Some((key, hash, plan))
         })
-        .collect()
-}
-
-fn collect_run_manifests(
-    project_dir: &Path,
-    manifests: &[(String, aube_manifest::PackageJson)],
-) -> BTreeMap<String, aube_manifest::PackageJson> {
-    manifests
-        .iter()
-        .map(|(rel, manifest)| {
-            let key = if rel == "." {
-                ".".to_string()
-            } else {
-                relative_path_or_original(&project_dir.join(rel).join("package.json"), project_dir)
-            };
-            let mut extra = BTreeMap::new();
-            for field in ["config", "bin"] {
-                if let Some(value) = manifest.extra.get(field) {
-                    extra.insert(field.to_string(), value.clone());
-                }
-            }
-            let plan = aube_manifest::PackageJson {
-                name: manifest.name.clone(),
-                version: manifest.version.clone(),
-                scripts: manifest.scripts.clone(),
-                engines: manifest.engines.clone(),
-                extra,
-                ..Default::default()
-            };
-            (key, plan)
-        })
-        .collect()
+        .collect();
+    let mut hashes = BTreeMap::new();
+    let mut plans = BTreeMap::new();
+    for (key, hash, plan) in snapshots {
+        hashes.insert(key.clone(), hash);
+        if let Some(plan) = plan {
+            plans.insert(key, plan);
+        }
+    }
+    (hashes, plans)
 }
 
 fn hash_settings(project_dir: &Path, cli_flags: &[(String, String)]) -> String {
@@ -1724,11 +1720,11 @@ fn empty_blake3_hash() -> &'static str {
 mod tests {
     use super::{
         InstallLayoutMode, InstallLayoutState, InstallState, InstalledPackageState,
-        WriteStateLayout, collect_package_json_hashes_from_manifests, empty_blake3_hash,
-        fresh_state_file, gvs_nested_links_are_current, hash_file, hash_settings,
-        install_state_file, member_lockfiles_stale, read_hoisted_placements,
-        read_or_migrate_fresh_state, read_run_manifest, relative_path_or_original, remove_state,
-        verify_install_layout, write_hoisted_placements,
+        WriteStateLayout, collect_package_json_run_state, empty_blake3_hash, fresh_state_file,
+        gvs_nested_links_are_current, hash_bytes, hash_file, hash_settings, install_state_file,
+        member_lockfiles_stale, read_hoisted_placements, read_or_migrate_fresh_state,
+        read_run_manifest, relative_path_or_original, remove_state, verify_install_layout,
+        write_hoisted_placements,
     };
     use std::collections::BTreeMap;
     use std::path::{Path, PathBuf};
@@ -2121,7 +2117,7 @@ mod tests {
     }
 
     #[test]
-    fn collect_package_json_hashes_from_manifests_uses_file_paths_for_workspaces() {
+    fn collect_package_json_run_state_uses_file_paths_for_workspaces() {
         let project_dir = temp_project_dir("manifest-hash-keys");
         let root_pkg = project_dir.join("package.json");
         let ws_pkg = project_dir.join("packages/foo/package.json");
@@ -2138,7 +2134,7 @@ mod tests {
             ),
         ];
 
-        let hashes = collect_package_json_hashes_from_manifests(&project_dir, &manifests);
+        let (hashes, _) = collect_package_json_run_state(&project_dir, &manifests);
 
         assert_eq!(hashes.get("."), Some(&hash_file(&root_pkg)));
         assert_eq!(
@@ -2182,6 +2178,30 @@ mod tests {
         )
         .expect("edited manifest should write");
         assert!(read_run_manifest(&project_dir, &project_dir).is_none());
+    }
+
+    #[test]
+    fn run_plan_and_hash_share_the_post_hook_snapshot() {
+        let project_dir = temp_project_dir("run-plan-snapshot");
+        let manifest_path = project_dir.join("package.json");
+        let before = aube_manifest::PackageJson::parse(
+            &manifest_path,
+            r#"{"scripts":{"dev":"echo before"}}"#.to_string(),
+        )
+        .expect("initial manifest should parse");
+        let after = r#"{"scripts":{"dev":"echo after"}}"#;
+        std::fs::write(&manifest_path, after).expect("post-hook manifest should write");
+
+        let (hashes, plans) =
+            collect_package_json_run_state(&project_dir, &[(".".to_string(), before)]);
+        assert_eq!(hashes.get("."), Some(&hash_bytes(after.as_bytes())));
+        assert_eq!(
+            plans
+                .get(".")
+                .and_then(|plan| plan.scripts.get("dev"))
+                .map(String::as_str),
+            Some("echo after")
+        );
     }
 
     #[test]

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -142,6 +142,11 @@ struct FreshnessState {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     member_lockfile_meta: BTreeMap<String, FileMeta>,
     package_json_hashes: BTreeMap<String, String>,
+    /// Script-launch subset of each installed workspace manifest, keyed like
+    /// `package_json_hashes`. Kept only in the compact freshness sidecar so it
+    /// is not duplicated in the full delta/install state.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    run_manifests: BTreeMap<String, aube_manifest::PackageJson>,
     /// Mtime + size per `package.json` keyed identically to
     /// `package_json_hashes`. Lets `package_jsons_stale` skip the
     /// BLAKE3 hash on the fast path: stat once, compare both fields,
@@ -222,6 +227,7 @@ impl From<&InstallState> for FreshnessState {
             member_lockfile_hashes: state.member_lockfile_hashes.clone(),
             member_lockfile_meta: state.member_lockfile_meta.clone(),
             package_json_hashes: state.package_json_hashes.clone(),
+            run_manifests: BTreeMap::new(),
             package_json_meta: state.package_json_meta.clone(),
             local_directory_hashes: state.local_directory_hashes.clone(),
             section_filtered: state.section_filtered,
@@ -546,6 +552,31 @@ fn package_jsons_stale(project_dir: &Path, state: &FreshnessState) -> Option<Str
     None
 }
 
+/// Load the install-generated script plan for `package_dir` after proving it
+/// still corresponds byte-for-byte to the live manifest. The content hash is
+/// intentionally checked even when mtime and size match: executing stale
+/// script text is a correctness and security boundary, so the normal
+/// freshness check's metadata shortcut is not sufficient here.
+pub(crate) fn read_run_manifest(
+    project_dir: &Path,
+    package_dir: &Path,
+) -> Option<aube_manifest::PackageJson> {
+    let state_path = state_dir(project_dir);
+    let state = read_fresh_state(&state_path)?;
+    let manifest_path = package_dir.join("package.json");
+    let key = if package_dir == project_dir {
+        ".".to_string()
+    } else {
+        relative_path_or_original(&manifest_path, project_dir)
+    };
+    let stored_hash = state.package_json_hashes.get(&key)?;
+    let content = std::fs::read(&manifest_path).ok()?;
+    if hash_bytes(&content) != *stored_hash {
+        return None;
+    }
+    state.run_manifests.get(&key).cloned()
+}
+
 /// Fingerprint every workspace member's lockfile for the
 /// `sharedWorkspaceLockfile=false` layout. Returns `(hashes, meta)`
 /// keyed by the member's importer path relative to `project_dir`.
@@ -712,6 +743,7 @@ fn collect_gvs_nested_links(
 pub struct WriteStateInput<'a> {
     pub section_filtered: bool,
     pub package_json_hashes: BTreeMap<String, String>,
+    pub manifests: &'a [(String, aube_manifest::PackageJson)],
     pub cli_flags: &'a [(String, String)],
     pub package_content_hashes: BTreeMap<String, String>,
     pub graph_lthash: String,
@@ -724,6 +756,7 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
     let WriteStateInput {
         section_filtered,
         package_json_hashes,
+        manifests,
         cli_flags,
         package_content_hashes,
         graph_lthash,
@@ -755,6 +788,7 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
             ))
         })
         .collect();
+    let run_manifests = collect_run_manifests(project_dir, manifests);
 
     // Capture (size, mtime) per manifest so the next freshness check
     // can skip the BLAKE3 hash on the warm path. See R1 docstring on
@@ -798,7 +832,8 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
         unreviewed_builds,
     };
 
-    let fresh_state = FreshnessState::from(&state);
+    let mut fresh_state = FreshnessState::from(&state);
+    fresh_state.run_manifests = run_manifests;
     if read_package_licenses(&state_path)
         .as_ref()
         .is_none_or(|licenses| licenses.fingerprint != license_fingerprint)
@@ -1417,6 +1452,37 @@ pub fn collect_package_json_hashes_from_manifests(
         .collect()
 }
 
+fn collect_run_manifests(
+    project_dir: &Path,
+    manifests: &[(String, aube_manifest::PackageJson)],
+) -> BTreeMap<String, aube_manifest::PackageJson> {
+    manifests
+        .iter()
+        .map(|(rel, manifest)| {
+            let key = if rel == "." {
+                ".".to_string()
+            } else {
+                relative_path_or_original(&project_dir.join(rel).join("package.json"), project_dir)
+            };
+            let mut extra = BTreeMap::new();
+            for field in ["config", "bin"] {
+                if let Some(value) = manifest.extra.get(field) {
+                    extra.insert(field.to_string(), value.clone());
+                }
+            }
+            let plan = aube_manifest::PackageJson {
+                name: manifest.name.clone(),
+                version: manifest.version.clone(),
+                scripts: manifest.scripts.clone(),
+                engines: manifest.engines.clone(),
+                extra,
+                ..Default::default()
+            };
+            (key, plan)
+        })
+        .collect()
+}
+
 fn hash_settings(project_dir: &Path, cli_flags: &[(String, String)]) -> String {
     // hash resolved settings not raw file bytes. old byte hash tripped on
     // noop edits like `optimisticRepeatInstall=true` (same as default).
@@ -1661,7 +1727,7 @@ mod tests {
         WriteStateLayout, collect_package_json_hashes_from_manifests, empty_blake3_hash,
         fresh_state_file, gvs_nested_links_are_current, hash_file, hash_settings,
         install_state_file, member_lockfiles_stale, read_hoisted_placements,
-        read_or_migrate_fresh_state, relative_path_or_original, remove_state,
+        read_or_migrate_fresh_state, read_run_manifest, relative_path_or_original, remove_state,
         verify_install_layout, write_hoisted_placements,
     };
     use std::collections::BTreeMap;
@@ -2082,6 +2148,43 @@ mod tests {
     }
 
     #[test]
+    fn persisted_run_manifest_requires_the_live_content_hash() {
+        let project_dir = temp_project_dir("run-plan-hash");
+        let manifest_path = project_dir.join("package.json");
+        let original = r#"{"name":"app","scripts":{"dev":"echo one"}}"#;
+        std::fs::write(&manifest_path, original).expect("manifest should write");
+        let state_path = project_dir.join("node_modules/.aube-state");
+        std::fs::create_dir_all(&state_path).expect("state dir should write");
+        let fresh = serde_json::json!({
+            "lockfile_hash": "",
+            "package_json_hashes": { ".": hash_file(&manifest_path) },
+            "run_manifests": {
+                ".": { "name": "app", "scripts": { "dev": "echo one" } }
+            }
+        });
+        std::fs::write(
+            fresh_state_file(&state_path),
+            serde_json::to_vec(&fresh).expect("fresh state should serialize"),
+        )
+        .expect("fresh state should write");
+
+        let plan = read_run_manifest(&project_dir, &project_dir).expect("plan should match");
+        assert_eq!(
+            plan.scripts.get("dev").map(String::as_str),
+            Some("echo one")
+        );
+
+        // Same byte length, different command. Hash validation must reject it
+        // even on filesystems where timestamp resolution is too coarse.
+        std::fs::write(
+            &manifest_path,
+            r#"{"name":"app","scripts":{"dev":"echo two"}}"#,
+        )
+        .expect("edited manifest should write");
+        assert!(read_run_manifest(&project_dir, &project_dir).is_none());
+    }
+
+    #[test]
     fn state_json_migrates_fresh_state_without_delta_maps() {
         let project_dir = temp_project_dir("fresh-migration");
         let state_path = project_dir.join(".aube-state");
@@ -2317,6 +2420,7 @@ mod tests {
             member_lockfile_hashes: hashes,
             member_lockfile_meta: BTreeMap::new(),
             package_json_hashes: BTreeMap::new(),
+            run_manifests: BTreeMap::new(),
             package_json_meta: BTreeMap::new(),
             local_directory_hashes: Some(BTreeMap::new()),
             section_filtered: false,


### PR DESCRIPTION
## Summary

- persist a compact per-workspace script/env launch plan in the install freshness sidecar
- snapshot the plan and hash together from the live post-hook manifest
- consume the plan on warm unfiltered runs only after an exact BLAKE3 content match
- offload persisted-state I/O and hashing from the async runtime worker

## Outcome

This exploration is a negative real-world result and should not merge as-is. It remains open intentionally so the implementation, safety boundary, and measurements are reviewable.

A warm zero-dependency script that launches real Node was measured on one pinned CPU (500 runs, 100 warmups):

| workflow | baseline | persisted plan | result |
|---|---:|---:|---:|
| `aubr check-version` | 15.3 ± 0.5 ms | 15.5 ± 0.9 ms | ~1% slower / within noise |

The saved second manifest parse does not repay deserializing `fresh.json`, hashing the live manifest, and crossing a blocking-task boundary. The tiny fixture also grows `fresh.json` by 197 bytes; monorepos scale with script count.

The content hash is non-negotiable: trusting only mtime/size could execute stale or attacker-controlled script text. Tests cover same-length command replacement and verify that install finalization derives the plan and hash from the same post-hook bytes. PR #1359 is the better process-local direction.

## Verification

- rebased through the merged run-path optimizations
- `cargo fmt --check`
- `cargo clippy -p aube --all-targets -- -D warnings`
- `cargo test -p aube` (831 unit tests plus integration suites)
- optimized release build and real Node launch benchmark

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Run commands now use the latest validated script configuration, with a fallback when no saved configuration is available.
  - Command previews display arguments more clearly while preserving safe quoting when needed.
  - Silent execution now consistently suppresses command output across sequential, recursive, and parallel runs.
  - Pre- and post-script execution follows the same output and argument-display behavior.
- **Bug Fixes**
  - Improved reliability when script configuration changes after installation.
  - Added validation to prevent stale configuration from being used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the script-execution path: a persisted plan can drive what actually runs. Hash-gated reuse is the safety boundary; a miss falls back to parsing the live manifest.
> 
> **Overview**
> Install now snapshots a compact per-workspace **run plan** (`scripts`, `engines`, `config`, `bin`) into the freshness sidecar, hashed from the **live post-hook** `package.json` rather than the in-memory pre-hook manifest.
> 
> Unfiltered `aube run` auto-installs first, then loads that plan off the async runtime via `spawn_blocking`. The plan is used only if the on-disk file’s BLAKE3 still matches; otherwise it falls back to a normal parse. Mtime/size shortcuts are intentionally skipped so same-length script edits cannot execute stale text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f480800d638e9afe61ae6a4648683807462e7be4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->