### PR TITLE
fix(release): preserve glibc 2.31 compatibility for arm64

### DIFF
--- a/.github/containers/release-arm64/Containerfile
+++ b/.github/containers/release-arm64/Containerfile
@@ -1,0 +1,82 @@
+# syntax=docker/dockerfile:1
+FROM ubuntu:20.04@sha256:8feb4d8ca5354def3d8fce243717141ce31e2c428701f6682bd2fafe15388214
+
+ARG LLVM_VERSION=20
+ARG LLVM_PACKAGE_VERSION=1:20.1.8~++20250708123950+0de59a293f7a-1~exp1~20250708004007.131
+ARG LLVM_KEY_SHA256=8b2a587ffd672c4687e7581dad4b2f6c1bb2ad6b480cd9771ba2ff48e0b8c75d
+ARG MISE_VERSION=2026.8.12
+ARG MISE_SHA256=071e2d16905360fa04762422a2a889692bb3a4d30f27650de50bc1ac0564840b
+
+# Direct package revisions from the Ubuntu focal arm64 and LLVM 20
+# repositories. Bump deliberately when refreshing the release toolchain.
+ARG BUILD_ESSENTIAL_VERSION=12.8ubuntu1.1
+ARG CA_CERTIFICATES_VERSION=20240203~20.04.1
+ARG CMAKE_VERSION=3.16.3-1ubuntu1.20.04.1
+ARG CURL_VERSION=7.68.0-1ubuntu2.25
+ARG GIT_VERSION=1:2.25.1-1ubuntu3.14
+ARG GNUPG_VERSION=2.2.19-3ubuntu2.5
+ARG NINJA_VERSION=1.10.0-1build1
+ARG PERL_VERSION=5.30.0-9ubuntu0.5
+ARG PKG_CONFIG_VERSION=0.29.1-0ubuntu4
+ARG WGET_VERSION=1.20.3-1ubuntu2.1
+ARG XZ_UTILS_VERSION=5.2.4-1ubuntu1.1
+
+# The mounted repository has a broader developer tool list; missing task
+# tools must not make this focused release image install unsupported assets.
+ENV DEBIAN_FRONTEND=noninteractive \
+    MISE_CACHE_DIR=/mise/cache \
+    MISE_CONFIG_DIR=/mise \
+    MISE_DATA_DIR=/mise \
+    MISE_INSTALL_PATH=/usr/local/bin/mise \
+    MISE_SYSTEM_DATA_DIR=/usr/local/share/mise \
+    MISE_TASK_RUN_AUTO_INSTALL=false \
+    MISE_TRUSTED_CONFIG_PATHS=/mise \
+    MISE_YES=1 \
+    CARGO_HOME=/usr/local/share/mise/cargo \
+    RUSTUP_HOME=/usr/local/share/mise/rustup \
+    RUSTUP_TOOLCHAIN=1.97.0 \
+    PATH=/usr/local/share/mise/cargo/bin:/usr/local/share/mise/installs/node/24.14.0/bin:/mise/shims:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      "build-essential=${BUILD_ESSENTIAL_VERSION}" \
+      "ca-certificates=${CA_CERTIFICATES_VERSION}" \
+      "cmake=${CMAKE_VERSION}" \
+      "curl=${CURL_VERSION}" \
+      "git=${GIT_VERSION}" \
+      "gnupg=${GNUPG_VERSION}" \
+      "ninja-build=${NINJA_VERSION}" \
+      "perl=${PERL_VERSION}" \
+      "pkg-config=${PKG_CONFIG_VERSION}" \
+      "wget=${WGET_VERSION}" \
+      "xz-utils=${XZ_UTILS_VERSION}" \
+    && install -d -m 0755 /etc/apt/keyrings \
+    && wget -qO /tmp/llvm-snapshot.gpg.key https://apt.llvm.org/llvm-snapshot.gpg.key \
+    && echo "${LLVM_KEY_SHA256}  /tmp/llvm-snapshot.gpg.key" | sha256sum -c - \
+    && gpg --dearmor -o /etc/apt/keyrings/llvm.gpg /tmp/llvm-snapshot.gpg.key \
+    && rm -f /tmp/llvm-snapshot.gpg.key \
+    && echo "deb [signed-by=/etc/apt/keyrings/llvm.gpg] https://apt.llvm.org/focal/ llvm-toolchain-focal-${LLVM_VERSION} main" \
+      > "/etc/apt/sources.list.d/llvm-toolchain-${LLVM_VERSION}.list" \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+      "bolt-${LLVM_VERSION}=${LLVM_PACKAGE_VERSION}" \
+      "clang-${LLVM_VERSION}=${LLVM_PACKAGE_VERSION}" \
+      "lld-${LLVM_VERSION}=${LLVM_PACKAGE_VERSION}" \
+      "llvm-${LLVM_VERSION}-tools=${LLVM_PACKAGE_VERSION}" \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p "$CARGO_HOME" "$RUSTUP_HOME" \
+    && curl --proto '=https' --tlsv1.2 -fsSL \
+      "https://github.com/jdx/mise/releases/download/v${MISE_VERSION}/mise-v${MISE_VERSION}-linux-arm64" \
+      -o "$MISE_INSTALL_PATH" \
+    && echo "${MISE_SHA256}  ${MISE_INSTALL_PATH}" | sha256sum -c - \
+    && chmod 0755 "$MISE_INSTALL_PATH"
+
+COPY mise.toml /mise/config.toml
+
+RUN mise install --system \
+    && mise exec -- node --version \
+    && mise exec -- rustc --version \
+    && chmod -R a+rX /mise /usr/local/share/mise

