### PR TITLE
ci: notarize the macOS release binary

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -128,6 +128,9 @@ jobs:
       AUBE_GH_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}
       CERTIFICATES_P12: ${{ secrets.CERTIFICATES_P12 }}
       CERTIFICATES_P12_PASS: ${{ secrets.CERTIFICATES_P12_PASS }}
+      APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+      APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+      APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
 
   # Build + codesign the C ABI libraries and attach them (plus aube.h)
   # to the draft release. Must complete before `publish-release`:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,12 @@ on:
         required: true
       CERTIFICATES_P12_PASS:
         required: true
+      APPLE_API_KEY_P8:
+        required: false
+      APPLE_API_KEY_ID:
+        required: false
+      APPLE_API_ISSUER_ID:
+        required: false
   workflow_dispatch:
     inputs:
       tag:
@@ -181,6 +187,71 @@ jobs:
           codesign: "Developer ID Application: Jeffrey Dickey (4993Y37DX6)"
           codesign_prefix: dev.jdx.
           dry-run: ${{ fromJSON(inputs.dry_run || 'false') }}
+      # Signing settles who built the binary; notarization is what Gatekeeper
+      # demands once an archive carries the quarantine bit, which is to say
+      # whenever someone downloads it in a browser rather than with curl.
+      # Without a ticket it is blocked behind a "cannot be verified" dialog that
+      # only a deliberate override gets past.
+      #
+      # The ticket lives on Apple's side and is keyed to the binary's cdhash, so
+      # nothing here rewrites what was already built or uploaded -- stapling
+      # would, but `stapler` only writes into bundles, disk images, and
+      # installer packages, and this is a bare Mach-O in an archive. Gatekeeper
+      # resolves the ticket online instead.
+      - name: Notarize macOS binaries
+        if: startsWith(matrix.os, 'macos') && !fromJSON(inputs.dry_run || 'false')
+        shell: bash
+        env:
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          BINARIES: target/${{ matrix.target }}/release/aube target/${{ matrix.target }}/release/aubr target/${{ matrix.target }}/release/aubx
+        run: |
+          set -euo pipefail
+
+          if [ -z "$APPLE_API_KEY_P8" ] || [ -z "$APPLE_API_KEY_ID" ] || [ -z "$APPLE_API_ISSUER_ID" ]; then
+            echo "::warning title=Not notarized::App Store Connect credentials are unset, so this release ships signed but un-notarized macOS binaries. Gatekeeper will block them for anyone who downloads an archive through a browser."
+            exit 0
+          fi
+
+          # Outside the workspace, so no later step can sweep the key into an
+          # artifact, and removed even when notarization fails.
+          work="$(mktemp -d)"
+          trap 'rm -rf "$work"' EXIT
+          printf '%s' "$APPLE_API_KEY_P8" | base64 --decode > "$work/key.p8"
+
+          # notarytool takes a container, never a bare executable. Copies are
+          # fine: a Mach-O carries its signature inline, so the cdhash the
+          # ticket is keyed to is the one already shipped.
+          mkdir "$work/stage"
+          for binary in $BINARIES; do
+            cp "$binary" "$work/stage/"
+          done
+          ditto -c -k --norsrc --noextattr "$work/stage" "$work/submission.zip"
+
+          # `--wait` is not a gate on its own: it can return zero on an Invalid
+          # submission, so the reported status is what decides. plutil reads
+          # JSON and ships with macOS, which keeps this off jq.
+          result="$(xcrun notarytool submit "$work/submission.zip" \
+            --key "$work/key.p8" \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER_ID" \
+            --output-format json \
+            --timeout 30m \
+            --wait)"
+          echo "$result"
+
+          status="$(printf '%s' "$result" | plutil -extract status raw -o - -)"
+          id="$(printf '%s' "$result" | plutil -extract id raw -o - -)"
+          if [ "$status" != "Accepted" ]; then
+            echo "::error::notarization returned $status for submission $id"
+            xcrun notarytool log "$id" \
+              --key "$work/key.p8" \
+              --key-id "$APPLE_API_KEY_ID" \
+              --issuer "$APPLE_API_ISSUER_ID" || true
+            exit 1
+          fi
+          echo "notarized: submission $id"
       - name: Upload binary (non-macOS)
         id: upload-non-macos
         if: ${{ !startsWith(matrix.os, 'macos') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,71 +187,6 @@ jobs:
           codesign: "Developer ID Application: Jeffrey Dickey (4993Y37DX6)"
           codesign_prefix: dev.jdx.
           dry-run: ${{ fromJSON(inputs.dry_run || 'false') }}
-      # Signing settles who built the binary; notarization is what Gatekeeper
-      # demands once an archive carries the quarantine bit, which is to say
-      # whenever someone downloads it in a browser rather than with curl.
-      # Without a ticket it is blocked behind a "cannot be verified" dialog that
-      # only a deliberate override gets past.
-      #
-      # The ticket lives on Apple's side and is keyed to the binary's cdhash, so
-      # nothing here rewrites what was already built or uploaded -- stapling
-      # would, but `stapler` only writes into bundles, disk images, and
-      # installer packages, and this is a bare Mach-O in an archive. Gatekeeper
-      # resolves the ticket online instead.
-      - name: Notarize macOS binaries
-        if: startsWith(matrix.os, 'macos') && !fromJSON(inputs.dry_run || 'false')
-        shell: bash
-        env:
-          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
-          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
-          BINARIES: target/${{ matrix.target }}/release/aube target/${{ matrix.target }}/release/aubr target/${{ matrix.target }}/release/aubx
-        run: |
-          set -euo pipefail
-
-          if [ -z "$APPLE_API_KEY_P8" ] || [ -z "$APPLE_API_KEY_ID" ] || [ -z "$APPLE_API_ISSUER_ID" ]; then
-            echo "::warning title=Not notarized::App Store Connect credentials are unset, so this release ships signed but un-notarized macOS binaries. Gatekeeper will block them for anyone who downloads an archive through a browser."
-            exit 0
-          fi
-
-          # Outside the workspace, so no later step can sweep the key into an
-          # artifact, and removed even when notarization fails.
-          work="$(mktemp -d)"
-          trap 'rm -rf "$work"' EXIT
-          printf '%s' "$APPLE_API_KEY_P8" | base64 --decode > "$work/key.p8"
-
-          # notarytool takes a container, never a bare executable. Copies are
-          # fine: a Mach-O carries its signature inline, so the cdhash the
-          # ticket is keyed to is the one already shipped.
-          mkdir "$work/stage"
-          for binary in $BINARIES; do
-            cp "$binary" "$work/stage/"
-          done
-          ditto -c -k --norsrc --noextattr "$work/stage" "$work/submission.zip"
-
-          # `--wait` is not a gate on its own: it can return zero on an Invalid
-          # submission, so the reported status is what decides. plutil reads
-          # JSON and ships with macOS, which keeps this off jq.
-          result="$(xcrun notarytool submit "$work/submission.zip" \
-            --key "$work/key.p8" \
-            --key-id "$APPLE_API_KEY_ID" \
-            --issuer "$APPLE_API_ISSUER_ID" \
-            --output-format json \
-            --timeout 30m \
-            --wait)"
-          echo "$result"
-
-          status="$(printf '%s' "$result" | plutil -extract status raw -o - -)"
-          id="$(printf '%s' "$result" | plutil -extract id raw -o - -)"
-          if [ "$status" != "Accepted" ]; then
-            echo "::error::notarization returned $status for submission $id"
-            xcrun notarytool log "$id" \
-              --key "$work/key.p8" \
-              --key-id "$APPLE_API_KEY_ID" \
-              --issuer "$APPLE_API_ISSUER_ID" || true
-            exit 1
-          fi
-          echo "notarized: submission $id"
       - name: Upload binary (non-macOS)
         id: upload-non-macos
         if: ${{ !startsWith(matrix.os, 'macos') }}
@@ -547,6 +482,86 @@ jobs:
           # name only matters for argv[0] dispatch inside the binary.
           codesign --sign "$IDENTITY" --options runtime --timestamp \
             --prefix dev.jdx. "$BIN_DIR/aube"
+      # Signing settles who built the binary; notarization is what Gatekeeper
+      # demands once an archive carries the quarantine bit, which is to say
+      # whenever someone downloads it in a browser rather than with curl.
+      # Without a ticket it is blocked behind a "cannot be verified" dialog that
+      # only a deliberate override gets past.
+      #
+      # The ticket lives on Apple's side and is keyed to the binary's cdhash, so
+      # nothing here rewrites what was already built or uploaded -- stapling
+      # would, but `stapler` only writes into bundles, disk images, and
+      # installer packages, and this is a bare Mach-O in an archive. Gatekeeper
+      # resolves the ticket online instead.
+      - name: Notarize macOS binary
+        if: startsWith(matrix.os, 'macos') && !fromJSON(inputs.dry_run || 'false')
+        shell: bash
+        env:
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          BINARIES: target/${{ matrix.target }}/release-pgo/aube
+        run: |
+          set -euo pipefail
+
+          if [ -z "$APPLE_API_KEY_P8" ] || [ -z "$APPLE_API_KEY_ID" ] || [ -z "$APPLE_API_ISSUER_ID" ]; then
+            echo "::warning title=Not notarized::App Store Connect credentials are unset, so this release ships signed but un-notarized macOS binaries. Gatekeeper will block them for anyone who downloads an archive through a browser."
+            exit 0
+          fi
+
+          # Outside the workspace, so no later step can sweep the key into an
+          # artifact, and removed even when notarization fails.
+          work="$(mktemp -d)"
+          trap 'rm -rf "$work"' EXIT
+          printf '%s' "$APPLE_API_KEY_P8" | base64 --decode > "$work/key.p8"
+
+          # notarytool takes a container, never a bare executable. Copies are
+          # fine: a Mach-O carries its signature inline, so the cdhash the
+          # ticket is keyed to is the one already shipped.
+          mkdir "$work/stage"
+          for binary in $BINARIES; do
+            cp "$binary" "$work/stage/"
+          done
+          # Apple rejects a binary without the hardened runtime or a secure
+          # timestamp. Naming a missing one here turns an opaque Invalid verdict
+          # into a diagnosis; Apple stays the authority on whether to accept.
+          for binary in $BINARIES; do
+            details="$(codesign --display --verbose=4 "$binary" 2>&1 || true)"
+            case "$details" in
+              *runtime*) ;;
+              *) echo "::warning title=No hardened runtime::$binary is signed without --options runtime, which Apple requires; expect an Invalid verdict below." ;;
+            esac
+            case "$details" in
+              *Timestamp=*) ;;
+              *) echo "::warning title=No secure timestamp::$binary carries no secure timestamp, which Apple requires; expect an Invalid verdict below." ;;
+            esac
+          done
+
+          ditto -c -k --norsrc --noextattr "$work/stage" "$work/submission.zip"
+
+          # `--wait` is not a gate on its own: it can return zero on an Invalid
+          # submission, so the reported status is what decides. plutil reads
+          # JSON and ships with macOS, which keeps this off jq.
+          result="$(xcrun notarytool submit "$work/submission.zip" \
+            --key "$work/key.p8" \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER_ID" \
+            --output-format json \
+            --timeout 30m \
+            --wait)"
+          echo "$result"
+
+          status="$(printf '%s' "$result" | plutil -extract status raw -o - -)"
+          id="$(printf '%s' "$result" | plutil -extract id raw -o - -)"
+          if [ "$status" != "Accepted" ]; then
+            echo "::error::notarization returned $status for submission $id"
+            xcrun notarytool log "$id" \
+              --key "$work/key.p8" \
+              --key-id "$APPLE_API_KEY_ID" \
+              --issuer "$APPLE_API_ISSUER_ID" || true
+            exit 1
+          fi
+          echo "notarized: submission $id"
       - name: Archive PGO binaries
         id: archive
         shell: bash


