### PR TITLE
chore(ci): bump mr-boxington action

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -14,11 +14,11 @@ runs:
   steps:
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563 # v1.0.1
+      uses: jdx/mr-boxington-action@ccdc5852f8bd93375379830a75f24794407443df # main
       with:
         version: 0.5.4
         backend: github
-    - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563 # v1.0.1
+    - uses: jdx/mr-boxington-action@ccdc5852f8bd93375379830a75f24794407443df # main
       with:
         version: 0.5.4
         backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -8,19 +8,24 @@ inputs:
   mirror-github-cache:
     description: Mirror a trusted main build into the restore-only cache used by fork PRs
     default: "false"
+  cache-links:
+    description: Cache native links; "auto" enables this on Linux
+    default: auto
 
 runs:
   using: composite
   steps:
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@ccdc5852f8bd93375379830a75f24794407443df # main
+      uses: jdx/mr-boxington-action@ccdc5852f8bd93375379830a75f24794407443df
       with:
         version: 0.5.4
         backend: github
-    - uses: jdx/mr-boxington-action@ccdc5852f8bd93375379830a75f24794407443df # main
+        cache-links: ${{ inputs.cache-links }}
+    - uses: jdx/mr-boxington-action@ccdc5852f8bd93375379830a75f24794407443df
       with:
         version: 0.5.4
+        cache-links: ${{ inputs.cache-links }}
         backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/aube


### PR DESCRIPTION
## Summary

Pin the merged mr-boxington action update from [jdx/mr-boxington-action#15](https://github.com/jdx/mr-boxington-action/pull/15). The action now enables eligible native-link caching automatically on Linux, with an explicit opt-out.

A controlled mise warm build improved from 124.7s to 84.9s (about 32%).

## Validation

- immutable action SHA
- YAML diff checked
- upstream action unit and platform matrix checks passed

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that adjusts build cache behavior; no application runtime or security-sensitive logic.
> 
> **Overview**
> Updates the composite **mbx** action to pin a newer **mr-boxington-action** commit and wires through a new **`cache-links`** input (default **`auto`**) to both cache restore/setup steps.
> 
> With **`auto`**, eligible Linux CI jobs can cache native links without workflow callers changing anything; existing **`backend`** and mirror behavior stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7938d9cb46ba136fc8d0a2b4a864144765fbb8bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable link caching for automation workflows.
  * Link caching defaults to automatic behavior, including enablement on Linux.

* **Chores**
  * Preserved existing version, backend, and conditional behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->