### PR TITLE
feat(doctor): flag undeclared imports in direct dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,7 @@ dependencies = [
  "aube-linker",
  "aube-lockfile",
  "aube-manifest",
+ "aube-phantom-scan",
  "aube-registry",
  "aube-resolver",
  "aube-runtime",
@@ -392,6 +393,26 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "tokio",
+]
+
+[[package]]
+name = "aube-phantom-core"
+version = "2.1.0"
+dependencies = [
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_ast_visit",
+ "oxc_parser",
+ "oxc_span",
+]
+
+[[package]]
+name = "aube-phantom-scan"
+version = "2.1.0"
+dependencies = [
+ "aube-phantom-core",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1071,6 +1092,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cow-utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1377,7 +1404,7 @@ dependencies = [
  "asn1-rs",
  "displaydoc",
  "nom",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "rusticata-macros",
 ]
@@ -1476,6 +1503,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "dragonbox_ecma"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd8e701084c37e7ef62d3f9e453b618130cbc0ef3573847785952a3ac3f746bf"
 
 [[package]]
 name = "duct"
@@ -2905,6 +2938,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonmax"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2924,6 +2963,16 @@ name = "num-bigint"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -3037,6 +3086,224 @@ name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
+name = "oxc-miette"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e0df30faa68797917ca4263e7a2f889ec829e4da2dcb3d6dc752f7a494180f3"
+dependencies = [
+ "cfg-if",
+ "memchr",
+ "owo-colors",
+ "oxc-miette-derive",
+ "textwrap",
+ "thiserror 2.0.20",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "oxc-miette-derive"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acc072d11d45ebe7801459b4e829184ba0934d68027fdc51d327335b53a95a49"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "oxc_allocator"
+version = "0.140.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f8245ba555b465d3577732d5f9d9306babb0aaa7b80e97a2ce21f74fae442a3"
+dependencies = [
+ "allocator-api2",
+ "hashbrown 0.17.1",
+ "oxc_data_structures",
+ "rustc-hash",
+]
+
+[[package]]
+name = "oxc_ast"
+version = "0.140.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3305400b90fff2a30b272b58fe6080d25369407b2ac37c4ac652996a9677efe0"
+dependencies = [
+ "bitflags 2.13.1",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_data_structures",
+ "oxc_diagnostics",
+ "oxc_estree",
+ "oxc_regular_expression",
+ "oxc_span",
+ "oxc_str",
+ "oxc_syntax",
+]
+
+[[package]]
+name = "oxc_ast_macros"
+version = "0.140.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef089097e96b74388a8025a9247bdb12774b99f5971926d9dafbe84a78f9efb7"
+dependencies = [
+ "phf",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "oxc_ast_visit"
+version = "0.140.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4640e6d0de2e0f6c820d1444a468d070c710111df76ce90a1694ac386641e133"
+dependencies = [
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_span",
+ "oxc_syntax",
+]
+
+[[package]]
+name = "oxc_data_structures"
+version = "0.140.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acfb6e704f95e115c0e9ea8bef791c3d915cd2fcd1643661cf0bf5172c818097"
+
+[[package]]
+name = "oxc_diagnostics"
+version = "0.140.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b33d8c59c55e2c581ff692468a6a7ff1f12477f0e687b52e27fc6f6346a5d77"
+dependencies = [
+ "cow-utils",
+ "oxc-miette",
+ "percent-encoding",
+]
+
+[[package]]
+name = "oxc_ecmascript"
+version = "0.140.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b3321b606c9217e8e5527cd01906b98e17f232acbb6fab7eac05236e7731d9a"
+dependencies = [
+ "cow-utils",
+ "num-bigint 0.5.1",
+ "num-traits",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_regular_expression",
+ "oxc_span",
+ "oxc_syntax",
+ "smallvec",
+]
+
+[[package]]
+name = "oxc_estree"
+version = "0.140.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad383009532dc6504973f02f68892b98f64be1c17e86115166b0a1223c7511e7"
+
+[[package]]
+name = "oxc_index"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "191884bee6c3744909a51acc7d78d4ae370d817b25875b10642f632327b6296e"
+dependencies = [
+ "nonmax",
+ "serde",
+]
+
+[[package]]
+name = "oxc_parser"
+version = "0.140.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8abd68f81349d37ea79f1d99d2370e15f282cc9fbe66e8544d072595744ab38e"
+dependencies = [
+ "bitflags 2.13.1",
+ "cow-utils",
+ "memchr",
+ "num-bigint 0.5.1",
+ "num-traits",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_data_structures",
+ "oxc_diagnostics",
+ "oxc_ecmascript",
+ "oxc_regular_expression",
+ "oxc_span",
+ "oxc_str",
+ "oxc_syntax",
+ "rustc-hash",
+ "seq-macro",
+]
+
+[[package]]
+name = "oxc_regular_expression"
+version = "0.140.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eba6a56b1c633963c09c383062e47fb8a99ff4a4ded6bd883fcf554f8e1a48f"
+dependencies = [
+ "bitflags 2.13.1",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_diagnostics",
+ "oxc_span",
+ "oxc_str",
+ "phf",
+ "rustc-hash",
+ "unicode-id-start",
+]
+
+[[package]]
+name = "oxc_span"
+version = "0.140.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83fa0a0fe6e5e2f5abb173a64afe8db711bb612acbc002c663fd13b08a8cbf3"
+dependencies = [
+ "compact_str",
+ "oxc-miette",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_estree",
+ "oxc_str",
+]
+
+[[package]]
+name = "oxc_str"
+version = "0.140.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9e9531af3bc70e5eb75d196c01011d5bc0de1f6de73f0fc8bf343384353794f"
+dependencies = [
+ "compact_str",
+ "hashbrown 0.17.1",
+ "oxc_allocator",
+ "oxc_estree",
+]
+
+[[package]]
+name = "oxc_syntax"
+version = "0.140.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f81863cdf973b6bcdcdbbae225619c08966be41efb64dc0ee0fd4b574f4ec18"
+dependencies = [
+ "bitflags 2.13.1",
+ "cow-utils",
+ "dragonbox_ecma",
+ "nonmax",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_estree",
+ "oxc_index",
+ "oxc_span",
+ "oxc_str",
+ "phf",
+ "unicode-id-start",
+]
 
 [[package]]
 name = "page_size"
@@ -3175,6 +3442,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
 dependencies = [
  "pest",
+]
+
+[[package]]
+name = "phf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -3985,6 +4295,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
 name = "serde"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4430,6 +4746,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4443,6 +4765,12 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "smawk"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
 name = "socket2"
@@ -4734,6 +5062,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
+ "smawk",
  "unicode-linebreak",
  "unicode-width 0.2.2",
 ]
@@ -5159,6 +5488,12 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicode-id-start"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b79ad29b5e19de4260020f8919b443b2ef0277d242ce532ec7b7a2cc8b6007"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,6 +201,8 @@ aube-store = { path = "crates/aube-store", version = "2" }
 aube-linker = { path = "crates/aube-linker", version = "2" }
 aube-lockfile = { path = "crates/aube-lockfile", version = "2" }
 aube-manifest = { path = "crates/aube-manifest", version = "2", default-features = false }
+aube-phantom-core = { path = "crates/aube-phantom-core", version = "2" }
+aube-phantom-scan = { path = "crates/aube-phantom-scan", version = "2" }
 aube-runtime = { path = "crates/aube-runtime", version = "2" }
 aube-scripts = { path = "crates/aube-scripts", version = "2" }
 aube-workspace = { path = "crates/aube-workspace", version = "2" }

--- a/crates/aube-phantom-core/Cargo.toml
+++ b/crates/aube-phantom-core/Cargo.toml
@@ -1,0 +1,32 @@
+# aube-phantom-core — the precision-critical phantom-classification
+# primitives (specifier extraction, package-name classification, Node
+# builtin recognition), ported from nub's `nub-phantom-core` (jdx/nub /
+# nubjs/nub, MIT) so `aube doctor` can flag a dependency that statically
+# imports a package it does not declare.
+#
+# LEAN OXC SUBSET: depends on the individual oxc parser/AST crates, not
+# the `oxc` umbrella with features=["full"] — the umbrella pulls the
+# transformer, codegen, semantic, minifier, and mangler, none of which
+# specifier extraction needs.
+[package]
+name = "aube-phantom-core"
+description = "phantom-dependency classification primitives for Aube"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+include = ["src/**/*.rs"]
+
+[lib]
+name = "aube_phantom_core"
+path = "src/lib.rs"
+
+[dependencies]
+oxc_allocator = "0.140"
+oxc_ast = "0.140"
+oxc_ast_visit = "0.140"
+oxc_parser = "0.140"
+oxc_span = "0.140"

--- a/crates/aube-phantom-core/src/builtins.rs
+++ b/crates/aube-phantom-core/src/builtins.rs
@@ -1,0 +1,95 @@
+//! Node builtin-module recognition. Ported from nub's `nub-phantom-core`
+//! (jdx/nub / nubjs/nub, MIT), unchanged.
+//!
+//! A `node:`-prefixed specifier is UNCONDITIONALLY a builtin (the prefix is
+//! reserved). A bare specifier is a builtin only if it names one of Node's
+//! built-in modules — the list below is the union across supported Node lines
+//! (18.19 floor → current), so we never mistake a real dependency for a builtin
+//! nor vice-versa.
+
+/// Bare names that resolve to a Node builtin. Kept as a sorted `&[&str]` for a
+/// binary-search membership test; the set changes only when Node adds a module.
+const BARE_BUILTINS: &[&str] = &[
+    "assert",
+    "async_hooks",
+    "buffer",
+    "child_process",
+    "cluster",
+    "console",
+    "constants",
+    "crypto",
+    "dgram",
+    "diagnostics_channel",
+    "dns",
+    "domain",
+    "events",
+    "fs",
+    "http",
+    "http2",
+    "https",
+    "inspector",
+    "module",
+    "net",
+    "os",
+    "path",
+    "perf_hooks",
+    "process",
+    "punycode",
+    "querystring",
+    "readline",
+    "repl",
+    "stream",
+    "string_decoder",
+    "sys",
+    "timers",
+    "tls",
+    "trace_events",
+    "tty",
+    "url",
+    "util",
+    "v8",
+    "vm",
+    "wasi",
+    "worker_threads",
+    "zlib",
+];
+
+/// Is `spec` (the full import specifier) a Node builtin?
+///
+/// Handles the `node:` prefix (always builtin, incl. `node:test`, `node:sea`,
+/// and any subpath like `node:stream/promises`), and bare builtins with an
+/// optional subpath (`fs/promises`, `stream/web`, `dns/promises`, `util/types`,
+/// `assert/strict`, `path/posix`, `timers/promises`, `inspector/promises`).
+pub fn is_builtin(spec: &str) -> bool {
+    if spec.strip_prefix("node:").is_some() {
+        return true;
+    }
+    // A bare builtin may carry a first-party subpath (`fs/promises`); match the
+    // head segment only.
+    let head = spec.split('/').next().unwrap_or(spec);
+    BARE_BUILTINS.binary_search(&head).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_builtin;
+
+    #[test]
+    fn builtin_list_is_sorted_for_binary_search() {
+        assert!(super::BARE_BUILTINS.is_sorted());
+    }
+
+    #[test]
+    fn recognizes_builtins_bare_prefixed_and_subpathed() {
+        assert!(is_builtin("fs"));
+        assert!(is_builtin("fs/promises"));
+        assert!(is_builtin("node:test"));
+        assert!(is_builtin("node:stream/promises"));
+        assert!(is_builtin("assert/strict"));
+        // A real dependency whose name merely starts like a builtin is NOT a
+        // builtin (head-segment match, exact).
+        assert!(!is_builtin("fs-extra"));
+        assert!(!is_builtin("path-to-regexp"));
+        assert!(!is_builtin("react"));
+    }
+}

--- a/crates/aube-phantom-core/src/extract.rs
+++ b/crates/aube-phantom-core/src/extract.rs
@@ -22,7 +22,7 @@
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
-    Argument, ConditionalExpression, Expression, IfStatement, ImportDeclarationSpecifier,
+    ConditionalExpression, Expression, IfStatement, ImportDeclarationSpecifier,
     LogicalExpression, Statement, TryStatement,
 };
 use oxc_ast_visit::{Visit, walk};
@@ -339,7 +339,9 @@ fn strip_html_comments(source: &str) -> String {
 
 /// If `call` is `require("lit")`, `require.resolve("lit")`, or the immediately-
 /// invoked `createRequire(...)("lit")`, return the literal specifier and which.
-/// Any non-string-literal argument yields `None`.
+/// The argument may be a string literal or a no-substitution template, matching
+/// the same static-string rule `import(...)` uses (see [`static_string`]); any
+/// other argument shape yields `None`.
 fn require_call<'a>(call: &'a oxc_ast::ast::CallExpression<'a>) -> Option<(&'a str, RefKind)> {
     let kind = match &call.callee {
         Expression::Identifier(id) if id.name == "require" => RefKind::Require,
@@ -351,16 +353,14 @@ fn require_call<'a>(call: &'a oxc_ast::ast::CallExpression<'a>) -> Option<(&'a s
         },
         // `createRequire(import.meta.url)("lit")` — the immediately-invoked form:
         // the callee is itself a `createRequire(...)` call whose result is a
-        // require function, so a string-literal outer argument is a real edge.
+        // require function, so a static-string outer argument is a real edge.
         // ONLY the direct IIFE is handled; a name bound to `createRequire(...)`
         // and called later needs dataflow and stays skipped (no false positives).
         Expression::CallExpression(inner) if is_create_require(&inner.callee) => RefKind::Require,
         _ => return None,
     };
-    match call.arguments.first() {
-        Some(Argument::StringLiteral(s)) => Some((&s.value, kind)),
-        _ => None,
-    }
+    let spec = static_string(call.arguments.first()?.as_expression()?)?;
+    Some((spec, kind))
 }
 
 /// True if `callee` names `createRequire` — bare (`createRequire(...)`) or a