--- a/.github/containers/release-arm64/mise.toml
+++ b/.github/containers/release-arm64/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+node = "24.14.0"
+rust = { version = "1.97", profile = "minimal", components = ["llvm-tools-preview"] }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,24 +298,148 @@ jobs:
         with:
           subject-path: ${{ steps.archive.outputs.path }}
 
+  # Native aarch64 GNU release. Build inside a cached Ubuntu 20.04 image so
+  # the linked artifact has a natural glibc 2.31 baseline while retaining
+  # native ARM64 execution for both Rust PGO and BOLT instrumentation training.
+  upload-assets-pgo-arm64-linux:
+    needs: generate-primer
+    runs-on: namespace-profile-endev-linux-arm64-large;overrides.cache-tag=aube-rust-linux-arm64
+    timeout-minutes: 180
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    env:
+      TARGET: aarch64-unknown-linux-gnu
+      LLVM_VERSION: "20"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref != '' && fromJSON(inputs.dry_run || 'false') && inputs.ref || format('refs/tags/{0}', inputs.tag) }}
+          submodules: recursive
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: metadata-primer
+          path: crates/aube-resolver/data
+      # Persist Cargo's registry and target across the container boundary;
+      # BuildKit only caches the image environment, not docker-run state.
+      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ${{ github.workspace }}/target
+      # BuildKit reuses unchanged dependency/toolchain layers from the GHA
+      # cache; changing the Containerfile or mise.toml invalidates only the
+      # layers after that change.
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      - name: Build cached ARM64 PGO environment
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .github/containers/release-arm64
+          file: .github/containers/release-arm64/Containerfile
+          platforms: linux/arm64
+          load: true
+          tags: aube-release-arm64:local
+          build-args: |
+            LLVM_VERSION=${{ env.LLVM_VERSION }}
+          cache-from: type=gha,scope=aube-release-arm64
+          # Only trusted release refs may write the shared cache. Dry runs
+          # can restore it but must not let an arbitrary ref poison it.
+          cache-to: ${{ !fromJSON(inputs.dry_run || 'false') && inputs.ref == '' && github.ref == 'refs/heads/main' && 'type=gha,mode=max,scope=aube-release-arm64' || '' }}
+
+      - name: PGO build (Focal + LLD + BOLT)
+        shell: bash
+        env:
+          AUBE_PGO_NO_LOCK: "1"
+          AUBE_PGO_BUILD_TOOL: cargo
+          AUBE_PGO_BOLT: "1"
+          AUBE_PGO_USE_LLD: "1"
+          AUBE_PGO_LLVM_VERSION: ${{ env.LLVM_VERSION }}
+        run: |
+          mkdir -p "$HOME/.cargo/registry" "$HOME/.cargo/git"
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            --volume "$GITHUB_WORKSPACE:/workspace" \
+            --volume "$HOME/.cargo/registry:/tmp/aube-home/.cargo/registry" \
+            --volume "$HOME/.cargo/git:/tmp/aube-home/.cargo/git" \
+            --workdir /workspace \
+            --env AUBE_PGO_NO_LOCK \
+            --env AUBE_PGO_BUILD_TOOL \
+            --env AUBE_PGO_BOLT \
+            --env AUBE_PGO_USE_LLD \
+            --env AUBE_PGO_LLVM_VERSION \
+            --env HOME=/tmp/aube-home \
+            --env CARGO_HOME=/tmp/aube-home/.cargo \
+            --env MISE_CACHE_DIR=/tmp/mise-cache \
+            aube-release-arm64:local \
+            bash -euo pipefail -c '
+              ldd --version | head -1
+              mise run --skip-tools build:pgo
+            '
+
+      - name: Validate glibc baseline
+        shell: bash
+        run: |
+          bin=target/release-pgo/aube
+          max_glibc=$(
+            readelf --version-info "$bin" \
+              | grep -oE 'GLIBC_[0-9]+(\.[0-9]+)*' \
+              | sort -Vu \
+              | tail -1
+          )
+          echo "Maximum required glibc symbol version: ${max_glibc:-none}"
+          if [ -n "$max_glibc" ] && \
+             [ "$(printf '%s\n' GLIBC_2.31 "$max_glibc" | sort -V | tail -1)" != "GLIBC_2.31" ]; then
+            echo "::error::ARM64 release requires $max_glibc, newer than GLIBC_2.31"
+            exit 1
+          fi
+          "$bin" --version
+
+      - name: Archive PGO binaries
+        id: archive
+        shell: bash
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          archive="aube-${TAG}-${TARGET}.tar.gz"
+          BIN_DIR="target/release-pgo"
+          ln -sf aube "$BIN_DIR/aubr"
+          ln -sf aube "$BIN_DIR/aubx"
+          tar -czf "$archive" -C "$BIN_DIR" aube aubr aubx
+          echo "path=$archive" >> "$GITHUB_OUTPUT"
+
+      - name: Upload archive to release
+        if: ${{ !fromJSON(inputs.dry_run || 'false') }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}
+          TAG: ${{ inputs.tag }}
+          ARCHIVE: ${{ steps.archive.outputs.path }}
+        run: gh release upload "$TAG" "$ARCHIVE" --clobber
+
+      - name: Upload archive as workflow artifact (dry run)
+        if: ${{ fromJSON(inputs.dry_run || 'false') }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: aube-${{ inputs.tag }}-aarch64-unknown-linux-gnu
+          path: ${{ steps.archive.outputs.path }}
+
+      - name: Attest release archive
+        if: ${{ !fromJSON(inputs.dry_run || 'false') }}
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: ${{ steps.archive.outputs.path }}
+
   # PGO-optimized targets: x86_64 Linux GNU/musl (cross-built on amd64)
-  # plus native aarch64 Linux GNU and native macOS arm64. Each builds
-  # via benchmarks/pgo.bash — instrument under release-pgo, train against
-  # the committed offline registry, rebuild with -Cprofile-use. The
-  # x86_64 Linux targets use build-tool=cross so the resulting binary
-  # preserves the current glibc baseline; the cross-built instrumented
-  # binary runs on the host for training (cross's older glibc is
-  # forward-compatible with the runner's). Cross.toml passes RUSTFLAGS
-  # through to the container so phase 1 / 3b RUSTFLAGS reach cargo
-  # inside cross. The aarch64 Linux row runs natively on
-  # `namespace-profile-endev-linux-arm64-large` (32 GB) so the same
-  # fat-LTO + profile-generate headroom argument from
-  # acdf415 applies, and we don't need QEMU to train. macOS arm64 is
-  # on the `-large` (12×28) variant because the previous instrumented
-  # binary segfaulted during training on the 6×14 base profile — fork
-  # pressure from `aube install` may have been racing under resource
-  # contention. Revisit moving back to base if `-large` proves stable
-  # across a few release cycles.
+  # plus native macOS arm64. The aarch64 GNU release is isolated above
+  # so its entire build runs inside Focal. Each remaining target builds via
+  # benchmarks/pgo.bash — instrument under release-pgo, train against the
+  # committed offline registry, and rebuild with -Cprofile-use. The x86_64
+  # Linux targets use build-tool=cross so the resulting binaries preserve
+  # their current libc baselines. macOS arm64 remains native on its existing
+  # hosted runner.
   upload-assets-pgo:
     needs: generate-primer
     runs-on: ${{ matrix.runner }}
@@ -354,11 +478,6 @@ jobs:
             runner: namespace-profile-endev-linux-amd64-large
             build-tool: cross
             bolt: false
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
-            runner: namespace-profile-endev-linux-arm64-large
-            build-tool: cargo
-            bolt: true
           - target: aarch64-apple-darwin
             os: macos-latest
             # Trying GitHub's standard Apple Silicon runner — the
@@ -468,6 +587,7 @@ jobs:
           AUBE_PGO_BUILD_TOOL: ${{ matrix.build-tool }}
           AUBE_PGO_TARGET: ${{ matrix.target }}
           AUBE_PGO_BOLT: ${{ matrix.bolt && '1' || '' }}
+          AUBE_PGO_LLVM_VERSION: ${{ matrix.bolt && '18' || '' }}
         run: bash benchmarks/pgo.bash
       - name: Codesign macOS binaries
         if: startsWith(matrix.os, 'macos')

--- a/benchmarks/pgo.bash
+++ b/benchmarks/pgo.bash
@@ -44,6 +44,14 @@
 #                               the resulting binary keeps cross's older
 #                               glibc baseline. Cross.toml passes RUSTFLAGS
 #                               through to the container.
+#   AUBE_PGO_USE_LLD=1          link both PGO build phases with clang + LLD.
+#                               Uses the LLVM installation selected below.
+#   AUBE_PGO_LLVM_VERSION=<n>   require /usr/lib/llvm-<n>/bin. Release CI
+#                               pins this for reproducibility; local builds
+#                               may omit it to auto-discover the newest
+#                               complete toolchain, then PATH as a fallback.
+#   RUSTFLAGS=<flags>           caller-provided flags are preserved and
+#                               prepended to the phase-specific PGO flags.
 #   AUBE_PGO_SKIP_FINAL_BUILD=1 stop after merging .profraw. Use when the
 #                               final optimized build is delegated to a
 #                               separate step (e.g. taiki-e action) that
@@ -81,6 +89,79 @@ PGO_REGISTRY_URL="http://127.0.0.1:$PGO_REGISTRY_PORT"
 PGO_NODE_BIN="$(node -p 'process.execPath')"
 PGO_NODE_DIR="$(dirname "$PGO_NODE_BIN")"
 PGO_TRAIN_PATH="$PGO_NODE_DIR:$PATH"
+BASE_RUSTFLAGS="${RUSTFLAGS:-}"
+
+find_llvm_prefix() {
+	local required_tools=""
+	local prefix tool complete tool_path
+
+	if [ -n "${AUBE_PGO_USE_LLD:-}" ]; then
+		required_tools="clang ld.lld"
+	fi
+	if [ -n "$PGO_BOLT" ]; then
+		required_tools="${required_tools:+$required_tools }llvm-bolt merge-fdata"
+	fi
+
+	prefix="${AUBE_PGO_LLVM_VERSION:+/usr/lib/llvm-$AUBE_PGO_LLVM_VERSION}"
+	if [ -n "$prefix" ]; then
+		for tool in $required_tools; do
+			if [ ! -x "$prefix/bin/$tool" ]; then
+				echo "ERROR: LLVM prefix $prefix is missing $tool" >&2
+				exit 1
+			fi
+		done
+		printf '%s\n' "$prefix"
+		return 0
+	fi
+
+	while IFS= read -r prefix; do
+		complete=1
+		for tool in $required_tools; do
+			if [ ! -x "$prefix/bin/$tool" ]; then
+				complete=0
+				break
+			fi
+		done
+		if [ "$complete" -eq 1 ]; then
+			printf '%s\n' "$prefix"
+			return 0
+		fi
+	done < <(find /usr/lib -maxdepth 1 -type d -name 'llvm-[0-9]*' 2>/dev/null | sort -V -r)
+
+	for tool in $required_tools; do
+		tool_path=$(command -v "$tool" || true)
+		if [ -z "$tool_path" ] || [ ! -x "$tool_path" ]; then
+			echo "ERROR: no installed LLVM toolchain found" >&2
+			exit 1
+		fi
+	done
+	printf '%s\n' PATH
+}
+
+LLVM_PREFIX=""
+LLVM_BINDIR=""
+if [ -n "${AUBE_PGO_USE_LLD:-}" ] || [ -n "$PGO_BOLT" ]; then
+	LLVM_PREFIX="$(find_llvm_prefix)"
+	if [ "$LLVM_PREFIX" = PATH ]; then
+		echo ">>> LLVM toolchain: PATH"
+	else
+		LLVM_BINDIR="$LLVM_PREFIX/bin"
+		export PATH="$LLVM_BINDIR:$PATH"
+		echo ">>> LLVM toolchain: $LLVM_PREFIX"
+	fi
+
+	if [ -n "${AUBE_PGO_USE_LLD:-}" ]; then
+		if [ -n "$LLVM_BINDIR" ]; then
+			PGO_CLANG="$LLVM_BINDIR/clang"
+			PGO_LLD="$LLVM_BINDIR/ld.lld"
+		else
+			PGO_CLANG="$(command -v clang)"
+			PGO_LLD="$(command -v ld.lld)"
+		fi
+		BASE_RUSTFLAGS="${BASE_RUSTFLAGS:+$BASE_RUSTFLAGS }-C linker=$PGO_CLANG -C link-arg=-fuse-ld=lld"
+		echo ">>> PGO linker: $PGO_CLANG + $PGO_LLD"
+	fi
+fi
 
 case "$PGO_WORKFLOW_RUNS" in
 '' | *[!0-9]*)
