### PR TITLE
chore(deps): bump usage to 6.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5233,15 +5233,15 @@ dependencies = [
 
 [[package]]
 name = "usage-argv"
-version = "6.2.0"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "857c0a155957d220665b2257ac7c58e168476ff7de09286940055ff78f622fb0"
+checksum = "832f849be4b8046c843219bc92d067a6689530df53f56e3c0a52ff5ebbd2f89b"
 
 [[package]]
 name = "usage-derive"
-version = "6.2.0"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b6be9a69c5659c8002ac46be4262fd6e3ef57db53787df0f85b2d116c9e790"
+checksum = "5634bb965ae075c5cedfc27942f7e6110bf5e7e169cba04de86346f4aeee41e7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5250,9 +5250,9 @@ dependencies = [
 
 [[package]]
 name = "usage-rs"
-version = "6.2.0"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "689ff9bfcf0c894d94a44171b27f6533db7d44a9615b17cef9b846590df13463"
+checksum = "12a8c2b63902582429527f21cd91d2da0065fb9222b8a2a5b87d8f77c7daf71e"
 dependencies = [
  "usage-argv",
  "usage-derive",
@@ -5262,18 +5262,18 @@ dependencies = [
 
 [[package]]
 name = "usage-test"
-version = "6.2.0"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73ccbe6b9a1023436ffecd83a52d8a74b9e825ce593fc07641f0359d13f427f"
+checksum = "574ec714315c7acd46b892ae156d105e346cb1a27b53759eb6cc6b0a45256adb"
 dependencies = [
  "usage-argv",
 ]
 
 [[package]]
 name = "usage-validation"
-version = "6.2.0"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4305722f11d47fba8f46bf67dcf2031b7b24ea6f8b7f7a9923f9e89df094582"
+checksum = "28b3fc495fd81873ed690217456010cf3d02be83169db535b23cb295136e3c29"
 dependencies = [
  "expr-lang",
 ]

--- a/docs/cli/add.md
+++ b/docs/cli/add.md
@@ -17,7 +17,7 @@ Add a dependency
 
   Installs into the aube/pnpm global directory and links its binaries into the global bin directory. Mirrors `pnpm add -g`.
 - **`-O --save-optional`** — Add as optional dependency
-- **`--allow-build…=<PKG>`** — Pre-approve a dependency's lifecycle scripts as part of the add.
+- **`--allow-build=<PKG>`** — Pre-approve a dependency's lifecycle scripts as part of the add.
 
   Writes `allowBuilds: { <pkg>: true }` into the workspace yaml (or `package.json#aube.allowBuilds`) before the install runs, so the named package's `preinstall` / `install` / `postinstall` scripts execute on this invocation. Repeatable — pass the flag once per package. Mirrors `pnpm add --allow-build=<pkg>`.
 
@@ -28,7 +28,7 @@ Add a dependency
 - **`--dangerously-allow-all-builds`** — Allow every dependency's lifecycle scripts to run.
 
   Bypasses the `allowBuilds` allowlist for this invocation. Do not use in CI. Mirrors pnpm's `--dangerously-allow-all-builds`.
-- **`--deny-build…=<PKG>`** — Mark a dependency's lifecycle scripts as reviewed and denied.
+- **`--deny-build=<PKG>`** — Mark a dependency's lifecycle scripts as reviewed and denied.
 
   Writes `allowBuilds: { <pkg>: false }` into the workspace yaml (or `package.json#aube.allowBuilds`) before the install runs, so the named package's lifecycle scripts stay skipped without tripping `strictDepBuilds=true`. Repeatable — pass the flag once per package.
 

--- a/docs/cli/audit.md
+++ b/docs/cli/audit.md
@@ -18,7 +18,7 @@ Check installed packages against the registry advisory DB
   Bare `--fix` writes package.json overrides for backwards compatibility. `--fix=update` refreshes the lockfile without writing overrides.
 
   **Choices:** `update`, `override`
-- **`--ignore… <ID>`** — Drop advisories whose ID matches one of these values.
+- **`--ignore <ID>`** — Drop advisories whose ID matches one of these values.
 
   Matches against the numeric npm advisory `id`, `github_advisory_id` (`GHSA-…`), and any entry in `cves[]` (case-insensitive). Repeatable; comma-separated values are also accepted.
 - **`--ignore-registry-errors`** — Use exit code 0 if the registry responds with an error.

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -837,7 +837,7 @@
           },
           {
             "name": "allow-build",
-            "usage": "--allow-build…=<PKG>",
+            "usage": "--allow-build=<PKG>",
             "help": "Pre-approve a dependency's lifecycle scripts as part of the add.",
             "help_long": "Pre-approve a dependency's lifecycle scripts as part of the add.\n\nWrites `allowBuilds: { <pkg>: true }` into the workspace yaml (or `package.json#aube.allowBuilds`) before the install runs, so the named package's `preinstall` / `install` / `postinstall` scripts execute on this invocation. Repeatable — pass the flag once per package. Mirrors `pnpm add --allow-build=<pkg>`.\n\nConflicts with `--no-save`, which only snapshots `package.json` and the lockfile and would leave an orphaned approval in the workspace yaml on restore. Also conflicts with `--deny-build` for the same package name.",
             "help_first_line": "Pre-approve a dependency's lifecycle scripts as part of the add.",
@@ -890,7 +890,7 @@
           },
           {
             "name": "deny-build",
-            "usage": "--deny-build…=<PKG>",
+            "usage": "--deny-build=<PKG>",
             "help": "Mark a dependency's lifecycle scripts as reviewed and denied.",
             "help_long": "Mark a dependency's lifecycle scripts as reviewed and denied.\n\nWrites `allowBuilds: { <pkg>: false }` into the workspace yaml (or `package.json#aube.allowBuilds`) before the install runs, so the named package's lifecycle scripts stay skipped without tripping `strictDepBuilds=true`. Repeatable — pass the flag once per package.\n\nConflicts with `--no-save`, which only snapshots `package.json` and the lockfile and would leave an orphaned denial in the workspace yaml on restore. Also conflicts with `--allow-build` for the same package name and with `--dangerously-allow-all-builds`.",
             "help_first_line": "Mark a dependency's lifecycle scripts as reviewed and denied.",
@@ -1496,7 +1496,7 @@
           },
           {
             "name": "ignore",
-            "usage": "--ignore… <ID>",
+            "usage": "--ignore <ID>",
             "help": "Drop advisories whose ID matches one of these values.",
             "help_long": "Drop advisories whose ID matches one of these values.\n\nMatches against the numeric npm advisory `id`, `github_advisory_id` (`GHSA-…`), and any entry in `cves[]` (case-insensitive). Repeatable; comma-separated values are also accepted.",
             "help_first_line": "Drop advisories whose ID matches one of these values.",
@@ -5459,7 +5459,7 @@
           },
           {
             "name": "package",
-            "usage": "-p --package… <PACKAGE>",
+            "usage": "-p --package <PACKAGE>",
             "help": "Install a specific package (repeatable).",
             "help_long": "Install a specific package (repeatable).\n\nOverrides inferring from the command.",
             "help_first_line": "Install a specific package (repeatable).",
@@ -5482,7 +5482,7 @@
           },
           {
             "name": "allow-build",
-            "usage": "--allow-build…=<PKG>",
+            "usage": "--allow-build=<PKG>",
             "help": "Allow named packages to run lifecycle scripts during the transient install. Use `--allow-build=<pkg>`.",
             "help_long": "Allow named packages to run lifecycle scripts during the transient install. Use `--allow-build=<pkg>`.\n\nRepeatable — pass once per package. The named package's `preinstall` / `install` / `postinstall` scripts execute during the transient install. Requires the equals form (`--allow-build=<pkg>`); space-separated forms are rejected. Mirrors pnpm's `pnpm dlx --allow-build=<pkg>` compatibility surface while keeping dlx scripts skipped unless explicitly approved.",
             "help_first_line": "Allow named packages to run lifecycle scripts during the transient install. Use `--allow-build=<pkg>`.",
@@ -7511,7 +7511,7 @@
           },
           {
             "name": "public-hoist-pattern",
-            "usage": "--public-hoist-pattern… <GLOB>",
+            "usage": "--public-hoist-pattern <GLOB>",
             "help": "Selectively hoist matching transitive deps to the root node_modules.",
             "help_long": "Selectively hoist matching transitive deps to the root node_modules.\n\nRepeatable; comma-separated values are also accepted.",
             "help_first_line": "Selectively hoist matching transitive deps to the root node_modules.",
@@ -16619,7 +16619,7 @@
       },
       {
         "name": "filter",
-        "usage": "-F --filter… <WORKSPACE>",
+        "usage": "-F --filter <WORKSPACE>",
         "help": "Scope command execution to workspace packages matching PATTERN.",
         "help_long": "Scope command execution to workspace packages matching PATTERN.\n\nSupports exact names (`my-pkg`), globs (`@scope/*`, `*-plugin`), paths (`./packages/api`), graph selectors (`pkg...`, `...pkg`), git-ref selectors (`[origin/main]`), and exclusions (`!pkg`). Repeatable; matches are OR-ed.\n\nCurrently honored by `run`, `test`, `start`, `stop`, `restart`, `install`, `exec`, `list`, `publish`, `deploy`, `add`, `remove`, `update`, `why`, and implicit-script invocations.",
         "help_first_line": "Scope command execution to workspace packages matching PATTERN.",
@@ -16791,7 +16791,7 @@
       },
       {
         "name": "filter-prod",
-        "usage": "--filter-prod… <PATTERN>",
+        "usage": "--filter-prod <PATTERN>",
         "help": "Production-only variant of `--filter`.",
         "help_long": "Production-only variant of `--filter`.\n\nSame selector grammar as `--filter`, but graph walks (`pkg...`, `...pkg`) only follow `dependencies` / `optionalDependencies` / `peerDependencies` edges — `devDependencies` (and packages reachable solely through them) are skipped. Non-graph forms (exact name, glob, path, `[git-ref]`) behave identically to `--filter`. Repeatable; can be combined with `--filter`.",
         "help_first_line": "Production-only variant of `--filter`.",

--- a/docs/cli/dlx.md
+++ b/docs/cli/dlx.md
@@ -14,10 +14,10 @@ Fetch a package into a throwaway environment and run its binary
 - **`-c --shell-mode`** — Run the assembled command line through `sh -c`.
 
   `<scratch>/node_modules/.bin` is prepended to `PATH`. Use this for pipelines, redirects, or env expansion (`aube dlx -p cowsay -c 'cowsay hello | tr a-z A-Z'`). Mirrors `pnpm dlx --shell-mode`.
-- **`-p --package… <PACKAGE>`** — Install a specific package (repeatable).
+- **`-p --package <PACKAGE>`** — Install a specific package (repeatable).
 
   Overrides inferring from the command.
-- **`--allow-build…=<PKG>`** — Allow named packages to run lifecycle scripts during the transient install. Use `--allow-build=<pkg>`.
+- **`--allow-build=<PKG>`** — Allow named packages to run lifecycle scripts during the transient install. Use `--allow-build=<pkg>`.
 
   Repeatable — pass once per package. The named package's `preinstall` / `install` / `postinstall` scripts execute during the transient install. Requires the equals form (`--allow-build=<pkg>`); space-separated forms are rejected. Mirrors pnpm's `pnpm dlx --allow-build=<pkg>` compatibility surface while keeping dlx scripts skipped unless explicitly approved.
 - **`-h --help`** — Print help

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -9,7 +9,7 @@
 - **`-C --dir <DIR>`** — Change to directory before running (like `make -C` or `mise --cd`)
 
   **Aliases:** `--cd`, `--prefix`
-- **`-F --filter… <WORKSPACE>`** — Scope command execution to workspace packages matching PATTERN.
+- **`-F --filter <WORKSPACE>`** — Scope command execution to workspace packages matching PATTERN.
 
   Supports exact names (`my-pkg`), globs (`@scope/*`, `*-plugin`), paths (`./packages/api`), graph selectors (`pkg...`, `...pkg`), git-ref selectors (`[origin/main]`), and exclusions (`!pkg`). Repeatable; matches are OR-ed.
 
@@ -36,7 +36,7 @@
 - **`--fail-if-no-match`** — Error when a workspace selector matches no packages.
 
   Accepted globally; selected commands already fail on empty matches.
-- **`--filter-prod… <PATTERN>`** — Production-only variant of `--filter`.
+- **`--filter-prod <PATTERN>`** — Production-only variant of `--filter`.
 
   Same selector grammar as `--filter`, but graph walks (`pkg...`, `...pkg`) only follow `dependencies` / `optionalDependencies` / `peerDependencies` edges — `devDependencies` (and packages reachable solely through them) are skipped. Non-graph forms (exact name, glob, path, `[git-ref]`) behave identically to `--filter`. Repeatable; can be combined with `--filter`.
 - **`--loglevel <LEVEL>`** — Set the log level. Logs at or above this level are shown.

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -57,7 +57,7 @@ Install all dependencies
 
   Mirrors pnpm's `--pnpmfile <path>`. Relative paths resolve against the project root; absolute paths are used as-is. Wins over `pnpmfilePath` from `pnpm-workspace.yaml`. A typo (target missing) is a hard miss with a warning rather than a silent fallback to the default.
 - **`--prefer-offline`** — Prefer cached metadata over revalidation; only hit the network on a miss.
-- **`--public-hoist-pattern… <GLOB>`** — Selectively hoist matching transitive deps to the root node_modules.
+- **`--public-hoist-pattern <GLOB>`** — Selectively hoist matching transitive deps to the root node_modules.
 
   Repeatable; comma-separated values are also accepted.
 - **`--resolution-mode <MODE>`** — How to resolve version ranges.

--- a/mise.lock
+++ b/mise.lock
@@ -413,40 +413,40 @@ checksum = "sha256:60cd368533d0ad73fa86d93d5bbf95ef40587245ce684ed138c1b31557b5f
 url = "https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_windows_amd64.exe"
 
 [[tools.usage]]
-version = "6.2.0"
+version = "6.4.0"
 backend = "aqua:jdx/usage"
 
 [tools.usage."platforms.linux-arm64"]
-checksum = "sha256:93502e6ec4c4efe5437a8ef0970b0d87cd88020e341bcdd6b0b78022ce316a4b"
-url = "https://github.com/jdx/usage/releases/download/v6.2.0/usage-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/527050809"
+checksum = "sha256:96acfe9a312da8af144dd516b9347bd7de62391ca797dba722aed48abe5ec21d"
+url = "https://github.com/jdx/usage/releases/download/v6.4.0/usage-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/528035595"
 
 [tools.usage."platforms.linux-arm64-musl"]
-checksum = "sha256:86d8273aee09adc471ac34e8e61ef8386fc26b2d06cc43985722b705a52c5a7e"
-url = "https://github.com/jdx/usage/releases/download/v6.2.0/usage-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/527051257"
+checksum = "sha256:60ff89e6d87cabcbc6c20fc851911c78490c605d38553147a62e1dce30e6470a"
+url = "https://github.com/jdx/usage/releases/download/v6.4.0/usage-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/528035659"
 
 [tools.usage."platforms.linux-x64"]
-checksum = "sha256:38df801e9ed2b4d23ea66793a25369f52d92c4aefd55ebacb6e343a2ab84528d"
-url = "https://github.com/jdx/usage/releases/download/v6.2.0/usage-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/527050648"
+checksum = "sha256:04007997a0524aa5934458530cd025e1745e0b0803aac74559cc03a26b66c53b"
+url = "https://github.com/jdx/usage/releases/download/v6.4.0/usage-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/528035518"
 
 [tools.usage."platforms.linux-x64-musl"]
-checksum = "sha256:ded7d1815254fe064b07a8f33251b8e112ec346c338e476ce0e9ee8d8babc0ed"
-url = "https://github.com/jdx/usage/releases/download/v6.2.0/usage-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/527051701"
+checksum = "sha256:c416e18838f974810f8b67ac1eed6ef170cf9ff48e165469563885f24c548d90"
+url = "https://github.com/jdx/usage/releases/download/v6.4.0/usage-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/528035933"
 
 [tools.usage."platforms.macos-arm64"]
-checksum = "sha256:6c2d37e3cba67d45fdfeb5edaff81962388bfde09667cc9ed35b0734b7c0a8c1"
-url = "https://github.com/jdx/usage/releases/download/v6.2.0/usage-universal-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/527053103"
+checksum = "sha256:c02f4235446b06f917747e6bdaa6496ea3f63a66c74081a5c1450da2c734f6f1"
+url = "https://github.com/jdx/usage/releases/download/v6.4.0/usage-universal-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/528044147"
 
 [tools.usage."platforms.macos-x64"]
-checksum = "sha256:6c2d37e3cba67d45fdfeb5edaff81962388bfde09667cc9ed35b0734b7c0a8c1"
-url = "https://github.com/jdx/usage/releases/download/v6.2.0/usage-universal-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/527053103"
+checksum = "sha256:c02f4235446b06f917747e6bdaa6496ea3f63a66c74081a5c1450da2c734f6f1"
+url = "https://github.com/jdx/usage/releases/download/v6.4.0/usage-universal-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/528044147"
 
 [tools.usage."platforms.windows-x64"]
-checksum = "sha256:c13234e43cee2b172376ade8d0cdd1ea26c8a2032275b283243b05de57256c3f"
-url = "https://github.com/jdx/usage/releases/download/v6.2.0/usage-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/527054199"
+checksum = "sha256:6ffa5d4deb26c6728ea9ab5d9c7b76c3c4ca75cb6bf49acdace1045512fa7cd3"
+url = "https://github.com/jdx/usage/releases/download/v6.4.0/usage-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/528039229"

--- a/mise.toml
+++ b/mise.toml
@@ -7,7 +7,7 @@ cargo.binstall_native = true
 
 [tools]
 actionlint = "latest"
-usage = "6.2.0"
+usage = "6.4.0"
 communique = "latest"
 "github:bnjbvr/cargo-machete" = "latest"
 "github:foresterre/cargo-msrv" = "latest"


### PR DESCRIPTION
## Summary
- bump usage-rs and the standalone usage renderer to 6.4.0
- refresh Cargo.lock and mise.lock
- regenerate CLI reference artifacts with usage 6.4.0

## Validation
- cargo check --locked
- cargo test --locked (835 unit tests and all end-to-end tests passed; one Node-shim environment failure was rerun successfully with the installed Node binary)
- mise run render
- mise --locked x usage -- usage --version
- mise lock usage --dry-run --json
- git diff --check
- upstream publish-cli run completed successfully: https://github.com/jdx/usage/actions/runs/32764359979

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile and doc-generator version bumps with no changes to aube’s CLI parsing or runtime logic in this diff.
> 
> **Overview**
> Bumps the **usage** toolchain and Rust **usage-rs** family from 6.2.0 to **6.4.0**, updating `mise.toml`, `mise.lock`, and `Cargo.lock`.
> 
> Regenerated CLI reference output (`docs/cli/commands.json` and related markdown) reflects usage 6.4.0’s formatting: repeatable flags no longer show the `…` suffix in usage lines (e.g. `--filter…` → `--filter`, `--allow-build…=<PKG>` → `--allow-build=<PKG>`). **Behavior of the flags is unchanged**—only generated help/docs wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2808bea94140fdab9fb21cac15f59ffa65f1adb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected CLI reference syntax for repeatable options, including build, filtering, package, ignore, and hoisting flags.
  * Removed misleading ellipses from displayed option names and usage examples.
* **Chores**
  * Updated the configured `usage` tool version from 6.2.0 to 6.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->