### PR TITLE
chore: generate release notes before publishing

### DIFF
--- a/.github/workflows/ffi.yml
+++ b/.github/workflows/ffi.yml
@@ -227,7 +227,7 @@ jobs:
       - name: Publish platform and root packages
         # `release: published` or an explicit manual npm backfill only —
         # never an asset-recovery dispatch or the workflow_call draft phase.
-        if: github.event_name == 'release' || (inputs.tag != '' && !inputs.draft_phase && inputs.publish_packages)
+        if: github.event_name == 'release' || (inputs.tag != '' && !inputs.draft_phase && inputs.publish_packages == true)
         shell: bash
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}

--- a/.github/workflows/ffi.yml
+++ b/.github/workflows/ffi.yml
@@ -68,9 +68,14 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing release tag (e.g. v1.28.0) to publish packages for. Empty runs a smoke build."
+        description: "Existing release tag (e.g. v1.28.0) to build packages and recover draft assets for. Empty runs a smoke build."
         required: false
         default: ""
+      publish_packages:
+        description: "Publish the built npm packages (for an explicit npm backfill)."
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ffi-${{ inputs.tag || github.ref }}
@@ -220,10 +225,9 @@ jobs:
             packages/libaube-*
             packages/aube.h
       - name: Publish platform and root packages
-        # `release: published` (or a manual dispatch backfill, where
-        # draft_phase is undeclared and thus falsy) only — never the
-        # workflow_call draft phase; see the trigger comment.
-        if: github.event_name == 'release' || (inputs.tag != '' && !inputs.draft_phase)
+        # `release: published` or an explicit manual npm backfill only —
+        # never an asset-recovery dispatch or the workflow_call draft phase.
+        if: github.event_name == 'release' || (inputs.tag != '' && !inputs.draft_phase && inputs.publish_packages)
         shell: bash
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -160,13 +160,12 @@ jobs:
   # with missing platform binaries (downstream npm / COPR / PPA jobs
   # would also fail trying to fetch the holes). To recover: manually
   # re-run `release.yml` (CLI binaries) or `ffi.yml` (C ABI libraries)
-  # via workflow_dispatch with the tag input, which fills in the
-  # missing assets, then either flip the draft by hand
-  # (`gh release edit $TAG --draft=false`) or workflow_dispatch the
-  # whole release-plz workflow again so this job runs.
+  # via workflow_dispatch with the tag input, which fills in the missing
+  # assets, then retry the failed jobs here. A manual publish should only
+  # happen after confirming the Communiqué notes are present too.
   publish-release:
     name: Publish release
-    needs: [release-plz-release, upload-assets, upload-ffi-assets]
+    needs: [release-plz-release, upload-assets, upload-ffi-assets, enhance-release]
     if: ${{ needs.release-plz-release.outputs.tag != '' }}
     runs-on: namespace-profile-endev-linux-amd64
     permissions:
@@ -184,7 +183,7 @@ jobs:
   # the broken release-note generation is visible and actionable.
   enhance-release:
     name: Enhance release notes
-    needs: [release-plz-release, publish-release]
+    needs: release-plz-release
     if: ${{ needs.release-plz-release.outputs.tag != '' }}
     runs-on: namespace-profile-endev-linux-amd64
     permissions:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -154,11 +154,12 @@ jobs:
       CERTIFICATES_P12_PASS: ${{ secrets.CERTIFICATES_P12_PASS }}
 
   # Flip the draft release to non-draft once *every* asset uploaded
-  # cleanly. With immutable GitHub releases enabled, a published
-  # release can't have its assets replaced — so if any matrix target
-  # failed, we leave the draft in place rather than ship a release
-  # with missing platform binaries (downstream npm / COPR / PPA jobs
-  # would also fail trying to fetch the holes). To recover: manually
+  # cleanly and Communiqué has written the final notes. With immutable
+  # GitHub releases enabled, a published release can't have its assets
+  # replaced — so if any matrix target failed, we leave the draft in
+  # place rather than ship a release with missing platform binaries
+  # (downstream npm / COPR / PPA jobs would also fail trying to fetch
+  # the holes). To recover: manually
   # re-run `release.yml` (CLI binaries) or `ffi.yml` (C ABI libraries)
   # via workflow_dispatch with the tag input, which fills in the missing
   # assets, then retry the failed jobs here. A manual publish should only

--- a/mise.lock
+++ b/mise.lock
@@ -40,44 +40,44 @@ url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_
 provenance = "github-attestations"
 
 [[tools.communique]]
-version = "1.2.3"
+version = "1.3.2"
 backend = "github:jdx/communique"
 
 [tools.communique."platforms.linux-arm64"]
