### PR TITLE
ci: skip Intel macOS builds outside releases

### DIFF
--- a/.github/workflows/ffi-impl.yml
+++ b/.github/workflows/ffi-impl.yml
@@ -34,20 +34,38 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'release' && inputs.tag == '' }}
 
 jobs:
+  targets:
+    runs-on: ubuntu-latest
+    outputs:
+      include: ${{ steps.targets.outputs.include }}
+    steps:
+      - id: targets
+        shell: bash
+        env:
+          INCLUDE_INTEL_MACOS: ${{ github.event_name == 'release' || inputs.tag != '' || inputs.draft_phase }}
+        run: |
+          include=$(jq -cn '[
+            {"runner":"macos-15","namespace_runner":"namespace-profile-endev-macos-arm64","target":"aarch64-apple-darwin","os":"darwin","cpu":"arm64","package":"darwin-arm64","binary":"libaube_ffi.dylib","ext":"dylib"},
+            {"runner":"macos-15-intel","namespace_runner":"namespace-profile-endev-macos-arm64","target":"x86_64-apple-darwin","os":"darwin","cpu":"x64","package":"darwin-x64","binary":"libaube_ffi.dylib","ext":"dylib"},
+            {"runner":"ubuntu-24.04-arm","namespace_runner":"namespace-profile-endev-linux-arm64-large","target":"aarch64-unknown-linux-gnu","os":"linux","cpu":"arm64","package":"linux-arm64","binary":"libaube_ffi.so","ext":"so"},
+            {"runner":"ubuntu-latest","namespace_runner":"namespace-profile-endev-linux-amd64","target":"x86_64-unknown-linux-gnu","os":"linux","cpu":"x64","package":"linux-x64","binary":"libaube_ffi.so","ext":"so"},
+            {"runner":"ubuntu-24.04-arm","namespace_runner":"namespace-profile-endev-linux-arm64-large","target":"aarch64-unknown-linux-musl","os":"linux","cpu":"arm64","libc":"musl","package":"linux-arm64-musl","binary":"libaube_ffi.so","ext":"so"},
+            {"runner":"ubuntu-latest","namespace_runner":"namespace-profile-endev-linux-amd64","target":"x86_64-unknown-linux-musl","os":"linux","cpu":"x64","libc":"musl","package":"linux-x64-musl","binary":"libaube_ffi.so","ext":"so"},
+            {"runner":"windows-latest","namespace_runner":"windows-latest","target":"aarch64-pc-windows-msvc","os":"win32","cpu":"arm64","package":"win32-arm64","binary":"aube_ffi.dll","ext":"dll"},
+            {"runner":"windows-latest","namespace_runner":"windows-latest","target":"x86_64-pc-windows-msvc","os":"win32","cpu":"x64","package":"win32-x64","binary":"aube_ffi.dll","ext":"dll"}
+          ]')
+          if [[ "$INCLUDE_INTEL_MACOS" != true ]]; then
+            include=$(jq -c 'map(select(.package != "darwin-x64"))' <<< "$include")
+          fi
+          echo "include=$include" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: targets
     name: ${{ matrix.package }}
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - { runner: macos-15, namespace_runner: namespace-profile-endev-macos-arm64, target: aarch64-apple-darwin, os: darwin, cpu: arm64, package: darwin-arm64, binary: libaube_ffi.dylib, ext: dylib }
-          - { runner: macos-15-intel, namespace_runner: namespace-profile-endev-macos-arm64, target: x86_64-apple-darwin, os: darwin, cpu: x64, package: darwin-x64, binary: libaube_ffi.dylib, ext: dylib }
-          - { runner: ubuntu-24.04-arm, namespace_runner: namespace-profile-endev-linux-arm64-large, target: aarch64-unknown-linux-gnu, os: linux, cpu: arm64, package: linux-arm64, binary: libaube_ffi.so, ext: so }
-          - { runner: ubuntu-latest, namespace_runner: namespace-profile-endev-linux-amd64, target: x86_64-unknown-linux-gnu, os: linux, cpu: x64, package: linux-x64, binary: libaube_ffi.so, ext: so }
-          - { runner: ubuntu-24.04-arm, namespace_runner: namespace-profile-endev-linux-arm64-large, target: aarch64-unknown-linux-musl, os: linux, cpu: arm64, libc: musl, package: linux-arm64-musl, binary: libaube_ffi.so, ext: so }
-          - { runner: ubuntu-latest, namespace_runner: namespace-profile-endev-linux-amd64, target: x86_64-unknown-linux-musl, os: linux, cpu: x64, libc: musl, package: linux-x64-musl, binary: libaube_ffi.so, ext: so }
-          - { runner: windows-latest, namespace_runner: windows-latest, target: aarch64-pc-windows-msvc, os: win32, cpu: arm64, package: win32-arm64, binary: aube_ffi.dll, ext: dll }
-          - { runner: windows-latest, namespace_runner: windows-latest, target: x86_64-pc-windows-msvc, os: win32, cpu: x64, package: win32-x64, binary: aube_ffi.dll, ext: dll }
+        include: ${{ fromJSON(needs.targets.outputs.include) }}
     runs-on: ${{ (github.event_name == 'release' || inputs.tag != '' || inputs.draft_phase || !inputs.trusted) && matrix.runner || matrix.namespace_runner }}
     timeout-minutes: 60
     env:
@@ -151,11 +169,14 @@ jobs:
         shell: bash
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          INCLUDE_INTEL_MACOS: ${{ github.event_name == 'release' || inputs.tag != '' || inputs.draft_phase }}
         run: |
           if [[ -n "$RELEASE_TAG" ]]; then VERSION=${RELEASE_TAG#v}; else VERSION="0.0.0-smoke.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"; fi
           VERSION="$VERSION" OUT_DIR="$PWD/packages" node crates/aube-ffi/npm/package.mjs
           cp crates/aube-ffi/include/aube.h packages/aube.h
-          test "$(find packages -maxdepth 1 -name '*.tgz' -print | wc -l)" -eq 9
+          expected=8
+          if [[ "$INCLUDE_INTEL_MACOS" == true ]]; then expected=9; fi
+          test "$(find packages -maxdepth 1 -name '*.tgz' -print | wc -l)" -eq "$expected"
       - name: Smoke-test raw library with Bun and Deno
         shell: bash
         env:

--- a/.github/workflows/node-addon-impl.yml
+++ b/.github/workflows/node-addon-impl.yml
@@ -24,20 +24,38 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'release' && inputs.tag == '' }}
 
 jobs:
+  targets:
+    runs-on: ubuntu-latest
+    outputs:
+      include: ${{ steps.targets.outputs.include }}
+    steps:
+      - id: targets
+        shell: bash
+        env:
+          INCLUDE_INTEL_MACOS: ${{ github.event_name == 'release' || inputs.tag != '' }}
+        run: |
+          include=$(jq -cn '[
+            {"runner":"macos-15","namespace_runner":"namespace-profile-endev-macos-arm64","target":"aarch64-apple-darwin","os":"darwin","cpu":"arm64","package":"darwin-arm64","binary":"libaube_node.dylib","smoke":true},
+            {"runner":"macos-15-intel","namespace_runner":"macos-15-intel","target":"x86_64-apple-darwin","os":"darwin","cpu":"x64","package":"darwin-x64","binary":"libaube_node.dylib","smoke":true},
+            {"runner":"ubuntu-24.04-arm","namespace_runner":"namespace-profile-endev-linux-arm64-large","target":"aarch64-unknown-linux-gnu","os":"linux","cpu":"arm64","package":"linux-arm64","binary":"libaube_node.so","smoke":true},
+            {"runner":"ubuntu-latest","namespace_runner":"namespace-profile-endev-linux-amd64","target":"x86_64-unknown-linux-gnu","os":"linux","cpu":"x64","package":"linux-x64","binary":"libaube_node.so","smoke":true},
+            {"runner":"ubuntu-24.04-arm","namespace_runner":"namespace-profile-endev-linux-arm64-large","target":"aarch64-unknown-linux-musl","os":"linux","cpu":"arm64","libc":"musl","package":"linux-arm64-musl","binary":"libaube_node.so"},
+            {"runner":"ubuntu-latest","namespace_runner":"namespace-profile-endev-linux-amd64","target":"x86_64-unknown-linux-musl","os":"linux","cpu":"x64","libc":"musl","package":"linux-x64-musl","binary":"libaube_node.so"},
+            {"runner":"windows-latest","namespace_runner":"windows-latest","target":"aarch64-pc-windows-msvc","os":"win32","cpu":"arm64","package":"win32-arm64","binary":"aube_node.dll"},
+            {"runner":"windows-latest","namespace_runner":"windows-latest","target":"x86_64-pc-windows-msvc","os":"win32","cpu":"x64","package":"win32-x64","binary":"aube_node.dll","smoke":true}
+          ]')
+          if [[ "$INCLUDE_INTEL_MACOS" != true ]]; then
+            include=$(jq -c 'map(select(.package != "darwin-x64"))' <<< "$include")
+          fi
+          echo "include=$include" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: targets
     name: ${{ matrix.package }}
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - { runner: macos-15, namespace_runner: namespace-profile-endev-macos-arm64, target: aarch64-apple-darwin, os: darwin, cpu: arm64, package: darwin-arm64, binary: libaube_node.dylib, smoke: true }
-          - { runner: macos-15-intel, namespace_runner: macos-15-intel, target: x86_64-apple-darwin, os: darwin, cpu: x64, package: darwin-x64, binary: libaube_node.dylib, smoke: true }
-          - { runner: ubuntu-24.04-arm, namespace_runner: namespace-profile-endev-linux-arm64-large, target: aarch64-unknown-linux-gnu, os: linux, cpu: arm64, package: linux-arm64, binary: libaube_node.so, smoke: true }
-          - { runner: ubuntu-latest, namespace_runner: namespace-profile-endev-linux-amd64, target: x86_64-unknown-linux-gnu, os: linux, cpu: x64, package: linux-x64, binary: libaube_node.so, smoke: true }
-          - { runner: ubuntu-24.04-arm, namespace_runner: namespace-profile-endev-linux-arm64-large, target: aarch64-unknown-linux-musl, os: linux, cpu: arm64, libc: musl, package: linux-arm64-musl, binary: libaube_node.so }
-          - { runner: ubuntu-latest, namespace_runner: namespace-profile-endev-linux-amd64, target: x86_64-unknown-linux-musl, os: linux, cpu: x64, libc: musl, package: linux-x64-musl, binary: libaube_node.so }
-          - { runner: windows-latest, namespace_runner: windows-latest, target: aarch64-pc-windows-msvc, os: win32, cpu: arm64, package: win32-arm64, binary: aube_node.dll }
-          - { runner: windows-latest, namespace_runner: windows-latest, target: x86_64-pc-windows-msvc, os: win32, cpu: x64, package: win32-x64, binary: aube_node.dll, smoke: true }
+        include: ${{ fromJSON(needs.targets.outputs.include) }}
     runs-on: ${{ (github.event_name == 'release' || inputs.tag != '' || !inputs.trusted) && matrix.runner || matrix.namespace_runner }}
     timeout-minutes: 60
     env:
@@ -143,10 +161,13 @@ jobs:
         shell: bash
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          INCLUDE_INTEL_MACOS: ${{ github.event_name == 'release' || inputs.tag != '' }}
         run: |
           if [[ -n "$RELEASE_TAG" ]]; then VERSION=${RELEASE_TAG#v}; else VERSION="0.0.0-smoke.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"; fi
           VERSION="$VERSION" OUT_DIR="$PWD/packages" node crates/aube-node/npm/package.mjs
-          test "$(find packages -maxdepth 1 -name '*.tgz' -print | wc -l)" -eq 9
+          expected=8
+          if [[ "$INCLUDE_INTEL_MACOS" == true ]]; then expected=9; fi
+          test "$(find packages -maxdepth 1 -name '*.tgz' -print | wc -l)" -eq "$expected"
       - name: Smoke-test installed packages with Node and Bun
         shell: bash
         run: | # zizmor: ignore[adhoc-packages] installs only tarballs built by the required matrix jobs

--- a/V3.md
+++ b/V3.md
@@ -4,6 +4,14 @@ This file tracks worthwhile breaking changes to batch into a future major
 release. Items belong here when they improve the long-term API or defaults but
 do not justify a major release on their own.
 
+## Platform support
+
+### Drop Intel macOS FFI support
+
+Stop building the `x86_64-apple-darwin` C ABI library and publishing the
+`@jdxcode/aube-ffi-darwin-x64` package. Remove it from the root FFI package's
+optional dependencies and platform loader at the same time.
+
 ## Security defaults
 
 ### Enable jailed dependency builds by default


### PR DESCRIPTION
## Summary

- omit `darwin-x64` from ordinary Node-API and FFI CI matrices
- retain Intel macOS builds for releases, package backfills, and FFI draft-release assets
- keep current npm package support intact and record the FFI support removal in `V3.md`
- adjust aggregate package-count assertions for CI versus release matrices

Follow-up to https://github.com/jdx/aube/pull/1390#discussion_r3872141564.

## Validation

- `actionlint .github/workflows/node-addon-impl.yml .github/workflows/ffi-impl.yml`
- `git diff --check origin/main`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which native artifacts are produced per workflow trigger; Intel macOS packages may be missing on non-release CI paths while release/tag flows still build them.
> 
> **Overview**
> **CI now builds fewer macOS targets on ordinary PR/smoke runs** by moving FFI and Node-API platform lists into a dedicated `targets` job and feeding the build matrix from its JSON output instead of a hard-coded `matrix.include` block.
> 
> On both `ffi-impl.yml` and `node-addon-impl.yml`, the `darwin-x64` (`x86_64-apple-darwin`) row is **dropped unless** `INCLUDE_INTEL_MACOS` is set (release, explicit tag, and for FFI also `draft_phase`). The aggregate pack step no longer assumes nine `*.tgz` files: it expects **8** by default and **9** when Intel macOS is included.
> 
> `V3.md` adds a planned breaking change to **fully remove Intel macOS FFI** (stop building/publishing `@jdxcode/aube-ffi-darwin-x64` and related loader wiring) in a future major release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 001cc6f24cafe46bf20f373a092fc0fe97d09005. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Build and package workflows now dynamically select supported targets.
  - Intel macOS artifacts are included for releases and designated draft builds.

- **Bug Fixes**
  - Package validation now expects the correct number of artifacts based on selected targets.

- **Breaking Changes**
  - Intel macOS FFI libraries and packages are no longer published by default.
  - Intel macOS support has been removed from optional dependencies and platform loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->