@@ -97,41 +178,15 @@ case "$PGO_REGISTRY_PORT" in
 esac
 
 if [ -n "$PGO_BOLT" ]; then
-	# Prefer `/usr/lib/llvm-NN/bin/llvm-bolt` over the unversioned
-	# `/usr/bin/llvm-bolt`. BOLT derives its runtime-lib search dir
-	# from `dirname(dirname(argv[0]))/lib`, so the versioned path
-	# resolves to `/usr/lib/llvm-NN/lib/libbolt_rt_instr.a` (where
-	# Debian/Ubuntu actually ship the static archive). The
-	# unversioned path looks in `/usr/lib/` and fails.
-	LLVM_BOLT=""
-	for candidate in /usr/lib/llvm-18/bin/llvm-bolt /usr/lib/llvm-19/bin/llvm-bolt /usr/lib/llvm-20/bin/llvm-bolt; do
-		if [ -x "$candidate" ]; then
-			LLVM_BOLT="$candidate"
-			break
-		fi
-	done
-	if [ -z "$LLVM_BOLT" ]; then
-		LLVM_BOLT=$(command -v llvm-bolt || true)
-	fi
-	if [ -z "$LLVM_BOLT" ]; then
-		echo "ERROR: AUBE_PGO_BOLT=1 but llvm-bolt is not installed" >&2
-		echo "  Install via apt.llvm.org: bolt-18 (or newer)" >&2
-		exit 1
-	fi
-	# Resolve `merge-fdata` next to `llvm-bolt` so a versioned
-	# bolt-18 install works without its directory being on PATH
-	# (e.g. local runs without the workflow's GITHUB_PATH append).
-	# Fall back to PATH only if no sibling exists.
-	bolt_bindir=$(dirname "$LLVM_BOLT")
-	if [ -x "$bolt_bindir/merge-fdata" ]; then
-		MERGE_FDATA="$bolt_bindir/merge-fdata"
+	# Keep BOLT and merge-fdata on the same versioned LLVM installation
+	# selected above. Using the versioned prefix also preserves BOLT's
+	# runtime lookup for /usr/lib/llvm-NN/lib/libbolt_rt_instr.a.
+	if [ -n "$LLVM_BINDIR" ]; then
+		LLVM_BOLT="$LLVM_BINDIR/llvm-bolt"
+		MERGE_FDATA="$LLVM_BINDIR/merge-fdata"
 	else
