### PR TITLE
security(ci): restrict trusted mbx runs to jdx

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -7,7 +7,7 @@ runs:
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
         version: 0.4.0
-        backend: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'github' || 'server' }}
+        backend: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'github' || 'server' }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/aube
         oidc-audience: https://cache.mise.jdx.dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
             runner: namespace-profile-endev-linux-amd64
           - os: macos-latest
             runner: namespace-profile-endev-macos-arm64
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && matrix.os || matrix.runner }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && matrix.os || matrix.runner }}
     timeout-minutes: 20
     permissions:
       contents: read
@@ -64,7 +64,7 @@ jobs:
   # lint failures don't block the BATS jobs from starting against a
   # known-good binary.
   test-linux:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 30
     permissions:
       contents: read
@@ -104,7 +104,7 @@ jobs:
     # PR-time gate only. `final` treats the resulting skipped job as a pass on
     # push/tag/dispatch runs.
     if: github.event_name == 'pull_request'
-    runs-on: ${{ (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 20
     permissions:
       contents: read
@@ -324,7 +324,7 @@ jobs:
       - bats-serial
       - windows
       - api-stability
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 2
     permissions: {}
     # Run on success or upstream failure but skip when the workflow is cancelled

--- a/.github/workflows/ffi.yml
+++ b/.github/workflows/ffi.yml
@@ -98,7 +98,7 @@ jobs:
           - { runner: ubuntu-latest, namespace_runner: namespace-profile-endev-linux-amd64, target: x86_64-unknown-linux-musl, os: linux, cpu: x64, libc: musl, package: linux-x64-musl, binary: libaube_ffi.so, ext: so }
           - { runner: windows-latest, namespace_runner: windows-latest, target: aarch64-pc-windows-msvc, os: win32, cpu: arm64, package: win32-arm64, binary: aube_ffi.dll, ext: dll }
           - { runner: windows-latest, namespace_runner: windows-latest, target: x86_64-pc-windows-msvc, os: win32, cpu: x64, package: win32-x64, binary: aube_ffi.dll, ext: dll }
-    runs-on: ${{ (github.event_name == 'release' || inputs.tag != '' || inputs.draft_phase || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]'))) && matrix.runner || matrix.namespace_runner }}
+    runs-on: ${{ (github.event_name == 'release' || inputs.tag != '' || inputs.draft_phase || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && matrix.runner || matrix.namespace_runner }}
     timeout-minutes: 60
     permissions: { contents: read, id-token: write }
     env:

--- a/.github/workflows/node-addon.yml
+++ b/.github/workflows/node-addon.yml
@@ -68,7 +68,7 @@ jobs:
           - { runner: ubuntu-latest, namespace_runner: namespace-profile-endev-linux-amd64, target: x86_64-unknown-linux-musl, os: linux, cpu: x64, libc: musl, package: linux-x64-musl, binary: libaube_node.so }
           - { runner: windows-latest, namespace_runner: windows-latest, target: aarch64-pc-windows-msvc, os: win32, cpu: arm64, package: win32-arm64, binary: aube_node.dll }
           - { runner: windows-latest, namespace_runner: windows-latest, target: x86_64-pc-windows-msvc, os: win32, cpu: x64, package: win32-x64, binary: aube_node.dll, smoke: true }
-    runs-on: ${{ (github.event_name == 'release' || inputs.tag != '' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]'))) && matrix.runner || matrix.namespace_runner }}
+    runs-on: ${{ (github.event_name == 'release' || inputs.tag != '' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && matrix.runner || matrix.namespace_runner }}
     timeout-minutes: 60
     permissions: { contents: read, id-token: write }
     env:


### PR DESCRIPTION
## Summary

- reserve Namespace runners and the server cache for same-repository PRs authored by `jdx`
- route every other PR author, including dependency bots, through GitHub-hosted runners and GitHub cache
- keep trusted-only repository secrets unavailable to non-`jdx` PRs

## Validation

- `git diff --check`
- actionlint workflow and expression validation
- confirmed no dependency-bot-specific trust predicates remain

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI trust boundaries for PRs; misconfigured expressions could block maintainer workflows or expose trusted runners/secrets to untrusted PR authors.
> 
> **Overview**
> Tightens **who gets trusted CI infrastructure on pull requests** by replacing the old **Dependabot exception** with an **author allowlist**: only same-repo PRs opened by **`jdx`** keep Namespace runners and the **mbx `server`** cache backend.
> 
> Every other PR—including forks, other maintainers, and dependency bots—now uses **GitHub-hosted runners** and the **GitHub cache backend** via the shared **`.github/actions/mbx`** action and matching **`runs-on`** expressions in **`ci.yml`**, **`ffi.yml`**, and **`node-addon.yml`** (build matrix jobs and **`final`** / **`api-stability`** where applicable).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3b1a9ffba7e1336e132269e37852be4bdd2b15e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull-request build and test workflows to select hosted runners for external contributions and most non-maintainer pull requests.
  * Standardized runner selection across backend, FFI, Node add-on, build, testing, and release validation workflows.
  * Maintainer-authored internal pull requests continue using the dedicated runner where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->