@@ -621,6 +621,31 @@ mod tests {
         assert!(
             neg.is_empty(),
             "bound-then-called createRequire + substituted template stay skipped"
+        );
+    }
+
+    #[test]
+    fn require_accepts_no_substitution_template_arguments() {
+        // A bare `require`/`require.resolve` call with a no-substitution
+        // template argument (`` require(`lit`) ``) carries the same
+        // attributable static string as a string literal — must be recorded
+        // the same way `import(...)` already is.
+        let got = specs(
+            r#"
+            const a = require(`tpl-dep`);
+            const b = require.resolve(`tpl-resolve-dep`);
+            const c = require(`pre-${x}`);
+            "#,
+        );
+        let has = |n: &str| got.iter().any(|(s, _, _)| s == n);
+        assert!(has("tpl-dep"), "require(`lit`) is analyzable");
+        assert!(
+            has("tpl-resolve-dep"),
+            "require.resolve(`lit`) is analyzable"
+        );
+        assert!(
+            !has("pre-${x}") && got.iter().all(|(s, _, _)| !s.starts_with("pre-")),
+            "a substituted template stays skipped"
         );
     }
 }

--- a/crates/aube-phantom-core/src/extract.rs
+++ b/crates/aube-phantom-core/src/extract.rs
@@ -1,0 +1,626 @@
+//! Extract import/require specifier OCCURRENCES from one source file. Ported
+//! from nub's `nub-phantom-core` (jdx/nub / nubjs/nub, MIT), unchanged.
+//!
+//! Every static `import`, runtime re-export, dynamic `import()`, `require()`, and
+//! `require.resolve()` with a string-literal argument is recorded, tagged `soft`
+//! when it appears lexically inside a runtime GUARD — a `try`/`catch`/`finally`,
+//! or a conditional branch (`if`/`else`, a ternary arm, the right of `&&`/`||`).
+//! Both are the "loaded only when the environment/condition permits" pattern the
+//! spec classifies soft (e.g. `if (typeof phantom !== 'undefined') require('system')`,
+//! or `try { require('opt') } catch {}`). A top-level, unconditional require is
+//! hard. Type-only imports/exports are dropped — they are erased before runtime
+//! and would false-flag a devDep-typed package as a phantom. A dynamic
+//! `import(...)`/`require(...)`/`createRequire(...)(...)` is recorded only when
+//! its argument is a STATIC string (a literal, or a no-substitution template);
+//! a substituted-template or computed specifier cannot be attributed to a
+//! package name and is skipped — guessing would risk a false positive.
+//!
+//! Guard-ness is LEXICAL, not control-flow: a require in a function DECLARED
+//! inside an `if`/`try` is marked soft even if that function is later called
+//! unconditionally. This only ever errs toward soft (a false negative on
+//! hardness), never toward a false phantom — safe for the never-false-flag bar.
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{
+    Argument, ConditionalExpression, Expression, IfStatement, ImportDeclarationSpecifier,
+    LogicalExpression, Statement, TryStatement,
+};
+use oxc_ast_visit::{Visit, walk};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+
+/// How a specifier was referenced. Kept for reporting; the classifier treats all
+/// as runtime edges (soft-ness, not kind, gates the phantom/soft split).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefKind {
+    StaticImport,
+    ReExport,
+    DynamicImport,
+    Require,
+    RequireResolve,
+}
+
+/// One reference to a specifier in a file.
+#[derive(Debug, Clone)]
+pub struct Occurrence {
+    /// The raw specifier string, exactly as written (`./x`, `lodash/fp`, `node:fs`).
+    pub spec: String,
+    /// Inside a `try`/`catch`/`finally` — a guarded (soft) load.
+    pub soft: bool,
+    pub kind: RefKind,
+}
+
+/// Parse `source` (its `SourceType` inferred from `path`) and return every
+/// specifier occurrence. A parse that panics yields an empty list (the file is
+/// simply not analyzed rather than aborting the package).
+///
+/// The production extraction path: a full, guard-aware AST visit. (A
+/// static-imports-only fast-path ladder was built and benchmarked but regressed
+/// the parse-dominated scan, so it was removed.)
+pub fn extract(path: &str, source: &str) -> Vec<Occurrence> {
+    // Framework single-file components (Astro/Vue/Svelte) keep their imports in a
+    // frontmatter / `<script>` block. A backend imported there for TYPES ONLY still
+    // breaks resolution under the global virtual store: the package's realpath
+    // escapes into the shared store, so a type-checker's upward `node_modules` walk
+    // can't reach the hoisted backend (nub#450). So for an SFC we parse only its
+    // script region, as TS, and DO keep type-only imports. Plain `.js`/`.ts` are
+    // unchanged — type-only imports stay dropped, so a devDep-typed package is
+    // never false-flagged as a runtime phantom.
+    if let Some(script) = sfc_script(path, source) {
+        let ts = SourceType::from_path("_.mts").unwrap_or_else(|_| SourceType::mjs());
+        return parse_and_visit(&script, ts, true);
+    }
+    // A `.d.ts` (`.d.mts`/`.d.cts`) is a package's TYPE surface. Its imports are
+    // type-position by nature (`import * as React from 'react'`, `import type …`),
+    // yet under the global virtual store they still drive TS's resolution: the
+    // package's realpath escapes into the shared store, so a type import of a
+    // top-level-only backend (`@types/react`, `astro/types`) fails to resolve
+    // (nub#450). So a declaration file is parsed with type imports KEPT, exactly
+    // like an SFC script region. Plain `.js`/`.ts` still drop type-only imports.
+    if is_dts(path) {
+        let ts = SourceType::from_path("_.mts").unwrap_or_else(|_| SourceType::mjs());
+        return parse_and_visit(source, ts, true);
+    }
+    let source_type = SourceType::from_path(path).unwrap_or_else(|_| SourceType::mjs());
+    parse_and_visit(source, source_type, false)
+}
+
+/// Parse `source` as `source_type` and collect specifier occurrences.
+/// `capture_types` retains type-only import/re-export specifiers — set only for
+/// SFC script blocks; false on the runtime path preserves the type-only drop.
+fn parse_and_visit(source: &str, source_type: SourceType, capture_types: bool) -> Vec<Occurrence> {
+    let allocator = Allocator::default();
+    let ret = Parser::new(&allocator, source, source_type).parse();
+    if ret.panicked {
+        return Vec::new();
+    }
+    let mut v = SpecVisitor {
+        guard_depth: 0,
+        out: Vec::new(),
+        capture_types,
+    };
+    v.visit_program(&ret.program);
+    v.out
+}
+
+struct SpecVisitor {
+    /// Lexical nesting inside a try/catch/finally OR a conditional branch. A
+    /// nonzero depth means the current position is only reached under a runtime
+    /// guard → any load here is soft.
+    guard_depth: u32,
+    out: Vec<Occurrence>,
+    /// Retain type-only import/re-export specifiers. Set only for SFC script
+    /// blocks, where a type-position phantom still breaks GVS resolution (nub#450).
+    capture_types: bool,
+}
+
+impl SpecVisitor {
+    fn record(&mut self, spec: &str, kind: RefKind) {
+        self.out.push(Occurrence {
+            spec: spec.to_string(),
+            soft: self.guard_depth > 0,
+            kind,
+        });
+    }
+}
+
+impl<'a> Visit<'a> for SpecVisitor {
+    fn visit_try_statement(&mut self, it: &TryStatement<'a>) {
+        // Everything lexically within a try — the try block, the catch handler,
+        // and the finalizer — is a guarded region: the canonical optional-load
+        // pattern is `try { x = require('opt') } catch { x = fallback }`.
+        self.guard_depth += 1;
+        walk::walk_try_statement(self, it);
+        self.guard_depth -= 1;
+    }
+
+    fn visit_if_statement(&mut self, it: &IfStatement<'a>) {
+        // The TEST runs unconditionally; the branches do not. Guard only the
+        // branch bodies so `if (typeof x !== 'undefined') require('x')` is soft
+        // while a require in the test itself stays hard.
+        self.visit_expression(&it.test);
+        self.guard_depth += 1;
+        self.visit_statement(&it.consequent);
+        if let Some(alt) = &it.alternate {
+            self.visit_statement(alt);
+        }
+        self.guard_depth -= 1;
+    }
+
+    fn visit_conditional_expression(&mut self, it: &ConditionalExpression<'a>) {
+        // Ternary: test unconditional, arms guarded.
+        self.visit_expression(&it.test);
+        self.guard_depth += 1;
+        self.visit_expression(&it.consequent);
+        self.visit_expression(&it.alternate);
+        self.guard_depth -= 1;
+    }
+
+    fn visit_logical_expression(&mut self, it: &LogicalExpression<'a>) {
+        // `a && require('x')` / `a || require('x')`: the left runs
+        // unconditionally, the right is short-circuit-guarded.
+        self.visit_expression(&it.left);
+        self.guard_depth += 1;
+        self.visit_expression(&it.right);
+        self.guard_depth -= 1;
+    }
+
+    fn visit_statement(&mut self, it: &Statement<'a>) {
+        match it {
+            // Static ESM import. `import type …` (declaration-level) is erased;
+            // an inline all-`type` named import is likewise erased. A bare
+            // `import "x"` (side effect) and any value specifier are runtime.
+            Statement::ImportDeclaration(decl)
+                if self.capture_types
+                    || (!decl.import_kind.is_type() && import_has_value(decl)) =>
+            {
+                self.record(&decl.source.value, RefKind::StaticImport);
+            }
+            // Runtime re-exports. `export { x } from 'y'` (value) and
+            // `export * from 'y'` load the module; `export type { … }` does not
+            // (unless `capture_types`, for SFC script blocks).
+            Statement::ExportNamedDeclaration(decl) => {
+                if let Some(src) = &decl.source
+                    && (self.capture_types
+                        || (!decl.export_kind.is_type() && export_named_has_value(decl)))
+                {
+                    self.record(&src.value, RefKind::ReExport);
+                }
+            }
+            Statement::ExportAllDeclaration(decl)
+                if self.capture_types || !decl.export_kind.is_type() =>
+            {
+                self.record(&decl.source.value, RefKind::ReExport);
+            }
+            _ => {}
+        }
+        walk::walk_statement(self, it);
+    }
+
+    fn visit_expression(&mut self, it: &Expression<'a>) {
+        match it {
+            // Dynamic `import(...)` — attributable when the source is a static
+            // string: a literal, or a no-substitution template (`import(`react`)`).
+            // A substituted template / computed source is skipped.
+            Expression::ImportExpression(imp) => {
+                if let Some(spec) = static_string(&imp.source) {
+                    self.record(spec, RefKind::DynamicImport);
+                }
+            }
+            // `require("x")` / `require.resolve("x")` / `createRequire(...)("x")`.
+            Expression::CallExpression(call) => {
+                if let Some((spec, kind)) = require_call(call) {
+                    self.record(spec, kind);
+                }
+            }
+            _ => {}
+        }
+        walk::walk_expression(self, it);
+    }
+}
+
+/// A named import declaration is a runtime (value) import unless every specifier
+/// is inline-`type`. A bare import (no specifiers) is always runtime.
+fn import_has_value(decl: &oxc_ast::ast::ImportDeclaration<'_>) -> bool {
+    match &decl.specifiers {
+        None => true,
+        Some(specs) if specs.is_empty() => true,
+        Some(specs) => specs.iter().any(|s| match s {
+            ImportDeclarationSpecifier::ImportSpecifier(named) => !named.import_kind.is_type(),
+            // default / namespace imports are always value bindings
+            _ => true,
+        }),
+    }
+}
+
+/// `export { a, type B } from 'y'` is a runtime re-export unless every specifier
+/// is inline-`type`.
+fn export_named_has_value(decl: &oxc_ast::ast::ExportNamedDeclaration<'_>) -> bool {
+    decl.specifiers.is_empty() || decl.specifiers.iter().any(|s| !s.export_kind.is_type())
+}
+
+/// A TypeScript declaration file (`.d.ts`/`.d.mts`/`.d.cts`) — a package's type
+/// surface, parsed with type imports kept (see [`extract`]).
+fn is_dts(path: &str) -> bool {
+    let file = path.rsplit(['/', '\\']).next().unwrap_or(path);
+    file.ends_with(".d.ts") || file.ends_with(".d.mts") || file.ends_with(".d.cts")
+}
+
+/// The analyzable script region of a single-file component, or `None` for a
+/// non-SFC path. `.astro` → the frontmatter between the leading `---` fence and
+/// its close; `.vue`/`.svelte` → the concatenated `<script>…</script>` bodies.
+fn sfc_script(path: &str, source: &str) -> Option<String> {
+    let file = path.rsplit(['/', '\\']).next().unwrap_or(path);
+    match file.rsplit_once('.').map(|(_, e)| e) {
+        Some("astro") => Some(astro_frontmatter(source)),
+        Some("vue" | "svelte") => Some(script_blocks(source)),
+        _ => None,
+    }
+}
+
+/// Astro frontmatter: the region between a leading `---` fence (its own line) and
+/// the next line that begins `---`. Empty when the file has no frontmatter.
+fn astro_frontmatter(source: &str) -> String {
+    let s = source.trim_start_matches('\u{feff}');
+    let Some(after) = s.strip_prefix("---") else {
+        return String::new();
+    };
+    let Some(body) = after
+        .strip_prefix("\r\n")
+        .or_else(|| after.strip_prefix('\n'))
+    else {
+        return String::new();
+    };
+    match body.find("\n---") {
+        Some(end) => body[..end].to_string(),
+        None => body.to_string(),
+    }
+}
+
+/// Concatenate the bodies of every `<script …>…</script>` block (Vue/Svelte),
+/// ignoring blocks inside `<!-- … -->` comments so a commented-out `<script>` is
+/// never mistaken for real component code (a false phantom).
+fn script_blocks(source: &str) -> String {
+    let source = strip_html_comments(source);
+    let mut out = String::new();
+    let mut rest = source.as_str();
+    while let Some(open) = rest.find("<script") {
+        let after = &rest[open..];
+        let Some(gt) = open_tag_end(after) else { break };
+        let body_start = open + gt + 1;
+        let Some(close) = rest[body_start..].find("</script>") else {
+            break;
+        };
+        out.push_str(&rest[body_start..body_start + close]);
+        out.push('\n');
+        rest = &rest[body_start + close + "</script>".len()..];
+    }
+    out
+}
+
+/// Index of the `>` that closes an open tag, skipping any `>` inside a quoted
+/// attribute value — Vue 3.3 `<script setup generic="T extends Record<string, X>">`
+/// carries one, and a naive `find('>')` would slice the body mid-attribute.
+fn open_tag_end(s: &str) -> Option<usize> {
+    let mut quote: Option<u8> = None;
+    for (i, &b) in s.as_bytes().iter().enumerate() {
+        match quote {
+            Some(q) => {
+                if b == q {
+                    quote = None;
+                }
+            }
+            None => match b {
+                b'"' | b'\'' => quote = Some(b),
+                b'>' => return Some(i),
+                _ => {}
+            },
+        }
+    }
+    None
+}
+
+/// Remove `<!-- … -->` comment spans (best-effort textual strip; a phantom scan
+/// tolerates the rare `-->` inside a string literal). An unterminated comment
+/// drops the remainder — commented-out code never counts.
+fn strip_html_comments(source: &str) -> String {
+    let mut out = String::new();
+    let mut rest = source;
+    while let Some(start) = rest.find("<!--") {
+        out.push_str(&rest[..start]);
+        match rest[start + 4..].find("-->") {
+            Some(end) => rest = &rest[start + 4 + end + 3..],
+            None => return out,
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+/// If `call` is `require("lit")`, `require.resolve("lit")`, or the immediately-
+/// invoked `createRequire(...)("lit")`, return the literal specifier and which.
+/// Any non-string-literal argument yields `None`.
+fn require_call<'a>(call: &'a oxc_ast::ast::CallExpression<'a>) -> Option<(&'a str, RefKind)> {
+    let kind = match &call.callee {
+        Expression::Identifier(id) if id.name == "require" => RefKind::Require,
+        Expression::StaticMemberExpression(m) => match &m.object {
+            Expression::Identifier(id) if id.name == "require" && m.property.name == "resolve" => {
+                RefKind::RequireResolve
+            }
+            _ => return None,
+        },
+        // `createRequire(import.meta.url)("lit")` — the immediately-invoked form:
+        // the callee is itself a `createRequire(...)` call whose result is a
+        // require function, so a string-literal outer argument is a real edge.
+        // ONLY the direct IIFE is handled; a name bound to `createRequire(...)`
+        // and called later needs dataflow and stays skipped (no false positives).
+        Expression::CallExpression(inner) if is_create_require(&inner.callee) => RefKind::Require,
+        _ => return None,
+    };
+    match call.arguments.first() {
+        Some(Argument::StringLiteral(s)) => Some((&s.value, kind)),
+        _ => None,
+    }
+}
+
+/// True if `callee` names `createRequire` — bare (`createRequire(...)`) or a
+/// member (`module.createRequire(...)`). The receiver is not checked: only Node's
+/// `createRequire` uses this name, and the outer call's argument must still be a
+/// string literal for anything to be recorded.
+fn is_create_require(callee: &Expression<'_>) -> bool {
+    match callee {
+        Expression::Identifier(id) => id.name == "createRequire",
+        Expression::StaticMemberExpression(m) => m.property.name == "createRequire",
+        _ => false,
+    }
+}
+
+/// The statically-known string value of `expr`: a string literal, or a template
+/// literal with no substitutions (a single quasi with a cooked value). A
+/// substituted template or any computed expression has no attributable value.
+fn static_string<'a>(expr: &'a Expression<'a>) -> Option<&'a str> {
+    match expr {
+        Expression::StringLiteral(s) => Some(&s.value),
+        Expression::TemplateLiteral(t) if t.expressions.is_empty() => {
+            t.quasis.first().and_then(|q| q.value.cooked.as_deref())
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RefKind, extract};
+
+    fn specs(src: &str) -> Vec<(String, bool, RefKind)> {
+        extract("mod.mjs", src)
+            .into_iter()
+            .map(|o| (o.spec, o.soft, o.kind))
+            .collect()
+    }
+
+    #[test]
+    fn captures_static_import_require_dynamic_and_reexport() {
+        let got = specs(
+            r#"
+            import a from "aa";
+            import "side-effect";
+            export { z } from "zz";
+            export * from "ss";
+            const b = require("bb");
+            const c = await import("cc");
+            require.resolve("dd");
+            "#,
+        );
+        let names: Vec<_> = got.iter().map(|(s, _, _)| s.as_str()).collect();
+        assert!(names.contains(&"aa"));
+        assert!(names.contains(&"side-effect"));
+        assert!(names.contains(&"zz"));
+        assert!(names.contains(&"ss"));
+        assert!(names.contains(&"bb"));
+        assert!(names.contains(&"cc"));
+        assert!(names.contains(&"dd"));
+    }
+
+    #[test]
+    fn try_catch_require_is_soft_toplevel_is_hard() {
+        let got = specs(
+            r#"
+            const hard = require("hard-dep");
+            let opt;
+            try { opt = require("soft-dep"); } catch {}
+            "#,
+        );
+        let hard = got.iter().find(|(s, _, _)| s == "hard-dep").unwrap();
+        let soft = got.iter().find(|(s, _, _)| s == "soft-dep").unwrap();
+        assert!(!hard.1, "top-level require must be hard");
+        assert!(soft.1, "require inside try must be soft");
+    }
+
+    #[test]
+    fn conditionally_guarded_requires_are_soft() {
+        // The esprima→'system' shape: a require inside a `typeof` env-guard `if`
+        // branch, plus `&&` and ternary guards. All soft; the top-level one hard.
+        let got = specs(
+            r#"
+            const hard = require("always");
+            if (typeof phantom !== "undefined") { var s = require("system"); }
+            const c = cond && require("andguard");
+            const t = flag ? require("ternguard") : null;
+            "#,
+        );
+        let soft = |n: &str| got.iter().find(|(s, _, _)| s == n).unwrap().1;
+        assert!(!soft("always"), "top-level require is hard");
+        assert!(soft("system"), "require in if-branch is soft");
+        assert!(soft("andguard"), "require in && right is soft");
+        assert!(soft("ternguard"), "require in ternary arm is soft");
+    }
+
+    #[test]
+    fn type_only_imports_are_dropped() {
+        // Inline `type` modifiers are TS syntax — parse as .mts.
+        let got: Vec<_> = extract(
+            "mod.mts",
+            r#"
+            import type { T } from "type-pkg";
+            import { type Only } from "inline-type-pkg";
+            import { value, type Also } from "mixed-pkg";
+            "#,
+        )
+        .into_iter()
+        .map(|o| (o.spec, o.soft, o.kind))
+        .collect();
+        let names: Vec<_> = got.iter().map(|(s, _, _)| s.as_str()).collect();
+        assert!(!names.contains(&"type-pkg"), "import type erased");
+        assert!(
+            !names.contains(&"inline-type-pkg"),
+            "all-inline-type erased"
+        );
+        assert!(names.contains(&"mixed-pkg"), "mixed import is runtime");
+    }
+
+    #[test]
+    fn astro_frontmatter_keeps_type_only_backend() {
+        // astro-icon's Icon.astro imports `astro/types` for TYPES ONLY; under the
+        // global virtual store that still breaks resolution (nub#450), so the SFC
+        // path parses the frontmatter and keeps the type import. The HTML template
+        // after the fence is not parsed.
+        let src = "---\nimport type { HTMLAttributes } from \"astro/types\";\nimport { getIconData } from \"@iconify/utils\";\n---\n<svg {...rest} />\n";
+        let names: Vec<_> = extract("components/Icon.astro", src)
+            .into_iter()
+            .map(|o| o.spec)
+            .collect();
+        assert!(
+            names.iter().any(|s| s == "astro/types"),
+            "type-only SFC import kept"
+        );
+        assert!(names.iter().any(|s| s == "@iconify/utils"));
+    }
+
+    #[test]
+    fn vue_svelte_script_block_scanned() {
+        let vue = "<template><div/></template>\n<script lang=\"ts\">\nimport type { Foo } from \"backend\";\n</script>\n";
+        let names: Vec<_> = extract("Comp.vue", vue)
+            .into_iter()
+            .map(|o| o.spec)
+            .collect();
+        assert!(names.iter().any(|s| s == "backend"), "vue <script> scanned");
+    }
+
+    #[test]
+    fn commented_out_script_block_is_ignored() {
+        // A commented-out <script> must not be parsed as real component code, or
+        // its imports would false-flag a phantom and force a needless disk eject.
+        let vue = "<template><div/></template>\n<!-- <script>import 'ghost';</script> -->\n<script setup lang=\"ts\">\nimport type { Foo } from \"real-backend\";\n</script>\n";
+        let names: Vec<_> = extract("Comp.vue", vue)
+            .into_iter()
+            .map(|o| o.spec)
+            .collect();
+        assert!(
+            names.iter().any(|s| s == "real-backend"),
+            "real <script> scanned"
+        );
+        assert!(
+            !names.iter().any(|s| s == "ghost"),
+            "commented <script> ignored: {names:?}"
+        );
+    }
+
+    #[test]
+    fn generic_script_setup_attribute_with_gt_is_sliced_correctly() {
+        // Vue 3.3 generics: the open tag carries a `>` inside the attribute
+        // value; the body must start after the real tag end or the parse is
+        // garbled and the block's imports are silently missed.
+        let vue = "<script setup lang=\"ts\" generic=\"T extends Record<string, unknown>\">\nimport type { Foo } from \"generic-backend\";\n</script>\n";
+        let names: Vec<_> = extract("Comp.vue", vue)
+            .into_iter()
+            .map(|o| o.spec)
+            .collect();
+        assert!(
+            names.iter().any(|s| s == "generic-backend"),
+            "generic <script setup> body scanned: {names:?}"
+        );
+    }
+
+    #[test]
+    fn non_sfc_type_only_still_dropped() {
+        // The runtime path is unchanged: a type-only import in a .ts stays dropped.
+        let names: Vec<_> = extract("x.ts", "import type { T } from \"type-pkg\";\n")
+            .into_iter()
+            .map(|o| o.spec)
+            .collect();
+        assert!(names.is_empty(), "type-only import in .ts still dropped");
+    }
+
+    #[test]
+    fn dts_keeps_type_surface_imports() {
+        // A declaration file's imports are type-position but still drive TS
+        // resolution under GVS (nub#450): both the value-syntax `import * as React`
+        // and a `import type` are kept, and a relative type re-export.
+        let dts = "import * as React from 'react';\nimport type { FormApi } from '@tanstack/form-core';\nexport type { Foo } from './internal';\n";
+        for path in ["index.d.ts", "dist/index.d.mts", "types.d.cts"] {
+            let names: Vec<_> = extract(path, dts).into_iter().map(|o| o.spec).collect();
+            assert!(names.iter().any(|s| s == "react"), "{path}: react kept");
+            assert!(
+                names.iter().any(|s| s == "@tanstack/form-core"),
+                "{path}: type-only import kept"
+            );
+            assert!(
+                names.iter().any(|s| s == "./internal"),
+                "{path}: relative type re-export kept (walked for .d.ts graph)"
+            );
+        }
+    }
+
+    #[test]
+    fn computed_specifiers_are_not_recorded() {
+        let got = specs(
+            r#"
+            const x = require("pre" + "fix");
+            const y = await import(`tpl${a}`);
+            require(dynamicVar);
+            "#,
+        );
+        assert!(got.is_empty(), "no attributable string literal → skip");
+    }
+
+    #[test]
+    fn createrequire_iife_and_no_substitution_template_are_caught() {
+        // R3: two analyzable dynamic forms previously dropped as false negatives —
+        // both carry a static string target. Guard-aware, like a bare require().
+        let got = specs(
+            r#"
+            const a = createRequire(import.meta.url)("cr-dep");
+            const b = module.createRequire(import.meta.url)("cr-member-dep");
+            const c = await import(`tpl-lit`);
+            let g;
+            if (cond) { g = createRequire(import.meta.url)("cr-guarded"); }
+            "#,
+        );
+        let has = |n: &str| got.iter().any(|(s, _, _)| s == n);
+        assert!(has("cr-dep"), "createRequire(...)('lit') is a require edge");
+        assert!(has("cr-member-dep"), "module.createRequire(...)('lit') too");
+        assert!(
+            has("tpl-lit"),
+            "no-substitution import(`lit`) is analyzable"
+        );
+        let soft = |n: &str| got.iter().find(|(s, _, _)| s == n).unwrap().1;
+        assert!(!soft("cr-dep"), "top-level createRequire require is hard");
+        assert!(soft("cr-guarded"), "createRequire in an if-branch is soft");
+
+        // Boundary — no new false positives: a createRequire result bound to a
+        // name and called later (needs dataflow) and a SUBSTITUTED template both
+        // stay skipped.
+        let neg = specs(
+            r#"
+            const r = createRequire(import.meta.url);
+            r("bound-later");
+            const d = import(`pre-${x}`);
+            "#,
+        );
+        assert!(
+            neg.is_empty(),
+            "bound-then-called createRequire + substituted template stay skipped"
+        );
+    }
+}

--- a/crates/aube-phantom-core/src/extract.rs
+++ b/crates/aube-phantom-core/src/extract.rs
@@ -363,14 +363,19 @@ fn require_call<'a>(call: &'a oxc_ast::ast::CallExpression<'a>) -> Option<(&'a s
     Some((spec, kind))
 }
 
-/// True if `callee` names `createRequire` — bare (`createRequire(...)`) or a
-/// member (`module.createRequire(...)`). The receiver is not checked: only Node's
-/// `createRequire` uses this name, and the outer call's argument must still be a
-/// string literal for anything to be recorded.
+/// True if `callee` names `createRequire` — bare (`createRequire(...)`) or the
+/// member form Node's own docs use (`module.createRequire(...)`). The member
+/// form's RECEIVER is checked (must be named `module`) so an unrelated object
+/// that happens to expose its own `.createRequire` method (`helper.createRequire()`)
+/// is not mistaken for Node's module loader; a name bound to `createRequire(...)`
+/// and called later still needs dataflow and stays skipped either way.
 fn is_create_require(callee: &Expression<'_>) -> bool {
     match callee {
         Expression::Identifier(id) => id.name == "createRequire",
-        Expression::StaticMemberExpression(m) => m.property.name == "createRequire",
+        Expression::StaticMemberExpression(m) => {
+            m.property.name == "createRequire"
+                && matches!(&m.object, Expression::Identifier(id) if id.name == "module")
+        }
         _ => false,
     }
 }
@@ -646,6 +651,24 @@ mod tests {
         assert!(
             !has("pre-${x}") && got.iter().all(|(s, _, _)| !s.starts_with("pre-")),
             "a substituted template stays skipped"
+        );
+    }
+
+    #[test]
+    fn unrelated_object_method_named_create_require_is_not_recognized() {
+        // An unrelated object exposing its own `.createRequire` method must
+        // not be mistaken for Node's module loader — only the bare
+        // `createRequire(...)` form and the `module.createRequire(...)` member
+        // form (the shape Node's own docs use) are recognized.
+        let got = specs(
+            r#"
+            const a = helper.createRequire()("not-a-dependency");
+            const b = someObj.createRequire(import.meta.url)("also-not-a-dependency");
+            "#,
+        );
+        assert!(
+            got.is_empty(),
+            "an unrelated object's createRequire method must not be recognized: {got:?}"
         );
     }
 }

--- a/crates/aube-phantom-core/src/lib.rs
+++ b/crates/aube-phantom-core/src/lib.rs
@@ -1,0 +1,15 @@
+//! Phantom-classification primitives ported from nub's `nub-phantom-core`
+//! (jdx/nub / nubjs/nub, MIT) for `aube doctor`'s undeclared-import check.
+//!
+//! - [`extract`] — oxc-parsed specifier occurrences, with guard modeling
+//!   (try/catch, conditional branches → `soft`) and type-only erasure.
+//! - [`specifier`] — bare-vs-relative-vs-nonpackage classification + package-name
+//!   extraction (`lodash/fp` → `lodash`).
+//! - [`builtins`] — Node builtin recognition (never a phantom).
+//!
+//! The *verdict* layer (what counts as a phantom against a declared surface)
+//! lives in `aube-phantom-scan`, not here.
+
+pub mod builtins;
+pub mod extract;
+pub mod specifier;

--- a/crates/aube-phantom-core/src/specifier.rs
+++ b/crates/aube-phantom-core/src/specifier.rs
@@ -1,0 +1,144 @@
+//! Classify an import/require specifier string into its shape, and extract the
+//! *package name* a bare specifier resolves to. Ported from nub's
+//! `nub-phantom-core` (jdx/nub / nubjs/nub, MIT), unchanged.
+//!
+//! The package name is the unit the classifier reasons about: `lodash/fp` and
+//! `lodash/get` both depend on the package `lodash`; `@babel/core/lib/x` depends
+//! on `@babel/core`. A phantom is decided per package name, not per subpath.
+
+/// What kind of thing an import specifier points at.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SpecKind {
+    /// A relative or absolute path (`./x`, `../y`, `/abs`) — an intra-package
+    /// module edge. Followed during the graph walk; never a dependency.
+    Relative,
+    /// A subpath-`imports` reference (`#internal`) — resolved against the
+    /// package's own `imports` map; a self reference, never a dependency.
+    ImportsHash,
+    /// Not an installable npm package: a protocol URL (`http:`/`data:`/`file:`),
+    /// a framework virtual module (`$app`, `$env`), a bundler template placeholder
+    /// (`{{storiesFilename}}`), or a Node internal (`_http_common`). None can be a
+    /// phantom, so they are dropped rather than counted.
+    NonPackage,
+    /// A bare specifier naming an external package. Carries the resolved package
+    /// name (`@scope/name` or `name`).
+    Bare(String),
+}
+
+/// Classify a specifier string.
+pub fn classify(spec: &str) -> SpecKind {
+    if spec.is_empty() {
+        // Defensive: an empty specifier is not a package edge.
+        return SpecKind::Relative;
+    }
+    if spec.starts_with('#') {
+        return SpecKind::ImportsHash;
+    }
+    if spec.starts_with('.') || spec.starts_with('/') {
+        return SpecKind::Relative;
+    }
+    // A `node:` specifier is a builtin, not a URL — keep it as a bare reference so
+    // the classifier records it as a builtin (never a phantom).
+    if spec.starts_with("node:") {
+        return SpecKind::Bare(spec.to_string());
+    }
+    // A protocol specifier has a scheme before `:`. Any remaining `scheme:` is a
+    // URL-ish non-package (http/https/data/file/…).
+    if let Some(idx) = spec.find(':') {
+        // Windows-drive-letter paths (`C:\`) would also match, but tarball
+        // specifiers are POSIX; treat any pre-`:` scheme as a URL.
+        if idx > 0 && spec[..idx].bytes().all(|b| b.is_ascii_alphabetic()) {
+            return SpecKind::NonPackage;
+        }
+    }
+    let name = package_name(spec);
+    if !is_npm_name(&name) {
+        return SpecKind::NonPackage;
+    }
+    SpecKind::Bare(name)
+}
+
+/// Could `name` be an installable npm package name? A reference whose head cannot
+/// be one is a framework virtual (`$app`), a bundler/AMD placeholder or virtual id
+/// (`{{x}}`, `env!env`, `tanstack-manifest:v`), or another runtime's internal
+/// (`_http_common`) — never a phantom. The npm grammar allows only
+/// `[A-Za-z0-9._~-]` in the name (plus `@`/`/` for a scope); npm itself forbids a
+/// leading `_`/`.`, and this classifier additionally rejects a leading `$` (a
+/// framework virtual like `$app`) and `~` (a bundler `~/…` src-root alias like
+/// `~/components`) — neither begins a real npm package. Legacy uppercase
+/// (`JSONStream`) is allowed; any out-of-grammar character (`:`/`!`/`{`/
+/// whitespace/…) rejects. Deliberately permissive on the character SET so no real
+/// dependency is dropped.
+fn is_npm_name(name: &str) -> bool {
+    let head = name.strip_prefix('@').unwrap_or(name);
+    let Some(first) = head.chars().next() else {
+        return false;
+    };
+    if matches!(first, '_' | '.' | '$' | '~') {
+        return false;
+    }
+    name.chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | '_' | '~' | '@' | '/'))
+}
+
+/// Extract the package name from a bare specifier.
+///
+/// `@scope/name/sub` → `@scope/name`; `name/sub` → `name`; `name` → `name`.
+fn package_name(spec: &str) -> String {
+    if let Some(scoped) = spec.strip_prefix('@') {
+        // Scoped: keep `@scope/name` (first two segments).
+        let mut parts = scoped.splitn(3, '/');
+        let scope = parts.next().unwrap_or("");
+        match parts.next() {
+            Some(name) => format!("@{scope}/{name}"),
+            // `@scope` with no name is malformed; return as-is so it can't be
+            // silently treated as some other package.
+            None => format!("@{scope}"),
+        }
+    } else {
+        spec.split('/').next().unwrap_or(spec).to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SpecKind, classify};
+
+    #[test]
+    fn extracts_package_name_scoped_and_unscoped_with_subpaths() {
+        assert_eq!(classify("lodash"), SpecKind::Bare("lodash".into()));
+        assert_eq!(classify("lodash/fp"), SpecKind::Bare("lodash".into()));
+        assert_eq!(
+            classify("@babel/core"),
+            SpecKind::Bare("@babel/core".into())
+        );
+        assert_eq!(
+            classify("@babel/core/lib/index.js"),
+            SpecKind::Bare("@babel/core".into())
+        );
+    }
+
+    #[test]
+    fn separates_relative_hash_and_url_from_bare() {
+        assert_eq!(classify("./local"), SpecKind::Relative);
+        assert_eq!(classify("../up"), SpecKind::Relative);
+        assert_eq!(classify("#internal/x"), SpecKind::ImportsHash);
+        assert_eq!(classify("https://esm.sh/x"), SpecKind::NonPackage);
+        assert_eq!(classify("data:text/js,1"), SpecKind::NonPackage);
+    }
+
+    #[test]
+    fn rejects_non_npm_names_virtuals_placeholders_internals() {
+        // SvelteKit virtual, Storybook template placeholder, Node internal — none
+        // is an installable npm package, so none is a phantom.
+        assert_eq!(classify("$app/environment"), SpecKind::NonPackage);
+        assert_eq!(classify("{{storiesFilename}}"), SpecKind::NonPackage);
+        assert_eq!(classify("_http_common"), SpecKind::NonPackage);
+        assert_eq!(classify("env!env"), SpecKind::NonPackage); // AMD plugin id
+        assert_eq!(classify("tanstack-manifest:v"), SpecKind::NonPackage); // virtual id
+        // Bundler `~/…` src-root alias — project-local, not an npm package.
+        assert_eq!(classify("~/components/Button"), SpecKind::NonPackage);
+        // A legacy uppercase name is still a real package.
+        assert_eq!(classify("JSONStream"), SpecKind::Bare("JSONStream".into()));
+    }
+}