-		MERGE_FDATA=$(command -v merge-fdata || true)
-	fi
-	if [ -z "$MERGE_FDATA" ]; then
-		echo "ERROR: AUBE_PGO_BOLT=1 but merge-fdata is not installed" >&2
-		echo "  Expected next to llvm-bolt at $bolt_bindir/merge-fdata" >&2
-		exit 1
+		LLVM_BOLT="$(command -v llvm-bolt)"
+		MERGE_FDATA="$(command -v merge-fdata)"
 	fi
 	echo ">>> BOLT toolchain: $LLVM_BOLT ($MERGE_FDATA)"
 fi
@@ -220,7 +275,7 @@ fi
 # ---------- Phase 1: instrumented build ----------
 echo ">>> [1/3] Building instrumented binary ($PGO_BUILD_TOOL, profile=$PGO_PROFILE${PGO_TARGET:+, target=$PGO_TARGET})"
 # shellcheck disable=SC2086 # intentional word-splitting on $target_arg
-RUSTFLAGS="-Cprofile-generate=$PGO_PROFRAW_DIR" \
+RUSTFLAGS="${BASE_RUSTFLAGS:+$BASE_RUSTFLAGS }-Cprofile-generate=$PGO_PROFRAW_DIR" \
 	"$PGO_BUILD_TOOL" build --profile="$PGO_PROFILE" $target_arg -p aube --bin aube
 
 INSTRUMENTED_BIN="$REPO_ROOT/target/${target_dir_part}${PGO_PROFILE}/aube"