### PR DESCRIPTION
The macOS binary is signed but never submitted to Apple's notary service. Signing settles *who* built it; notarization is what Gatekeeper demands once an archive carries the quarantine bit — which is to say whenever someone downloads it in a browser rather than with `curl`. Without a ticket it is blocked behind a "cannot be verified" dialog that only a deliberate override gets past.

`upload-rust-binary-action` signs in place at `target/<target>/release/` and archives from those same bytes, so this step submits exactly what users download. Notable choices, all commented in place:

- **Nothing is stapled**, and nothing rewrites the artifact. The ticket lives on Apple's side keyed to the binary's cdhash; `stapler` only writes into bundles, disk images, and installer packages, and this is a bare Mach-O in an archive. Gatekeeper resolves the ticket online.
- **The status is parsed, not inferred from the exit code.** `notarytool submit --wait` can return zero on an `Invalid` submission, so the JSON `status` decides. A rejection prints `notarytool log` before failing.
- **`plutil` parses the JSON**, not `jq`, so this assumes nothing about the runner image.
- **The three credentials are optional** (`required: false`), passed through from `release-plz.yml`. Absent them the release still ships a signed binary and emits a `Not notarized` warning, rather than failing a release on a secret that is not configured yet.

## Verification

I cannot notarize for real from here, so the step was exercised against a stubbed `xcrun`:

- **Accepted** — base64 → key file, `ditto -c -k --norsrc --noextattr` produced a clean zip of the staged binaries, every flag reached `notarytool` intact, status parsed as `Accepted`, exit 0.
- **Invalid** — the stub deliberately exits **0** while reporting `Invalid`; the step still failed and fetched the notary log, confirming the status check and not the exit code is the gate.
- **No credentials** — warned and exited 0.
- The `trap` left no key or temp directory behind in any case.
- `bash -n` and `shellcheck` clean; the workflow parses and the step is ordered after signing and before the upload.

## What you need to do

Nothing in this PR works until three repository secrets exist: `APPLE_API_KEY_P8` (base64 of an App Store Connect **team** API key `.p8` with the Developer role), `APPLE_API_KEY_ID`, and `APPLE_API_ISSUER_ID`. It must be a team key — `notarytool` takes an issuer only for those. Until then, releases ship signed but un-notarized and annotate a warning.

This is one of several sibling PRs applying the same step across the jdx.dev CLIs. They each carry their own copy; if you would rather consolidate, a composite action would collapse all seven into one — happy to do that instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release gate for macOS PGO artifacts—failed notarization fails the job and can block publishing until Apple accepts or credentials are fixed; optional secrets limit blast radius when unset.
> 
> **Overview**
> Adds **Apple notarization** to the macOS PGO release path so browser-downloaded archives can pass Gatekeeper without a manual override. The reusable `release` workflow accepts three optional App Store Connect secrets; `release-plz` forwards them from repo secrets.
> 
> After **codesign** on macOS (non–dry-run), a new step stages the signed `aube` binary, zips it with `ditto`, and submits it with `xcrun notarytool`. It treats JSON **`status == Accepted`** as success (not the CLI exit code), pulls **`notarytool log`** on rejection, and stores the `.p8` key in a temp dir with a cleanup trap. Missing credentials emit a workflow warning and skip notarization so releases still ship signed-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 207039c03ad3fa75cc5f8a7707cbca6eb12d8f94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS PGO release binaries can now be notarized automatically before distribution.
  * Release signing supports Apple App Store Connect credentials.
  * Notarization failures provide access to diagnostic logs.
  * Release checks warn when required hardened-runtime or secure-timestamp metadata is missing.

* **Bug Fixes**
  * Releases continue successfully when notarization credentials are unavailable, with a warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## On ordering: the release stays drafted if notarization fails

The asset is uploaded by the signing step, so notarization runs after upload. That is safe here because publication is separately gated: `publish-release` (`gh release edit --draft=false`) declares `needs: [..., upload-assets, ...]`, and this notarize step lives inside `upload-assets`. A rejected submission fails that job, `publish-release` never runs, and the release stays a draft with the asset attached but unpublished.

This also works because Apple stores the ticket against the binary cdhash rather than stapling it into the artifact, so a successful notarization retroactively covers bytes already uploaded.
