### PR TITLE
chore: release v2.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "aube-codes"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "aube-ffi"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "aube",
  "aube-codes",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "aube-node"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "aube",
  "aube-codes",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "aube-runtime"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "aube-util",
  "base64 0.23.1",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "aube-codes",
  "blake3",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "aube-codes",
  "aube-manifest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ inherits = "release"
 panic = "unwind"
 
 [workspace.package]
-version = "2.2.0"
+version = "2.2.1"
 edition = "2024"
 # Kept at the floor mise can build with (its distro packaging pins the
 # toolchain) so mise can embed the library crates. CI enforces this via

--- a/crates/aube-codes/CHANGELOG.md
+++ b/crates/aube-codes/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1](https://github.com/jdx/aube/compare/aube-codes-v2.2.0...aube-codes-v2.2.1) - 2026-08-29
+
+### Other
+
+- refresh benchmarks for v2.2.0 ([#1384](https://github.com/jdx/aube/pull/1384))
+- *(sponsors)* replace 37signals with omacom foundation ([#1380](https://github.com/jdx/aube/pull/1380))
+
 ## [2.2.0](https://github.com/jdx/aube/compare/aube-codes-v2.1.0...aube-codes-v2.2.0) - 2026-08-25
 
 ### Fixed

--- a/crates/aube-linker/CHANGELOG.md
+++ b/crates/aube-linker/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1](https://github.com/jdx/aube/compare/aube-linker-v2.2.0...aube-linker-v2.2.1) - 2026-08-29
+
+### Other
+
+- refresh benchmarks for v2.2.0 ([#1384](https://github.com/jdx/aube/pull/1384))
+- *(sponsors)* replace 37signals with omacom foundation ([#1380](https://github.com/jdx/aube/pull/1380))
+
 ## [2.2.0](https://github.com/jdx/aube/compare/aube-linker-v2.1.0...aube-linker-v2.2.0) - 2026-08-25
 
 ### Other

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1](https://github.com/jdx/aube/compare/aube-lockfile-v2.2.0...aube-lockfile-v2.2.1) - 2026-08-29
+
+### Fixed
+
+- *(lockfile)* accept retained importer peers ([#1402](https://github.com/jdx/aube/pull/1402))
+- *(resolver)* match pnpm importer peer semantics ([#1399](https://github.com/jdx/aube/pull/1399))
+
+### Other
+
+- refresh benchmarks for v2.2.0 ([#1384](https://github.com/jdx/aube/pull/1384))
+- *(sponsors)* replace 37signals with omacom foundation ([#1380](https://github.com/jdx/aube/pull/1380))
+
 ## [2.2.0](https://github.com/jdx/aube/compare/aube-lockfile-v2.1.0...aube-lockfile-v2.2.0) - 2026-08-25
 
 ### Other

--- a/crates/aube-manifest/CHANGELOG.md
+++ b/crates/aube-manifest/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1](https://github.com/jdx/aube/compare/aube-manifest-v2.2.0...aube-manifest-v2.2.1) - 2026-08-29
+
+### Fixed
+
+- *(resolver)* match pnpm importer peer semantics ([#1399](https://github.com/jdx/aube/pull/1399))
+
+### Other
+
+- refresh benchmarks for v2.2.0 ([#1384](https://github.com/jdx/aube/pull/1384))
+- *(sponsors)* replace 37signals with omacom foundation ([#1380](https://github.com/jdx/aube/pull/1380))
+
 ## [2.2.0](https://github.com/jdx/aube/compare/aube-manifest-v2.1.0...aube-manifest-v2.2.0) - 2026-08-25
 
 ### Other

--- a/crates/aube-registry/CHANGELOG.md
+++ b/crates/aube-registry/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1](https://github.com/jdx/aube/compare/aube-registry-v2.2.0...aube-registry-v2.2.1) - 2026-08-29
+
+### Other
+
+- *(install)* validate trustPolicy from compact trust histories ([#1403](https://github.com/jdx/aube/pull/1403))
+- refresh benchmarks for v2.2.0 ([#1384](https://github.com/jdx/aube/pull/1384))
+- *(sponsors)* replace 37signals with omacom foundation ([#1380](https://github.com/jdx/aube/pull/1380))
+
 ## [2.2.0](https://github.com/jdx/aube/compare/aube-registry-v2.1.0...aube-registry-v2.2.0) - 2026-08-25
 
 ### Other

--- a/crates/aube-resolver/CHANGELOG.md
+++ b/crates/aube-resolver/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1](https://github.com/jdx/aube/compare/aube-resolver-v2.2.0...aube-resolver-v2.2.1) - 2026-08-29
+
+### Fixed
+
+- *(resolver)* match pnpm importer peer semantics ([#1399](https://github.com/jdx/aube/pull/1399))
+
+### Other
+
+- *(install)* validate trustPolicy from compact trust histories ([#1403](https://github.com/jdx/aube/pull/1403))
+- refresh benchmarks for v2.2.0 ([#1384](https://github.com/jdx/aube/pull/1384))
+- *(sponsors)* replace 37signals with omacom foundation ([#1380](https://github.com/jdx/aube/pull/1380))
+
 ## [2.2.0](https://github.com/jdx/aube/compare/aube-resolver-v2.1.0...aube-resolver-v2.2.0) - 2026-08-25
 
 ### Other

--- a/crates/aube-runtime/CHANGELOG.md
+++ b/crates/aube-runtime/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1](https://github.com/jdx/aube/compare/aube-runtime-v2.2.0...aube-runtime-v2.2.1) - 2026-08-29
+
+### Other
+
+- refresh benchmarks for v2.2.0 ([#1384](https://github.com/jdx/aube/pull/1384))
+- *(sponsors)* replace 37signals with omacom foundation ([#1380](https://github.com/jdx/aube/pull/1380))
+
 ## [2.2.0](https://github.com/jdx/aube/compare/aube-runtime-v2.1.0...aube-runtime-v2.2.0) - 2026-08-25
 
 ### Other

--- a/crates/aube-scripts/CHANGELOG.md
+++ b/crates/aube-scripts/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1](https://github.com/jdx/aube/compare/aube-scripts-v2.2.0...aube-scripts-v2.2.1) - 2026-08-29
+
+### Other
+
+- refresh benchmarks for v2.2.0 ([#1384](https://github.com/jdx/aube/pull/1384))
+- *(sponsors)* replace 37signals with omacom foundation ([#1380](https://github.com/jdx/aube/pull/1380))
+
 ## [2.2.0](https://github.com/jdx/aube/compare/aube-scripts-v2.1.0...aube-scripts-v2.2.0) - 2026-08-25
 
 ### Other

--- a/crates/aube-settings/CHANGELOG.md
+++ b/crates/aube-settings/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1](https://github.com/jdx/aube/compare/aube-settings-v2.2.0...aube-settings-v2.2.1) - 2026-08-29
+
+### Fixed
+
+- *(resolver)* match pnpm importer peer semantics ([#1399](https://github.com/jdx/aube/pull/1399))
+
+### Other
+
+- *(install)* validate trustPolicy from compact trust histories ([#1403](https://github.com/jdx/aube/pull/1403))
+- refresh benchmarks for v2.2.0 ([#1384](https://github.com/jdx/aube/pull/1384))
+- *(sponsors)* replace 37signals with omacom foundation ([#1380](https://github.com/jdx/aube/pull/1380))
+
 ## [2.2.0](https://github.com/jdx/aube/compare/aube-settings-v2.1.0...aube-settings-v2.2.0) - 2026-08-25
 
 ### Fixed

--- a/crates/aube-store/CHANGELOG.md
+++ b/crates/aube-store/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1](https://github.com/jdx/aube/compare/aube-store-v2.2.0...aube-store-v2.2.1) - 2026-08-29
+
+### Other
+
+- refresh benchmarks for v2.2.0 ([#1384](https://github.com/jdx/aube/pull/1384))
+- *(sponsors)* replace 37signals with omacom foundation ([#1380](https://github.com/jdx/aube/pull/1380))
+
 ## [2.2.0](https://github.com/jdx/aube/compare/aube-store-v2.1.0...aube-store-v2.2.0) - 2026-08-25
 
 ### Other

--- a/crates/aube-util/CHANGELOG.md
+++ b/crates/aube-util/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1](https://github.com/jdx/aube/compare/aube-util-v2.2.0...aube-util-v2.2.1) - 2026-08-29
+
+### Other
+
+- refresh benchmarks for v2.2.0 ([#1384](https://github.com/jdx/aube/pull/1384))
+- *(sponsors)* replace 37signals with omacom foundation ([#1380](https://github.com/jdx/aube/pull/1380))
+
 ## [2.2.0](https://github.com/jdx/aube/compare/aube-util-v2.1.0...aube-util-v2.2.0) - 2026-08-25
 
 ### Other

--- a/crates/aube-workspace/CHANGELOG.md
+++ b/crates/aube-workspace/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1](https://github.com/jdx/aube/compare/aube-workspace-v2.2.0...aube-workspace-v2.2.1) - 2026-08-29
+
+### Other
+
+- refresh benchmarks for v2.2.0 ([#1384](https://github.com/jdx/aube/pull/1384))
+- *(sponsors)* replace 37signals with omacom foundation ([#1380](https://github.com/jdx/aube/pull/1380))
+
 ## [2.2.0](https://github.com/jdx/aube/compare/aube-workspace-v2.1.0...aube-workspace-v2.2.0) - 2026-08-25
 
 ### Other

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1](https://github.com/jdx/aube/compare/v2.2.0...v2.2.1) - 2026-08-29
+
+### Fixed
+
+- *(install)* repair stale cached node-gyp ([#1407](https://github.com/jdx/aube/pull/1407))
+- *(install)* verify the already-linked shortcut against the expected target ([#1406](https://github.com/jdx/aube/pull/1406))
+- *(install)* refresh bin shims after dependency builds ([#1404](https://github.com/jdx/aube/pull/1404))
+- *(resolver)* match pnpm importer peer semantics ([#1399](https://github.com/jdx/aube/pull/1399))
+
+### Other
+
+- *(install)* validate trustPolicy from compact trust histories ([#1403](https://github.com/jdx/aube/pull/1403))
+- *(install)* cut freshness and repeat-install overhead on large repos ([#1400](https://github.com/jdx/aube/pull/1400))
+- refresh benchmarks for v2.2.0 ([#1384](https://github.com/jdx/aube/pull/1384))
+- *(sponsors)* replace 37signals with omacom foundation ([#1380](https://github.com/jdx/aube/pull/1380))
+
 ## [2.2.0](https://github.com/jdx/aube/compare/v2.1.0...v2.2.0) - 2026-08-25
 
 ### Added

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "2.2.0",
-  "releasedAt": "2026-08-25T12:24:51Z"
+  "version": "2.2.1",
+  "releasedAt": "2026-08-29T02:08:47Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v2.2.1`

This PR bumps the workspace to `v2.2.1` and regenerates CHANGELOG entries, `aube.usage.kdl`, the CLI docs, and the benchmark results.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The PR is mechanical, but it tags a patch that bundles resolver, lockfile, install, and trust-policy behavior changes that can alter resolution outcomes and install results on real monorepos.
> 
> **Overview**
> **Release packaging** for `v2.2.1`: bumps `[workspace.package].version` and every workspace crate in `Cargo.lock` from `2.2.0` to `2.2.1`, updates `release.json`, and adds matching **2.2.1** sections to per-crate `CHANGELOG.md` files (no new Rust logic in this diff).
> 
> The notes that will ship with the release center on **install/link correctness** (stale cached node-gyp repair, validating already-linked shortcuts, refreshing bin shims after builds), **pnpm parity** for importer peer semantics and retained importer peers in the lockfile, **trustPolicy** validation from compact trust histories, and **large-repo install performance** (less freshness / repeat-install overhead). Benchmark refresh and sponsor list updates are also recorded in the changelogs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd39f52968c1675cec748d87e5641cc6bf0e1948. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->