@@ -379,7 +434,7 @@ echo ">>> Rebuilding with -Cprofile-use${PGO_BOLT:+ + --emit-relocs}"
 # branch targets when it moves blocks around; without them it falls
 # back to a much less effective mode that only reorders within
 # functions.
-phase3b_rustflags="-Cprofile-use=$PGO_MERGED -Cllvm-args=-pgo-warn-missing-function=false"
+phase3b_rustflags="${BASE_RUSTFLAGS:+$BASE_RUSTFLAGS }-Cprofile-use=$PGO_MERGED -Cllvm-args=-pgo-warn-missing-function=false"
 if [ -n "$PGO_BOLT" ]; then
 	phase3b_rustflags="$phase3b_rustflags -C link-arg=-Wl,--emit-relocs -C link-arg=-Wl,-q"
 fi


### PR DESCRIPTION
## Summary

Build ARM64 PGO release binaries in a pinned Ubuntu 20.04 container so they
remain compatible with glibc 2.31+ systems.

## Changes

- Add a reproducible ARM64 release container using mise.
- Pin Ubuntu, mise, Node, Rust, LLVM, and BOLT tooling.
- Preserve Cargo and BuildKit caching across container builds.
- Keep packaging, attestation, signing, and release upload on the host.
- Simplify LLVM toolchain discovery for PGO builds.

## Validation

- Completed a native ARM64 GitHub Actions PGO build with 20 workflow runs.
- Validated the resulting binary in Ubuntu 20.04.
- Confirmed ARM64 execution, dependency resolution, and install behavior.
- Confirmed the maximum required glibc symbol is `GLIBC_2.30`.

The upstream Namespace release runner and credentialed upload path were not
available from the fork.

*AI-assisted — Tool: pi; model: openai-codex/gpt-5.6-luna; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ARM64 release builds for Linux.
  * Added automated ARM64 release packaging, validation, upload, and attestation.
  * Added support for configurable LLVM toolchains during profile-guided optimization builds.

* **Bug Fixes**
  * Improved preservation of existing build flags during optimized builds.
  * Added compatibility validation for the supported glibc baseline.

* **Chores**
  * Pinned ARM64 release tooling, including Node.js, Rust, Ubuntu, and LLVM versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->