### PR TITLE
chore(sponsors): replace 37signals with omacom foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 </p>
 
 <p align="center">
-  Sponsored by <a href="https://entire.io">entire.io</a> and <a href="https://37signals.com">37signals</a>.<br>
+  Sponsored by <a href="https://entire.io">entire.io</a> and <a href="https://omarchy.org/patrons/">Omacom Foundation</a>.<br>
   <a href="https://jdx.dev/sponsors.html">View all sponsors</a>.
 </p>
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,22 @@
 </p>
 
 <p align="center">
-  Sponsored by <a href="https://entire.io">entire.io</a> and <a href="https://omarchy.org/patrons/">Omacom Foundation</a>.<br>
-  <a href="https://jdx.dev/sponsors.html">View all sponsors</a>.
+  Sponsored by<br><br>
+  <a href="https://entire.io">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://jdx.dev/sponsors/entire-lockup.svg">
+      <img src="https://jdx.dev/sponsors/entire-lockup-on-light.svg" alt="Entire" height="36">
+    </picture>
+  </a>
+  &nbsp;&nbsp;&nbsp;
+  <a href="https://omarchy.org/patrons/">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://jdx.dev/sponsors/omacom-foundation.svg">
+      <img src="https://jdx.dev/sponsors/omacom-foundation-on-light.svg" alt="Omacom Foundation" height="36">
+    </picture>
+  </a>
+  <br><br>
+  <a href="https://jdx.dev/sponsors.html">View all sponsors</a>
 </p>
 
 ## Why Try It

--- a/crates/aube/src/commands/sponsors.rs
+++ b/crates/aube/src/commands/sponsors.rs
@@ -3,7 +3,7 @@ pub struct SponsorsArgs;
 
 pub async fn run(_args: SponsorsArgs) -> miette::Result<()> {
     println!(
-        "aube and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n\nView all sponsors: https://jdx.dev/sponsors.html"
+        "aube and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  Omacom Foundation - https://omarchy.org/patrons/\n\nView all sponsors: https://jdx.dev/sponsors.html"
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary
- replace 37signals with the Omacom Foundation in the README and `aube sponsors` output
- add linked, theme-aware Entire and Omarchy wordmarks to the README

## Verification
- `cargo fmt --all --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*