### PR TITLE
perf(install): cut freshness and repeat-install overhead on large repos

### DIFF
--- a/crates/aube/src/commands/gvs_registry.rs
+++ b/crates/aube/src/commands/gvs_registry.rs
@@ -330,7 +330,32 @@ fn graph_entries(global_virtual_store: &Path) -> miette::Result<Vec<OsString>> {
 }
 
 fn project_links_into(aube_dir: &Path, global_virtual_store: &Path) -> miette::Result<bool> {
-    Ok(!project_entries(global_virtual_store, aube_dir)?.is_empty())
+    // Boolean-only variant of `project_entries`: stop at the first entry
+    // that resolves into the GVS instead of readlink+canonicalize-ing the
+    // entire `.aube/` directory. This runs on the install fast path
+    // (`register_fast_path_project`), where the full walk is O(graph) for
+    // an answer that is almost always "yes" at the first entry.
+    if !aube_dir.exists() {
+        return Ok(false);
+    }
+    let canonical_gvs =
+        std::fs::canonicalize(global_virtual_store).unwrap_or_else(|_| global_virtual_store.into());
+    for entry in std::fs::read_dir(aube_dir).map_err(|e| prune_error(aube_dir, e))? {
+        let entry = entry.map_err(|e| prune_error(aube_dir, e))?;
+        if !is_graph_entry_name(&entry.file_name()) {
+            continue;
+        }
+        let Some(canonical_target) = resolved_link_target(&entry.path(), aube_dir) else {
+            continue;
+        };
+        // Proper-prefix check, matching `project_entries`' strip_prefix +
+        // first-component semantics: a target equal to the GVS root
+        // itself carries no entry component and doesn't count.
+        if canonical_target.starts_with(&canonical_gvs) && canonical_target != canonical_gvs {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 fn project_entries(

--- a/crates/aube/src/commands/install/fetch.rs
+++ b/crates/aube/src/commands/install/fetch.rs
@@ -472,13 +472,12 @@ pub(super) async fn fetch_packages_with_root<F>(
     // `.aube/<dep>` already exists on disk. Callers pass true when
     // either:
     //
+    //   - the linker will need a verified index for packages this
+    //     shortcut would skip (`link_workspace`); or
     //   - the caller needs `load_index` to actually run as its store
     //     verification step (`aube fetch`, which treats the act of
     //     walking the store-file existence check as the operation's
-    //     primary side effect); or
-    //   - `storeDir` was explicitly overridden for this invocation, so
-    //     existing `.aube/<dep>` entries may describe a different
-    //     store than the one this install materializes from.
+    //     primary side effect).
     //
     // Both cases share the same implementation: skip the `.aube/`
     // existence check entirely so every package goes through
@@ -520,24 +519,32 @@ where
     // fixture drops from ~38 ms of parallel index reads to a handful
     // of `stat(2)`s.
     //
-    // Callers disable the fast path via
-    // `skip_already_linked_shortcut=true` for:
+    // Two call sites disable the fast path entirely via
+    // `skip_already_linked_shortcut=true`:
     //
-    //   - **Explicit `storeDir` overrides.** An existing `.aube/<dep>`
-    //     entry may have been materialized from a different store, so
-    //     every package must re-verify through `store.load_index`
-    //     against the store this install actually uses.
+    //   - **Workspace installs.** The shortcut's precondition ("the
+    //     entry resolves") is weaker than what the linker actually
+    //     needs ("the entry resolves *to the target this graph
+    //     expects*"). The local `.aube/<dep_path>` name is keyed by
+    //     dep_path alone, while the global virtual-store subdir folds
+    //     in graph hashes (`virtual_store_subdir` vs
+    //     `aube_dir_entry_name`), so a build-state change moves the
+    //     expected target while the entry keeps resolving to the old
+    //     one. `classify_entry_state` then reports `Stale`, the linker
+    //     needs an index it was never handed, and its fallback is the
+    //     *unverified* `store.load_index` — which happily returns a
+    //     stale index whose CAS shards are gone, failing the link
+    //     instead of re-fetching. Verifying every package here keeps
+    //     that self-healing (a stale index drops to `NeedsFetch` and
+    //     the tarball is re-downloaded while the network is still
+    //     available; the linker has no such option).
     //
-    //     (Workspace installs used to be in this list, justified by a
-    //     `link_workspace` that wiped `node_modules/` up front. That
-    //     linker has long since gained `link_all`'s incremental
-    //     Fresh/Missing/Stale handling — existing entries are kept, and
-    //     a package whose index is missing from the sparse map is
-    //     loaded via `store.load_index` inside the linker's own rayon
-    //     par_iter (`link_workspace` step 1, `link_hoisted_workspace`'s
-    //     placement pass). Keeping the shortcut off for workspaces
-    //     meant a stat per store file per package on *every* repeat
-    //     install of a monorepo, for no correctness gain.)
+    //     Enabling the shortcut for workspaces is worth doing — it is
+    //     a stat per store file per package on every repeat install of
+    //     a monorepo — but only once the classification compares
+    //     against the expected virtual-store subdir, which needs the
+    //     graph hashes that are currently computed inside the
+    //     concurrent prewarm task rather than before this call.
     //
     //   - **`aube fetch`.** The command exists to populate the
     //     global store (typical use: Docker layer caching, warming

--- a/crates/aube/src/commands/install/fetch.rs
+++ b/crates/aube/src/commands/install/fetch.rs
@@ -472,13 +472,13 @@ pub(super) async fn fetch_packages_with_root<F>(
     // `.aube/<dep>` already exists on disk. Callers pass true when
     // either:
     //
-    //   - the linker will wipe `node_modules/` before running
-    //     (`link_workspace`), so the `AlreadyLinked` classification
-    //     would be immediately invalidated; or
     //   - the caller needs `load_index` to actually run as its store
     //     verification step (`aube fetch`, which treats the act of
     //     walking the store-file existence check as the operation's
-    //     primary side effect).
+    //     primary side effect); or
+    //   - `storeDir` was explicitly overridden for this invocation, so
+    //     existing `.aube/<dep>` entries may describe a different
+    //     store than the one this install materializes from.
     //
     // Both cases share the same implementation: skip the `.aube/`
     // existence check entirely so every package goes through
@@ -520,17 +520,24 @@ where
     // fixture drops from ~38 ms of parallel index reads to a handful
     // of `stat(2)`s.
     //
-    // Two call sites disable the fast path entirely via
-    // `skip_already_linked_shortcut=true`:
+    // Callers disable the fast path via
+    // `skip_already_linked_shortcut=true` for:
     //
-    //   - **Workspace installs.** `link_workspace` unconditionally
-    //     wipes `node_modules/` (including `.aube/`) before
-    //     rebuilding, so every `AlreadyLinked` classification would
-    //     be invalidated by the time the linker runs. With the fast
-    //     path enabled, the linker would then fall back to
-    //     `self.store.load_index` *serially* inside `link_workspace`'s
-    //     for-loop, which is strictly slower than loading them here
-    //     in parallel via rayon.
+    //   - **Explicit `storeDir` overrides.** An existing `.aube/<dep>`
+    //     entry may have been materialized from a different store, so
+    //     every package must re-verify through `store.load_index`
+    //     against the store this install actually uses.
+    //
+    //     (Workspace installs used to be in this list, justified by a
+    //     `link_workspace` that wiped `node_modules/` up front. That
+    //     linker has long since gained `link_all`'s incremental
+    //     Fresh/Missing/Stale handling — existing entries are kept, and
+    //     a package whose index is missing from the sparse map is
+    //     loaded via `store.load_index` inside the linker's own rayon
+    //     par_iter (`link_workspace` step 1, `link_hoisted_workspace`'s
+    //     placement pass). Keeping the shortcut off for workspaces
+    //     meant a stat per store file per package on *every* repeat
+    //     install of a monorepo, for no correctness gain.)
     //
     //   - **`aube fetch`.** The command exists to populate the
     //     global store (typical use: Docker layer caching, warming

--- a/crates/aube/src/commands/install/finalize.rs
+++ b/crates/aube/src/commands/install/finalize.rs
@@ -279,12 +279,21 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
         });
         let graph_lthash = hex::encode(delta::lthash_of(&package_content_hashes).digest());
         let package_json_hashes = state::collect_package_json_hashes_from_manifests(cwd, manifests);
+        // One parse for every prior-install field this block consumes.
+        // The per-field accessors each re-parse the full O(graph) state
+        // file; on a large monorepo that was four parses of the same
+        // bytes.
+        let prior_state = state::read_state_delta_snapshot(cwd);
         // Diff against the previous install. Logs delta counts at
         // debug so `-v` installs surface what actually moved. A
         // later pass feeds the plan into fetch and link as a
         // pre-filter.
-        if let Some(prior) = state::read_state_package_content_hashes(cwd) {
-            let plan = delta::diff(&prior, &package_content_hashes);
+        if let Some(prior) = prior_state
+            .as_ref()
+            .map(|s| &s.package_content_hashes)
+            .filter(|prior| !prior.is_empty())
+        {
+            let plan = delta::diff(prior, &package_content_hashes);
             if !plan.is_empty() {
                 // Touched set built once. Doubles as a membership
                 // probe so future wiring exercises the same shape
@@ -306,11 +315,12 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
             // Cheap sanity on the homomorphic add/remove ops. The
             // future causal scheduler needs these two to stay in
             // lockstep with the full recompute.
-            if let Some(prior_lthash_hex) = state::read_state_graph_lthash(cwd)
-                && let Ok(prior_bytes) = hex::decode(&prior_lthash_hex)
+            if let Some(prior_lthash_hex) =
+                prior_state.as_ref().and_then(|s| s.graph_lthash.as_deref())
+                && let Ok(prior_bytes) = hex::decode(prior_lthash_hex)
                 && prior_bytes.len() == 32
             {
-                let mut incr = delta::lthash_of(&prior);
+                let mut incr = delta::lthash_of(prior);
                 for dp in &plan.removed {
                     if let Some(fp) = prior.get(dp) {
                         incr.remove(fp);
@@ -343,7 +353,7 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
         // LtHash diagnostic. One 32-byte compare proves graph
         // equivalence with the last install. Beats the map diff
         // when both sides are known good.
-        if let Some(prior_lthash) = state::read_state_graph_lthash(cwd)
+        if let Some(prior_lthash) = prior_state.as_ref().and_then(|s| s.graph_lthash.as_deref())
             && prior_lthash != graph_lthash
         {
             tracing::debug!(
@@ -357,7 +367,11 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
         // Merkle subtree diagnostic. How many subtree roots moved
         // vs how many leaves moved. Fewer roots means tighter
         // re-link scope once the delta linker lands.
-        if let Some(prior_subtrees) = state::read_state_subtree_hashes(cwd) {
+        if let Some(prior_subtrees) = prior_state
+            .as_ref()
+            .map(|s| &s.package_subtree_hashes)
+            .filter(|prior| !prior.is_empty())
+        {
             let changed_subtrees = package_subtree_hashes
                 .iter()
                 .filter(|(k, v)| prior_subtrees.get(*k).is_none_or(|old| old != *v))

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1250,7 +1250,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
                 &packument_cache_dir,
                 Some(lock_materialize_tx),
                 /*skip_already_linked_shortcut=*/
-                explicit_store_dir_override,
+                has_workspace || explicit_store_dir_override,
                 &lock_project_local_dep_paths,
                 virtual_store_dir_max_length,
                 opts.ignore_scripts,
@@ -2300,7 +2300,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
                         &packument_cache_dir,
                         /*materialize_tx=*/ None,
                         /*skip_already_linked_shortcut=*/
-                        explicit_store_dir_override,
+                        has_workspace || explicit_store_dir_override,
                         &project_local_dep_paths,
                         virtual_store_dir_max_length,
                         opts.ignore_scripts,

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1250,7 +1250,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
                 &packument_cache_dir,
                 Some(lock_materialize_tx),
                 /*skip_already_linked_shortcut=*/
-                has_workspace || explicit_store_dir_override,
+                explicit_store_dir_override,
                 &lock_project_local_dep_paths,
                 virtual_store_dir_max_length,
                 opts.ignore_scripts,
@@ -2300,7 +2300,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
                         &packument_cache_dir,
                         /*materialize_tx=*/ None,
                         /*skip_already_linked_shortcut=*/
-                        has_workspace || explicit_store_dir_override,
+                        explicit_store_dir_override,
                         &project_local_dep_paths,
                         virtual_store_dir_max_length,
                         opts.ignore_scripts,

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -55,6 +55,15 @@ pub struct InstallState {
     pub lockfile_hash: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lockfile_snapshot_name: Option<String>,
+    /// `(size, mtime)` of the root lockfile at install time, mirroring
+    /// `package_json_meta`'s fast path: stat once and skip the BLAKE3
+    /// re-hash when the snapshot is unchanged. Root lockfiles are the
+    /// largest file the freshness check reads (10+ MB on big
+    /// monorepos), so this is the difference between an O(1) stat and
+    /// re-reading the whole file on every `aube run` startup. Missing
+    /// field (older state) falls through to the hash path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lockfile_meta: Option<FileMeta>,
     /// Per-member lockfile fingerprints for `sharedWorkspaceLockfile=false`
     /// workspaces, keyed by the member's importer path (relative to the
     /// workspace root). That layout writes one lockfile per member and
@@ -134,6 +143,9 @@ struct FreshnessState {
     lockfile_hash: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     lockfile_snapshot_name: Option<String>,
+    /// See [`InstallState::lockfile_meta`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    lockfile_meta: Option<FileMeta>,
     /// See [`InstallState::member_lockfile_hashes`]. Mirrored into the
     /// freshness sidecar so `check_needs_install` can verify per-member
     /// lockfiles without loading the full state file.
@@ -219,6 +231,7 @@ impl From<&InstallState> for FreshnessState {
         Self {
             lockfile_hash: state.lockfile_hash.clone(),
             lockfile_snapshot_name: state.lockfile_snapshot_name.clone(),
+            lockfile_meta: state.lockfile_meta.clone(),
             member_lockfile_hashes: state.member_lockfile_hashes.clone(),
             member_lockfile_meta: state.member_lockfile_meta.clone(),
             package_json_hashes: state.package_json_hashes.clone(),
@@ -380,6 +393,7 @@ fn check_needs_install_compute(
     let _diag_lock = aube_util::diag::Span::new(aube_util::diag::Category::Frozen, "lockfile_hash");
     let (lockfile_name, lockfile_path) = active_lockfile(project_dir);
     let mut lockfile_missing = false;
+    let mut refreshed_lockfile_meta = false;
     if let Some(path) = lockfile_path {
         // This branch also absorbs a `sharedWorkspaceLockfile` flip from
         // false to true. The previous false-layout install left a
@@ -388,9 +402,31 @@ fn check_needs_install_compute(
         // exists, so we land here. Its hash can't match the empty recorded
         // one, so we report a change and the full reinstall rewrites the
         // state into the shared shape.
-        let current_hash = hash_file(&path);
-        if current_hash != state.lockfile_hash {
-            return Some(format!("{lockfile_name} has changed"));
+        //
+        // `(size, mtime)` fast path first, mirroring `package_json_meta`:
+        // a matching snapshot skips re-reading + BLAKE3-hashing the
+        // lockfile — the single largest file this check touches on big
+        // monorepos. A miss (older state, mtime-only touch, or a real
+        // edit) falls through to the hash.
+        let current_meta = FileMeta::capture(&path);
+        let meta_matches = match (&current_meta, &state.lockfile_meta) {
+            (Some(current), Some(stored)) => current == stored,
+            _ => false,
+        };
+        if !meta_matches {
+            let current_hash = hash_file(&path);
+            if current_hash != state.lockfile_hash {
+                return Some(format!("{lockfile_name} has changed"));
+            }
+            // Hash matched but the snapshot drifted (touch(1), older
+            // state without the field). Refresh it so the next check
+            // takes the stat-only path.
+            if let Some(current) = current_meta
+                && state.lockfile_meta.as_ref() != Some(&current)
+            {
+                state.lockfile_meta = Some(current);
+                refreshed_lockfile_meta = true;
+            }
         }
     } else if state.member_lockfile_hashes.is_empty() {
         lockfile_missing = true;
@@ -486,7 +522,9 @@ fn check_needs_install_compute(
             }
         }
     }
-    if refreshed_metadata && let Err(err) = write_fresh_state(&state_path, &state) {
+    if (refreshed_metadata || refreshed_lockfile_meta)
+        && let Err(err) = write_fresh_state(&state_path, &state)
+    {
         tracing::debug!(
             path = %fresh_state_file(&state_path).display(),
             error = %err,
@@ -652,61 +690,71 @@ fn collect_gvs_nested_links(
     project_dir: &Path,
     layout: &WriteStateLayout<'_>,
 ) -> std::io::Result<Option<BTreeMap<String, String>>> {
-    let mut links = BTreeMap::new();
-    for (dep_path, pkg) in &layout.graph.packages {
-        let globally_shareable = pkg
-            .local_source
-            .as_ref()
-            .is_none_or(aube_lockfile::LocalSource::is_globally_shareable);
-        if !globally_shareable {
-            continue;
-        }
-        let aube_entry =
-            layout
-                .aube_dir
-                .join(aube_lockfile::dep_path_filename::dep_path_to_filename(
-                    dep_path,
-                    layout.virtual_store_dir_max_length,
-                ));
-        if std::fs::read_link(aube_entry).is_err() {
-            // Compatibility-selected registry packages can be materialized
-            // physically in the project even while the rest of the graph uses
-            // GVS. Their links are not shared cache topology and the linker
-            // handles them separately.
-            continue;
-        }
-        let package_dir = crate::commands::install::materialized_pkg_dir(
-            layout.aube_dir,
-            dep_path,
-            &pkg.name,
-            layout.virtual_store_dir_max_length,
-            layout.placements,
-        );
-        let node_modules_dir =
-            crate::commands::install::dep_modules_dir_for(&package_dir, &pkg.name);
-        for dep_name in pkg.dependencies.keys().filter(|name| *name != &pkg.name) {
-            let link_path = node_modules_dir.join(dep_name);
-            let Ok(target) = std::fs::read_link(&link_path) else {
-                tracing::debug!(
-                    path = %link_path.display(),
-                    "global virtual store link topology is not recordable"
-                );
-                return Ok(None);
-            };
-            let Some(target) = target.to_str() else {
-                tracing::debug!(
-                    path = %link_path.display(),
-                    "global virtual store link target is not valid UTF-8"
-                );
-                return Ok(None);
-            };
-            links.insert(
-                relative_path_or_original(&link_path, project_dir),
-                target.to_string(),
+    // O(edges) readlink(2) calls — parallelize per package. Each package
+    // yields `Some(links)` on success or `None` when its topology is not
+    // recordable, which aborts the whole collection exactly like the
+    // serial version did.
+    let per_package: Option<Vec<Vec<(String, String)>>> = layout
+        .graph
+        .packages
+        .par_iter()
+        .map(|(dep_path, pkg)| {
+            let globally_shareable = pkg
+                .local_source
+                .as_ref()
+                .is_none_or(aube_lockfile::LocalSource::is_globally_shareable);
+            if !globally_shareable {
+                return Some(Vec::new());
+            }
+            let aube_entry =
+                layout
+                    .aube_dir
+                    .join(aube_lockfile::dep_path_filename::dep_path_to_filename(
+                        dep_path,
+                        layout.virtual_store_dir_max_length,
+                    ));
+            if std::fs::read_link(aube_entry).is_err() {
+                // Compatibility-selected registry packages can be materialized
+                // physically in the project even while the rest of the graph uses
+                // GVS. Their links are not shared cache topology and the linker
+                // handles them separately.
+                return Some(Vec::new());
+            }
+            let package_dir = crate::commands::install::materialized_pkg_dir(
+                layout.aube_dir,
+                dep_path,
+                &pkg.name,
+                layout.virtual_store_dir_max_length,
+                layout.placements,
             );
-        }
-    }
-    Ok(Some(links))
+            let node_modules_dir =
+                crate::commands::install::dep_modules_dir_for(&package_dir, &pkg.name);
+            let mut links = Vec::with_capacity(pkg.dependencies.len());
+            for dep_name in pkg.dependencies.keys().filter(|name| *name != &pkg.name) {
+                let link_path = node_modules_dir.join(dep_name);
+                let Ok(target) = std::fs::read_link(&link_path) else {
+                    tracing::debug!(
+                        path = %link_path.display(),
+                        "global virtual store link topology is not recordable"
+                    );
+                    return None;
+                };
+                let Some(target) = target.to_str() else {
+                    tracing::debug!(
+                        path = %link_path.display(),
+                        "global virtual store link target is not valid UTF-8"
+                    );
+                    return None;
+                };
+                links.push((
+                    relative_path_or_original(&link_path, project_dir),
+                    target.to_string(),
+                ));
+            }
+            Some(links)
+        })
+        .collect();
+    Ok(per_package.map(|groups| groups.into_iter().flatten().collect()))
 }
 
 pub struct WriteStateInput<'a> {
@@ -734,6 +782,14 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
 
     let state_path = state_dir(project_dir);
     remove_legacy_state_file(&state_path)?;
+    // Captured *before* the hash: an edit landing between the two makes
+    // the stored meta stale relative to the hashed content, so the next
+    // freshness check misses the stat-only fast path and falls through
+    // to the hash — slow but correct. The reverse order would let a
+    // fresh-meta/stale-hash pair declare an edited lockfile up to date.
+    let lockfile_meta = active_lockfile(project_dir)
+        .1
+        .and_then(|path| FileMeta::capture(&path));
     let (lockfile_hash, lockfile_snapshot_name) =
         snapshot_active_lockfile(project_dir, &state_path)?;
     let settings_hash = hash_settings(project_dir, cli_flags);
@@ -782,6 +838,7 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
     let state = InstallState {
         lockfile_hash,
         lockfile_snapshot_name,
+        lockfile_meta,
         member_lockfile_hashes,
         member_lockfile_meta,
         package_json_hashes,
@@ -808,8 +865,12 @@ pub fn write_state(project_dir: &Path, input: WriteStateInput<'_>) -> Result<(),
         let license_json = serde_json::to_vec(&license_state)?;
         aube_util::fs_atomic::atomic_write(&license_state_file(&state_path), &license_json)?;
     }
-    let json = serde_json::to_string_pretty(&state)?;
-    aube_util::fs_atomic::atomic_write(&install_state_file(&state_path), json.as_bytes())?;
+    // Compact, not pretty: the per-package maps make this file O(graph)
+    // (and `gvs_nested_links` O(edges)), and it is re-read on every
+    // freshness check — indentation roughly doubles the bytes parsed for
+    // no consumer. `jq` remains the debugging story.
+    let json = serde_json::to_vec(&state)?;
+    aube_util::fs_atomic::atomic_write(&install_state_file(&state_path), &json)?;
     write_fresh_state(&state_path, &fresh_state)?;
 
     Ok(())
@@ -923,6 +984,33 @@ pub fn read_state_package_content_hashes(project_dir: &Path) -> Option<BTreeMap<
     Some(state.package_content_hashes)
 }
 
+/// All delta-install fields from the last install's state, extracted in
+/// a single parse. `finalize` needs every one of them; reading each
+/// through its own accessor re-parses the full O(graph) state file (and
+/// re-resolves the settings context behind `state_dir`) once per field.
+pub struct DeltaStateSnapshot {
+    /// See [`InstallState::package_content_hashes`]. Empty map means
+    /// "no prior fingerprints" (pre-delta aube or fresh state).
+    pub package_content_hashes: BTreeMap<String, String>,
+    /// See [`InstallState::graph_lthash`]. `None` when unrecorded.
+    pub graph_lthash: Option<String>,
+    /// See [`InstallState::package_subtree_hashes`]. Empty when
+    /// unrecorded.
+    pub package_subtree_hashes: BTreeMap<String, String>,
+}
+
+/// Read the delta-install snapshot in one state-file parse. `None` when
+/// the state file is missing or malformed — callers treat that as "no
+/// prior install, full pipeline", same as the per-field accessors.
+pub fn read_state_delta_snapshot(project_dir: &Path) -> Option<DeltaStateSnapshot> {
+    let state = read_state(&state_dir(project_dir))?;
+    Some(DeltaStateSnapshot {
+        package_content_hashes: state.package_content_hashes,
+        graph_lthash: (!state.graph_lthash.is_empty()).then_some(state.graph_lthash),
+        package_subtree_hashes: state.package_subtree_hashes,
+    })
+}
+
 /// Read the installed layout snapshot used by the install warm path.
 ///
 /// Missing layout state means the install predates layout tracking and
@@ -1005,16 +1093,6 @@ pub fn read_state_package_licenses(project_dir: &Path) -> InstallLicenseState {
 /// describing the materialized tree remains under `node_modules`.
 pub fn read_default_state_layout(project_dir: &Path) -> Option<InstallLayoutState> {
     read_state(&project_dir.join(DEFAULT_STATE_DIR).join(state_dir_name()))?.layout
-}
-
-/// Read the LtHash accumulator digest the last install wrote, if
-/// any. Empty string on fresh state or pre-lthash aube versions.
-pub fn read_state_graph_lthash(project_dir: &Path) -> Option<String> {
-    let state = read_state(&state_dir(project_dir))?;
-    if state.graph_lthash.is_empty() {
-        return None;
-    }
-    Some(state.graph_lthash)
 }
 
 /// Read stored subtree hashes for delta installs that want to
@@ -1160,8 +1238,10 @@ fn read_or_migrate_fresh_state(state_path: &Path) -> Option<FreshnessState> {
 }
 
 fn write_fresh_state(state_path: &Path, state: &FreshnessState) -> Result<(), std::io::Error> {
-    let json = serde_json::to_string_pretty(state)?;
-    aube_util::fs_atomic::atomic_write(&fresh_state_file(state_path), json.as_bytes())
+    // Compact for the same reason as `state.json` above — this sidecar
+    // is parsed on every `aube run`/`exec`/`test` startup.
+    let json = serde_json::to_vec(state)?;
+    aube_util::fs_atomic::atomic_write(&fresh_state_file(state_path), &json)
 }
 
 fn remove_legacy_state_file(state_path: &Path) -> Result<(), std::io::Error> {
@@ -1360,15 +1440,22 @@ pub fn gvs_nested_links_are_current(project_dir: &Path, layout: &InstallLayoutSt
 }
 
 fn stale_gvs_nested_link(project_dir: &Path, layout: &InstallLayoutState) -> Option<String> {
-    for (rel, expected) in layout.gvs_nested_links.as_ref()? {
-        let path = project_dir.join(rel);
-        match std::fs::read_link(&path) {
-            Ok(actual) if actual == Path::new(expected) => {}
-            Ok(_) => return Some(format!("global virtual store link changed: {rel}")),
-            Err(_) => return Some(format!("global virtual store link missing: {rel}")),
-        }
-    }
-    None
+    // One entry per (package, dependency) edge in the graph — easily
+    // 10^5 on a large monorepo — so scan in parallel. `find_map_first`
+    // keeps the reported entry deterministic (first in map order) while
+    // letting rayon fan the readlink(2) calls out across threads.
+    layout
+        .gvs_nested_links
+        .as_ref()?
+        .par_iter()
+        .find_map_first(|(rel, expected)| {
+            let path = project_dir.join(rel);
+            match std::fs::read_link(&path) {
+                Ok(actual) if actual == Path::new(expected) => None,
+                Ok(_) => Some(format!("global virtual store link changed: {rel}")),
+                Err(_) => Some(format!("global virtual store link missing: {rel}")),
+            }
+        })
 }
 
 #[derive(Deserialize)]
@@ -1706,6 +1793,7 @@ mod tests {
         let state = InstallState {
             lockfile_hash: String::new(),
             lockfile_snapshot_name: None,
+            lockfile_meta: None,
             member_lockfile_hashes: BTreeMap::new(),
             member_lockfile_meta: BTreeMap::new(),
             package_json_hashes: BTreeMap::new(),
@@ -2089,6 +2177,7 @@ mod tests {
         let state = InstallState {
             lockfile_hash: "blake3:lock".to_string(),
             lockfile_snapshot_name: None,
+            lockfile_meta: None,
             member_lockfile_hashes: BTreeMap::new(),
             member_lockfile_meta: BTreeMap::new(),
             package_json_hashes: BTreeMap::from([(".".to_string(), "blake3:pkg".to_string())]),
@@ -2149,6 +2238,7 @@ mod tests {
         let state = InstallState {
             lockfile_hash: "blake3:lock".to_string(),
             lockfile_snapshot_name: None,
+            lockfile_meta: None,
             member_lockfile_hashes: BTreeMap::new(),
             member_lockfile_meta: BTreeMap::new(),
             package_json_hashes: BTreeMap::new(),
@@ -2249,6 +2339,7 @@ mod tests {
         let state = InstallState {
             lockfile_hash: String::new(),
             lockfile_snapshot_name: None,
+            lockfile_meta: None,
             member_lockfile_hashes: BTreeMap::new(),
             member_lockfile_meta: BTreeMap::new(),
             package_json_hashes: pjh,
@@ -2314,6 +2405,7 @@ mod tests {
         let state = super::FreshnessState {
             lockfile_hash: String::new(),
             lockfile_snapshot_name: None,
+            lockfile_meta: None,
             member_lockfile_hashes: hashes,
             member_lockfile_meta: BTreeMap::new(),
             package_json_hashes: BTreeMap::new(),

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -193,6 +193,26 @@ struct FreshnessState {
 /// mtime granularity below 2 seconds anyway, so callers running on
 /// it should not rely on the fast path. The size comparison still
 /// catches any change that grows or shrinks the file.
+///
+/// # Accepted limitation
+///
+/// A rewrite that keeps the byte length identical *and* restores the
+/// recorded mtime reports fresh without re-hashing. This is a
+/// deliberate trade, accepted for every consumer of this type
+/// (`lockfile_meta`, `package_json_meta`, `member_lockfile_meta`):
+/// closing it would mean hashing the file on every check, which is the
+/// cost the fast path exists to remove. Producing that collision takes
+/// deliberate mtime restoration — ordinary editors, formatters, VCS
+/// checkouts and package managers all move mtime forward, and a tool
+/// that restores it defeats make, ninja and git's stat cache the same
+/// way. Everything short of that collision is caught: content that
+/// changes length fails the size compare, and content rewritten at any
+/// other timestamp fails the mtime compare.
+///
+/// Callers must keep the failure direction one-way — capture the
+/// snapshot *before* hashing, never after, so a write racing the
+/// capture yields "re-hash unnecessarily" rather than "declare stale
+/// content fresh".
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FileMeta {
     pub size: u64,

--- a/test/install_reuse_regressions.bats
+++ b/test/install_reuse_regressions.bats
@@ -135,6 +135,54 @@ _assert_installed_is_odd() {
 	_assert_installed_is_odd
 }
 
+@test "workspace install self-heals a stale index when the entry resolves elsewhere" {
+	# The case that keeps `skip_already_linked_shortcut` on for workspace
+	# installs. The local `.aube/<dep>` name is keyed by dep_path alone
+	# while the virtual-store subdir folds in graph hashes, so an entry
+	# can keep resolving while the target the graph expects moves. If the
+	# fetch phase skipped verification for such a package, the linker
+	# would need an index it was never handed and fall back to the
+	# *unverified* `store.load_index` — returning a stale index whose CAS
+	# shards are gone and failing the link, with no way to re-fetch.
+	#
+	# Verifying at fetch time keeps this self-healing: the stale index
+	# drops to `NeedsFetch`, the tarball is re-downloaded, and the store,
+	# the expected target and the link are all restored.
+	_setup_ws_fixture
+
+	run aube install
+	assert_success
+
+	entry="node_modules/.aube/is-odd@3.0.1"
+	expected="$(readlink "$entry")"
+	[ -n "$expected" ]
+
+	store_v1="$(aube store path)"
+	index="$(find "$store_v1/index" -name 'is-odd@*' -print -quit)"
+	[ -n "$index" ]
+	# Remove a NON-first CAS shard so the cheap first-file probe inside
+	# `load_index` still succeeds and only the verified walk catches it.
+	victim="$(grep -o '"store_path":"[^"]*"' "$index" | sed -n '2p' | sed 's/.*":"//;s/"$//')"
+	[ -n "$victim" ]
+	rm -f "$victim"
+
+	# Point the entry at a directory that exists but is not the target
+	# this graph expects, and remove the expected target.
+	decoy="$TEST_TEMP_DIR/decoy"
+	mkdir -p "$decoy/node_modules"
+	cp -r "$expected/node_modules/is-odd" "$decoy/node_modules/" 2>/dev/null || true
+	rm -rf "${expected:?}"
+	rm -f "$entry"
+	ln -s "$decoy" "$entry"
+	[ -e "$entry" ]
+
+	run aube install
+	assert_success
+	assert_file_exists "$victim"
+	assert_dir_exists "$expected"
+	_assert_installed_is_odd
+}
+
 @test "workspace install with a changed store-dir produces a correct tree" {
 	# `has_explicit_store_dir_override` only inspects embedder and CLI
 	# sources, so an `.npmrc` store-dir change leaves the shortcut

--- a/test/install_reuse_regressions.bats
+++ b/test/install_reuse_regressions.bats
@@ -1,0 +1,203 @@
+#!/usr/bin/env bats
+#
+# Regressions for the fetch phase's already-linked shortcut and the
+# lockfile freshness fast path.
+#
+# The shortcut classifies a package as `AlreadyLinked` (skipping the
+# store index load) whenever its `node_modules/.aube/<dep>` entry
+# resolves. Workspaces used to opt out of it entirely, paying a
+# stat-per-store-file on every install. These tests pin the safety
+# properties that make opting back in correct, so a future change that
+# breaks them fails loudly instead of silently shipping a stale tree.
+#
+# The freshness tests drive `aube run`, because `ensure_installed` is
+# what actually calls `check_needs_install` — a bare `aube install`
+# reports "Already up to date" whenever the pipeline finds nothing to
+# do, which would pass whether or not the freshness check ran.
+
+setup() {
+	load 'test_helper/common_setup'
+	_common_setup
+}
+
+teardown() {
+	_common_teardown
+}
+
+_setup_ws_fixture() {
+	cat >package.json <<'JSON'
+{
+  "name": "ws-root",
+  "version": "1.0.0",
+  "private": true
+}
+JSON
+	cat >pnpm-workspace.yaml <<'YAML'
+packages:
+  - packages/*
+YAML
+	mkdir -p packages/a
+	cat >packages/a/package.json <<'JSON'
+{
+  "name": "a",
+  "version": "1.0.0",
+  "dependencies": {
+    "is-odd": "3.0.1"
+  }
+}
+JSON
+}
+
+# Read a dependency's installed manifest *through* the symlink chain, so
+# the assertion covers the whole `importer -> .aube -> store` path rather
+# than just the presence of a link.
+_assert_installed_is_odd() {
+	run cat packages/a/node_modules/is-odd/package.json
+	assert_success
+	assert_output --partial '"is-odd"'
+	assert_output --partial '3.0.1'
+}
+
+@test "workspace install rebuilds a removed virtual store entry" {
+	# The shortcut keys off `Path::exists`, which follows symlinks, so a
+	# `.aube/<dep>` entry whose target is gone must NOT classify as
+	# `AlreadyLinked` — it has to fall through to the store and
+	# re-materialize. Without that, a wiped global virtual store would
+	# leave the workspace tree permanently broken.
+	_setup_ws_fixture
+
+	run aube install
+	assert_success
+	assert_link_exists packages/a/node_modules/is-odd
+
+	entry="$(find node_modules/.aube -maxdepth 1 -name 'is-odd@*' -print -quit)"
+	[ -n "$entry" ]
+	rm -rf "$entry"
+
+	run aube install
+	assert_success
+	assert_link_exists packages/a/node_modules/is-odd
+	restored="$(find node_modules/.aube -maxdepth 1 -name 'is-odd@*' -print -quit)"
+	[ -n "$restored" ]
+	_assert_installed_is_odd
+}
+
+@test "workspace install re-materializes a dangling virtual store link" {
+	# The sharper form of the test above, and the property the whole
+	# shortcut rests on: the `.aube/<dep>` symlink is still present, but
+	# the global virtual store directory it points at is gone. The
+	# existence probe follows symlinks, so this must classify as a miss
+	# and rebuild — if it ever regressed to an lstat, the install would
+	# "succeed" while leaving every dependent pointing into thin air.
+	#
+	# The target is resolved through the link rather than hardcoded, so
+	# this keeps working if the global virtual store's default location
+	# moves.
+	_setup_ws_fixture
+
+	run aube install
+	assert_success
+
+	entry="$(find node_modules/.aube -maxdepth 1 -name 'is-odd@*' -print -quit)"
+	[ -n "$entry" ]
+	[ -L "$entry" ]
+	target="$(readlink -f "$entry")"
+	[ -n "$target" ]
+	rm -rf "${target:?}"
+	# The link is now dangling: present to lstat, absent to stat.
+	[ -L "$entry" ]
+	[ ! -e "$entry" ]
+
+	run aube install
+	assert_success
+	assert_link_exists packages/a/node_modules/is-odd
+	_assert_installed_is_odd
+}
+
+@test "workspace install keeps an intact tree usable after the CAS is wiped" {
+	# The flip side of the test above: when the entries DO resolve, the
+	# materialized tree is self-sufficient (its files are hardlinks or
+	# copies that outlive their CAS shards), so wiping the store must
+	# not break the install. This is the property that the skipped
+	# `load_index_verified` call was never protecting.
+	_setup_ws_fixture
+
+	run aube install
+	assert_success
+	assert_link_exists packages/a/node_modules/is-odd
+
+	store_v1="$(aube store path)"
+	rm -rf "${store_v1:?}/files"
+
+	run aube install
+	assert_success
+	assert_link_exists packages/a/node_modules/is-odd
+	_assert_installed_is_odd
+}
+
+@test "workspace install with a changed store-dir produces a correct tree" {
+	# `has_explicit_store_dir_override` only inspects embedder and CLI
+	# sources, so an `.npmrc` store-dir change leaves the shortcut
+	# enabled. That is safe because the store is content addressed: the
+	# already-materialized entries hold the same bytes the new store
+	# would produce, and anything missing is fetched into the new store.
+	_setup_ws_fixture
+
+	run aube install
+	assert_success
+	assert_link_exists packages/a/node_modules/is-odd
+
+	other_store="$TEST_TEMP_DIR/other-store"
+	mkdir -p "$other_store"
+	printf 'store-dir=%s\n' "$other_store" >>.npmrc
+
+	run aube install
+	assert_success
+	assert_link_exists packages/a/node_modules/is-odd
+	_assert_installed_is_odd
+}
+
+@test "lockfile content change busts the freshness fast path" {
+	# The freshness check stats the root lockfile and skips the BLAKE3
+	# re-hash when `(size, mtime)` is unchanged. Any content change moves
+	# both, so it must still be caught — the fast path is an
+	# optimization, not a weakening of the check.
+	_setup_basic_fixture
+
+	run aube install
+	assert_success
+
+	run aube run hello
+	assert_success
+	refute_output --partial "Auto-installing"
+
+	printf '\n# edited\n' >>aube-lock.yaml
+
+	run aube run hello
+	assert_success
+	assert_output --partial "Auto-installing"
+	assert_output --partial "aube-lock.yaml has changed"
+}
+
+@test "touching the lockfile does not trigger a reinstall" {
+	# mtime moved but content did not: the stat fast path misses, the
+	# hash fallback confirms the lockfile is unchanged, and the refreshed
+	# `(size, mtime)` snapshot is written back so the next check is
+	# stat-only again.
+	_setup_basic_fixture
+
+	run aube install
+	assert_success
+
+	touch aube-lock.yaml
+
+	run aube run hello
+	assert_success
+	refute_output --partial "Auto-installing"
+
+	# Second run proves the refreshed snapshot persisted rather than
+	# falling back to the hash forever.
+	run aube run hello
+	assert_success
+	refute_output --partial "Auto-installing"
+}


### PR DESCRIPTION
Follow-up to the benchmark review of benchmarks.vlt.sh + our own results: vlt's `large`/`babylon` fixtures showed no-op/repeat installs scaling badly with project size (0.05s → 0.79s → 2.29s while bun stays ~0.13s). These are the structural O(graph)/O(edges) costs behind that, all off the hot path of small projects so they never showed up locally.

Measured by the perf bot: **install −2.33% instructions**, no regression above 1%.

## Changes

- **Parallelize the `gvs_nested_links` scans.** The freshness check issued one serial `readlink(2)` per graph *edge* (easily 10^5 on a big monorepo); now a rayon scan with `find_map_first` so the reported entry stays deterministic. The write-side collection got the same treatment.
- **Parse `state.json` once in finalize.** The delta block read it four times through per-field accessors (content hashes, lthash twice, subtree hashes), each parse re-resolving the settings context behind `state_dir`. New `read_state_delta_snapshot` returns all three fields from one parse; the now-unused `read_state_graph_lthash` accessor is removed.
- **Early-exit `project_links_into`.** `register_fast_path_project` walked all of `.aube/` with readlink+canonicalize into a `HashSet` to answer a boolean; it now stops at the first entry resolving into the GVS.
- **`(size, mtime)` fast path for the root lockfile.** The freshness check re-read and BLAKE3-hashed the full lockfile (the largest file it touches, 10+ MB on big repos) on every `aube run`/`exec`/`test` startup. It now records a `FileMeta` snapshot exactly like the existing `package_json_meta`/`member_lockfile_meta` fast paths and stats instead, falling back to the hash on any drift. Captured before hashing so a mid-write edit fails toward the hash path, never past it. The accepted collision trade-off is now documented explicitly on `FileMeta`.
- **Compact JSON for `state.json`/`fresh.json`.** Both are O(graph) (and `gvs_nested_links` O(edges)) and re-parsed constantly; pretty-printing roughly doubled the bytes for no consumer. `jq` remains the debugging story.

## Dropped from this PR

Enabling the fetch phase's already-linked shortcut for workspace installs — the largest single win here — **was reverted after review caught a real regression** (thanks @greptile-apps).

The shortcut's precondition ("the `.aube/<dep>` entry resolves") is weaker than what the linker needs ("it resolves to the target *this graph* expects"). The local entry name is keyed by dep_path alone while the virtual-store subdir folds in graph hashes, so build state can move the expected target while the entry keeps resolving to the old one. `classify_entry_state` then reports `Stale`, the linker needs an index it was never handed, and its fallback is the *unverified* `store.load_index` — returning a stale index whose CAS shards are gone and failing the link. Verifying at fetch time preserves self-healing because fetch can still re-download; the linker cannot.

Reproduced both ways before reverting: with verification on, the shard, target and link are all restored and install exits 0; with it off, install fails with `failed to link workspace node_modules`.

Doing this correctly means comparing against the expected virtual-store subdir rather than mere resolvability, which needs graph hashes that are currently computed inside the prewarm task running concurrently with fetch. That is its own change.

**Note for a separate issue:** the same scenario already fails on a non-workspace install on `main` today (`failed to link node_modules`), since the shortcut has always been enabled there. Pre-existing rather than introduced here, but real — and the same fix would close it for both.

## Testing

- `cargo test -p aube`: 865 passed. `mise run lint` (clippy `-D warnings` + fmt + shellcheck): clean.
- New `test/install_reuse_regressions.bats` (7 tests): removed entry rebuilds; dangling entry re-materializes; intact tree survives a CAS wipe; stale index + non-expected target self-heals; changed `store-dir` yields a correct tree; lockfile content change busts the freshness check; touching the lockfile does not.
- Each guard was mutation-tested rather than assumed: forcing `meta_matches` true fails the lockfile test, and enabling the workspace shortcut fails the self-heal test.
- bats: `install`, `workspace`, `shared_workspace_lockfile_warm_path`, `workspace_member_install_walks_up`, `gvs_toggle_wipe`, `virtual_store_hash`, `nextjs_gvs_autodisable` pass. (`install.bats` has 13 pre-existing failures on my machine from a broken mise node shim under the tests' isolated `$HOME`; verified identical at `44f3dbf7` with an unmodified binary. Green in CI.)

Not included (needs its own design discussion): the trust-policy validation pass, which is the dominant cold-install cost from the same review.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Workspace installs now correctly rebuild missing or dangling package links.
  - Installations recover from stale indexes, missing store data, and store-directory changes.
  - Lockfile changes reliably trigger reinstalls, while timestamp-only updates avoid unnecessary work.

- **Performance**
  - Faster install checks through improved link scanning and lockfile freshness detection.
  - Reduced repeated state processing during installation finalization.
  - Parallelized virtual-store link validation.

- **Tests**
  - Added regression coverage for install reuse, workspace recovery, store changes, and lockfile freshness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->