### PR TITLE
security(ci): isolate mbx OIDC permissions

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -19,7 +19,7 @@ self-hosted-runner:
     - namespace-profile-endev-linux-arm64-large;overrides.cache-tag=aube-rust-linux-arm64
 
 paths:
-  .github/workflows/ci.yml:
+  .github/workflows/ci-impl.yml:
     # actionlint 1.7.12 predates GitHub's native parallel step groups.
     # Remove this once actionlint recognizes the `parallel` keyword.
     ignore:

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,13 +1,18 @@
 name: Set up mbx
 description: Select the trusted jdx server or fork-safe GitHub cache backend
 
+inputs:
+  backend:
+    description: Explicit backend for structurally trusted or untrusted callers
+    default: auto
+
 runs:
   using: composite
   steps:
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
         version: 0.4.0
-        backend: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'github' || 'server' }}
+        backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/aube
         oidc-audience: https://cache.mise.jdx.dev

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -109,6 +109,7 @@ jobs:
     # PR-time gate only. `final` treats the resulting skipped job as a pass on
     # push/tag/dispatch runs.
     if: github.event_name == 'pull_request'
+    continue-on-error: true
     runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 20
     env:

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -1,0 +1,369 @@
+name: ci implementation
+
+# Full CI matrix for aube — linux, macos, and windows build/test + BATS
+# integration shards. This workflow is the canonical CI entry point;
+# .buildkite/ is left in place but is expected to be disabled at the
+# GitHub-App level so it doesn't double-run or consume vCPU minutes.
+
+on:
+  workflow_call:
+    inputs:
+      trusted:
+        required: true
+        type: boolean
+      mbx-backend:
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+
+jobs:
+  # Build debug artifacts for every OS that runs BATS or needs a binary
+  # downstream. Linux + macOS use mise so tool pins and env parity with
+  # `mise run build` are guaranteed. Windows ships no BATS run (BATS is
+  # bash-only, junction-links kick in on NTFS) so its build + test live
+  # in the dedicated `windows` job below.
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            runner: namespace-profile-endev-linux-amd64
+          - os: macos-latest
+            runner: namespace-profile-endev-macos-arm64
+    runs-on: ${{ !inputs.trusted && matrix.os || matrix.runner }}
+    timeout-minutes: 20
+    env:
+      RUSTFLAGS: "-D warnings"
+    steps:
+      - name: Assert OIDC is unavailable to untrusted CI
+        if: ${{ !inputs.trusted }}
+        run: |
+          test -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
+          test -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5 # zizmor: ignore[cache-poisoning] PRs restore only; saves are restricted to main
+        with:
+          cache_save: ${{ github.ref == 'refs/heads/main' }}
+      - run: mise run build
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: aube-${{ matrix.os }}
+          path: target/debug/aube
+          retention-days: 1
+          if-no-files-found: error
+
+  # Linux-only test + lint + render + docs:build. Matches the
+  # `linux / test` step in .buildkite/pipeline.sh. Split from `build` so
+  # lint failures don't block the BATS jobs from starting against a
+  # known-good binary.
+  test-linux:
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    timeout-minutes: 30
+    env:
+      RUSTFLAGS: "-D warnings"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5 # zizmor: ignore[cache-poisoning] PRs restore only; saves are restricted to main
+        with:
+          cache_save: ${{ github.ref == 'refs/heads/main' }}
+      - run: node benchmarks/validate-results.mts
+      - run: mise run test
+      - run: mise run lint
+      - run: cargo-machete
+      - run: mise x cargo:cargo-audit@0.22.1 -- cargo audit --deny warnings
+      - run: mise x cargo:cargo-deny@0.19.6 -- cargo deny check bans licenses sources
+      - run: mbx msrv --manifest-path crates/aube/Cargo.toml verify --output-format minimal
+      - run: mise run render
+      - name: assert render produces no diff
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::'mise run render' produced changes. Run it locally and commit."
+            git status
+            git diff
+            exit 1
+          fi
+      - run: mise run docs:build
+
+  # Check every published Rust library against main and guard the C ABI export
+  # set against the frozen crates/aube-ffi/abi-symbols.txt manifest. Any failure
+  # makes this job red, while `final` treats the job as advisory.
+  api-stability:
+    # PR-time gate only. `final` treats the resulting skipped job as a pass on
+    # push/tag/dispatch runs.
+    if: github.event_name == 'pull_request'
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    timeout-minutes: 20
+    env:
+      CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback
+      RUSTFLAGS: "-D warnings"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5 # zizmor: ignore[cache-poisoning] PRs restore only; saves are restricted to main
+        with:
+          cache_save: false
+      # Both parallel API checks invoke Cargo. Complete rustup's lazy toolchain
+      # installation first so they cannot race while installing components.
+      - name: Prepare Rust toolchain
+        run: rustc --version
+      - name: Fetch semver baseline
+        run: git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+      # Run the independent Rust and C ABI checks concurrently, preserving both
+      # results so the final step can report every failure before failing the job.
+      - parallel:
+          - name: Published Rust APIs — cargo-semver-checks
+            run: |
+              set +e
+              ./bin/cargo-semver-checks semver-checks \
+                --baseline-rev origin/main \
+                --package aube \
+                --package aube-codes \
+                --package aube-linker \
+                --package aube-lockfile \
+                --package aube-manifest \
+                --package aube-registry \
+                --package aube-resolver \
+                --package aube-runtime \
+                --package aube-scripts \
+                --package aube-settings \
+                --package aube-store \
+                --package aube-util \
+                --package aube-workspace
+              semver_status=$?
+              set -e
+              printf '%s\n' "$semver_status" > /tmp/semver-status
+          - name: C ABI — frozen export set
+            run: |
+              set +e
+              (
+                mbx build --locked --profile ffi -p aube-ffi &&
+                grep -vE '^[[:space:]]*(#|$)' crates/aube-ffi/abi-symbols.txt | sort -u > /tmp/abi-expected.txt &&
+                nm -D --defined-only --extern-only target/ffi/libaube_ffi.so \
+                  | awk '{ print $3 }' | grep '^aube_' | sort -u > /tmp/abi-actual.txt &&
+                diff -u /tmp/abi-expected.txt /tmp/abi-actual.txt
+              )
+              ffi_status=$?
+              set -e
+              printf '%s\n' "$ffi_status" > /tmp/ffi-status
+      - name: Report API stability
+        if: always()
+        run: |
+          if [ ! -s /tmp/semver-status ] || [ ! -s /tmp/ffi-status ]; then
+            echo "::error::one or more API stability checks did not report a result"
+            exit 1
+          fi
+          SEMVER=$(cat /tmp/semver-status)
+          FFI=$(cat /tmp/ffi-status)
+          fail=0
+          if [ "$SEMVER" -ne 0 ]; then
+            echo "::error::Rust API compatibility check failed. Inspect the cargo-semver-checks output above."
+            fail=1
+          fi
+          if [ "$FFI" -ne 0 ]; then
+            echo "::error::C ABI exports drifted from crates/aube-ffi/abi-symbols.txt."
+            fail=1
+          fi
+          exit $fail
+
+  # BATS integration shards. Linux runs 4 shards (matches Buildkite),
+  # macOS runs 2. Keep these on GitHub-hosted runners: the jail-build
+  # tests assert native OS sandbox behavior that does not match the
+  # Namespace runner profiles.
+  # Each shard downloads the OS-matched debug binary from `build` and
+  # invokes mise-task ci:bats:nonserial with its shard index. mise provisions
+  # rush as the parallel driver on both platforms.
+  #
+  # retry handles the rare BATS flake (process teardown racing npm
+  # cache writes, etc.); the Buildkite side has the same retry:1.
+  bats:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            runner: ubuntu-latest
+            shard: 0
+            count: 4
+          - os: ubuntu-latest
+            runner: ubuntu-latest
+            shard: 1
+            count: 4
+          - os: ubuntu-latest
+            runner: ubuntu-latest
+            shard: 2
+            count: 4
+          - os: ubuntu-latest
+            runner: ubuntu-latest
+            shard: 3
+            count: 4
+          - os: macos-latest
+            runner: macos-latest
+            shard: 0
+            count: 2
+          - os: macos-latest
+            runner: macos-latest
+            shard: 1
+            count: 2
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 25
+    permissions:
+      contents: read
+    env:
+      AUBE_CI_OS: ${{ startsWith(matrix.os, 'ubuntu') && 'linux' || 'macos' }}
+      AUBE_BATS_SHARD_INDEX: ${{ matrix.shard }}
+      AUBE_BATS_SHARD_COUNT: ${{ matrix.count }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5 # zizmor: ignore[cache-poisoning] PRs restore only; saves are restricted to main
+        with:
+          cache_save: ${{ github.ref == 'refs/heads/main' }}
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: aube-${{ matrix.os }}
+          path: target/debug
+      - run: chmod +x target/debug/aube
+      - name: Run BATS shard ${{ matrix.shard }}/${{ matrix.count }}
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+        with:
+          timeout_minutes: 20
+          max_attempts: 2
+          command: mise run ci:bats:nonserial
+
+  # Serial BATS jobs — tests tagged `serial` that can't run under
+  # parallel (e.g. stateful store-lock tests, global env mutation).
+  # Keep these paired with the non-serial BATS jobs on GitHub-hosted
+  # runners for the same jail-build compatibility reasons.
+  bats-serial:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            runner: ubuntu-latest
+          - os: macos-latest
+            runner: macos-latest
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 25
+    permissions:
+      contents: read
+    env:
+      AUBE_CI_OS: ${{ startsWith(matrix.os, 'ubuntu') && 'linux' || 'macos' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5 # zizmor: ignore[cache-poisoning] PRs restore only; saves are restricted to main
+        with:
+          cache_save: ${{ github.ref == 'refs/heads/main' }}
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: aube-${{ matrix.os }}
+          path: target/debug
+      - run: chmod +x target/debug/aube
+      - name: Run serial BATS
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+        with:
+          timeout_minutes: 20
+          max_attempts: 2
+          command: mise run ci:bats:serial
+
+  # Windows parity: build + unit tests + Rust-native e2e smoke. No BATS
+  # on Windows — BATS is bash-only and the linker uses NTFS junctions
+  # rather than real symlinks (matching pnpm), so we just exercise the
+  # cargo test suite to catch platform regressions. Developer Mode is
+  # not required on GitHub-hosted windows-latest runners.
+  windows:
+    runs-on: windows-latest
+    timeout-minutes: 20
+    env:
+      MBX_TARGET_VIEWS: "0"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
+      - run: mbx build --workspace
+      - run: mbx test --workspace
+
+  # Aggregator that required-status-checks can target. If any upstream job
+  # failed, was cancelled, or was skipped, this step exits non-zero so the PR is
+  # blocked. Lets the branch-protection rule depend on one name instead of ten.
+  # Exception: the PR-only API job may skip outside pull requests, and any
+  # failure in that job is advisory even though the job itself remains red.
+  final:
+    needs:
+      - build
+      - test-linux
+      - bats
+      - bats-serial
+      - windows
+      - api-stability
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    timeout-minutes: 2
+    permissions: {}
+    # Run on success or upstream failure but skip when the workflow is cancelled
+    # — `always()` would override `cancel-in-progress` and waste a runner.
+    if: ${{ !cancelled() }}
+    steps:
+      - name: Gate on upstream job results
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          # Jobs whose `if:` legitimately skips them in this event. A skip
+          # here is a pass; every other job must actually succeed.
+          SKIP_OK = {"api-stability"}
+          ADVISORY_FAILURE = {"api-stability"}
+          needs = json.loads(os.environ["NEEDS_JSON"])
+          failed = False
+          for name, data in sorted(needs.items()):
+              result = data.get("result", "unknown")
+              if result == "success":
+                  print(f"::notice::{name}: {result}")
+              elif result == "failure" and name in ADVISORY_FAILURE:
+                  print(f"::warning::{name}: {result} (advisory; inspect for an unintended major bump)")
+              elif result == "skipped" and name in SKIP_OK:
+                  print(f"::notice::{name}: {result} (allowed to skip)")
+              else:
+                  print(f"::error::{name}: {result}")
+                  failed = True
+
+          if failed:
+              print("One or more upstream jobs did not complete successfully.")
+              sys.exit(1)
+
+          print("All CI jobs completed successfully.")
+          PY

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -110,6 +110,9 @@ jobs:
     # push/tag/dispatch runs.
     if: github.event_name == 'pull_request'
     continue-on-error: true
+    outputs:
+      results_present: ${{ steps.report.outputs.results_present }}
+      checks_passed: ${{ steps.report.outputs.checks_passed }}
     runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 20
     env:
@@ -170,12 +173,16 @@ jobs:
               set -e
               printf '%s\n' "$ffi_status" > /tmp/ffi-status
       - name: Report API stability
+        id: report
         if: always()
         run: |
           if [ ! -s /tmp/semver-status ] || [ ! -s /tmp/ffi-status ]; then
+            echo "results_present=false" >> "$GITHUB_OUTPUT"
+            echo "checks_passed=false" >> "$GITHUB_OUTPUT"
             echo "::error::one or more API stability checks did not report a result"
             exit 1
           fi
+          echo "results_present=true" >> "$GITHUB_OUTPUT"
           SEMVER=$(cat /tmp/semver-status)
           FFI=$(cat /tmp/ffi-status)
           fail=0
@@ -186,6 +193,11 @@ jobs:
           if [ "$FFI" -ne 0 ]; then
             echo "::error::C ABI exports drifted from crates/aube-ffi/abi-symbols.txt."
             fail=1
+          fi
+          if [ "$fail" -eq 0 ]; then
+            echo "checks_passed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "checks_passed=false" >> "$GITHUB_OUTPUT"
           fi
           exit $fail
 
@@ -352,7 +364,13 @@ jobs:
           failed = False
           for name, data in sorted(needs.items()):
               result = data.get("result", "unknown")
-              if result == "success":
+              outputs = data.get("outputs", {})
+              if name == "api-stability" and result != "skipped" and outputs.get("results_present") != "true":
+                  print(f"::error::{name}: one or more checks did not report a result")
+                  failed = True
+              elif name == "api-stability" and outputs.get("checks_passed") == "false":
+                  print(f"::warning::{name}: compatibility check failed (advisory; inspect for an unintended major bump)")
+              elif result == "success":
                   print(f"::notice::{name}: {result}")
               elif result == "failure" and name in ADVISORY_FAILURE:
                   print(f"::warning::{name}: {result} (advisory; inspect for an unintended major bump)")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,366 +1,49 @@
 name: ci
 
-# Full CI matrix for aube — linux, macos, and windows build/test + BATS
-# integration shards. This workflow is the canonical CI entry point;
-# .buildkite/ is left in place but is expected to be disabled at the
-# GitHub-App level so it doesn't double-run or consume vCPU minutes.
-
 on:
   workflow_dispatch:
   pull_request:
   push:
     branches: ["main"]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions: {}
 
-env:
-  CARGO_TERM_COLOR: always
-  CARGO_INCREMENTAL: "0"
-
 jobs:
-  # Build debug artifacts for every OS that runs BATS or needs a binary
-  # downstream. Linux + macOS use mise so tool pins and env parity with
-  # `mise run build` are guaranteed. Windows ships no BATS run (BATS is
-  # bash-only, junction-links kick in on NTFS) so its build + test live
-  # in the dedicated `windows` job below.
-  build:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64
-          - os: macos-latest
-            runner: namespace-profile-endev-macos-arm64
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && matrix.os || matrix.runner }}
-    timeout-minutes: 20
+  trusted:
+    if: ${{ github.actor == 'jdx' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')) }}
     permissions:
       contents: read
       id-token: write
-    env:
-      RUSTFLAGS: "-D warnings"
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/mbx
-      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5 # zizmor: ignore[cache-poisoning] PRs restore only; saves are restricted to main
-        with:
-          cache_save: ${{ github.ref == 'refs/heads/main' }}
-      - run: mise run build
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: aube-${{ matrix.os }}
-          path: target/debug/aube
-          retention-days: 1
-          if-no-files-found: error
+    uses: ./.github/workflows/ci-impl.yml
+    with:
+      trusted: true
+      mbx-backend: server
 
-  # Linux-only test + lint + render + docs:build. Matches the
-  # `linux / test` step in .buildkite/pipeline.sh. Split from `build` so
-  # lint failures don't block the BATS jobs from starting against a
-  # known-good binary.
-  test-linux:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
-    timeout-minutes: 30
+  untrusted:
+    if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
     permissions:
       contents: read
-      id-token: write
-    env:
-      RUSTFLAGS: "-D warnings"
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/mbx
-      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5 # zizmor: ignore[cache-poisoning] PRs restore only; saves are restricted to main
-        with:
-          cache_save: ${{ github.ref == 'refs/heads/main' }}
-      - run: node benchmarks/validate-results.mts
-      - run: mise run test
-      - run: mise run lint
-      - run: cargo-machete
-      - run: mise x cargo:cargo-audit@0.22.1 -- cargo audit --deny warnings
-      - run: mise x cargo:cargo-deny@0.19.6 -- cargo deny check bans licenses sources
-      - run: mbx msrv --manifest-path crates/aube/Cargo.toml verify --output-format minimal
-      - run: mise run render
-      - name: assert render produces no diff
-        run: |
-          if [ -n "$(git status --porcelain)" ]; then
-            echo "::error::'mise run render' produced changes. Run it locally and commit."
-            git status
-            git diff
-            exit 1
-          fi
-      - run: mise run docs:build
+    uses: ./.github/workflows/ci-impl.yml
+    with:
+      trusted: false
+      mbx-backend: github
 
-  # Check every published Rust library against main and guard the C ABI export
-  # set against the frozen crates/aube-ffi/abi-symbols.txt manifest. Any failure
-  # makes this job red, while `final` treats the job as advisory.
-  api-stability:
-    # PR-time gate only. `final` treats the resulting skipped job as a pass on
-    # push/tag/dispatch runs.
-    if: github.event_name == 'pull_request'
-    runs-on: ${{ (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
-    timeout-minutes: 20
-    permissions:
-      contents: read
-      id-token: write
-    env:
-      CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback
-      RUSTFLAGS: "-D warnings"
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-      - uses: ./.github/actions/mbx
-      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5 # zizmor: ignore[cache-poisoning] PRs restore only; saves are restricted to main
-        with:
-          cache_save: false
-      # Both parallel API checks invoke Cargo. Complete rustup's lazy toolchain
-      # installation first so they cannot race while installing components.
-      - name: Prepare Rust toolchain
-        run: rustc --version
-      - name: Fetch semver baseline
-        run: git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
-      # Run the independent Rust and C ABI checks concurrently, preserving both
-      # results so the final step can report every failure before failing the job.
-      - parallel:
-          - name: Published Rust APIs — cargo-semver-checks
-            run: |
-              set +e
-              ./bin/cargo-semver-checks semver-checks \
-                --baseline-rev origin/main \
-                --package aube \
-                --package aube-codes \
-                --package aube-linker \
-                --package aube-lockfile \
-                --package aube-manifest \
-                --package aube-registry \
-                --package aube-resolver \
-                --package aube-runtime \
-                --package aube-scripts \
-                --package aube-settings \
-                --package aube-store \
-                --package aube-util \
-                --package aube-workspace
-              semver_status=$?
-              set -e
-              printf '%s\n' "$semver_status" > /tmp/semver-status
-          - name: C ABI — frozen export set
-            run: |
-              set +e
-              (
-                mbx build --locked --profile ffi -p aube-ffi &&
-                grep -vE '^[[:space:]]*(#|$)' crates/aube-ffi/abi-symbols.txt | sort -u > /tmp/abi-expected.txt &&
-                nm -D --defined-only --extern-only target/ffi/libaube_ffi.so \
-                  | awk '{ print $3 }' | grep '^aube_' | sort -u > /tmp/abi-actual.txt &&
-                diff -u /tmp/abi-expected.txt /tmp/abi-actual.txt
-              )
-              ffi_status=$?
-              set -e
-              printf '%s\n' "$ffi_status" > /tmp/ffi-status
-      - name: Report API stability
-        if: always()
-        run: |
-          if [ ! -s /tmp/semver-status ] || [ ! -s /tmp/ffi-status ]; then
-            echo "::error::one or more API stability checks did not report a result"
-            exit 1
-          fi
-          SEMVER=$(cat /tmp/semver-status)
-          FFI=$(cat /tmp/ffi-status)
-          fail=0
-          if [ "$SEMVER" -ne 0 ]; then
-            echo "::error::Rust API compatibility check failed. Inspect the cargo-semver-checks output above."
-            fail=1
-          fi
-          if [ "$FFI" -ne 0 ]; then
-            echo "::error::C ABI exports drifted from crates/aube-ffi/abi-symbols.txt."
-            fail=1
-          fi
-          exit $fail
-
-  # BATS integration shards. Linux runs 4 shards (matches Buildkite),
-  # macOS runs 2. Keep these on GitHub-hosted runners: the jail-build
-  # tests assert native OS sandbox behavior that does not match the
-  # Namespace runner profiles.
-  # Each shard downloads the OS-matched debug binary from `build` and
-  # invokes mise-task ci:bats:nonserial with its shard index. mise provisions
-  # rush as the parallel driver on both platforms.
-  #
-  # retry handles the rare BATS flake (process teardown racing npm
-  # cache writes, etc.); the Buildkite side has the same retry:1.
-  bats:
-    needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            runner: ubuntu-latest
-            shard: 0
-            count: 4
-          - os: ubuntu-latest
-            runner: ubuntu-latest
-            shard: 1
-            count: 4
-          - os: ubuntu-latest
-            runner: ubuntu-latest
-            shard: 2
-            count: 4
-          - os: ubuntu-latest
-            runner: ubuntu-latest
-            shard: 3
-            count: 4
-          - os: macos-latest
-            runner: macos-latest
-            shard: 0
-            count: 2
-          - os: macos-latest
-            runner: macos-latest
-            shard: 1
-            count: 2
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 25
-    permissions:
-      contents: read
-    env:
-      AUBE_CI_OS: ${{ startsWith(matrix.os, 'ubuntu') && 'linux' || 'macos' }}
-      AUBE_BATS_SHARD_INDEX: ${{ matrix.shard }}
-      AUBE_BATS_SHARD_COUNT: ${{ matrix.count }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5 # zizmor: ignore[cache-poisoning] PRs restore only; saves are restricted to main
-        with:
-          cache_save: ${{ github.ref == 'refs/heads/main' }}
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: aube-${{ matrix.os }}
-          path: target/debug
-      - run: chmod +x target/debug/aube
-      - name: Run BATS shard ${{ matrix.shard }}/${{ matrix.count }}
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
-        with:
-          timeout_minutes: 20
-          max_attempts: 2
-          command: mise run ci:bats:nonserial
-
-  # Serial BATS jobs — tests tagged `serial` that can't run under
-  # parallel (e.g. stateful store-lock tests, global env mutation).
-  # Keep these paired with the non-serial BATS jobs on GitHub-hosted
-  # runners for the same jail-build compatibility reasons.
-  bats-serial:
-    needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            runner: ubuntu-latest
-          - os: macos-latest
-            runner: macos-latest
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 25
-    permissions:
-      contents: read
-    env:
-      AUBE_CI_OS: ${{ startsWith(matrix.os, 'ubuntu') && 'linux' || 'macos' }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5 # zizmor: ignore[cache-poisoning] PRs restore only; saves are restricted to main
-        with:
-          cache_save: ${{ github.ref == 'refs/heads/main' }}
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: aube-${{ matrix.os }}
-          path: target/debug
-      - run: chmod +x target/debug/aube
-      - name: Run serial BATS
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
-        with:
-          timeout_minutes: 20
-          max_attempts: 2
-          command: mise run ci:bats:serial
-
-  # Windows parity: build + unit tests + Rust-native e2e smoke. No BATS
-  # on Windows — BATS is bash-only and the linker uses NTFS junctions
-  # rather than real symlinks (matching pnpm), so we just exercise the
-  # cargo test suite to catch platform regressions. Developer Mode is
-  # not required on GitHub-hosted windows-latest runners.
-  windows:
-    runs-on: windows-latest
-    timeout-minutes: 20
-    env:
-      MBX_TARGET_VIEWS: "0"
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/mbx
-      - run: mbx build --workspace
-      - run: mbx test --workspace
-
-  # Aggregator that required-status-checks can target. If any upstream job
-  # failed, was cancelled, or was skipped, this step exits non-zero so the PR is
-  # blocked. Lets the branch-protection rule depend on one name instead of ten.
-  # Exception: the PR-only API job may skip outside pull requests, and any
-  # failure in that job is advisory even though the job itself remains red.
   final:
-    needs:
-      - build
-      - test-linux
-      - bats
-      - bats-serial
-      - windows
-      - api-stability
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
-    timeout-minutes: 2
+    name: final
+    if: ${{ always() && !cancelled() && needs.trusted.result != 'cancelled' && needs.untrusted.result != 'cancelled' }}
     permissions: {}
-    # Run on success or upstream failure but skip when the workflow is cancelled
-    # — `always()` would override `cancel-in-progress` and waste a runner.
-    if: ${{ !cancelled() }}
+    needs: [trusted, untrusted]
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
     steps:
-      - name: Gate on upstream job results
+      - name: Check selected workflow result
         env:
-          NEEDS_JSON: ${{ toJSON(needs) }}
+          TRUSTED_RESULT: ${{ needs.trusted.result }}
+          UNTRUSTED_RESULT: ${{ needs.untrusted.result }}
         run: |
-          python3 - <<'PY'
-          import json
-          import os
-          import sys
-
-          # Jobs whose `if:` legitimately skips them in this event. A skip
-          # here is a pass; every other job must actually succeed.
-          SKIP_OK = {"api-stability"}
-          ADVISORY_FAILURE = {"api-stability"}
-          needs = json.loads(os.environ["NEEDS_JSON"])
-          failed = False
-          for name, data in sorted(needs.items()):
-              result = data.get("result", "unknown")
-              if result == "success":
-                  print(f"::notice::{name}: {result}")
-              elif result == "failure" and name in ADVISORY_FAILURE:
-                  print(f"::warning::{name}: {result} (advisory; inspect for an unintended major bump)")
-              elif result == "skipped" and name in SKIP_OK:
-                  print(f"::notice::{name}: {result} (allowed to skip)")
-              else:
-                  print(f"::error::{name}: {result}")
-                  failed = True
-
-          if failed:
-              print("One or more upstream jobs did not complete successfully.")
-              sys.exit(1)
-
-          print("All CI jobs completed successfully.")
-          PY
+          if [[ "$TRUSTED_RESULT" == success && "$UNTRUSTED_RESULT" == skipped ]] ||
+             [[ "$TRUSTED_RESULT" == skipped && "$UNTRUSTED_RESULT" == success ]]; then
+            exit 0
+          fi
+          echo "trusted=$TRUSTED_RESULT untrusted=$UNTRUSTED_RESULT"
+          exit 1

--- a/.github/workflows/docs-impl.yml
+++ b/.github/workflows/docs-impl.yml
@@ -1,0 +1,80 @@
+name: docs implementation
+
+on:
+  workflow_call:
+    inputs:
+      trusted:
+        required: true
+        type: boolean
+      mbx-backend:
+        required: true
+        type: string
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+env:
+  CARGO_INCREMENTAL: "0"
+
+jobs:
+  build:
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    steps:
+      - name: Assert OIDC is unavailable to untrusted docs builds
+        if: ${{ !inputs.trusted }}
+        run: |
+          test -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
+          test -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+      - name: Build aube
+        run: mbx build
+      - name: Setup Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      - name: Render CLI docs from usage spec
+        run: |
+          ./target/debug/aube usage > aube.usage.kdl
+          rm -rf docs/cli && mkdir -p docs/cli
+          usage g markdown -mf aube.usage.kdl --out-dir docs/cli --url-prefix /cli
+          usage g json     -f aube.usage.kdl > docs/cli/commands.json
+      - name: Install docs dependencies with aube
+        run: |
+          cd docs
+          ../target/debug/aube install
+      - name: Build docs site with aube
+        env:
+          AUBE_UPDATE_STARS: "1"
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          cd docs
+          ../target/debug/aube run docs:build
+          touch .vitepress/dist/.nojekyll
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
+        with:
+          path: docs/.vitepress/dist
+          # v5 excludes dotfiles by default; .nojekyll is created above
+          # to disable GitHub Pages' Jekyll processing for the VitePress
+          # build, so it must ship inside the artifact.
+          include-hidden-files: true
+
+  deploy:
+    if: inputs.trusted
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: namespace-profile-endev-linux-amd64
+    name: Deploy
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/docs-impl.yml
+++ b/.github/workflows/docs-impl.yml
@@ -10,16 +10,13 @@ on:
         required: true
         type: string
 
-concurrency:
-  group: pages
-  cancel-in-progress: false
-
 env:
   CARGO_INCREMENTAL: "0"
 
 jobs:
   build:
     runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    timeout-minutes: 30
     steps:
       - name: Assert OIDC is unavailable to untrusted docs builds
         if: ${{ !inputs.trusted }}
@@ -68,11 +65,15 @@ jobs:
 
   deploy:
     if: inputs.trusted
+    concurrency:
+      group: pages
+      cancel-in-progress: false
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     needs: build
     runs-on: namespace-profile-endev-linux-amd64
+    timeout-minutes: 10
     name: Deploy
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,7 @@ on:
       - "mise.lock"
       - "benchmarks/results.json"
       - ".github/workflows/docs.yml"
+      - ".github/workflows/docs-impl.yml"
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,69 +16,43 @@ on:
 
 permissions: {}
 
-concurrency:
-  group: pages
-  cancel-in-progress: false
-
-env:
-  CARGO_INCREMENTAL: "0"
-
 jobs:
-  build:
-    runs-on: namespace-profile-endev-linux-amd64
+  trusted:
+    if: ${{ github.actor == 'jdx' }}
     permissions:
       contents: read
       id-token: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - uses: ./.github/actions/mbx
-      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
-      - name: Build aube
-        run: mbx build
-      - name: Setup Pages
-        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
-      - name: Render CLI docs from usage spec
-        run: |
-          ./target/debug/aube usage > aube.usage.kdl
-          rm -rf docs/cli && mkdir -p docs/cli
-          usage g markdown -mf aube.usage.kdl --out-dir docs/cli --url-prefix /cli
-          usage g json     -f aube.usage.kdl > docs/cli/commands.json
-      - name: Install docs dependencies with aube
-        run: |
-          cd docs
-          ../target/debug/aube install
-      - name: Build docs site with aube
-        env:
-          AUBE_UPDATE_STARS: "1"
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          cd docs
-          ../target/debug/aube run docs:build
-          touch .vitepress/dist/.nojekyll
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
-        with:
-          path: docs/.vitepress/dist
-          # v5 excludes dotfiles by default; .nojekyll is created above
-          # to disable GitHub Pages' Jekyll processing for the VitePress
-          # build, so it must ship inside the artifact.
-          include-hidden-files: true
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    needs: build
-    runs-on: namespace-profile-endev-linux-amd64
-    name: Deploy
-    permissions:
       pages: write
-      id-token: write
+    uses: ./.github/workflows/docs-impl.yml
+    with:
+      trusted: true
+      mbx-backend: server
+
+  untrusted:
+    if: ${{ github.actor != 'jdx' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/docs-impl.yml
+    with:
+      trusted: false
+      mbx-backend: github
+
+  docs:
+    name: docs
+    if: ${{ always() && !cancelled() && needs.trusted.result != 'cancelled' && needs.untrusted.result != 'cancelled' }}
+    permissions: {}
+    needs: [trusted, untrusted]
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+      - name: Check selected workflow result
+        env:
+          TRUSTED_RESULT: ${{ needs.trusted.result }}
+          UNTRUSTED_RESULT: ${{ needs.untrusted.result }}
+        run: |
+          if [[ "$TRUSTED_RESULT" == success && "$UNTRUSTED_RESULT" == skipped ]] ||
+             [[ "$TRUSTED_RESULT" == skipped && "$UNTRUSTED_RESULT" == success ]]; then
+            exit 0
+          fi
+          echo "trusted=$TRUSTED_RESULT untrusted=$UNTRUSTED_RESULT"
+          exit 1

--- a/.github/workflows/ffi-impl.yml
+++ b/.github/workflows/ffi-impl.yml
@@ -1,0 +1,243 @@
+name: ffi implementation
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: false
+        type: string
+        default: ""
+      draft_phase:
+        required: false
+        type: boolean
+        default: false
+      publish_packages:
+        required: false
+        type: boolean
+        default: false
+      trusted:
+        required: true
+        type: boolean
+      mbx-backend:
+        required: true
+        type: string
+    secrets:
+      AUBE_GH_TOKEN:
+        required: false
+      CERTIFICATES_P12:
+        required: false
+      CERTIFICATES_P12_PASS:
+        required: false
+
+concurrency:
+  group: ffi-${{ inputs.tag || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'release' && inputs.tag == '' }}
+
+jobs:
+  build:
+    name: ${{ matrix.package }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { runner: macos-15, namespace_runner: namespace-profile-endev-macos-arm64, target: aarch64-apple-darwin, os: darwin, cpu: arm64, package: darwin-arm64, binary: libaube_ffi.dylib, ext: dylib }
+          - { runner: macos-15-intel, namespace_runner: namespace-profile-endev-macos-arm64, target: x86_64-apple-darwin, os: darwin, cpu: x64, package: darwin-x64, binary: libaube_ffi.dylib, ext: dylib }
+          - { runner: ubuntu-24.04-arm, namespace_runner: namespace-profile-endev-linux-arm64-large, target: aarch64-unknown-linux-gnu, os: linux, cpu: arm64, package: linux-arm64, binary: libaube_ffi.so, ext: so }
+          - { runner: ubuntu-latest, namespace_runner: namespace-profile-endev-linux-amd64, target: x86_64-unknown-linux-gnu, os: linux, cpu: x64, package: linux-x64, binary: libaube_ffi.so, ext: so }
+          - { runner: ubuntu-24.04-arm, namespace_runner: namespace-profile-endev-linux-arm64-large, target: aarch64-unknown-linux-musl, os: linux, cpu: arm64, libc: musl, package: linux-arm64-musl, binary: libaube_ffi.so, ext: so }
+          - { runner: ubuntu-latest, namespace_runner: namespace-profile-endev-linux-amd64, target: x86_64-unknown-linux-musl, os: linux, cpu: x64, libc: musl, package: linux-x64-musl, binary: libaube_ffi.so, ext: so }
+          - { runner: windows-latest, namespace_runner: windows-latest, target: aarch64-pc-windows-msvc, os: win32, cpu: arm64, package: win32-arm64, binary: aube_ffi.dll, ext: dll }
+          - { runner: windows-latest, namespace_runner: windows-latest, target: x86_64-pc-windows-msvc, os: win32, cpu: x64, package: win32-x64, binary: aube_ffi.dll, ext: dll }
+    runs-on: ${{ (github.event_name == 'release' || inputs.tag != '' || inputs.draft_phase || !inputs.trusted) && matrix.runner || matrix.namespace_runner }}
+    timeout-minutes: 60
+    env:
+      MBX_TARGET_VIEWS: ${{ matrix.os == 'win32' && '0' || '1' }}
+    steps:
+      - name: Assert OIDC is unavailable to untrusted CI
+        if: ${{ !inputs.trusted && github.event_name != 'release' && inputs.tag == '' && !inputs.draft_phase }}
+        shell: bash
+        run: |
+          test -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
+          test -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with: { persist-credentials: false, ref: "${{ inputs.tag || github.ref }}" }
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with: { node-version: "24", package-manager-cache: false }
+      - uses: ./.github/actions/mbx
+        if: github.event_name != 'release' && inputs.tag == '' && !inputs.draft_phase
+        with:
+          backend: ${{ inputs.mbx-backend }}
+      - name: Install Rust target
+        shell: bash
+        run: rustup target add '${{ matrix.target }}'
+      - name: Install musl compiler
+        if: matrix.libc == 'musl'
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+      - name: Build C ABI library
+        if: github.event_name != 'release' && inputs.tag == '' && !inputs.draft_phase
+        shell: bash
+        run: |
+          if [[ '${{ matrix.libc }}' == musl ]]; then
+            export RUSTFLAGS='-C target-feature=-crt-static'
+          fi
+          mbx build --locked --profile ffi -p aube-ffi --target '${{ matrix.target }}'
+      - name: Build release C ABI library
+        if: github.event_name == 'release' || inputs.tag != '' || inputs.draft_phase
+        shell: bash
+        run: |
+          if [[ '${{ matrix.libc }}' == musl ]]; then
+            export RUSTFLAGS='-C target-feature=-crt-static'
+          fi
+          cargo build --locked --profile ffi -p aube-ffi --target '${{ matrix.target }}'
+      - name: Import macOS signing certificate
+        if: (github.event_name == 'release' || inputs.tag != '') && matrix.os == 'darwin'
+        uses: apple-actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7.0.0
+        with:
+          p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
+          p12-password: ${{ secrets.CERTIFICATES_P12_PASS }}
+      - name: Sign macOS library
+        if: (github.event_name == 'release' || inputs.tag != '') && matrix.os == 'darwin'
+        shell: bash
+        run: |
+          codesign --force --sign 'Developer ID Application: Jeffrey Dickey (4993Y37DX6)' \
+            --options runtime --timestamp \
+            'target/${{ matrix.target }}/ffi/${{ matrix.binary }}'
+      - name: Set package version
+        id: version
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          if [[ -n "$RELEASE_TAG" ]]; then version=${RELEASE_TAG#v}; else version="0.0.0-smoke.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"; fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Stage library and platform package
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          OUT_DIR: ${{ runner.temp }}/ffi
+          AUBE_FFI_BINARY: target/${{ matrix.target }}/ffi/${{ matrix.binary }}
+          AUBE_FFI_OS: ${{ matrix.os }}
+          AUBE_FFI_CPU: ${{ matrix.cpu }}
+          AUBE_FFI_LIBC: ${{ matrix.libc }}
+          AUBE_FFI_TARGET: ${{ matrix.target }}
+        run: |
+          mkdir -p "$OUT_DIR"
+          cp "$AUBE_FFI_BINARY" "$OUT_DIR/libaube-${AUBE_FFI_TARGET}.${{ matrix.ext }}"
+          node crates/aube-ffi/npm/package.mjs
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: aube-ffi-${{ matrix.package }}
+          path: ${{ runner.temp }}/ffi/*
+          if-no-files-found: error
+
+  packages:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with: { persist-credentials: false, ref: "${{ inputs.tag || github.ref }}" }
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with: { node-version: "24", package-manager-cache: false }
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          tool_versions: |
+            bun 1.3.11
+            deno 2.9.2
+          install_args: bun deno
+          cache: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with: { pattern: aube-ffi-*, path: packages, merge-multiple: true }
+      - name: Pack root npm package
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          if [[ -n "$RELEASE_TAG" ]]; then VERSION=${RELEASE_TAG#v}; else VERSION="0.0.0-smoke.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"; fi
+          VERSION="$VERSION" OUT_DIR="$PWD/packages" node crates/aube-ffi/npm/package.mjs
+          cp crates/aube-ffi/include/aube.h packages/aube.h
+          test "$(find packages -maxdepth 1 -name '*.tgz' -print | wc -l)" -eq 9
+      - name: Smoke-test raw library with Bun and Deno
+        shell: bash
+        env:
+          AUBE_FFI_LIBRARY: ${{ github.workspace }}/packages/libaube-x86_64-unknown-linux-gnu.so
+        run: |
+          bun run crates/aube-ffi/poc/bun.ts
+          deno run --allow-env=AUBE_FFI_LIBRARY --allow-ffi --allow-read --allow-write crates/aube-ffi/poc/deno.ts
+      - name: Smoke-test npm packages and declarations
+        shell: bash
+        run: | # zizmor: ignore[adhoc-packages] installs only tarballs built by required matrix jobs
+          mkdir npm-smoke
+          cd npm-smoke
+          npm init --yes >/dev/null
+          npm install --force --ignore-scripts --no-package-lock ../packages/*.tgz
+          node -e "const ffi=require('@jdxcode/aube-ffi'); require('fs').accessSync(ffi.libraryPath); require('fs').accessSync(ffi.headerPath)"
+          cp "$GITHUB_WORKSPACE/crates/aube-ffi/npm/typecheck.ts" .
+          npx --yes --package=typescript@5.9.3 tsc --strict --noEmit \
+            --lib ES2022,DOM --module NodeNext --moduleResolution NodeNext typecheck.ts
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: aube-ffi-distribution
+          path: |
+            packages/*.tgz
+            packages/libaube-*
+            packages/aube.h
+          if-no-files-found: error
+      - uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        if: github.event_name == 'release' || inputs.tag != ''
+        with:
+          subject-path: |
+            packages/*.tgz
+            packages/libaube-*
+            packages/aube.h
+      - name: Publish platform and root packages
+        # `release: published` or an explicit manual npm backfill only —
+        # never an asset-recovery dispatch or the workflow_call draft phase.
+        if: github.event_name == 'release' || (inputs.tag != '' && !inputs.draft_phase && inputs.publish_packages == true)
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          version=${RELEASE_TAG#v}; tag=latest; [[ "$version" == *-* ]] && tag=next
+          publish_package() {
+            local package=$1 name
+            name=$(tar -xOf "$package" package/package.json | jq -r .name)
+            if npm view "${name}@${version}" version >/dev/null 2>&1; then
+              echo "${name}@${version} is already published"
+              return
+            fi
+            npm publish "$package" --access public --provenance --tag "$tag"
+          }
+          # Relative paths need the ./ prefix or npm parses them as
+          # hosted-git owner/repo shorthands instead of local tarballs.
+          for package in ./packages/*-darwin-*.tgz ./packages/*-linux-*.tgz ./packages/*-win32-*.tgz; do publish_package "$package"; done
+          publish_package "./packages/jdxcode-aube-ffi-${version}.tgz"
+
+  # Attach the C ABI libraries + header to the (still-draft) GitHub
+  # release. Runs on the workflow_call from release-plz.yml during a
+  # real release, or on a workflow_dispatch with `tag` as the recovery
+  # path for a draft whose ffi assets are missing. Never on the
+  # `release: published` event: under immutable releases that is
+  # always too late to add assets.
+  release-assets:
+    if: inputs.tag != ''
+    needs: packages
+    runs-on: ubuntu-latest
+    # Uploads authenticate with AUBE_GH_TOKEN (the PAT release.yml
+    # already uses for draft asset uploads), not github.token.
+    permissions: {}
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with: { name: aube-ffi-distribution, path: packages }
+      - name: Attach C ABI assets to draft release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        # No checkout in this job, so gh needs the repo passed explicitly.
+        run: |
+          is_draft=$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)
+          if [[ "$is_draft" != "true" ]]; then
+            echo "::notice::release $RELEASE_TAG is already published; immutable releases cannot gain assets, skipping upload"
+            exit 0
+          fi
+          gh release upload --repo "$GITHUB_REPOSITORY" "$RELEASE_TAG" packages/libaube-* packages/aube.h --clobber

--- a/.github/workflows/ffi-impl.yml
+++ b/.github/workflows/ffi-impl.yml
@@ -196,7 +196,7 @@ jobs:
         shell: bash
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
-        run: |
+        run: | # zizmor: ignore[use-trusted-publishing] publishes each tarball with npm provenance via OIDC
           version=${RELEASE_TAG#v}; tag=latest; [[ "$version" == *-* ]] && tag=next
           publish_package() {
             local package=$1 name

--- a/.github/workflows/ffi.yml
+++ b/.github/workflows/ffi.yml
@@ -17,6 +17,7 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/ffi.yml"
+      - ".github/workflows/ffi-impl.yml"
   push:
     branches: [main]
     paths:
@@ -34,6 +35,7 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/ffi.yml"
+      - ".github/workflows/ffi-impl.yml"
   release:
     types: [published]
   workflow_call:

--- a/.github/workflows/ffi.yml
+++ b/.github/workflows/ffi.yml
@@ -36,24 +36,11 @@ on:
       - ".github/workflows/ffi.yml"
   release:
     types: [published]
-  # Called from release-plz.yml between the CLI asset upload and the
-  # draft→published flip. With immutable GitHub releases enabled, a
-  # release's asset list freezes the moment it publishes — so the C ABI
-  # libraries must be attached while the release is still a draft. npm
-  # publishing intentionally stays on the `release: published` event
-  # above: npm doesn't care about release immutability, and gating it
-  # on the published release means packages only go out for releases
-  # that actually shipped.
   workflow_call:
     inputs:
       tag:
         required: true
         type: string
-      # Constant marker distinguishing the draft-phase call from a
-      # direct workflow_dispatch: inside a called workflow,
-      # github.event_name reflects the *caller's* event, which is
-      # itself workflow_dispatch when release-plz.yml is manually
-      # re-run — so the event name alone can't gate the npm publish.
       draft_phase:
         required: false
         type: boolean
@@ -77,211 +64,55 @@ on:
         type: boolean
         default: false
 
-concurrency:
-  group: ffi-${{ inputs.tag || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'release' && inputs.tag == '' }}
-
 permissions: {}
 
 jobs:
-  build:
-    name: ${{ matrix.package }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - { runner: macos-15, namespace_runner: namespace-profile-endev-macos-arm64, target: aarch64-apple-darwin, os: darwin, cpu: arm64, package: darwin-arm64, binary: libaube_ffi.dylib, ext: dylib }
-          - { runner: macos-15-intel, namespace_runner: namespace-profile-endev-macos-arm64, target: x86_64-apple-darwin, os: darwin, cpu: x64, package: darwin-x64, binary: libaube_ffi.dylib, ext: dylib }
-          - { runner: ubuntu-24.04-arm, namespace_runner: namespace-profile-endev-linux-arm64-large, target: aarch64-unknown-linux-gnu, os: linux, cpu: arm64, package: linux-arm64, binary: libaube_ffi.so, ext: so }
-          - { runner: ubuntu-latest, namespace_runner: namespace-profile-endev-linux-amd64, target: x86_64-unknown-linux-gnu, os: linux, cpu: x64, package: linux-x64, binary: libaube_ffi.so, ext: so }
-          - { runner: ubuntu-24.04-arm, namespace_runner: namespace-profile-endev-linux-arm64-large, target: aarch64-unknown-linux-musl, os: linux, cpu: arm64, libc: musl, package: linux-arm64-musl, binary: libaube_ffi.so, ext: so }
-          - { runner: ubuntu-latest, namespace_runner: namespace-profile-endev-linux-amd64, target: x86_64-unknown-linux-musl, os: linux, cpu: x64, libc: musl, package: linux-x64-musl, binary: libaube_ffi.so, ext: so }
-          - { runner: windows-latest, namespace_runner: windows-latest, target: aarch64-pc-windows-msvc, os: win32, cpu: arm64, package: win32-arm64, binary: aube_ffi.dll, ext: dll }
-          - { runner: windows-latest, namespace_runner: windows-latest, target: x86_64-pc-windows-msvc, os: win32, cpu: x64, package: win32-x64, binary: aube_ffi.dll, ext: dll }
-    runs-on: ${{ (github.event_name == 'release' || inputs.tag != '' || inputs.draft_phase || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && matrix.runner || matrix.namespace_runner }}
-    timeout-minutes: 60
-    permissions: { contents: read, id-token: write }
-    env:
-      MBX_TARGET_VIEWS: ${{ matrix.os == 'win32' && '0' || '1' }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with: { persist-credentials: false, ref: "${{ inputs.tag || github.ref }}" }
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with: { node-version: "24", package-manager-cache: false }
-      - uses: ./.github/actions/mbx
-        if: github.event_name != 'release' && inputs.tag == '' && !inputs.draft_phase
-      - name: Install Rust target
-        shell: bash
-        run: rustup target add '${{ matrix.target }}'
-      - name: Install musl compiler
-        if: matrix.libc == 'musl'
-        run: sudo apt-get update && sudo apt-get install -y musl-tools
-      - name: Build C ABI library
-        if: github.event_name != 'release' && inputs.tag == '' && !inputs.draft_phase
-        shell: bash
-        run: |
-          if [[ '${{ matrix.libc }}' == musl ]]; then
-            export RUSTFLAGS='-C target-feature=-crt-static'
-          fi
-          mbx build --locked --profile ffi -p aube-ffi --target '${{ matrix.target }}'
-      - name: Build release C ABI library
-        if: github.event_name == 'release' || inputs.tag != '' || inputs.draft_phase
-        shell: bash
-        run: |
-          if [[ '${{ matrix.libc }}' == musl ]]; then
-            export RUSTFLAGS='-C target-feature=-crt-static'
-          fi
-          cargo build --locked --profile ffi -p aube-ffi --target '${{ matrix.target }}'
-      - name: Import macOS signing certificate
-        if: (github.event_name == 'release' || inputs.tag != '') && matrix.os == 'darwin'
-        uses: apple-actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7.0.0
-        with:
-          p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
-          p12-password: ${{ secrets.CERTIFICATES_P12_PASS }}
-      - name: Sign macOS library
-        if: (github.event_name == 'release' || inputs.tag != '') && matrix.os == 'darwin'
-        shell: bash
-        run: |
-          codesign --force --sign 'Developer ID Application: Jeffrey Dickey (4993Y37DX6)' \
-            --options runtime --timestamp \
-            'target/${{ matrix.target }}/ffi/${{ matrix.binary }}'
-      - name: Set package version
-        id: version
-        shell: bash
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
-        run: |
-          if [[ -n "$RELEASE_TAG" ]]; then version=${RELEASE_TAG#v}; else version="0.0.0-smoke.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"; fi
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-      - name: Stage library and platform package
-        shell: bash
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-          OUT_DIR: ${{ runner.temp }}/ffi
-          AUBE_FFI_BINARY: target/${{ matrix.target }}/ffi/${{ matrix.binary }}
-          AUBE_FFI_OS: ${{ matrix.os }}
-          AUBE_FFI_CPU: ${{ matrix.cpu }}
-          AUBE_FFI_LIBC: ${{ matrix.libc }}
-          AUBE_FFI_TARGET: ${{ matrix.target }}
-        run: |
-          mkdir -p "$OUT_DIR"
-          cp "$AUBE_FFI_BINARY" "$OUT_DIR/libaube-${AUBE_FFI_TARGET}.${{ matrix.ext }}"
-          node crates/aube-ffi/npm/package.mjs
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: aube-ffi-${{ matrix.package }}
-          path: ${{ runner.temp }}/ffi/*
-          if-no-files-found: error
+  trusted:
+    if: ${{ github.event_name == 'release' || inputs.tag != '' || (github.actor == 'jdx' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx'))) }}
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/ffi-impl.yml
+    with:
+      tag: ${{ inputs.tag || '' }}
+      draft_phase: ${{ inputs.draft_phase || false }}
+      publish_packages: ${{ inputs.publish_packages || false }}
+      trusted: true
+      mbx-backend: server
+    secrets:
+      AUBE_GH_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}
+      CERTIFICATES_P12: ${{ secrets.CERTIFICATES_P12 }}
+      CERTIFICATES_P12_PASS: ${{ secrets.CERTIFICATES_P12_PASS }}
+
+  untrusted:
+    if: ${{ github.event_name != 'release' && inputs.tag == '' && (github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/ffi-impl.yml
+    with:
+      tag: ""
+      draft_phase: false
+      publish_packages: false
+      trusted: false
+      mbx-backend: github
 
   packages:
-    needs: build
-    runs-on: ubuntu-latest
-    permissions: { contents: read, id-token: write, attestations: write }
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with: { persist-credentials: false, ref: "${{ inputs.tag || github.ref }}" }
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with: { node-version: "24", package-manager-cache: false }
-      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
-        with:
-          tool_versions: |
-            bun 1.3.11
-            deno 2.9.2
-          install_args: bun deno
-          cache: false
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with: { pattern: aube-ffi-*, path: packages, merge-multiple: true }
-      - name: Pack root npm package
-        shell: bash
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
-        run: |
-          if [[ -n "$RELEASE_TAG" ]]; then VERSION=${RELEASE_TAG#v}; else VERSION="0.0.0-smoke.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"; fi
-          VERSION="$VERSION" OUT_DIR="$PWD/packages" node crates/aube-ffi/npm/package.mjs
-          cp crates/aube-ffi/include/aube.h packages/aube.h
-          test "$(find packages -maxdepth 1 -name '*.tgz' -print | wc -l)" -eq 9
-      - name: Smoke-test raw library with Bun and Deno
-        shell: bash
-        env:
-          AUBE_FFI_LIBRARY: ${{ github.workspace }}/packages/libaube-x86_64-unknown-linux-gnu.so
-        run: |
-          bun run crates/aube-ffi/poc/bun.ts
-          deno run --allow-env=AUBE_FFI_LIBRARY --allow-ffi --allow-read --allow-write crates/aube-ffi/poc/deno.ts
-      - name: Smoke-test npm packages and declarations
-        shell: bash
-        run: | # zizmor: ignore[adhoc-packages] installs only tarballs built by required matrix jobs
-          mkdir npm-smoke
-          cd npm-smoke
-          npm init --yes >/dev/null
-          npm install --force --ignore-scripts --no-package-lock ../packages/*.tgz
-          node -e "const ffi=require('@jdxcode/aube-ffi'); require('fs').accessSync(ffi.libraryPath); require('fs').accessSync(ffi.headerPath)"
-          cp "$GITHUB_WORKSPACE/crates/aube-ffi/npm/typecheck.ts" .
-          npx --yes --package=typescript@5.9.3 tsc --strict --noEmit \
-            --lib ES2022,DOM --module NodeNext --moduleResolution NodeNext typecheck.ts
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: aube-ffi-distribution
-          path: |
-            packages/*.tgz
-            packages/libaube-*
-            packages/aube.h
-          if-no-files-found: error
-      - uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
-        if: github.event_name == 'release' || inputs.tag != ''
-        with:
-          subject-path: |
-            packages/*.tgz
-            packages/libaube-*
-            packages/aube.h
-      - name: Publish platform and root packages
-        # `release: published` or an explicit manual npm backfill only —
-        # never an asset-recovery dispatch or the workflow_call draft phase.
-        if: github.event_name == 'release' || (inputs.tag != '' && !inputs.draft_phase && inputs.publish_packages == true)
-        shell: bash
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
-        run: |
-          version=${RELEASE_TAG#v}; tag=latest; [[ "$version" == *-* ]] && tag=next
-          publish_package() {
-            local package=$1 name
-            name=$(tar -xOf "$package" package/package.json | jq -r .name)
-            if npm view "${name}@${version}" version >/dev/null 2>&1; then
-              echo "${name}@${version} is already published"
-              return
-            fi
-            npm publish "$package" --access public --provenance --tag "$tag"
-          }
-          # Relative paths need the ./ prefix or npm parses them as
-          # hosted-git owner/repo shorthands instead of local tarballs.
-          for package in ./packages/*-darwin-*.tgz ./packages/*-linux-*.tgz ./packages/*-win32-*.tgz; do publish_package "$package"; done
-          publish_package "./packages/jdxcode-aube-ffi-${version}.tgz"
-
-  # Attach the C ABI libraries + header to the (still-draft) GitHub
-  # release. Runs on the workflow_call from release-plz.yml during a
-  # real release, or on a workflow_dispatch with `tag` as the recovery
-  # path for a draft whose ffi assets are missing. Never on the
-  # `release: published` event: under immutable releases that is
-  # always too late to add assets.
-  release-assets:
-    if: inputs.tag != ''
-    needs: packages
-    runs-on: ubuntu-latest
-    # Uploads authenticate with AUBE_GH_TOKEN (the PAT release.yml
-    # already uses for draft asset uploads), not github.token.
+    name: packages
+    if: ${{ always() && !cancelled() && needs.trusted.result != 'cancelled' && needs.untrusted.result != 'cancelled' }}
     permissions: {}
+    needs: [trusted, untrusted]
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
     steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with: { name: aube-ffi-distribution, path: packages }
-      - name: Attach C ABI assets to draft release
-        shell: bash
+      - name: Check selected workflow result
         env:
-          GH_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}
-          RELEASE_TAG: ${{ inputs.tag }}
-        # No checkout in this job, so gh needs the repo passed explicitly.
+          TRUSTED_RESULT: ${{ needs.trusted.result }}
+          UNTRUSTED_RESULT: ${{ needs.untrusted.result }}
         run: |
-          is_draft=$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)
-          if [[ "$is_draft" != "true" ]]; then
-            echo "::notice::release $RELEASE_TAG is already published; immutable releases cannot gain assets, skipping upload"
+          if [[ "$TRUSTED_RESULT" == success && "$UNTRUSTED_RESULT" == skipped ]] ||
+             [[ "$TRUSTED_RESULT" == skipped && "$UNTRUSTED_RESULT" == success ]]; then
             exit 0
           fi
-          gh release upload --repo "$GITHUB_REPOSITORY" "$RELEASE_TAG" packages/libaube-* packages/aube.h --clobber
+          echo "trusted=$TRUSTED_RESULT untrusted=$UNTRUSTED_RESULT"
+          exit 1

--- a/.github/workflows/node-addon-impl.yml
+++ b/.github/workflows/node-addon-impl.yml
@@ -13,6 +13,11 @@ on:
       mbx-backend:
         required: true
         type: string
+    secrets:
+      CERTIFICATES_P12:
+        required: false
+      CERTIFICATES_P12_PASS:
+        required: false
 
 concurrency:
   group: node-addon-${{ inputs.tag || github.ref }}

--- a/.github/workflows/node-addon-impl.yml
+++ b/.github/workflows/node-addon-impl.yml
@@ -1,0 +1,193 @@
+name: node-addon implementation
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: false
+        type: string
+        default: ""
+      trusted:
+        required: true
+        type: boolean
+      mbx-backend:
+        required: true
+        type: string
+
+concurrency:
+  group: node-addon-${{ inputs.tag || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'release' && inputs.tag == '' }}
+
+jobs:
+  build:
+    name: ${{ matrix.package }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { runner: macos-15, namespace_runner: namespace-profile-endev-macos-arm64, target: aarch64-apple-darwin, os: darwin, cpu: arm64, package: darwin-arm64, binary: libaube_node.dylib, smoke: true }
+          - { runner: macos-15-intel, namespace_runner: macos-15-intel, target: x86_64-apple-darwin, os: darwin, cpu: x64, package: darwin-x64, binary: libaube_node.dylib, smoke: true }
+          - { runner: ubuntu-24.04-arm, namespace_runner: namespace-profile-endev-linux-arm64-large, target: aarch64-unknown-linux-gnu, os: linux, cpu: arm64, package: linux-arm64, binary: libaube_node.so, smoke: true }
+          - { runner: ubuntu-latest, namespace_runner: namespace-profile-endev-linux-amd64, target: x86_64-unknown-linux-gnu, os: linux, cpu: x64, package: linux-x64, binary: libaube_node.so, smoke: true }
+          - { runner: ubuntu-24.04-arm, namespace_runner: namespace-profile-endev-linux-arm64-large, target: aarch64-unknown-linux-musl, os: linux, cpu: arm64, libc: musl, package: linux-arm64-musl, binary: libaube_node.so }
+          - { runner: ubuntu-latest, namespace_runner: namespace-profile-endev-linux-amd64, target: x86_64-unknown-linux-musl, os: linux, cpu: x64, libc: musl, package: linux-x64-musl, binary: libaube_node.so }
+          - { runner: windows-latest, namespace_runner: windows-latest, target: aarch64-pc-windows-msvc, os: win32, cpu: arm64, package: win32-arm64, binary: aube_node.dll }
+          - { runner: windows-latest, namespace_runner: windows-latest, target: x86_64-pc-windows-msvc, os: win32, cpu: x64, package: win32-x64, binary: aube_node.dll, smoke: true }
+    runs-on: ${{ (github.event_name == 'release' || inputs.tag != '' || !inputs.trusted) && matrix.runner || matrix.namespace_runner }}
+    timeout-minutes: 60
+    env:
+      MBX_TARGET_VIEWS: ${{ matrix.os == 'win32' && '0' || '1' }}
+    steps:
+      - name: Assert OIDC is unavailable to untrusted CI
+        if: ${{ !inputs.trusted && github.event_name != 'release' && inputs.tag == '' }}
+        shell: bash
+        run: |
+          test -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
+          test -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with: { persist-credentials: false, ref: "${{ inputs.tag || github.ref }}" }
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with: { node-version: "24", package-manager-cache: false }
+      - uses: ./.github/actions/mbx
+        if: github.event_name != 'release' && inputs.tag == ''
+        with:
+          backend: ${{ inputs.mbx-backend }}
+      - name: Install Rust target
+        shell: bash
+        run: rustup target add '${{ matrix.target }}'
+      - name: Install musl compiler
+        if: matrix.libc == 'musl'
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+      - name: Build addon
+        if: github.event_name != 'release' && inputs.tag == ''
+        shell: bash
+        run: |
+          if [[ '${{ matrix.libc }}' == musl ]]; then
+            export RUSTFLAGS='-C target-feature=-crt-static'
+          fi
+          mbx build --locked --profile napi -p aube-node --target '${{ matrix.target }}'
+      - name: Build release addon
+        if: github.event_name == 'release' || inputs.tag != ''
+        shell: bash
+        run: |
+          if [[ '${{ matrix.libc }}' == musl ]]; then
+            export RUSTFLAGS='-C target-feature=-crt-static'
+          fi
+          cargo build --locked --profile napi -p aube-node --target '${{ matrix.target }}'
+      - name: Import macOS signing certificate
+        if: (github.event_name == 'release' || inputs.tag != '') && matrix.os == 'darwin'
+        uses: apple-actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7.0.0
+        with:
+          p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
+          p12-password: ${{ secrets.CERTIFICATES_P12_PASS }}
+      - name: Sign macOS addon
+        if: (github.event_name == 'release' || inputs.tag != '') && matrix.os == 'darwin'
+        shell: bash
+        run: |
+          codesign --force --sign 'Developer ID Application: Jeffrey Dickey (4993Y37DX6)' \
+            --options runtime --timestamp \
+            'target/${{ matrix.target }}/napi/${{ matrix.binary }}'
+      - name: Set package version
+        id: version
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          if [[ -n "$RELEASE_TAG" ]]; then version=${RELEASE_TAG#v}; else version="0.0.0-smoke.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"; fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Pack platform package
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          OUT_DIR: ${{ runner.temp }}/packages
+          AUBE_NODE_BINARY: target/${{ matrix.target }}/napi/${{ matrix.binary }}
+          AUBE_NODE_OS: ${{ matrix.os }}
+          AUBE_NODE_CPU: ${{ matrix.cpu }}
+          AUBE_NODE_LIBC: ${{ matrix.libc }}
+        run: node crates/aube-node/npm/package.mjs
+      - name: Smoke-load native addon
+        if: matrix.smoke
+        shell: bash
+        env:
+          SMOKE_ADDON: ${{ runner.temp }}/aube.node
+        run: |
+          cp 'target/${{ matrix.target }}/napi/${{ matrix.binary }}' "$SMOKE_ADDON"
+          node -e "require(process.env.SMOKE_ADDON)"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: aube-node-${{ matrix.package }}
+          path: ${{ runner.temp }}/packages/*.tgz
+          if-no-files-found: error
+
+  packages:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with: { persist-credentials: false, ref: "${{ inputs.tag || github.ref }}" }
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with: { node-version: "24", package-manager-cache: false }
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          tool_versions: bun 1.3.11
+          install_args: bun
+          cache: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with: { pattern: aube-node-*, path: packages, merge-multiple: true }
+      - name: Pack root package
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          if [[ -n "$RELEASE_TAG" ]]; then VERSION=${RELEASE_TAG#v}; else VERSION="0.0.0-smoke.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"; fi
+          VERSION="$VERSION" OUT_DIR="$PWD/packages" node crates/aube-node/npm/package.mjs
+          test "$(find packages -maxdepth 1 -name '*.tgz' -print | wc -l)" -eq 9
+      - name: Smoke-test installed packages with Node and Bun
+        shell: bash
+        run: | # zizmor: ignore[adhoc-packages] installs only tarballs built by the required matrix jobs
+          mkdir npm-smoke
+          cd npm-smoke
+          npm init --yes >/dev/null
+          npm install --force --ignore-scripts --no-package-lock ../packages/*.tgz
+          node -e "require('@jdxcode/aube-node')"
+          node --input-type=module -e "import { install } from '@jdxcode/aube-node'; if (typeof install !== 'function') process.exit(1)"
+          cp "$GITHUB_WORKSPACE/crates/aube-node/npm/typecheck.ts" .
+          npx --yes --package=typescript@5.9.3 tsc --strict --noEmit \
+            --lib ES2022,DOM --module NodeNext --moduleResolution NodeNext typecheck.ts
+          cd ..
+          mkdir bun-smoke
+          cd bun-smoke
+          bun init --yes >/dev/null
+          # Cross-compiling hosts install every optional target package before
+          # building their platform matrix.
+          bun install --os="*" --cpu="*" ../packages/*.tgz
+          bun -e "require('@jdxcode/aube-node')"
+          AUBE_NODE_OS=linux AUBE_NODE_ARCH=x64 AUBE_NODE_LIBC=glibc \
+            bun "$GITHUB_WORKSPACE/crates/aube-node/npm/compile-smoke.mjs"
+          test "$(stat --format=%s aube-node-smoke)" -lt 157286400
+          ./aube-node-smoke
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with: { name: aube-node-npm-packages, path: "packages/*.tgz", if-no-files-found: error }
+      - uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        if: github.event_name == 'release' || inputs.tag != ''
+        with: { subject-path: "packages/*.tgz" }
+      - name: Publish platform and root packages
+        if: github.event_name == 'release' || inputs.tag != ''
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          version=${RELEASE_TAG#v}; tag=latest; [[ "$version" == *-* ]] && tag=next
+          publish_package() {
+            local package=$1 name
+            name=$(tar -xOf "$package" package/package.json | jq -r .name)
+            if npm view "${name}@${version}" version >/dev/null 2>&1; then
+              echo "${name}@${version} is already published"
+              return
+            fi
+            npm publish "$package" --access public --provenance --tag "$tag"
+          }
+          # Relative paths need the ./ prefix or npm parses them as
+          # hosted-git owner/repo shorthands instead of local tarballs.
+          for package in ./packages/*-darwin-*.tgz ./packages/*-linux-*.tgz ./packages/*-win32-*.tgz; do publish_package "$package"; done
+          publish_package "./packages/jdxcode-aube-node-${version}.tgz"

--- a/.github/workflows/node-addon-impl.yml
+++ b/.github/workflows/node-addon-impl.yml
@@ -176,7 +176,7 @@ jobs:
         shell: bash
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
-        run: |
+        run: | # zizmor: ignore[use-trusted-publishing] publishes each tarball with npm provenance via OIDC
           version=${RELEASE_TAG#v}; tag=latest; [[ "$version" == *-* ]] && tag=next
           publish_package() {
             local package=$1 name

--- a/.github/workflows/node-addon.yml
+++ b/.github/workflows/node-addon.yml
@@ -19,6 +19,7 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/node-addon.yml"
+      - ".github/workflows/node-addon-impl.yml"
   push:
     branches: [main]
     paths:
@@ -38,6 +39,7 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/node-addon.yml"
+      - ".github/workflows/node-addon-impl.yml"
   release:
     types: [published]
   workflow_dispatch:
@@ -61,6 +63,9 @@ jobs:
       tag: ${{ inputs.tag || '' }}
       trusted: true
       mbx-backend: server
+    secrets:
+      CERTIFICATES_P12: ${{ secrets.CERTIFICATES_P12 }}
+      CERTIFICATES_P12_PASS: ${{ secrets.CERTIFICATES_P12_PASS }}
 
   untrusted:
     if: ${{ github.event_name != 'release' && inputs.tag == '' && (github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) }}

--- a/.github/workflows/node-addon.yml
+++ b/.github/workflows/node-addon.yml
@@ -47,176 +47,47 @@ on:
         required: false
         default: ""
 
-concurrency:
-  group: node-addon-${{ inputs.tag || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'release' && inputs.tag == '' }}
-
 permissions: {}
 
 jobs:
-  build:
-    name: ${{ matrix.package }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - { runner: macos-15, namespace_runner: namespace-profile-endev-macos-arm64, target: aarch64-apple-darwin, os: darwin, cpu: arm64, package: darwin-arm64, binary: libaube_node.dylib, smoke: true }
-          - { runner: macos-15-intel, namespace_runner: macos-15-intel, target: x86_64-apple-darwin, os: darwin, cpu: x64, package: darwin-x64, binary: libaube_node.dylib, smoke: true }
-          - { runner: ubuntu-24.04-arm, namespace_runner: namespace-profile-endev-linux-arm64-large, target: aarch64-unknown-linux-gnu, os: linux, cpu: arm64, package: linux-arm64, binary: libaube_node.so, smoke: true }
-          - { runner: ubuntu-latest, namespace_runner: namespace-profile-endev-linux-amd64, target: x86_64-unknown-linux-gnu, os: linux, cpu: x64, package: linux-x64, binary: libaube_node.so, smoke: true }
-          - { runner: ubuntu-24.04-arm, namespace_runner: namespace-profile-endev-linux-arm64-large, target: aarch64-unknown-linux-musl, os: linux, cpu: arm64, libc: musl, package: linux-arm64-musl, binary: libaube_node.so }
-          - { runner: ubuntu-latest, namespace_runner: namespace-profile-endev-linux-amd64, target: x86_64-unknown-linux-musl, os: linux, cpu: x64, libc: musl, package: linux-x64-musl, binary: libaube_node.so }
-          - { runner: windows-latest, namespace_runner: windows-latest, target: aarch64-pc-windows-msvc, os: win32, cpu: arm64, package: win32-arm64, binary: aube_node.dll }
-          - { runner: windows-latest, namespace_runner: windows-latest, target: x86_64-pc-windows-msvc, os: win32, cpu: x64, package: win32-x64, binary: aube_node.dll, smoke: true }
-    runs-on: ${{ (github.event_name == 'release' || inputs.tag != '' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && matrix.runner || matrix.namespace_runner }}
-    timeout-minutes: 60
-    permissions: { contents: read, id-token: write }
-    env:
-      MBX_TARGET_VIEWS: ${{ matrix.os == 'win32' && '0' || '1' }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with: { persist-credentials: false, ref: "${{ inputs.tag || github.ref }}" }
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with: { node-version: "24", package-manager-cache: false }
-      - uses: ./.github/actions/mbx
-        if: github.event_name != 'release' && inputs.tag == ''
-      - name: Install Rust target
-        shell: bash
-        run: rustup target add '${{ matrix.target }}'
-      - name: Install musl compiler
-        if: matrix.libc == 'musl'
-        run: sudo apt-get update && sudo apt-get install -y musl-tools
-      - name: Build addon
-        if: github.event_name != 'release' && inputs.tag == ''
-        shell: bash
-        run: |
-          if [[ '${{ matrix.libc }}' == musl ]]; then
-            export RUSTFLAGS='-C target-feature=-crt-static'
-          fi
-          mbx build --locked --profile napi -p aube-node --target '${{ matrix.target }}'
-      - name: Build release addon
-        if: github.event_name == 'release' || inputs.tag != ''
-        shell: bash
-        run: |
-          if [[ '${{ matrix.libc }}' == musl ]]; then
-            export RUSTFLAGS='-C target-feature=-crt-static'
-          fi
-          cargo build --locked --profile napi -p aube-node --target '${{ matrix.target }}'
-      - name: Import macOS signing certificate
-        if: (github.event_name == 'release' || inputs.tag != '') && matrix.os == 'darwin'
-        uses: apple-actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7.0.0
-        with:
-          p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
-          p12-password: ${{ secrets.CERTIFICATES_P12_PASS }}
-      - name: Sign macOS addon
-        if: (github.event_name == 'release' || inputs.tag != '') && matrix.os == 'darwin'
-        shell: bash
-        run: |
-          codesign --force --sign 'Developer ID Application: Jeffrey Dickey (4993Y37DX6)' \
-            --options runtime --timestamp \
-            'target/${{ matrix.target }}/napi/${{ matrix.binary }}'
-      - name: Set package version
-        id: version
-        shell: bash
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
-        run: |
-          if [[ -n "$RELEASE_TAG" ]]; then version=${RELEASE_TAG#v}; else version="0.0.0-smoke.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"; fi
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-      - name: Pack platform package
-        shell: bash
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-          OUT_DIR: ${{ runner.temp }}/packages
-          AUBE_NODE_BINARY: target/${{ matrix.target }}/napi/${{ matrix.binary }}
-          AUBE_NODE_OS: ${{ matrix.os }}
-          AUBE_NODE_CPU: ${{ matrix.cpu }}
-          AUBE_NODE_LIBC: ${{ matrix.libc }}
-        run: node crates/aube-node/npm/package.mjs
-      - name: Smoke-load native addon
-        if: matrix.smoke
-        shell: bash
-        env:
-          SMOKE_ADDON: ${{ runner.temp }}/aube.node
-        run: |
-          cp 'target/${{ matrix.target }}/napi/${{ matrix.binary }}' "$SMOKE_ADDON"
-          node -e "require(process.env.SMOKE_ADDON)"
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: aube-node-${{ matrix.package }}
-          path: ${{ runner.temp }}/packages/*.tgz
-          if-no-files-found: error
+  trusted:
+    if: ${{ github.event_name == 'release' || inputs.tag != '' || (github.actor == 'jdx' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx'))) }}
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/node-addon-impl.yml
+    with:
+      tag: ${{ inputs.tag || '' }}
+      trusted: true
+      mbx-backend: server
+
+  untrusted:
+    if: ${{ github.event_name != 'release' && inputs.tag == '' && (github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/node-addon-impl.yml
+    with:
+      tag: ""
+      trusted: false
+      mbx-backend: github
 
   packages:
-    needs: build
+    name: packages
+    if: ${{ always() && !cancelled() && needs.trusted.result != 'cancelled' && needs.untrusted.result != 'cancelled' }}
+    permissions: {}
+    needs: [trusted, untrusted]
     runs-on: ubuntu-latest
-    permissions: { contents: read, id-token: write, attestations: write }
+    timeout-minutes: 1
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with: { persist-credentials: false, ref: "${{ inputs.tag || github.ref }}" }
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with: { node-version: "24", package-manager-cache: false }
-      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
-        with:
-          tool_versions: bun 1.3.11
-          install_args: bun
-          cache: false
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with: { pattern: aube-node-*, path: packages, merge-multiple: true }
-      - name: Pack root package
-        shell: bash
+      - name: Check selected workflow result
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          TRUSTED_RESULT: ${{ needs.trusted.result }}
+          UNTRUSTED_RESULT: ${{ needs.untrusted.result }}
         run: |
-          if [[ -n "$RELEASE_TAG" ]]; then VERSION=${RELEASE_TAG#v}; else VERSION="0.0.0-smoke.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"; fi
-          VERSION="$VERSION" OUT_DIR="$PWD/packages" node crates/aube-node/npm/package.mjs
-          test "$(find packages -maxdepth 1 -name '*.tgz' -print | wc -l)" -eq 9
-      - name: Smoke-test installed packages with Node and Bun
-        shell: bash
-        run: | # zizmor: ignore[adhoc-packages] installs only tarballs built by the required matrix jobs
-          mkdir npm-smoke
-          cd npm-smoke
-          npm init --yes >/dev/null
-          npm install --force --ignore-scripts --no-package-lock ../packages/*.tgz
-          node -e "require('@jdxcode/aube-node')"
-          node --input-type=module -e "import { install } from '@jdxcode/aube-node'; if (typeof install !== 'function') process.exit(1)"
-          cp "$GITHUB_WORKSPACE/crates/aube-node/npm/typecheck.ts" .
-          npx --yes --package=typescript@5.9.3 tsc --strict --noEmit \
-            --lib ES2022,DOM --module NodeNext --moduleResolution NodeNext typecheck.ts
-          cd ..
-          mkdir bun-smoke
-          cd bun-smoke
-          bun init --yes >/dev/null
-          # Cross-compiling hosts install every optional target package before
-          # building their platform matrix.
-          bun install --os="*" --cpu="*" ../packages/*.tgz
-          bun -e "require('@jdxcode/aube-node')"
-          AUBE_NODE_OS=linux AUBE_NODE_ARCH=x64 AUBE_NODE_LIBC=glibc \
-            bun "$GITHUB_WORKSPACE/crates/aube-node/npm/compile-smoke.mjs"
-          test "$(stat --format=%s aube-node-smoke)" -lt 157286400
-          ./aube-node-smoke
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with: { name: aube-node-npm-packages, path: "packages/*.tgz", if-no-files-found: error }
-      - uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
-        if: github.event_name == 'release' || inputs.tag != ''
-        with: { subject-path: "packages/*.tgz" }
-      - name: Publish platform and root packages
-        if: github.event_name == 'release' || inputs.tag != ''
-        shell: bash
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
-        run: |
-          version=${RELEASE_TAG#v}; tag=latest; [[ "$version" == *-* ]] && tag=next
-          publish_package() {
-            local package=$1 name
-            name=$(tar -xOf "$package" package/package.json | jq -r .name)
-            if npm view "${name}@${version}" version >/dev/null 2>&1; then
-              echo "${name}@${version} is already published"
-              return
-            fi
-            npm publish "$package" --access public --provenance --tag "$tag"
-          }
-          # Relative paths need the ./ prefix or npm parses them as
-          # hosted-git owner/repo shorthands instead of local tarballs.
-          for package in ./packages/*-darwin-*.tgz ./packages/*-linux-*.tgz ./packages/*-win32-*.tgz; do publish_package "$package"; done
-          publish_package "./packages/jdxcode-aube-node-${version}.tgz"
+          if [[ "$TRUSTED_RESULT" == success && "$UNTRUSTED_RESULT" == skipped ]] ||
+             [[ "$TRUSTED_RESULT" == skipped && "$UNTRUSTED_RESULT" == success ]]; then
+            exit 0
+          fi
+          echo "trusted=$TRUSTED_RESULT untrusted=$UNTRUSTED_RESULT"
+          exit 1


### PR DESCRIPTION
## Summary

- structurally cap untrusted Rust CI, docs, Node-addon, and FFI workflows so they cannot mint GitHub OIDC tokens
- pass explicit trust and mbx backend inputs into reusable implementations
- keep trusted `jdx` runs on Namespace/server and all other actors on GitHub-hosted/GitHub cache
- retain release, attestation, publishing, and Pages permissions only on trusted callers; release mbx setup remains disabled
- preserve artifacts, packaging jobs, exact release inputs, and explicit secrets

Validated first with both trusted and forced-untrusted runs in jdx/tak#61. This follows up #1382.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes who can mint OIDC tokens and which cache/release paths run in CI; misconfigured `if:` or permissions could block merges or weaken isolation for fork/untrusted PRs.
> 
> **Overview**
> **Splits CI, docs, FFI, and Node-addon workflows** into thin entry workflows that run either a **trusted** or **untrusted** reusable implementation—never both—based on actor and PR fork/head metadata.
> 
> **Trusted callers** keep `id-token: write` (and release-only bits like Pages deploy, npm provenance, signing secrets) and pass `trusted: true` with **mbx `server`** and Namespace runners where applicable. **Untrusted callers** get **contents: read only**, `trusted: false`, **mbx `github`**, GitHub-hosted runners, and an explicit step that **fails if OIDC token request env vars are set**.
> 
> The **`mbx` composite action** gains a `backend` input (default `auto`) so implementations pass `server` or `github` structurally instead of inferring only inside the action.
> 
> **Status aggregation** moves up: top-level `final` / `docs` / `packages` jobs now only require exactly one of `trusted`/`untrusted` to succeed; detailed gating (including **advisory** `api-stability` on PRs via `continue-on-error` and job outputs) stays inside `ci-impl.yml`. **actionlint** is pointed at `ci-impl.yml` for the parallel-step ignore rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb3d05694651bc67e7b5fc13f601dde87fc219d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable automation for CI, documentation, FFI artifacts, and Node native addon packages.
  * Added support for Linux, macOS, Windows, musl, and multiple JavaScript runtimes.
  * Added automated testing, packaging, publishing, signing, provenance checks, and release asset uploads.
  * Added backend selection for trusted and untrusted build workflows.
* **Security**
  * Improved separation between trusted and untrusted builds with restricted credentials and permissions.
* **Documentation**
  * Automated documentation builds and trusted deployments to GitHub Pages.
* **Reliability**
  * Improved workflow result validation and reporting for build and compatibility checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->