### PR TITLE
feat(embed): expose node-gyp bootstrap

### DIFF
--- a/crates/aube/src/commands/install/node_gyp_bootstrap.rs
+++ b/crates/aube/src/commands/install/node_gyp_bootstrap.rs
@@ -178,6 +178,7 @@ pub async fn bootstrap_node_gyp(project_dir: &Path) -> miette::Result<PathBuf> {
     let bin_dir = ensure_cached(project_dir).await?;
     node_gyp_binary(&bin_dir).ok_or_else(|| {
         miette!(
+            code = aube_codes::errors::ERR_AUBE_EMBED_INSTALL_FAILED,
             "node-gyp bootstrap completed but no executable exists in {}",
             bin_dir.display()
         )

--- a/crates/aube/src/commands/install/node_gyp_bootstrap.rs
+++ b/crates/aube/src/commands/install/node_gyp_bootstrap.rs
@@ -79,7 +79,7 @@ fn tool_root() -> miette::Result<PathBuf> {
     Ok(cache.join("tools").join("node-gyp"))
 }
 
-pub async fn ensure_cached(project_dir: &Path) -> miette::Result<PathBuf> {
+pub(crate) async fn ensure_cached(project_dir: &Path) -> miette::Result<PathBuf> {
     let root = tool_root()?;
     let tool_dir = root.join(BUCKET);
     let bin_dir = tool_dir.join("node_modules").join(".bin");
@@ -160,10 +160,20 @@ pub(crate) fn lazy_js_shim_path() -> miette::Result<PathBuf> {
     Ok(shim_dir.join("node-gyp.js"))
 }
 
-pub(crate) async fn print_bootstrapped_binary(project_dir: &Path) -> miette::Result<()> {
+/// Materialize aube's cached node-gyp installation and return its executable.
+///
+/// Aube's lazy `node-gyp` shims invoke the current executable with the private
+/// `__node-gyp-bootstrap <project-dir>` command. For a standalone aube process
+/// that executable is aube itself. An embedding host must intercept that
+/// command before its own argument parser, call this function, and print the
+/// returned path to stdout.
+///
+/// The bootstrap stays fully in-process and inherits the outer project's
+/// registry configuration. Aube owns the cache layout, version selection, and
+/// cross-process locking; the host does not need an `aube` or `npm` executable.
+pub async fn bootstrap_node_gyp(project_dir: &Path) -> miette::Result<PathBuf> {
     let bin_dir = ensure_cached(project_dir).await?;
-    println!("{}", bin_dir.join(primary_binary_name()).display());
-    Ok(())
+    Ok(bin_dir.join(primary_binary_name()))
 }
 
 /// The `node-gyp` shell shim: resolves the real binary through the

--- a/crates/aube/src/commands/install/node_gyp_bootstrap.rs
+++ b/crates/aube/src/commands/install/node_gyp_bootstrap.rs
@@ -66,11 +66,14 @@ fn node_gyp_on_path() -> bool {
 /// (sometimes `.exe` alongside), so a bare-string check would always
 /// miss the bootstrapped shim and the fast-path would never fire.
 pub(crate) fn node_gyp_bin_exists(bin_dir: &Path) -> bool {
-    BINARY_NAMES.iter().any(|name| bin_dir.join(name).exists())
+    node_gyp_binary(bin_dir).is_some()
 }
 
-fn primary_binary_name() -> &'static str {
-    BINARY_NAMES[0]
+fn node_gyp_binary(bin_dir: &Path) -> Option<PathBuf> {
+    BINARY_NAMES
+        .iter()
+        .map(|name| bin_dir.join(name))
+        .find(|path| path.is_file())
 }
 
 fn tool_root() -> miette::Result<PathBuf> {
@@ -173,7 +176,12 @@ pub(crate) fn lazy_js_shim_path() -> miette::Result<PathBuf> {
 /// cross-process locking; the host does not need an `aube` or `npm` executable.
 pub async fn bootstrap_node_gyp(project_dir: &Path) -> miette::Result<PathBuf> {
     let bin_dir = ensure_cached(project_dir).await?;
-    Ok(bin_dir.join(primary_binary_name()))
+    node_gyp_binary(&bin_dir).ok_or_else(|| {
+        miette!(
+            "node-gyp bootstrap completed but no executable exists in {}",
+            bin_dir.display()
+        )
+    })
 }
 
 /// The `node-gyp` shell shim: resolves the real binary through the
@@ -491,6 +499,18 @@ mod tests {
         let path = dir.join("node-gyp");
         std::fs::create_dir_all(&path).unwrap();
         assert!(!shim_is_current(&path, SH_SHIM));
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn resolves_exe_only_cache() {
+        let dir = tempdir();
+        let exe = dir.join("node-gyp.exe");
+        std::fs::write(&exe, b"").unwrap();
+
+        assert_eq!(node_gyp_binary(&dir), Some(exe.clone()));
+        assert!(exe.is_file());
         let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/crates/aube/src/embed.rs
+++ b/crates/aube/src/embed.rs
@@ -9,6 +9,7 @@
 use std::path::{Path, PathBuf};
 
 pub use crate::commands::add::AddToProjectOptions;
+pub use crate::commands::install::node_gyp_bootstrap::bootstrap_node_gyp;
 pub use crate::commands::install::{
     DepSelection, EmbedderInstallOverrides, FrozenMode, INSTALL_OUTPUT_CODE_LIFECYCLE_SCRIPT,
     InstallControl, InstallEvent, InstallOutputLevel, InstallOutputMode, InstallPhase,

--- a/crates/aube/src/lib.rs
+++ b/crates/aube/src/lib.rs
@@ -1036,7 +1036,8 @@ async fn async_main(cli: Cli, invoked_as_aubr: bool) -> miette::Result<Option<i3
 
     match cli.command {
         Some(Commands::NodeGypBootstrap { project_dir }) => {
-            commands::install::node_gyp_bootstrap::print_bootstrapped_binary(&project_dir).await?
+            let binary = embed::bootstrap_node_gyp(&project_dir).await?;
+            println!("{}", binary.display());
         }
         Some(Commands::Access(args)) => commands::access::run(args).await?,
         Some(Commands::Activate(args)) => commands::activate::run(args)?,


### PR DESCRIPTION
## Summary

- expose aube’s existing locked, in-process node-gyp bootstrap through the stable embedding facade
- return the resolved executable path so a host can service aube’s private lazy-shim command without duplicating cache or install policy
- route standalone aube’s hidden command through the same public API

This lets embedders such as mise keep only a small command adapter while aube continues to own the node-gyp version, cache layout, npmrc propagation, and cross-process locking. It requires neither an ambient npm executable nor a separately installed aube binary.

## Verification

- `cargo test -p aube node_gyp`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the public embed surface and native-addon bootstrap path (cache, locking, Windows binary resolution). Failure modes affect lifecycle installs, not auth or user data.
> 
> **Overview**
> Exposes aube’s in-process `node-gyp` bootstrap on the embedding facade so hosts (e.g. mise) can service lazy shims without an `aube` or `npm` binary.
> 
> `bootstrap_node_gyp` materializes the cached install and returns the resolved executable path. Standalone aube’s hidden `__node-gyp-bootstrap` command now uses the same API. Binary lookup uses `is_file()` across platform names so Windows `.exe`/`.cmd` caches are found, with a clearer error if bootstrap succeeds but no executable is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d74a50284d21e303bfb1c481a5ecff5082f4526. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a reusable Node.js gyp bootstrap capability for standalone and embedded integrations.
  - The bootstrap operation now returns the resolved executable path.
- **Improvements**
  - The NodeGypBootstrap command displays the executable path after setup.
  - Improved Windows support by recognizing `.exe` binaries.
- **Bug Fixes**
  - Added clearer error reporting when no executable is available after bootstrapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->