### PR TITLE
chore(deps): update chacha20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,9 +833,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",


### PR DESCRIPTION
## Summary

- update `chacha20` from 0.10.1 to 0.10.2 in `Cargo.lock`
- replace the yanked release that causes `cargo audit --deny warnings` to fail

## Validation

- `mise x cargo:cargo-audit@0.22.1 -- cargo audit --deny warnings`
- `cargo check --locked`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only patch bump for a transitive crypto crate; no code or API changes in this repo.
> 
> **Overview**
> Updates the locked **`chacha20`** crate from **0.10.1** to **0.10.2** in `Cargo.lock` only—no application source changes.
> 
> This swaps out a **yanked** 0.10.1 release so **`cargo audit --deny warnings`** can pass again while keeping the same minor line of the dependency tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4411ecd1eca184b78ea98b77caf6b8b90e9d86e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->