### PR TITLE
fix(ci): allow API stability checks to finish

### DIFF
--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -115,7 +115,9 @@ jobs:
       results_present: ${{ steps.report.outputs.results_present }}
       checks_passed: ${{ steps.report.outputs.checks_passed }}
     runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
-    timeout-minutes: 20
+    # cargo-semver-checks builds both revisions of every published crate. A
+    # cold cache can exceed 20 minutes, especially alongside the C ABI build.
+    timeout-minutes: 30
     env:
       CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback
       RUSTFLAGS: "-D warnings"


### PR DESCRIPTION
## Summary

- raise the API stability job timeout from 20 to 30 minutes
- document the cold-cache cost of checking both revisions of every published crate alongside the C ABI build

## Context

The API stability job on #1387 reached the 20-minute limit while `cargo-semver-checks` was still processing the published crates. The check now covers 13 packages and builds both the current and baseline revisions, so the original limit no longer provides enough cold-cache headroom.

## Validation

- `git diff --check`
- `actionlint .github/workflows/ci-impl.yml`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only timeout and comment change with no effect on application code or security behavior.
> 
> **Overview**
> Raises the **`api-stability`** job limit from **20 to 30 minutes** in `ci-impl.yml` so PR runs are less likely to be killed while `cargo-semver-checks` and the parallel C ABI build are still running.
> 
> Adds an inline comment that semver checking builds both revisions of every published crate, which on a cold cache can exceed the old limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c321d61de8c746e552dc83a4d41c498418a80112. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the API stability check time limit to reduce failures during longer builds.
  * Added context explaining the extended time allowance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->