### PR TITLE
fix(ci): simplify final job condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
   final:
     name: final
-    if: ${{ always() && !cancelled() && needs.trusted.result != 'cancelled' && needs.untrusted.result != 'cancelled' }}
+    if: ${{ !cancelled() }}
     permissions: {}
     needs: [trusted, untrusted]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- align the wrapper `final` job with the `!cancelled()` fan-in pattern used by the reusable workflow and other projects
- leave result validation to the existing trusted/untrusted result-checking step

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/ci-impl.yml`
- `git diff --check`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI orchestration only; success criteria remain in the existing shell check step.
> 
> **Overview**
> The wrapper **`final`** job in `ci.yml` now uses **`if: ${{ !cancelled() }}`** instead of gating on `always()` and both `trusted`/`untrusted` not being `cancelled`.
> 
> That matches the fan-in pattern already used in **`ci-impl.yml`**. Pass/fail is unchanged: the **Check selected workflow result** step still requires exactly one of `trusted` or `untrusted` to succeed and the other to be skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28c83250cddc3ce3d8e2c5cd7cccf7154920b227. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow completion handling so final status processing runs whenever the workflow is not cancelled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->