### PR TITLE
ci: seed mbx cache for fork PRs

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -5,10 +5,19 @@ inputs:
   backend:
     description: Explicit backend for structurally trusted or untrusted callers
     default: auto
+  mirror-github-cache:
+    description: Mirror a trusted main build into the restore-only cache used by fork PRs
+    default: "false"
 
 runs:
   using: composite
   steps:
+    - name: Restore the fork PR cache mirror
+      if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
+      with:
+        version: 0.4.0
+        backend: github
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
         version: 0.4.0

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -54,6 +54,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.mbx-backend }}
+          mirror-github-cache: "true"
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5 # zizmor: ignore[cache-poisoning] PRs restore only; saves are restricted to main
         with:
           cache_save: ${{ github.ref == 'refs/heads/main' }}
@@ -324,6 +325,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.mbx-backend }}
+          mirror-github-cache: "true"
       - run: mbx build --workspace
       - run: mbx test --workspace
 


### PR DESCRIPTION
## Summary

- restore the fork-facing GitHub Actions mbx cache in one canonical CI job per supported OS
- keep the trusted server backend active for compilation, then save the updated local store under the exact key format fork PRs restore
- restrict mirror writes to jdx pushes on main; fork and other untrusted PR runs remain restore-only and OIDC-free

## Validation

- actionlint
- high-severity zizmor audit
- git diff check
- confirmed release workflows do not enable the mirror

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI cache behavior and when GitHub-backed mbx restores run; writes are gated to trusted main pushes, but misconfiguration could affect fork PR cache freshness or restore semantics.
> 
> **Overview**
> Adds an optional **`mirror-github-cache`** input to the composite **mbx** setup action. When enabled, a **pre-step** restores the fork-facing **GitHub** mbx cache, but only on **`main` pushes by `jdx`**; the existing step still picks **server vs GitHub** via `backend: auto`.
> 
> **`ci-impl`** turns the flag on for the per-OS **canonical build** jobs (**Linux/macOS `build`** and **`windows`**), so trusted main compiles can populate the same cache keys fork PRs restore, while other jobs (e.g. **`test-linux`**, **`api-stability`**) stay unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2ac4ee159f9c65c73648b13e50df6ee5467eae5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved build caching for continuous integration across Linux, macOS, and Windows environments.
  - Added optional cache mirroring to help maintain consistent build performance across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->