--- a/crates/aube-phantom-scan/Cargo.toml
+++ b/crates/aube-phantom-scan/Cargo.toml
@@ -1,0 +1,26 @@
+# aube-phantom-scan — the reachable-graph phantom SCANNER for `aube doctor`,
+# ported from nub's `nub-phantom-scan` (jdx/nub / nubjs/nub, MIT), trimmed to
+# the filesystem-backed walk only. nub's CAS-index variant (extract-time
+# scanning before a navigable tree exists) is specific to nub's own
+# package-linking pipeline and does not apply to diagnosing an
+# already-installed node_modules tree.
+[package]
+name = "aube-phantom-scan"
+description = "reachable-graph phantom-dependency scanner for Aube"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+include = ["src/**/*.rs"]
+
+[lib]
+name = "aube_phantom_scan"
+path = "src/lib.rs"
+
+[dependencies]
+aube-phantom-core = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/aube-phantom-scan/src/classify.rs
+++ b/crates/aube-phantom-scan/src/classify.rs
@@ -1,0 +1,315 @@
+//! Classify each referenced package against the manifest's declared surface.
+//!
+//! Aggregation rule: a package is HARD-needed if it is referenced by at least one
+//! UNGUARDED occurrence; it is soft only if EVERY occurrence is guarded (in a
+//! try/catch). The classification then answers the one question that matters —
+//! is this reference covered by something a consumer install makes resolvable?
+//!
+//! Ported from nub's `nub-phantom-scan` (jdx/nub / nubjs/nub, MIT), unchanged.
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+use crate::graph::Reference;
+use crate::manifest::Manifest;
+use aube_phantom_core::builtins::is_builtin;
+
+/// The verdict for one referenced package.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Verdict {
+    /// Undeclared and hard-required — a genuine phantom dependency.
+    HardPhantom,
+    /// Undeclared but only ever loaded under a try/catch — a soft/optional load,
+    /// not a hard break.
+    SoftPhantom,
+    /// Undeclared and reachable ONLY from the `.d.ts` type surface — a
+    /// type-position import that needs nothing at runtime, whether its types
+    /// come from a declared `@types/<pkg>` twin or the package's own bundled
+    /// types. NOT a phantom; excluded from compat targets. This is the class
+    /// that flagged `estree` (pnpm#13981) and, when gated on a declared
+    /// `@types/<pkg>` twin, `typescript` (pnpm#14128) — a type-only import is
+    /// not a runtime dependency regardless of where its types come from.
+    TypeOnly,
+    /// Declared as an OPTIONAL peer (`peerDependenciesMeta.<x>.optional`). NOT a
+    /// phantom — the pick-your-plugin pattern. Tracked so the report can show how
+    /// much a naive scan over-counts.
+    DeclaredOptionalPeer,
+    /// Declared as a required peer.
+    DeclaredPeer,
+    /// Declared in `dependencies`/`optionalDependencies`, or bundled.
+    Declared,
+    /// A Node builtin.
+    Builtin,
+    /// A self reference (the package's own name / subpath).
+    SelfRef,
+}
+
+/// One classified package reference.
+#[derive(Debug, Clone, Serialize)]
+pub struct Finding {
+    pub package: String,
+    pub verdict: Verdict,
+    /// True if every occurrence was guarded (try/catch or a conditional branch).
+    soft: bool,
+    /// Reachable from the package's main entry surface.
+    pub(crate) from_main: bool,
+    /// Reachable from a non-`.` `exports` subpath (the adapter surface).
+    pub(crate) from_subpath: bool,
+    /// Reachable from the `.d.ts` TYPE surface — a DECLARED PEER with this set is
+    /// the nub#450 peer-type class (its `@types/<peer>` must be project-local).
+    pub(crate) from_types: bool,
+    /// Example raw specifiers (deduped) showing how it was referenced.
+    pub specifiers: Vec<String>,
+}
+
+impl Finding {
+    /// The subpath-adapter class the GVS-default bug hinges on: a HARD phantom
+    /// reachable ONLY from a non-`.` `exports` subpath (not the main graph). This
+    /// is the `<pkg>/<adapter>` that statically imports a consumer-installed
+    /// backend it never declares (`@hookform/resolvers/zod` → `zod`).
+    pub fn is_subpath_adapter(&self) -> bool {
+        self.verdict == Verdict::HardPhantom && self.from_subpath && !self.from_main
+    }
+}
+
+/// Classify all references against `manifest`. Returns one `Finding` per distinct
+/// referenced package, sorted by package name.
+pub fn classify(manifest: &Manifest, references: &[Reference]) -> Vec<Finding> {
+    // Aggregate per package: soft-ness ANDs (hard wins), provenance ORs, collect
+    // example specs.
+    struct Agg {
+        all_soft: bool,
+        from_main: bool,
+        from_subpath: bool,
+        from_types: bool,
+        specs: Vec<String>,
+    }
+    let mut by_pkg: BTreeMap<String, Agg> = BTreeMap::new();
+    for r in references {
+        let e = by_pkg.entry(r.package.clone()).or_insert(Agg {
+            all_soft: true,
+            from_main: false,
+            from_subpath: false,
+            from_types: false,
+            specs: Vec::new(),
+        });
+        e.all_soft &= r.soft;
+        e.from_main |= r.from_main;
+        e.from_subpath |= r.from_subpath;
+        e.from_types |= r.from_types;
+        if !e.specs.contains(&r.raw) {
+            e.specs.push(r.raw.clone());
+        }
+    }
+
+    by_pkg
+        .into_iter()
+        .map(|(package, agg)| {
+            let base = verdict_for(manifest, &package, agg.all_soft);
+            // A reference reachable ONLY from the `.d.ts` type surface needs
+            // nothing at runtime, whether its types come from a declared
+            // `@types/<pkg>` twin (eslint/estree) or the package's own bundled
+            // types (typescript, zod) — reclassify it TypeOnly unconditionally
+            // so it never becomes a compat target. pnpm#14128: gating this on a
+            // declared `@types/<pkg>` twin flagged `@typescript-eslint/types`'s
+            // `import type { Program } from 'typescript'` as a HardPhantom,
+            // because there is no separate `@types/typescript` package to find —
+            // typescript ships its own types, so `types_satisfied` never held.
+            let type_surface_only = agg.from_types && !agg.from_main && !agg.from_subpath;
+            let verdict = if type_surface_only
+                && matches!(base, Verdict::HardPhantom | Verdict::SoftPhantom)
+            {
+                Verdict::TypeOnly
+            } else {
+                base
+            };
+            Finding {
+                package,
+                verdict,
+                soft: agg.all_soft,
+                from_main: agg.from_main,
+                from_subpath: agg.from_subpath,
+                from_types: agg.from_types,
+                specifiers: agg.specs,
+            }
+        })
+        .collect()
+}
+
+fn verdict_for(manifest: &Manifest, package: &str, all_soft: bool) -> Verdict {
+    if is_self(manifest, package) {
+        return Verdict::SelfRef;
+    }
+    if is_builtin(package) {
+        return Verdict::Builtin;
+    }
+    if manifest.deps.contains(package) || manifest.bundled.contains(package) {
+        return Verdict::Declared;
+    }
+    if manifest.optional_peers.contains(package) {
+        return Verdict::DeclaredOptionalPeer;
+    }
+    if manifest.required_peers.contains(package) {
+        return Verdict::DeclaredPeer;
+    }
+    // Undeclared.
+    if all_soft {
+        Verdict::SoftPhantom
+    } else {
+        Verdict::HardPhantom
+    }
+}
+
+/// A reference to the package's own name is a self import (resolvable via the
+/// package's own `exports`), never a phantom.
+fn is_self(manifest: &Manifest, package: &str) -> bool {
+    package == manifest.name
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Verdict, classify};
+    use crate::graph::Reference;
+    use crate::manifest::Manifest;
+
+    fn refs(items: &[(&str, &str, bool)]) -> Vec<Reference> {
+        items
+            .iter()
+            .map(|(p, raw, soft)| Reference {
+                package: (*p).to_string(),
+                raw: (*raw).to_string(),
+                soft: *soft,
+                from_main: true,
+                from_subpath: false,
+                from_types: false,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn declared_optional_peer_is_not_a_phantom() {
+        // @hookform/resolvers-style: zod is a DECLARED optional peer, referenced
+        // by the /zod subpath. Must NOT be flagged phantom.
+        let m = Manifest::parse(
+            br#"{"name":"@hookform/resolvers","peerDependencies":{"zod":"*"},
+                 "peerDependenciesMeta":{"zod":{"optional":true}}}"#,
+        )
+        .unwrap();
+        let f = classify(&m, &refs(&[("zod", "zod", false)]));
+        assert_eq!(f[0].verdict, Verdict::DeclaredOptionalPeer);
+    }
+
+    #[test]
+    fn undeclared_hard_require_is_a_phantom_soft_is_not() {
+        let m = Manifest::parse(br#"{"name":"pkg","dependencies":{"a":"1"}}"#).unwrap();
+        let f = classify(
+            &m,
+            &refs(&[
+                ("a", "a", false),         // declared
+                ("ghost", "ghost", false), // hard phantom
+                ("maybe", "maybe", true),  // soft phantom
+                ("fs", "fs", false),       // builtin
+            ]),
+        );
+        let v = |name: &str| f.iter().find(|x| x.package == name).unwrap().verdict;
+        assert_eq!(v("a"), Verdict::Declared);
+        assert_eq!(v("ghost"), Verdict::HardPhantom);
+        assert_eq!(v("maybe"), Verdict::SoftPhantom);
+        assert_eq!(v("fs"), Verdict::Builtin);
+    }
+
+    #[test]
+    fn one_hard_occurrence_beats_a_soft_one() {
+        // Same undeclared package referenced both guarded and unguarded → hard.
+        let m = Manifest::parse(br#"{"name":"pkg"}"#).unwrap();
+        let f = classify(&m, &refs(&[("x", "x", true), ("x", "x/sub", false)]));
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].verdict, Verdict::HardPhantom);
+        assert!(!f[0].soft);
+    }
+
+    #[test]
+    fn type_surface_only_is_type_only_not_a_phantom() {
+        // eslint/`estree` (pnpm#13981): `estree` is referenced only from a `.d.ts`
+        // type surface (from_types, not from_main/from_subpath), is undeclared,
+        // but its `@types/estree` twin is declared. It must be TypeOnly, not a
+        // HardPhantom, so it never becomes a compat target. A runtime import of an
+        // undeclared package stays a hard phantom.
+        let m =
+            Manifest::parse(br#"{"name":"eslint","dependencies":{"@types/estree":"*"}}"#).unwrap();
+        let estree = Reference {
+            package: "estree".into(),
+            raw: "estree".into(),
+            soft: false,
+            from_main: false,
+            from_subpath: false,
+            from_types: true,
+        };
+        let ghost = Reference {
+            package: "ghost".into(),
+            raw: "ghost".into(),
+            soft: false,
+            from_main: true,
+            from_subpath: false,
+            from_types: false,
+        };
+        let f = classify(&m, &[estree, ghost]);
+        let estree_v = f.iter().find(|x| x.package == "estree").unwrap();
+        let ghost_v = f.iter().find(|x| x.package == "ghost").unwrap();
+        assert_eq!(estree_v.verdict, Verdict::TypeOnly);
+        assert_eq!(ghost_v.verdict, Verdict::HardPhantom);
+    }
+
+    #[test]
+    fn type_surface_only_needs_no_types_twin_at_all() {
+        // pnpm#14128: `@typescript-eslint/types`'s only reference to `typescript`
+        // is `import type { Program } from 'typescript'` in a `.d.ts` file.
+        // Gating TypeOnly on a declared `@types/typescript` twin flagged this a
+        // HardPhantom, because typescript ships its own types — there is no
+        // separate `@types/typescript` package to find. A type-surface-only
+        // reference must be TypeOnly regardless of where (or whether) a types
+        // twin is declared, since it needs nothing at runtime either way.
+        let m = Manifest::parse(br#"{"name":"@typescript-eslint/types"}"#).unwrap();
+        let typescript = Reference {
+            package: "typescript".into(),
+            raw: "typescript".into(),
+            soft: false,
+            from_main: false,
+            from_subpath: false,
+            from_types: true,
+        };
+        let f = classify(&m, &[typescript]);
+        let v = f.iter().find(|x| x.package == "typescript").unwrap();
+        assert_eq!(v.verdict, Verdict::TypeOnly);
+    }
+
+    #[test]
+    fn subpath_only_hard_phantom_is_the_adapter_class() {
+        let m = Manifest::parse(br#"{"name":"@hookform/resolvers"}"#).unwrap();
+        // A hard phantom reached only from a subpath export is the adapter class;
+        // one reached from the main graph is not.
+        let subpath_only = Reference {
+            package: "zod".into(),
+            raw: "zod/v4/core".into(),
+            soft: false,
+            from_main: false,
+            from_subpath: true,
+            from_types: false,
+        };
+        let main_reached = Reference {
+            package: "junk".into(),
+            raw: "junk".into(),
+            soft: false,
+            from_main: true,
+            from_subpath: false,
+            from_types: false,
+        };
+        let f = classify(&m, &[subpath_only, main_reached]);
+        let zod = f.iter().find(|x| x.package == "zod").unwrap();
+        let junk = f.iter().find(|x| x.package == "junk").unwrap();
+        assert!(zod.is_subpath_adapter());
+        assert!(!junk.is_subpath_adapter());
+    }
+}

--- a/crates/aube-phantom-scan/src/graph.rs
+++ b/crates/aube-phantom-scan/src/graph.rs
@@ -1,0 +1,420 @@
+//! Walk the module graph reachable from a package's PUBLISHED entry points,
+//! collecting the bare-specifier occurrences seen along the way.
+//!
+//! Restricting to reachable files is what keeps a `devDependencies`-only import
+//! in a test/example file (never referenced by `exports`/`main`/`bin`) from being
+//! mistaken for a phantom: those files are simply never reached. Relative edges
+//! are followed (with Node-style extension/index resolution); bare edges become
+//! candidate dependencies.
+//!
+//! Ported from nub's `nub-phantom-scan` (jdx/nub / nubjs/nub, MIT), trimmed to
+//! the filesystem-backed walk only — nub's CAS-index variant (extract-time
+//! scanning before a navigable tree exists) is specific to nub's own
+//! package-linking pipeline and does not apply here.
+
+use std::collections::{BTreeMap, VecDeque};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::manifest::{Entry, EntryKind};
+use aube_phantom_core::extract::{Occurrence, extract};
+use aube_phantom_core::specifier::{self, SpecKind};
+
+/// Provenance bit: reached from the main surface (`main`/`bin`/`exports."."`).
+const FROM_MAIN: u8 = 0b001;
+/// Provenance bit: reached from a non-`.` `exports` subpath (the adapter surface).
+const FROM_SUBPATH: u8 = 0b010;
+/// Provenance bit: reached from the `.d.ts` TYPE surface (`types`/`typings`/an
+/// `exports` `types` condition/`index.d.ts`).
+const FROM_TYPES: u8 = 0b100;
+
+/// A bare-specifier reference collected from a reachable file.
+#[derive(Debug, Clone)]
+pub struct Reference {
+    /// Package name the specifier resolves to (`@scope/name` or `name`).
+    pub(crate) package: String,
+    /// The raw specifier (kept for the report — shows the exact subpath).
+    pub(crate) raw: String,
+    /// Guarded (try/catch or a conditional branch) at every occurrence collapses
+    /// to soft; a single unguarded occurrence makes the package hard.
+    pub(crate) soft: bool,
+    /// Reachable from the main entry surface.
+    pub(crate) from_main: bool,
+    /// Reachable from a non-`.` `exports` subpath — the "consumer opts into
+    /// `<pkg>/<subpath>`" adapter surface. A hard phantom reachable ONLY from a
+    /// subpath (not main) is the subpath-adapter class.
+    pub(crate) from_subpath: bool,
+    /// Reachable from the `.d.ts` TYPE surface.
+    pub(crate) from_types: bool,
+}
+
+/// Result of the reachable-module walk.
+#[derive(Debug, Default)]
+pub struct Walk {
+    pub references: Vec<Reference>,
+    pub files_analyzed: usize,
+    /// Relative imports that could not be resolved to a file on disk (a tell of
+    /// an incomplete install or an exotic resolver condition; reported, not fatal).
+    pub unresolved_relative: usize,
+}
+
+/// Cap the walk so a pathological package (thousands of files) can't stall a
+/// scan. Real published entry graphs are far smaller.
+const MAX_FILES: usize = 6000;
+
+/// Walk from `entry_points`, following relative edges and collecting bare
+/// references. Each reachable file accumulates a provenance mask (which entry
+/// surface(s) reach it); a bare reference inherits its file's final mask, so the
+/// report can separate subpath-adapter phantoms from main-graph ones.
+///
+/// Two phases keep provenance correct across diamonds: (1) BFS parses each file
+/// once (cached) and propagates provenance bits to fixpoint — a file re-reached
+/// with new bits is re-queued for propagation only, never re-parsed; (2) build
+/// references from the cache using each file's FINAL mask.
+pub fn walk(root: &Path, entry_points: &[Entry]) -> Walk {
+    let mut result = Walk::default();
+    let mut parsed: BTreeMap<PathBuf, Vec<Occurrence>> = BTreeMap::new();
+    let mut flags: BTreeMap<PathBuf, u8> = BTreeMap::new();
+    let mut queue: VecDeque<PathBuf> = VecDeque::new();
+
+    for ep in entry_points {
+        let prefer_dts = ep.kind == EntryKind::Types;
+        if let Some(resolved) = fs_resolve(root, root, &ep.path, prefer_dts, 0) {
+            let bit = match ep.kind {
+                EntryKind::Main => FROM_MAIN,
+                EntryKind::Subpath => FROM_SUBPATH,
+                EntryKind::Types => FROM_TYPES,
+            };
+            if add_flags(&mut flags, &resolved, bit) {
+                queue.push_back(resolved);
+            }
+        }
+    }
+
+    while let Some(file) = queue.pop_front() {
+        let fflags = *flags.get(&file).unwrap_or(&0);
+        // Parse once; a re-queue for provenance propagation reuses the cache.
+        if !parsed.contains_key(&file) {
+            if parsed.len() >= MAX_FILES {
+                continue;
+            }
+            let Ok(text) = fs::read_to_string(&file) else {
+                continue;
+            };
+            let rel = file
+                .strip_prefix(root)
+                .unwrap_or(&file)
+                .to_string_lossy()
+                .into_owned();
+            parsed.insert(file.clone(), extract(&rel, &text));
+        }
+        // Collect relative edges first (immutable borrow of the cache) then
+        // propagate — avoids holding a borrow across the flags mutation.
+        let mut targets = Vec::new();
+        for occ in &parsed[&file] {
+            if let SpecKind::Relative = specifier::classify(&occ.spec) {
+                let from_dir = file.parent().unwrap_or(root);
+                let prefer_dts = file
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(crate::manifest::is_dts_like);
+                match fs_resolve(root, from_dir, &occ.spec, prefer_dts, 0) {
+                    Some(t) => targets.push(t),
+                    None => result.unresolved_relative += 1,
+                }
+            }
+        }
+        // `ImportsHash` (self) and `NonPackage` (URL/virtual/internal) are not
+        // dependency edges; only `Bare` references are collected in phase 2.
+        for t in targets {
+            if add_flags(&mut flags, &t, fflags) {
+                queue.push_back(t);
+            }
+        }
+    }
+
+    result.files_analyzed = parsed.len();
+    for (file, occs) in &parsed {
+        let fflags = *flags.get(file).unwrap_or(&0);
+        for occ in occs {
+            if let SpecKind::Bare(package) = specifier::classify(&occ.spec) {
+                result.references.push(Reference {
+                    package,
+                    raw: occ.spec.clone(),
+                    soft: occ.soft,
+                    from_main: fflags & FROM_MAIN != 0,
+                    from_subpath: fflags & FROM_SUBPATH != 0,
+                    from_types: fflags & FROM_TYPES != 0,
+                });
+            }
+        }
+    }
+    result
+}
+
+/// OR `bit` into `key`'s provenance mask. Returns true if the mask GREW (new
+/// file, or new bits) — the caller then (re)queues it so the new provenance
+/// propagates to its edges. The 2-bit lattice bounds re-queues to ≤2 per file.
+fn add_flags(flags: &mut BTreeMap<PathBuf, u8>, key: &PathBuf, bit: u8) -> bool {
+    let entry = flags.entry(key.clone()).or_insert(0);
+    let before = *entry;
+    *entry |= bit;
+    *entry != before
+}
+
+/// Bound on `main`-chasing recursion. A dir whose `package.json` `main` points
+/// back at itself (`"."`/`""`/`"./"`) or a mutual `main` cycle across dirs would
+/// otherwise recurse forever → a stack-overflow ABORT that kills the whole scan
+/// (a process abort, not a catchable panic). Such manifests occur in the wild, so
+/// the cap is a hard robustness requirement, not a nicety.
+const MAX_RESOLVE_DEPTH: u32 = 16;
+
+/// Node-style RUNTIME resolution extensions, in priority order — used when
+/// resolving from a runtime (`.js`/`.ts`/SFC) source or a Main/Subpath entry.
+const JS_EXTS: [&str; 8] = ["js", "cjs", "mjs", "jsx", "ts", "tsx", "mts", "cts"];
+
+/// TypeScript DECLARATION extensions — used when resolving from a `.d.ts` source
+/// or a `Types` entry. A type-surface edge is resolved to `.d.ts` ONLY and never
+/// diverts to a `.js` sibling: the standard compiled layout ships `widgets.js`
+/// beside `widgets.d.ts`, and resolving a type re-export to the `.js` would both
+/// capture that `.js`'s RUNTIME imports as type references (over-flag) and skip
+/// the real `widgets.d.ts` (missed type imports).
+const DTS_EXTS: [&str; 3] = ["d.ts", "d.mts", "d.cts"];
+
+/// Extension ladder + file-acceptance predicate keyed to the resolution surface.
+/// The runtime surface admits JS/SFC files (byte-identical to the pre-type-surface
+/// behavior); the type surface admits `.d.ts` only.
+fn surface_exts(prefer_dts: bool) -> &'static [&'static str] {
+    if prefer_dts { &DTS_EXTS } else { &JS_EXTS }
+}
+
+fn resolvable_name(name: &str, prefer_dts: bool) -> bool {
+    if prefer_dts {
+        crate::manifest::is_dts_like(name)
+    } else {
+        crate::manifest::is_js_like(name) || crate::manifest::is_sfc_like(name)
+    }
+}
+
+/// On the type surface, TS resolves a `./widgets.js` re-export's TYPES at
+/// `./widgets.d.ts` (the NodeNext convention: the specifier keeps the runtime
+/// extension, the declaration sits beside it). Strip any runtime/declaration
+/// extension so the `.d.ts` ladder re-appends the declaration form. `./widgets` →
+/// `./widgets`; `./widgets.js` → `./widgets`; `./widgets.d.ts` → `./widgets`.
+fn dts_stem(spec: &str) -> &str {
+    for ext in [
+        ".d.ts", ".d.mts", ".d.cts", ".js", ".cjs", ".mjs", ".jsx", ".ts", ".tsx", ".mts", ".cts",
+    ] {
+        if let Some(stem) = spec.strip_suffix(ext) {
+            return stem;
+        }
+    }
+    spec
+}
+
+fn fs_resolve(
+    root: &Path,
+    from_dir: &Path,
+    spec: &str,
+    prefer_dts: bool,
+    depth: u32,
+) -> Option<PathBuf> {
+    if depth > MAX_RESOLVE_DEPTH {
+        return None;
+    }
+    // On the type surface, `./widgets.js` re-exports resolve types at
+    // `./widgets.d.ts`; strip the extension so the `.d.ts` ladder re-appends it.
+    let spec = if prefer_dts { dts_stem(spec) } else { spec };
+    let joined = from_dir.join(spec);
+    // Keep the walk inside the package tree (a `../../` that climbs out is not
+    // part of the published surface).
+    let base = normalize(&joined);
+    if !base.starts_with(root) {
+        return None;
+    }
+    let exts = surface_exts(prefer_dts);
+
+    // 1. Exact file (runtime surface only — the type surface always stems + appends).
+    if !prefer_dts && is_resolvable_file(&base, prefer_dts) {
+        return Some(base);
+    }
+    // 2. `base.<ext>`.
+    for ext in exts {
+        let cand = with_appended_ext(&base, ext);
+        if is_resolvable_file(&cand, prefer_dts) {
+            return Some(cand);
+        }
+    }
+    // 3. `base/index.<ext>`.
+    for ext in exts {
+        let cand = base.join(format!("index.{ext}"));
+        if is_resolvable_file(&cand, prefer_dts) {
+            return Some(cand);
+        }
+    }
+    // 4. `base/package.json` → its `types`/`main` (depth-bounded). The type surface
+    // chases `types`/`typings`; the runtime surface chases `main`.
+    let pkg = base.join("package.json");
+    if let Ok(raw) = fs::read(&pkg) {
+        if let Ok(v) = serde_json::from_slice::<serde_json::Value>(&raw)
+            && let Some(entry) = manifest_entry(&v, prefer_dts)
+        {
+            return fs_resolve(root, &base, &entry, prefer_dts, depth + 1);
+        }
+        // package.json with no entry → default `index.<ext>` in that dir.
+        for ext in exts {
+            let cand = base.join(format!("index.{ext}"));
+            if is_resolvable_file(&cand, prefer_dts) {
+                return Some(cand);
+            }
+        }
+    }
+    None
+}
+
+/// The relevant entry field of a nested `package.json` for the current surface:
+/// `types`/`typings` for the type walk, `main` for runtime.
+fn manifest_entry(v: &serde_json::Value, prefer_dts: bool) -> Option<String> {
+    let fields: &[&str] = if prefer_dts {
+        &["types", "typings"]
+    } else {
+        &["main"]
+    };
+    fields
+        .iter()
+        .find_map(|f| v.get(*f).and_then(|m| m.as_str()))
+        .map(str::to_string)
+}
+
+/// Existence + surface-appropriate extension check (`.d.ts` on the type surface,
+/// JS/SFC on the runtime surface).
+fn is_resolvable_file(p: &Path, prefer_dts: bool) -> bool {
+    if !p.is_file() {
+        return false;
+    }
+    let name = p.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    resolvable_name(name, prefer_dts)
+}
+
+/// Append an extension to a path's file name (`a/b` + `js` → `a/b.js`), rather
+/// than replacing an existing one (`a/b.min` must become `a/b.min.js`).
+fn with_appended_ext(base: &Path, ext: &str) -> PathBuf {
+    let mut s = base.as_os_str().to_os_string();
+    s.push(".");
+    s.push(ext);
+    PathBuf::from(s)
+}
+
+/// Lexically normalize `.`/`..` segments WITHOUT touching the filesystem (we do
+/// not want symlink resolution). Used only to enforce the stay-under-root
+/// invariant.
+fn normalize(p: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for comp in p.components() {
+        use std::path::Component::*;
+        match comp {
+            ParentDir => {
+                out.pop();
+            }
+            CurDir => {}
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::walk;
+    use crate::manifest::{Entry, EntryKind};
+    use std::fs;
+
+    fn scratch(name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "aube-phantom-graph-{}-{}",
+            name,
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn main_entry(path: &str) -> Entry {
+        Entry {
+            path: path.to_string(),
+            kind: EntryKind::Main,
+        }
+    }
+
+    #[test]
+    fn follows_relative_edges_collects_bare_ignores_unreached() {
+        let root = scratch("reach");
+        // entry → ./util (reached) imports "declared-dep"; orphan test file
+        // imports "dev-only" but is never referenced.
+        fs::write(
+            root.join("index.js"),
+            "require('./util'); require('real-dep');",
+        )
+        .unwrap();
+        fs::write(root.join("util.js"), "import x from 'util-dep';").unwrap();
+        fs::write(root.join("test.js"), "require('dev-only');").unwrap();
+
+        let w = walk(&root, &[main_entry("index.js")]);
+        let pkgs: Vec<_> = w.references.iter().map(|r| r.package.as_str()).collect();
+        assert!(pkgs.contains(&"real-dep"));
+        assert!(pkgs.contains(&"util-dep"));
+        assert!(
+            !pkgs.contains(&"dev-only"),
+            "unreached test file must not contribute"
+        );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn self_cyclic_main_does_not_stack_overflow() {
+        // A dir whose package.json `main` points back at itself would recurse
+        // forever without the depth cap → process abort, killing the whole scan.
+        let root = scratch("cycle");
+        fs::write(root.join("index.js"), "require('./lib');").unwrap();
+        fs::create_dir_all(root.join("lib")).unwrap();
+        fs::write(root.join("lib/package.json"), r#"{"main":"."}"#).unwrap();
+        // Must return (not abort); the cyclic dir simply resolves to nothing.
+        let w = walk(&root, &[main_entry("index.js")]);
+        assert_eq!(w.files_analyzed, 1); // only index.js; lib/ resolves to no file
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn subpath_provenance_separates_adapter_from_main_graph() {
+        let root = scratch("subpath");
+        // main graph imports `main-dep`; the `./zod` adapter subpath imports
+        // `backend-zod`. The zod import must carry from_subpath && !from_main.
+        fs::write(root.join("index.js"), "require('main-dep');").unwrap();
+        fs::write(root.join("zod.js"), "import 'backend-zod';").unwrap();
+
+        let w = walk(
+            &root,
+            &[
+                main_entry("index.js"),
+                Entry {
+                    path: "zod.js".to_string(),
+                    kind: EntryKind::Subpath,
+                },
+            ],
+        );
+        let zod = w
+            .references
+            .iter()
+            .find(|r| r.package == "backend-zod")
+            .unwrap();
+        assert!(zod.from_subpath && !zod.from_main, "adapter-only backend");
+        let main = w
+            .references
+            .iter()
+            .find(|r| r.package == "main-dep")
+            .unwrap();
+        assert!(main.from_main && !main.from_subpath, "main-graph dep");
+        let _ = fs::remove_dir_all(&root);
+    }
+}

--- a/crates/aube-phantom-scan/src/graph.rs
+++ b/crates/aube-phantom-scan/src/graph.rs
@@ -229,7 +229,11 @@ fn fs_resolve(
     // Keep the walk inside the package tree (a `../../` that climbs out is not
     // part of the published surface).
     let base = normalize(&joined);
-    if !base.starts_with(root) {
+    // `root` itself must go through the same lexical normalization as `base` —
+    // a caller-supplied root carrying a `.`/`..` component (e.g.
+    // `./node_modules/foo`) would otherwise never satisfy `starts_with` against
+    // the normalized `base`, silently resolving nothing.
+    if !base.starts_with(normalize(root)) {
         return None;
     }
     let exts = surface_exts(prefer_dts);
@@ -345,6 +349,27 @@ mod tests {
             path: path.to_string(),
             kind: EntryKind::Main,
         }
+    }
+
+    #[test]
+    fn root_with_a_dot_component_still_resolves() {
+        // A caller passing `root` with a lexical `.`/`..` component (e.g. via
+        // `some_dir.join("./node_modules/foo")`) must still walk correctly —
+        // `root` needs the same normalization `base` already gets, or the
+        // `starts_with` containment check never matches and the walk silently
+        // resolves nothing.
+        let real_root = scratch("dot-root");
+        fs::write(real_root.join("index.js"), "require('real-dep');").unwrap();
+        let dotted_root = real_root.join(".");
+
+        let w = walk(&dotted_root, &[main_entry("index.js")]);
+        assert_eq!(w.files_analyzed, 1, "entry must resolve through a dotted root");
+        assert!(
+            w.references.iter().any(|r| r.package == "real-dep"),
+            "reference must be collected: {:?}",
+            w.references
+        );
+        let _ = fs::remove_dir_all(&real_root);
     }
 
     #[test]

--- a/crates/aube-phantom-scan/src/lib.rs
+++ b/crates/aube-phantom-scan/src/lib.rs
@@ -1,0 +1,110 @@
+//! aube-phantom-scan — scan an already-installed package's PUBLISHED,
+//! reachable code for UNDECLARED (phantom) dependencies, for `aube doctor`.
+//!
+//! Ported from nub's `nub-phantom-scan` (jdx/nub / nubjs/nub, MIT). nub reduces
+//! the same walk + classify pipeline to a boolean eject decision consumed by its
+//! install pipeline; `aube doctor` only needs the classified [`classify::Finding`]
+//! list to report, so this crate stops at [`scan`] rather than nub's
+//! `ScanResult`/`scan_extracted`/`scan_index` reduction.
+//!
+//! The pipeline: walk the module graph from `exports`/`main`/`bin` → extract
+//! import/require specifiers (via `aube-phantom-core`'s oxc parser) → classify
+//! each against the declared surface.
+
+pub mod classify;
+pub mod graph;
+pub mod manifest;
+
+use std::path::Path;
+
+pub use classify::{Finding, Verdict};
+use manifest::Manifest;
+
+/// Scan an already-installed package tree rooted at `root` (the dir holding
+/// `package.json`) and classify every reachable bare reference. Returns `None`
+/// when the tree has no parseable `package.json` — the caller treats it as
+/// "nothing to report", never a hard failure.
+pub fn scan(root: &Path) -> Option<Vec<Finding>> {
+    let raw = std::fs::read(root.join("package.json")).ok()?;
+    let manifest = Manifest::parse(&raw)?;
+    let walk = graph::walk(root, &manifest.entry_points);
+    Some(classify::classify(&manifest, &walk.references))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::scan;
+    use std::fs;
+
+    fn scratch(name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "aube-phantom-scan-e2e-{}-{}",
+            name,
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn flags_hard_phantoms_only() {
+        let root = scratch("fixture");
+        fs::write(
+            root.join("package.json"),
+            r#"{
+                "name": "demo",
+                "main": "index.js",
+                "dependencies": { "declared-dep": "1" },
+                "peerDependencies": { "zod": "*" },
+                "peerDependenciesMeta": { "zod": { "optional": true } }
+            }"#,
+        )
+        .unwrap();
+        fs::write(
+            root.join("index.js"),
+            r#"const a = require('declared-dep');
+               const ghost = require('undeclared-ghost');
+               let opt; try { opt = require('soft-ghost'); } catch {}
+               let z; try { z = require('zod'); } catch {}"#,
+        )
+        .unwrap();
+
+        let findings = scan(&root).unwrap();
+        let verdict = |name: &str| findings.iter().find(|f| f.package == name).unwrap().verdict;
+        assert_eq!(verdict("declared-dep"), super::Verdict::Declared);
+        assert_eq!(verdict("undeclared-ghost"), super::Verdict::HardPhantom);
+        assert_eq!(verdict("soft-ghost"), super::Verdict::SoftPhantom);
+        assert_eq!(verdict("zod"), super::Verdict::DeclaredOptionalPeer);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn type_only_reference_to_a_self_typed_package_is_never_a_phantom() {
+        // Regression: pnpm#14128 / nub's classify.rs fix. A type-only reference
+        // reachable only from the `.d.ts` surface must classify TypeOnly even
+        // when the referenced package (here, a stand-in for `typescript`) ships
+        // its own types and has no separate `@types/<pkg>` twin declared.
+        let root = scratch("dts-fixture");
+        fs::write(
+            root.join("package.json"),
+            r#"{"name":"demo","main":"index.js","types":"index.d.ts"}"#,
+        )
+        .unwrap();
+        fs::write(root.join("index.js"), "module.exports = {};").unwrap();
+        fs::write(
+            root.join("index.d.ts"),
+            "import type { Program } from 'self-typed-pkg';\nexport declare const x: Program;\n",
+        )
+        .unwrap();
+
+        let findings = scan(&root).unwrap();
+        let verdict = findings
+            .iter()
+            .find(|f| f.package == "self-typed-pkg")
+            .unwrap()
+            .verdict;
+        assert_eq!(verdict, super::Verdict::TypeOnly);
+        let _ = fs::remove_dir_all(&root);
+    }
+}

--- a/crates/aube-phantom-scan/src/manifest.rs
+++ b/crates/aube-phantom-scan/src/manifest.rs
@@ -1,0 +1,484 @@
+//! Parse a package's `package.json` into (a) its DECLARED dependency surface —
+//! the sets a specifier is checked against — and (b) its published ENTRY POINTS,
+//! the roots of the reachable-module walk. Ported from nub's
+//! `nub-phantom-scan` (jdx/nub / nubjs/nub, MIT), unchanged.
+//!
+//! The declared surface deliberately mirrors what a consumer install actually
+//! makes resolvable at runtime: `dependencies`, `optionalDependencies`, and
+//! `peerDependencies` (split by the `peerDependenciesMeta.<x>.optional` flag),
+//! plus bundled deps. `devDependencies` are intentionally EXCLUDED — they are not
+//! installed for consumers, so an import of one from published code is a phantom.
+
+use std::collections::BTreeSet;
+
+use serde_json::Value;
+
+/// The declared dependency surface a specifier is classified against.
+#[derive(Debug, Default)]
+pub struct Manifest {
+    pub name: String,
+    /// `dependencies` ∪ `optionalDependencies` — hard-declared, always resolvable.
+    pub(crate) deps: BTreeSet<String>,
+    /// Required peers (`peerDependencies` without an `optional` meta flag).
+    pub(crate) required_peers: BTreeSet<String>,
+    /// Optional peers (`peerDependenciesMeta.<x>.optional === true`). Declared —
+    /// NOT phantoms — but reported as their own category (the pick-your-plugin
+    /// pattern that a naive detector over-flags).
+    pub(crate) optional_peers: BTreeSet<String>,
+    /// `bundledDependencies` / `bundleDependencies` — shipped inside the tarball.
+    pub(crate) bundled: BTreeSet<String>,
+    /// `devDependencies` — NOT part of the runtime-resolvable surface (kept out of
+    /// `deps` for that reason), but tracked separately ONLY so a TYPE-surface
+    /// import of `<pkg>` can be considered satisfied when `@types/<pkg>` is
+    /// declared here. It never counts toward runtime resolution.
+    pub(crate) dev_deps: BTreeSet<String>,
+    /// Published entry files (relative paths from the package root) — the roots
+    /// of the reachable-module walk, each tagged by whether it is the main entry
+    /// or a non-`.` `exports` subpath (the adapter surface).
+    pub entry_points: Vec<Entry>,
+}
+
+/// Which published surface an entry belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EntryKind {
+    /// `main` / `module` / `bin` / the `exports."."` root.
+    Main,
+    /// A non-`.` `exports` subpath (`./zod`, `./vitest`) — the adapter surface a
+    /// consumer opts into by importing `<pkg>/<subpath>`.
+    Subpath,
+    /// A `.d.ts` TYPE surface (`types`/`typings` field, an `exports` `types`
+    /// condition, or the `index.d.ts` default) — the root of the declaration-file
+    /// graph. Reached references carry `from_types` so a type-position peer import
+    /// (`import * as React from 'react'` in a `.d.ts`) is separable from a runtime
+    /// one; this is what drives the nub#450 `@types/<peer>` reachability eject
+    /// without touching runtime-phantom detection.
+    Types,
+}
+
+/// A published entry file + its surface kind.
+#[derive(Debug, Clone)]
+pub struct Entry {
+    pub(crate) path: String,
+    pub(crate) kind: EntryKind,
+}
+
+impl Manifest {
+    /// Parse from raw `package.json` bytes. Returns `None` if the JSON is
+    /// unparseable or has no name (a package with no identity can't be analyzed).
+    pub fn parse(raw: &[u8]) -> Option<Manifest> {
+        let v: Value = serde_json::from_slice(raw).ok()?;
+        let name = v.get("name")?.as_str()?.to_string();
+
+        let mut m = Manifest {
+            name: name.clone(),
+            ..Default::default()
+        };
+
+        collect_keys(&v, "dependencies", &mut m.deps);
+        collect_keys(&v, "optionalDependencies", &mut m.deps);
+        collect_keys(&v, "peerDependencies", &mut m.required_peers);
+        collect_keys(&v, "devDependencies", &mut m.dev_deps);
+
+        // Move any peer flagged optional out of required_peers into optional_peers.
+        if let Some(meta) = v.get("peerDependenciesMeta").and_then(Value::as_object) {
+            for (peer, cfg) in meta {
+                let optional = cfg
+                    .get("optional")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                if optional {
+                    m.required_peers.remove(peer);
+                    m.optional_peers.insert(peer.clone());
+                }
+            }
+        }
+
+        collect_bundled(&v, &mut m.bundled);
+        m.entry_points = collect_entry_points(&v);
+        Some(m)
+    }
+}
+
+fn collect_keys(v: &Value, field: &str, out: &mut BTreeSet<String>) {
+    if let Some(obj) = v.get(field).and_then(Value::as_object) {
+        for k in obj.keys() {
+            out.insert(k.clone());
+        }
+    }
+}
+
+/// `bundledDependencies`/`bundleDependencies` is an ARRAY of names (both spellings
+/// are valid npm).
+fn collect_bundled(v: &Value, out: &mut BTreeSet<String>) {
+    for field in ["bundledDependencies", "bundleDependencies"] {
+        if let Some(arr) = v.get(field).and_then(Value::as_array) {
+            for item in arr {
+                if let Some(s) = item.as_str() {
+                    out.insert(s.to_string());
+                }
+            }
+        }
+    }
+}
+
+/// Gather the published entry files from `main`, `module`, `bin`, and `exports`,
+/// each tagged Main or Subpath, PLUS the `.d.ts` TYPE surface (`types`/`typings`,
+/// `exports` `types` conditions, or the TS default roots) tagged Types. A
+/// recognized JS file is kept directly; an extensionless / directory-style target
+/// (`"./dist/index"`, `"./dist"`) is kept as a candidate and resolved Node-style
+/// by the graph walk; non-JS asset conditions (`.json`/`.node`/`.wasm`/`.css`)
+/// carry no analyzable imports and are filtered.
+fn collect_entry_points(v: &Value) -> Vec<Entry> {
+    // Dedup on (kind, path) so a file exported at both `.` and a subpath seeds
+    // both surfaces into the walk.
+    let mut seen: BTreeSet<(u8, String)> = BTreeSet::new();
+    let mut out = Vec::new();
+    let mut push =
+        |p: &str, kind: EntryKind, out: &mut Vec<Entry>, seen: &mut BTreeSet<(u8, String)>| {
+            let norm = normalize_rel(p);
+            let key = (kind as u8, norm.clone());
+            if is_entry_candidate(&norm) && seen.insert(key) {
+                out.push(Entry { path: norm, kind });
+            }
+        };
+
+    for field in ["main", "module"] {
+        if let Some(s) = v.get(field).and_then(Value::as_str) {
+            push(s, EntryKind::Main, &mut out, &mut seen);
+        }
+    }
+
+    match v.get("bin") {
+        Some(Value::String(s)) => push(s, EntryKind::Main, &mut out, &mut seen),
+        Some(Value::Object(map)) => {
+            for b in map.values() {
+                if let Some(s) = b.as_str() {
+                    push(s, EntryKind::Main, &mut out, &mut seen);
+                }
+            }
+        }
+        _ => {}
+    }
+
+    // The top level of `exports` decides the kind: a `.`-keyed subpath map splits
+    // `.` (Main) from every `./x` (Subpath); a bare condition map or string is the
+    // main entry (sugar for `.`).
+    if let Some(exports) = v.get("exports") {
+        match exports {
+            Value::Object(map) if map.keys().any(|k| k.starts_with('.')) => {
+                for (k, child) in map {
+                    let kind = if k == "." {
+                        EntryKind::Main
+                    } else {
+                        EntryKind::Subpath
+                    };
+                    walk_exports(child, kind, &mut out, &mut seen, &mut push);
+                }
+            }
+            other => walk_exports(other, EntryKind::Main, &mut out, &mut seen, &mut push),
+        }
+    }
+
+    // Fallback: a package with no explicit entry resolves `./index.js` (Node's
+    // default main). Give the walk a root so an entry-less legacy package is
+    // still analyzed.
+    if out.is_empty() {
+        out.push(Entry {
+            path: "index.js".to_string(),
+            kind: EntryKind::Main,
+        });
+    }
+
+    // TYPE-surface roots (`.d.ts`) — the explicit `types`/`typings` field and every
+    // `exports` `types` condition, else the TS default roots. Seeded as
+    // `EntryKind::Types` so reached references carry `from_types` (nub#450). Runtime
+    // entry collection above is untouched.
+    let mut type_targets: Vec<String> = Vec::new();
+    for field in ["types", "typings"] {
+        if let Some(s) = v.get(field).and_then(Value::as_str) {
+            type_targets.push(s.to_string());
+        }
+    }
+    if let Some(exports) = v.get("exports") {
+        collect_export_types(exports, &mut type_targets);
+    }
+    if type_targets.is_empty() {
+        // No explicit type surface → TS's defaults: each Main entry's colocated
+        // declaration (`x.js` → `x.d.ts`, `./dist` → `./dist/index.d.ts`) plus the
+        // root `index.d.ts`. The Types-surface resolver stems the runtime extension
+        // and re-appends `.d.ts` (see `graph::dts_stem`), so the RAW main path is
+        // passed through and resolves to its declaration — no path rewrite here.
+        // Only synthesized when no explicit `types` exists; an authoritative field
+        // must not be shadowed by a default that may not exist.
+        let colocated: Vec<String> = out
+            .iter()
+            .filter(|e| e.kind == EntryKind::Main)
+            .map(|e| e.path.clone())
+            .collect();
+        type_targets.extend(colocated);
+        type_targets.push("index.d.ts".to_string());
+    }
+    for p in &type_targets {
+        push(p, EntryKind::Types, &mut out, &mut seen);
+    }
+
+    out
+}
+
+/// Recursively gather every `types`/`typings` condition target inside an
+/// `exports` subtree (the type surface of `.` and every subpath).
+fn collect_export_types(node: &Value, out: &mut Vec<String>) {
+    match node {
+        Value::Object(map) => {
+            for (k, child) in map {
+                if (k == "types" || k == "typings")
+                    && let Some(s) = child.as_str()
+                {
+                    out.push(s.to_string());
+                } else {
+                    collect_export_types(child, out);
+                }
+            }
+        }
+        Value::Array(arr) => {
+            for child in arr {
+                collect_export_types(child, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Recursively collect every relative-path leaf of an `exports` subtree, carrying
+/// the surface `kind` down. Skips `types`/`typings` (they point at `.d.ts`).
+fn walk_exports(
+    node: &Value,
+    kind: EntryKind,
+    out: &mut Vec<Entry>,
+    seen: &mut BTreeSet<(u8, String)>,
+    push: &mut impl FnMut(&str, EntryKind, &mut Vec<Entry>, &mut BTreeSet<(u8, String)>),
+) {
+    match node {
+        Value::String(s) => push(s, kind, out, seen),
+        Value::Object(map) => {
+            for (k, child) in map {
+                if k == "types" || k == "typings" {
+                    continue;
+                }
+                walk_exports(child, kind, out, seen, push);
+            }
+        }
+        Value::Array(arr) => {
+            for child in arr {
+                walk_exports(child, kind, out, seen, push);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Strip a leading `./` and collapse a leading `/`; entry paths are relative to
+/// the package root.
+fn normalize_rel(p: &str) -> String {
+    p.trim_start_matches("./")
+        .trim_start_matches('/')
+        .to_string()
+}
+
+/// Whether a `main`/`module`/`bin`/`exports` target should SEED the reachable
+/// walk. Admits a recognized JS file (parsed directly) OR an EXTENSIONLESS /
+/// directory-style target — Node resolves `"./dist/index"` → `./dist/index.js`
+/// and `"./dist"` → `./dist/index.js` at runtime, and the graph walk's
+/// `resolve_entry` runs that SAME ladder, so on-disk resolution is deferred to
+/// it (a path that resolves to nothing is simply never analyzed — no false
+/// entry). A non-JS asset/type extension (`.json`/`.node`/`.wasm`/`.css`, a
+/// `.d.ts` stub) carries no analyzable imports, so it is dropped here and never
+/// costs a resolver probe. The `is_js_like`-only gate this replaced dropped
+/// extensionless mains outright → `files_analyzed: 0` → every phantom missed.
+fn is_entry_candidate(path: &str) -> bool {
+    is_js_like(path) || is_sfc_like(path) || is_dts_like(path) || extension(path).is_none()
+}
+
+/// A TypeScript declaration file (`.d.ts`/`.d.mts`/`.d.cts`) — the type surface a
+/// `Types` entry seeds and the file class the graph walk resolves for that entry.
+pub(crate) fn is_dts_like(path: &str) -> bool {
+    path.ends_with(".d.ts") || path.ends_with(".d.mts") || path.ends_with(".d.cts")
+}
+
+/// A JS-like runtime file (extension we can parse for imports). Excludes `.json`,
+/// `.node`, `.wasm`, `.css`, and `.d.ts` type stubs.
+pub(crate) fn is_js_like(path: &str) -> bool {
+    if path.ends_with(".d.ts") || path.ends_with(".d.mts") || path.ends_with(".d.cts") {
+        return false;
+    }
+    matches!(
+        extension(path),
+        Some("js" | "cjs" | "mjs" | "jsx" | "ts" | "tsx" | "mts" | "cts")
+    )
+}
+
+/// A single-file component (Astro/Vue/Svelte) whose imports live in a
+/// frontmatter / `<script>` block. Under the global virtual store a backend it
+/// imports there — even for TYPES ONLY — still needs project-local
+/// materialization: the package's realpath escapes into the shared store, so a
+/// type-checker's upward `node_modules` walk can't reach the hoisted backend
+/// otherwise (nub#450). The graph walk resolves these and `extract` reads their
+/// script region.
+pub(crate) fn is_sfc_like(path: &str) -> bool {
+    matches!(extension(path), Some("astro" | "vue" | "svelte"))
+}
+
+fn extension(path: &str) -> Option<&str> {
+    let file = path.rsplit('/').next().unwrap_or(path);
+    file.rsplit_once('.').map(|(_, e)| e)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Manifest;
+
+    #[test]
+    fn splits_optional_peers_out_of_required_and_excludes_dev() {
+        let raw = br#"{
+            "name": "pkg",
+            "dependencies": { "a": "1" },
+            "devDependencies": { "jest": "1" },
+            "peerDependencies": { "react": "*", "zod": "*" },
+            "peerDependenciesMeta": { "zod": { "optional": true } }
+        }"#;
+        let m = Manifest::parse(raw).unwrap();
+        assert!(m.deps.contains("a"));
+        // devDependencies are NOT in any resolvable set → phantom-eligible.
+        assert!(!m.deps.contains("jest") && !m.required_peers.contains("jest"));
+        assert!(m.required_peers.contains("react"));
+        assert!(m.optional_peers.contains("zod")); // optional peer moved out of required
+        assert!(!m.required_peers.contains("zod"));
+    }
+
+    #[test]
+    fn collects_entry_points_from_exports_including_type_surface() {
+        let raw = br#"{
+            "name": "pkg",
+            "exports": {
+                ".": { "import": "./dist/index.mjs", "require": "./dist/index.cjs", "types": "./dist/index.d.ts" },
+                "./sub": "./dist/sub.js"
+            }
+        }"#;
+        let m = Manifest::parse(raw).unwrap();
+        let entry = |p: &str| m.entry_points.iter().find(|e| e.path == p);
+        assert_eq!(
+            entry("dist/index.mjs").unwrap().kind,
+            super::EntryKind::Main
+        );
+        assert_eq!(
+            entry("dist/index.cjs").unwrap().kind,
+            super::EntryKind::Main
+        );
+        // `./sub` is a non-`.` export → the adapter surface.
+        assert_eq!(
+            entry("dist/sub.js").unwrap().kind,
+            super::EntryKind::Subpath
+        );
+        // The `types` condition IS collected — as a Types entry, the `.d.ts` type
+        // surface the peer-type walk seeds (nub#450). An explicit `types` suppresses
+        // the `index.d.ts` fallback, so no synthesized default appears.
+        assert_eq!(
+            entry("dist/index.d.ts").unwrap().kind,
+            super::EntryKind::Types
+        );
+        assert!(!m.entry_points.iter().any(|e| e.path == "index.d.ts"));
+    }
+
+    #[test]
+    fn synthesizes_default_type_roots_only_without_explicit_types() {
+        // No `types` field / `exports` types condition → TS's defaults: each Main
+        // entry's colocated `.d.ts` plus the root `index.d.ts`, all as Types
+        // entries (nub#450). react-pdf's shape (no types field, real index.d.ts).
+        let m = Manifest::parse(br#"{"name":"p","main":"./index.js"}"#).unwrap();
+        let types: Vec<&str> = m
+            .entry_points
+            .iter()
+            .filter(|e| e.kind == super::EntryKind::Types)
+            .map(|e| e.path.as_str())
+            .collect();
+        assert!(
+            types.contains(&"index.d.ts"),
+            "root index.d.ts default: {types:?}"
+        );
+    }
+
+    #[test]
+    fn direct_sfc_export_is_collected_as_entry() {
+        // A package publishing an .astro/.vue/.svelte directly (not via a JS
+        // re-export) must still be scanned, or its type-only phantoms are missed
+        // under GVS (nub#450, codex review P1).
+        let raw = br#"{
+            "name": "pkg",
+            "exports": { "./Icon": "./components/Icon.astro", "./Widget": "./Widget.vue" }
+        }"#;
+        let m = Manifest::parse(raw).unwrap();
+        assert_eq!(
+            m.entry_points
+                .iter()
+                .find(|e| e.path == "components/Icon.astro")
+                .unwrap()
+                .kind,
+            super::EntryKind::Subpath
+        );
+        assert!(m.entry_points.iter().any(|e| e.path == "Widget.vue"));
+    }
+
+    #[test]
+    fn keeps_extensionless_and_directory_entries_drops_asset_mains() {
+        // The recall bug: an extensionless `main` (Node resolves `./dist/index`
+        // → `./dist/index.js`) must survive as a candidate for the graph walk to
+        // resolve — not be dropped for lacking a literal JS extension. A
+        // directory-style main is the same shape. `.json`/`.node`/`.d.ts` targets
+        // carry no analyzable imports and stay filtered.
+        let has = |m: &Manifest, p: &str| m.entry_points.iter().any(|e| e.path == p);
+
+        let ext = Manifest::parse(br#"{"name":"p","main":"./dist/index"}"#).unwrap();
+        assert!(
+            has(&ext, "dist/index"),
+            "extensionless main kept as candidate"
+        );
+
+        let dir = Manifest::parse(br#"{"name":"p","main":"./dist"}"#).unwrap();
+        assert!(has(&dir, "dist"), "directory-style main kept as candidate");
+
+        let json = Manifest::parse(br#"{"name":"p","main":"./data.json"}"#).unwrap();
+        assert!(
+            !has(&json, "data.json"),
+            ".json main dropped (not analyzable)"
+        );
+        // No RUNTIME entry survived → the entry-less fallback (`index.js`) seeds it.
+        // (A synthesized `index.d.ts` Types entry also appears — the type-surface
+        // default — so filter to the Main surface here.)
+        let mains: Vec<&str> = json
+            .entry_points
+            .iter()
+            .filter(|e| e.kind == super::EntryKind::Main)
+            .map(|e| e.path.as_str())
+            .collect();
+        assert_eq!(mains, vec!["index.js"]);
+
+        let native = Manifest::parse(br#"{"name":"p","main":"./addon.node"}"#).unwrap();
+        assert!(!has(&native, "addon.node"), ".node main dropped");
+
+        // Extensionless conditional target inside an `exports` map is admitted too,
+        // and its `types` condition is collected as the Types surface.
+        let exp = Manifest::parse(
+            br#"{"name":"p","exports":{".":{"import":"./dist/index","types":"./dist/index.d.ts"}}}"#,
+        )
+        .unwrap();
+        assert!(has(&exp, "dist/index"), "extensionless exports target kept");
+        assert_eq!(
+            exp.entry_points
+                .iter()
+                .find(|e| e.path == "dist/index.d.ts")
+                .unwrap()
+                .kind,
+            super::EntryKind::Types
+        );
+    }
+}

--- a/crates/aube/Cargo.toml
+++ b/crates/aube/Cargo.toml
@@ -43,6 +43,7 @@ aube-codes = { workspace = true }
 aube-lockfile = { workspace = true }
 aube-runtime = { workspace = true }
 aube-manifest = { workspace = true }
+aube-phantom-scan = { workspace = true }
 aube-registry = { workspace = true }
 aube-util = { workspace = true }
 aube-resolver = { workspace = true }

--- a/crates/aube/src/commands/doctor.rs
+++ b/crates/aube/src/commands/doctor.rs
@@ -113,6 +113,7 @@ fn build_report(anchor: &Path, in_project: bool) -> miette::Result<Report> {
         check_install_state(anchor, &mut report);
         check_foreign_package_manager_dirs(anchor, &mut report);
         check_virtual_store_links(anchor, &mut report)?;
+        check_phantom_dependencies(anchor, &mut report);
     } else {
         let mut s = Section::new("project");
         s.push(
@@ -364,6 +365,55 @@ fn check_foreign_package_manager_dirs(anchor: &Path, report: &mut Report) {
     }
 }
 
+/// Scan every direct dependency's published code for a phantom import — a
+/// static import its own `package.json` does not declare. Resolves by
+/// accident under npm's flat `node_modules`; breaks under aube's strict,
+/// symlinked virtual store. Scoped to DIRECT deps only, one level deep: a
+/// transitive phantom is that transitive dependency's own maintainer's
+/// problem, surfaced when doctor runs against that package's own repo.
+fn check_phantom_dependencies(anchor: &Path, report: &mut Report) {
+    let Ok(manifest) = aube_manifest::PackageJson::from_path(&anchor.join("package.json")) else {
+        return;
+    };
+    let modules_dir = super::project_modules_dir(anchor);
+    let mut direct: Vec<&str> = manifest.dependencies.keys().map(String::as_str).collect();
+    direct.extend(manifest.optional_dependencies.keys().map(String::as_str));
+    direct.sort_unstable();
+    direct.dedup();
+    let declared_at_root: std::collections::BTreeSet<&str> = direct.iter().copied().collect();
+
+    for dep_name in direct {
+        let dep_dir = modules_dir.join(dep_name);
+        if !dep_dir.join("package.json").is_file() {
+            continue;
+        }
+        let Some(findings) = aube_phantom_scan::scan(&dep_dir) else {
+            continue;
+        };
+        for finding in findings {
+            if finding.verdict != aube_phantom_scan::Verdict::HardPhantom {
+                continue;
+            }
+            // Already declared at the project root — the flat layout resolves it
+            // the same way a direct root dependency does, so it is not phantom
+            // from the consumer's perspective even if this dep's OWN manifest
+            // does not declare it.
+            if declared_at_root.contains(finding.package.as_str()) {
+                continue;
+            }
+            let adapter = if finding.is_subpath_adapter() {
+                " (reachable only via a subpath import)"
+            } else {
+                ""
+            };
+            report.warnings.push(format!(
+                "{dep_name} imports '{}' without declaring it{adapter}",
+                finding.package
+            ));
+        }
+    }
+}
+
 fn check_virtual_store_links(anchor: &Path, report: &mut Report) -> miette::Result<()> {
     let links = super::check::run_report(anchor).wrap_err("failed to walk the virtual store")?;
     if !links.issues.is_empty() {
@@ -490,5 +540,38 @@ mod tests {
         .unwrap();
         let report = build_report(cwd, true).unwrap();
         assert!(report.sections.iter().any(|s| s.title == "project"));
+    }
+
+    #[test]
+    fn flags_a_direct_dependency_with_an_undeclared_import() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cwd = tmp.path();
+        std::fs::write(
+            cwd.join("package.json"),
+            r#"{"name":"demo","dependencies":{"dep-with-phantom":"1.0.0"}}"#,
+        )
+        .unwrap();
+        let dep_dir = crate::commands::project_modules_dir(cwd).join("dep-with-phantom");
+        std::fs::create_dir_all(&dep_dir).unwrap();
+        std::fs::write(
+            dep_dir.join("package.json"),
+            r#"{"name":"dep-with-phantom","main":"index.js"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dep_dir.join("index.js"),
+            "module.exports = require('undeclared-ghost');",
+        )
+        .unwrap();
+
+        let report = build_report(cwd, true).unwrap();
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|w| w.contains("dep-with-phantom") && w.contains("undeclared-ghost")),
+            "expected a phantom-dependency warning: {:?}",
+            report.warnings
+        );
     }
 }


### PR DESCRIPTION
`aube doctor` now flags a direct dependency that statically imports a package it never declares, using a graph-walk + classify pipeline ported from nub's `nub-phantom-core`/`nub-phantom-scan` (jdx/nub / nubjs/nub, MIT).

<details>
<summary>
Full test suite passes: 35 new crate tests, plus a doctor fixture test for the undeclared-import warning.
</summary>

This adds two new crates, `aube-phantom-core` and `aube-phantom-scan`, trimmed from nub's originals to the filesystem-backed walk `aube doctor` needs, since nub's CAS-index variant only applies to nub's own extract-time package-linking hooks. The new `check_phantom_dependencies` check walks each direct dependency's published entry points and warns when it finds a static import that dependency's own `package.json` does not declare. A reference reachable only from the `.d.ts` type surface always classifies as type-only, matching nub's fix for [pnpm#14128](https://github.com/pnpm/pnpm/issues/14128), because a type-only import needs nothing at runtime regardless of where its types come from.

`cargo test -p aube-phantom-core -p aube-phantom-scan` passes all 35 tests. `cargo test -p aube doctor::` passes too, including the new fixture test that asserts a direct dependency's undeclared import surfaces as a doctor warning. `cargo build -p aube` builds clean.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added phantom-dependency scanning for direct and optional dependencies.
  * Detects undeclared runtime imports, including hard and soft phantom dependencies.
  * Supports package exports, subpaths, type declarations, single-file components, dynamic imports, and `require` usage.
  * Recognizes Node built-ins and npm package specifiers.
  * `aube doctor` reports undeclared dependency imports during project diagnostics.
* **Bug Fixes**
  * Ignores commented-out scripts, invalid manifests, asset-only exports, and unreachable modules.
  * Distinguishes type-only references and guarded imports from runtime dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->