-checksum = "sha256:083e1dd1a0c3894118af9b80d9feea11ed7470f7161964719d8073905fc9e4aa"
-url = "https://github.com/jdx/communique/releases/download/v1.2.3/communique-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/477186422"
+checksum = "sha256:02eb34a853e85410cb191534dd9f6324aa91ab1796e7a217c8e052c85373061a"
+url = "https://github.com/jdx/communique/releases/download/v1.3.2/communique-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/525626337"
 provenance = "github-attestations"
 
 [tools.communique."platforms.linux-arm64-musl"]
-checksum = "sha256:bab19453334ca0df1de46e7b33dda2f26abc7bae132aaf5d2ba629462c9c468f"
-url = "https://github.com/jdx/communique/releases/download/v1.2.3/communique-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/477186389"
+checksum = "sha256:49ac501d845a6e3e3ba094d436f1417c7245914103c574fd2c6d46e9c39e2238"
+url = "https://github.com/jdx/communique/releases/download/v1.3.2/communique-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/525618951"
 provenance = "github-attestations"
 
 [tools.communique."platforms.linux-x64"]
-checksum = "sha256:180f970282986f27f7fa9ee216e4971e8dec3624869d4222f22f3e2535fccc58"
-url = "https://github.com/jdx/communique/releases/download/v1.2.3/communique-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/477186105"
+checksum = "sha256:be280e35a22ff787dd6cc596d36f3ecf7a3ff3f16efdfb284154e8977895573b"
+url = "https://github.com/jdx/communique/releases/download/v1.3.2/communique-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/525619184"
 provenance = "github-attestations"
 provenance_verified = true
 
 [tools.communique."platforms.linux-x64-musl"]
-checksum = "sha256:23010d19c9dc0bb09fefc43916b03b7b16f0d07761980bb54166170ce85d9112"
-url = "https://github.com/jdx/communique/releases/download/v1.2.3/communique-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/477186277"
+checksum = "sha256:8eebec71e8a57b04793fa85bbb798f48e1b50bda12813e3c8db857eaa1f4bca9"
+url = "https://github.com/jdx/communique/releases/download/v1.3.2/communique-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/525621690"
 provenance = "github-attestations"
 
 [tools.communique."platforms.macos-arm64"]
-checksum = "sha256:668683480d8b8d62de9616c3a2258f802daf6ce3440d2fa6cf1f7d72eecade89"
-url = "https://github.com/jdx/communique/releases/download/v1.2.3/communique-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/477186196"
+checksum = "sha256:c5eca847e9d1b4c8c8cb5633ffbbbf8e8659b86cf3e43083c0f6304db5137e86"
+url = "https://github.com/jdx/communique/releases/download/v1.3.2/communique-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/525622989"
 provenance = "github-attestations"
 
 [tools.communique."platforms.windows-x64"]
-checksum = "sha256:63f2370f9c6ff97b31f9be266d8860dd65dce0aafb269c492de7cdbb9d29d782"
-url = "https://github.com/jdx/communique/releases/download/v1.2.3/communique-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/477186666"
+checksum = "sha256:82dad4450baf31869005287fa87c74b3513d2d16aae6996bfb3cd9cd40dcfffc"
+url = "https://github.com/jdx/communique/releases/download/v1.3.2/communique-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/525619633"
 provenance = "github-attestations"
 
 [[tools."github:bnjbvr/cargo-machete"]]


### PR DESCRIPTION
## Summary

- enhance the release-plz draft in parallel with asset uploads
- make publication wait for CLI assets, FFI assets, and final release notes
- keep recovery guidance aligned with the new dependency ordering
- update the locked Communiqué binary to a draft-safe release
- keep manual FFI asset recovery from publishing npm packages implicitly

## Validation

- actionlint with ShellCheck enabled
- git diff --check
- verified release-plz continues to create draft releases

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the GitHub release publish gate and npm publish conditions for FFI packages. A job-graph mistake could ship drafts without notes or skip/accidentally trigger npm.
> 
> **Overview**
> Release publication now waits for Communiqué notes as well as CLI/FFI assets, so drafts are no longer flipped live with the raw git-cliff body.
> 
> `enhance-release` runs in parallel with asset uploads (depends only on `release-plz-release`). `publish-release` then needs all three. Recovery comments match that order: re-run asset workflows, then retry failed jobs, and only publish by hand after notes exist.
> 
> Manual `ffi.yml` dispatch no longer publishes npm by default. Asset recovery uses the tag input; npm backfill requires `publish_packages`. Communiqué is bumped to 1.3.2.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e09efa2bf31dc18fb39b5ada381ab06e49ec9816. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Process**
  * Release publication now waits for release notes and sponsor information to be added.
  * Updated recovery guidance helps restore missing release assets before publishing.
  * Manual publication should only occur after confirming the enhanced release notes are available.
  * Package publishing is disabled by default for manual runs and requires explicit confirmation during tagged releases.
  * Asset-recovery and draft release workflows no longer publish packages automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



