### PR TITLE
fix(store): keep the global virtual store out of the cache dir

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -72,7 +72,7 @@ flagset virtual-store-args {
         long_help #"""
 Force the shared global virtual store off for this invocation.
 
-Packages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.
+Packages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).
 """#
     }
     flag "--enable-global-virtual-store --enable-gvs" help="Force the shared global virtual store on for this invocation." help_heading="Virtual store" conflicts=--disable-global-virtual-store {

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -1150,17 +1150,19 @@ default = "undefined"
 docs = """
 Relocates the global virtual store — the shared tree of materialized
 package directories that `node_modules/.aube/<dep>` symlinks into when
-`enableGlobalVirtualStore` is on. Unset, it lives at
-`<cacheDir>/virtual-store/`. Aube stores registry-managed entries in a
-versioned child directory below this root so older releases cannot share
-entries that a current `aube store prune` may remove.
+`enableGlobalVirtualStore` is on. Unset, it lives store-adjacent at
+`<storeDir>/v1/virtual-store/`, next to the CAS `files/` and `index/`
+directories — on the same volume as the content store (so the hardlink
+fast path always applies) and outside `cacheDir` (so deleting the cache
+never severs the symlinks every installed project points into it).
+Installs whose virtual store predates this default keep using the
+legacy `<cacheDir>/virtual-store/` tree for as long as it exists.
+Aube stores registry-managed entries in a versioned child directory
+below this root so older releases cannot share entries that a current
+`aube store prune` may remove.
 
 Set this when the global virtual store belongs somewhere other than
-the rest of the cache — typically to put it on the same volume as
-`storeDir` while leaving packument metadata on the system disk.
-Setting `cacheDir` moves the virtual store too, so reach for that one
-when you want the whole cache to travel together and this one when you
-want to split them.
+the store — for example a dedicated volume shared between machines.
 
 Entries in the global virtual store are hardlinked out of the content
 store, so keep this on the same volume as `storeDir`. When they land
@@ -2729,7 +2731,7 @@ sources.npmrc = ["stateDir"]
 examples = []
 
 [cacheDir]
-description = "Directory for the global virtual store and cached package metadata."
+description = "Directory for cached package metadata."
 type = "path"
 default = "platform cache dir (`$XDG_CACHE_HOME/aube`)"
 docs = """
@@ -2740,23 +2742,22 @@ Overrides the cache directory. Unset, aube derives it per platform
 its own name to; this setting takes a complete path instead, so
 `AUBE_CACHE_DIR=/mnt/fast/aube` puts the cache directly there.
 
-The global virtual store (`<cacheDir>/virtual-store/`) and cached
-packument metadata (`<cacheDir>/packuments-v1/`,
-`<cacheDir>/packuments-full-v1/`) live under this directory. The
+Cached packument metadata (`<cacheDir>/packuments-v1/`,
+`<cacheDir>/packuments-full-v1/`) lives under this directory. The
 content-addressable store is *not* here — it is `storeDir`, which
-defaults under `$XDG_DATA_HOME` instead. A few smaller caches (the OSV
-advisory mirror, the bootstrapped `node-gyp`, git clones) still follow
-the platform cache dir regardless of this setting.
+defaults under `$XDG_DATA_HOME` instead, and the global virtual store
+defaults next to that store (`<storeDir>/v1/virtual-store/`), not under
+the cache; a virtual store created by an older aube at
+`<cacheDir>/virtual-store/` keeps being used for as long as it exists.
+A few smaller caches (the OSV advisory mirror, the bootstrapped
+`node-gyp`, git clones) still follow the platform cache dir regardless
+of this setting.
 
-Set this alongside `storeDir` when the store lives on a non-default
-volume. Entries in the global virtual store are hardlinked out of the
-CAS, so on installs with the global virtual store enabled, a `cacheDir`
-and `storeDir` split across filesystems degrades every install to a
-per-file copy and aube warns about it. Pointing both at the same volume
-(`AUBE_CACHE_DIR=/mnt/dev/cache/aube` plus
-`AUBE_STORE_DIR=/mnt/dev/stores/aube`) keeps the hardlink fast path.
-Use `globalVirtualStoreDir` to move only the virtual store and leave
-the metadata caches where they are.
+Once the virtual store no longer lives here, everything under this
+directory is regenerable: deleting it costs the next install some
+registry round-trips but breaks nothing. Use `globalVirtualStoreDir`
+to move only the virtual store and leave the metadata caches where
+they are.
 """
 sources.cli = []
 sources.env = ["npm_config_cache_dir", "NPM_CONFIG_CACHE_DIR", "AUBE_CACHE_DIR"]

--- a/crates/aube/src/cli_args.rs
+++ b/crates/aube/src/cli_args.rs
@@ -138,7 +138,8 @@ pub struct VirtualStoreArgs {
     /// Force the shared global virtual store off for this invocation.
     ///
     /// Packages are materialized inside the project's virtual store
-    /// instead of symlinked from `~/.cache/aube/virtual-store/`.
+    /// instead of symlinked from the shared store-adjacent tree
+    /// (`~/.local/share/aube/store/v1/virtual-store/`).
     #[usage(long, long = "disable-gvs", conflicts = "--enable-gvs")]
     pub disable_global_virtual_store: bool,
 

--- a/crates/aube/src/commands/install/fetch.rs
+++ b/crates/aube/src/commands/install/fetch.rs
@@ -754,8 +754,20 @@ where
          * Cross run persisted under `tarball:default` so this path
          * shares its converged operating point with the streaming
          * tarball path.
+         *
+         * Ceiling is the blocking pool size (an explicit
+         * `networkConcurrency` above it is honored): every streaming
+         * import holds one blocking thread for its whole download, so
+         * permits past the pool only open sockets whose imports queue
+         * behind earlier ones. The previous literal 256 sat at 2x the
+         * pool and let slow-start park half the fleet in that queue.
          */
         let sem_seed = network_concurrency.unwrap_or_else(default_lockfile_network_concurrency);
+        // `.max(4)` keeps the bounds valid (min_limit is 4) under a
+        // tiny AUBE_TOKIO_BLOCKING benchmarking override.
+        let sem_max = crate::tokio_blocking_pool_size()
+            .max(network_concurrency.unwrap_or(0))
+            .max(4);
         let lockfile_persistent = aube_util::adaptive::global_persistent_state();
         let semaphore = match lockfile_persistent.as_ref() {
             Some(state) => aube_util::adaptive::AdaptiveLimit::from_persistent(
@@ -763,9 +775,9 @@ where
                 "tarball:default",
                 sem_seed.clamp(64, 128),
                 4,
-                256,
+                sem_max,
             ),
-            None => aube_util::adaptive::AdaptiveLimit::new(sem_seed.clamp(64, 128), 4, 256),
+            None => aube_util::adaptive::AdaptiveLimit::new(sem_seed.clamp(64, 128), 4, sem_max),
         };
         if let Some(state) = lockfile_persistent.clone() {
             lockfile_persist_handle = Some((state, std::sync::Arc::clone(&semaphore)));

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -1470,19 +1470,22 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
                  * Adaptive tarball concurrency. Loaded from the
                  * cross run persistent store when available so the
                  * limiter starts where a previous run converged
-                 * instead of cold ramping from the ceiling. Falls
-                 * back to seed 256 (h2 stream cap) on first ever
-                 * run. Floor 4 keeps progress under continuous
-                 * 429 / 503. Persisted back at end of fetch phase
-                 * so the next invocation benefits.
+                 * instead of cold ramping from the ceiling. Floor 4
+                 * keeps progress under continuous 429 / 503.
+                 * Persisted back at end of fetch phase so the next
+                 * invocation benefits.
                  */
                 // Honor user-configured `networkConcurrency` (or
                 // `AUBE_NETWORK_CONCURRENCY` env override) as the
                 // seed. Adaptive grow/shrink still operate around
                 // it. Floor 4 keeps progress under continuous
-                // throttling regardless of seed.
+                // throttling regardless of seed. Ceiling is the
+                // blocking pool size (a larger explicit seed wins):
+                // each streaming import holds one blocking thread for
+                // its whole download, so permits past the pool only
+                // queue imports behind earlier ones.
                 let tarball_seed = fetch_network_concurrency.max(4);
-                let tarball_max = tarball_seed.max(256);
+                let tarball_max = tarball_seed.max(crate::tokio_blocking_pool_size());
                 let persistent = aube_util::adaptive::global_persistent_state();
                 let semaphore = match persistent.as_ref() {
                     Some(state) => aube_util::adaptive::AdaptiveLimit::from_persistent(

--- a/crates/aube/src/commands/settings_context.rs
+++ b/crates/aube/src/commands/settings_context.rs
@@ -580,11 +580,11 @@ pub(crate) fn resolved_cache_dir_with_ctx(
 /// entries symlink into.
 ///
 /// `globalVirtualStoreDir` wins when set and is used as the store root (no
-/// `virtual-store` suffix); otherwise the root lands under the resolved
-/// [`resolved_cache_dir`]. Registry-aware entries live in a versioned child
-/// directory so older aube releases cannot create or reuse entries that the
-/// current project registry may later prune. The dedicated setting exists
-/// because this tree — unlike the rest of the cache — has to sit on
+/// `virtual-store` suffix); otherwise the root defaults store-adjacent
+/// (see [`default_global_virtual_store_root`]). Registry-aware entries
+/// live in a versioned child directory so older aube releases cannot
+/// create or reuse entries that the current project registry may later
+/// prune. The dedicated setting exists because this tree has to sit on
 /// the same volume as `storeDir` to be hardlinkable, which is not
 /// necessarily where the packument caches belong.
 ///
@@ -602,10 +602,58 @@ pub(crate) fn global_virtual_store_dir_with_ctx(
 ) -> std::path::PathBuf {
     let root = aube_settings::resolved::global_virtual_store_dir(ctx)
         .and_then(|raw| expand_setting_path(&raw, cwd))
-        .unwrap_or_else(|| {
-            resolved_cache_dir_with_ctx(cwd, ctx).join(aube_store::VIRTUAL_STORE_SUBDIR)
-        });
+        .unwrap_or_else(|| default_global_virtual_store_root(cwd, ctx));
     root.join(GVS_REGISTRY_NAMESPACE_VERSION)
+}
+
+/// Default root of the global virtual store when `globalVirtualStoreDir`
+/// is unset: `<storeDir>/v1/virtual-store`, next to the CAS `files/` and
+/// `index/` dirs.
+///
+/// Store-adjacent rather than under `cacheDir` for the same reason the
+/// cached indexes migrated out of the cache dir: the cache is the one
+/// tree users (and CI cache eviction, and `rm -rf ~/.cache`) may delete
+/// at any time, while this tree is not regenerable state in the same
+/// sense — every project's `node_modules/.aube/<dep_path>` symlinks
+/// point into it, so deleting it severs every GVS-linked project at
+/// once. Colocation also puts it on the CAS volume by construction, so
+/// the hardlink fast path holds without the `WARN_AUBE_GVS_CROSS_VOLUME`
+/// copy fallback that the cache-relative default hit whenever cache and
+/// data lived on different filesystems.
+///
+/// Installs that predate this default keep their `<cacheDir>/virtual-store`
+/// tree for as long as it exists. Unlike the index migration this tree
+/// cannot be renamed into place: existing projects embed its absolute
+/// path in their symlink farms, and renaming it would dangle them all —
+/// exactly the breakage the relocation is meant to prevent. Once the
+/// legacy tree is gone (the user cleared their cache), the next install
+/// materializes into the store-adjacent root and projects re-link there.
+fn default_global_virtual_store_root(
+    cwd: &std::path::Path,
+    ctx: &aube_settings::ResolveCtx<'_>,
+) -> std::path::PathBuf {
+    let legacy = resolved_cache_dir_with_ctx(cwd, ctx).join(aube_store::VIRTUAL_STORE_SUBDIR);
+    if legacy.exists() {
+        return legacy;
+    }
+    let store_v1 = match resolved_store_dir_with_ctx(cwd, ctx) {
+        // Mirrors `open_store_for_maintenance_with_ctx`: a custom
+        // `storeDir` gets the `v1` schema suffix appended.
+        Some(custom) => custom.join("v1"),
+        None => match aube_store::dirs::store_dir() {
+            // `store_dir()` is `<data>/aube/store/v1/files`; the GVS
+            // sits next to `files/` under the same schema version.
+            Some(files) => files
+                .parent()
+                .map(std::path::Path::to_path_buf)
+                .unwrap_or(files),
+            // No home dir to derive a data dir from: stay on the
+            // legacy cache-relative root rather than inventing a
+            // third location.
+            None => return legacy,
+        },
+    };
+    store_v1.join(aube_store::VIRTUAL_STORE_SUBDIR)
 }
 
 /// Resolve the `virtualStoreDirMaxLength` setting, falling back to the
@@ -826,5 +874,103 @@ mod package_manager_mismatch_tests {
     #[test]
     fn skip_auto_install_defaults_off() {
         assert!(!skip_auto_install_on_package_manager_mismatch());
+    }
+}
+
+#[cfg(test)]
+mod global_virtual_store_dir_tests {
+    use super::global_virtual_store_dir_with_ctx;
+    use aube_settings::ResolveCtx;
+    use std::collections::BTreeMap;
+
+    fn ctx_with_env<'a>(
+        env: &'a [(String, String)],
+        ws: &'a BTreeMap<String, yaml_serde::Value>,
+    ) -> ResolveCtx<'a> {
+        ResolveCtx {
+            managed_aube_config: &[],
+            project_aube_config: &[],
+            project_npmrc: &[],
+            user_aube_config: &[],
+            user_npmrc: &[],
+            workspace_yaml: ws,
+            env,
+            cli: &[],
+            embedder_defaults: &[],
+        }
+    }
+
+    #[test]
+    fn gvs_defaults_next_to_store_when_no_legacy_tree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = tmp.path().join("cache");
+        let store = tmp.path().join("store");
+        let env = vec![
+            (
+                "AUBE_CACHE_DIR".into(),
+                cache.to_string_lossy().into_owned(),
+            ),
+            (
+                "AUBE_STORE_DIR".into(),
+                store.to_string_lossy().into_owned(),
+            ),
+        ];
+        let ws = BTreeMap::new();
+        let ctx = ctx_with_env(&env, &ws);
+        assert_eq!(
+            global_virtual_store_dir_with_ctx(tmp.path(), &ctx),
+            store.join("v1").join("virtual-store").join("v1"),
+        );
+    }
+
+    #[test]
+    fn gvs_keeps_legacy_cache_tree_when_present() {
+        // Pre-relocation installs have projects whose `.aube` symlink
+        // farms embed the cache-relative path; the legacy root stays
+        // authoritative for as long as it exists.
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = tmp.path().join("cache");
+        let store = tmp.path().join("store");
+        std::fs::create_dir_all(cache.join("virtual-store")).unwrap();
+        let env = vec![
+            (
+                "AUBE_CACHE_DIR".into(),
+                cache.to_string_lossy().into_owned(),
+            ),
+            (
+                "AUBE_STORE_DIR".into(),
+                store.to_string_lossy().into_owned(),
+            ),
+        ];
+        let ws = BTreeMap::new();
+        let ctx = ctx_with_env(&env, &ws);
+        assert_eq!(
+            global_virtual_store_dir_with_ctx(tmp.path(), &ctx),
+            cache.join("virtual-store").join("v1"),
+        );
+    }
+
+    #[test]
+    fn explicit_setting_wins_over_both_defaults() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = tmp.path().join("cache");
+        let gvs = tmp.path().join("gvs");
+        std::fs::create_dir_all(cache.join("virtual-store")).unwrap();
+        let env = vec![
+            (
+                "AUBE_CACHE_DIR".into(),
+                cache.to_string_lossy().into_owned(),
+            ),
+            (
+                "AUBE_GLOBAL_VIRTUAL_STORE_DIR".into(),
+                gvs.to_string_lossy().into_owned(),
+            ),
+        ];
+        let ws = BTreeMap::new();
+        let ctx = ctx_with_env(&env, &ws);
+        assert_eq!(
+            global_virtual_store_dir_with_ctx(tmp.path(), &ctx),
+            gvs.join("v1"),
+        );
     }
 }

--- a/crates/aube/src/lib.rs
+++ b/crates/aube/src/lib.rs
@@ -888,7 +888,10 @@ fn inner_main() -> miette::Result<i32> {
      * while the linker is also fanning out hardlinks on the same
      * pool. 64 was saturating, queueing late tarballs behind
      * earlier finishers. 128 covers worst case fat tarball
-     * pipeline plus linker plus side effects.
+     * pipeline plus linker plus side effects. The tarball
+     * AdaptiveLimit ceilings derive from this same number (see
+     * `tokio_blocking_pool_size`), so the two can't drift apart
+     * again.
      *
      * AUBE_TOKIO_WORKERS / AUBE_TOKIO_BLOCKING for benchmarking.
      */
@@ -903,7 +906,7 @@ fn inner_main() -> miette::Result<i32> {
         .map(|n| n.get())
         .unwrap_or(4);
     let workers = parse_env("AUBE_TOKIO_WORKERS", cpu_count.min(8));
-    let blocking = parse_env("AUBE_TOKIO_BLOCKING", 128);
+    let blocking = tokio_blocking_pool_size();
     // Every aubr invocation starts on the lightweight runtime. If its
     // synchronous freshness probe finds that dependencies need installing,
     // auto_install lazily creates a multi-thread runtime for that work only.
@@ -941,6 +944,24 @@ fn inner_main() -> miette::Result<i32> {
 
 fn aubr_uses_current_thread(invoked_as_aubr: bool, cli: &Cli) -> bool {
     invoked_as_aubr && matches!(cli.command.as_ref(), Some(Commands::Run(_)))
+}
+
+/// Size of the tokio blocking-thread pool the install runtime is built
+/// with (`AUBE_TOKIO_BLOCKING` overrides the default of 128).
+///
+/// Every streaming tarball import pins one blocking thread for the
+/// whole download (the `ChunkReader` bridge blocks on the chunk
+/// channel), so a tarball limiter allowed to grow past this pool only
+/// opens sockets whose imports queue behind earlier ones — the extra
+/// permits hold connections without making progress. The tarball
+/// `AdaptiveLimit` ceilings therefore derive from this value rather
+/// than carrying their own literal.
+pub(crate) fn tokio_blocking_pool_size() -> usize {
+    std::env::var("AUBE_TOKIO_BLOCKING")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(128)
 }
 
 async fn async_main(cli: Cli, invoked_as_aubr: bool) -> miette::Result<Option<i32>> {

--- a/crates/aube/tests/embed.rs
+++ b/crates/aube/tests/embed.rs
@@ -242,7 +242,7 @@ async fn facade_warm_install_registers_the_host_virtual_store() {
     let overrides = aube::embed::EmbedderInstallOverrides {
         use_global_virtual_store: Some(true),
         cache_dir: Some(host_cache.clone()),
-        store_dir: Some(host_store),
+        store_dir: Some(host_store.clone()),
     };
 
     let mut options = InstallOptions::new(project.path());
@@ -253,7 +253,9 @@ async fn facade_warm_install_registers_the_host_virtual_store() {
         .await
         .unwrap();
 
-    let projects_dir = host_cache.join("virtual-store/v1/.projects");
+    // The GVS defaults store-adjacent (`<storeDir>/v1/virtual-store`),
+    // not under the embedder cache dir.
+    let projects_dir = host_store.join("v1/virtual-store/v1/.projects");
     std::fs::remove_dir_all(&projects_dir).unwrap();
 
     let mut options = InstallOptions::new(project.path());

--- a/docs/cli/add.md
+++ b/docs/cli/add.md
@@ -93,7 +93,7 @@ Add a dependency
 ## Virtual store
 - **`--disable-global-virtual-store`** — Force the shared global virtual store off for this invocation.
 
-  Packages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.
+  Packages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).
 
   **Aliases:** `--disable-gvs`
 - **`--enable-global-virtual-store`** — Force the shared global virtual store on for this invocation.

--- a/docs/cli/ci.md
+++ b/docs/cli/ci.md
@@ -42,7 +42,7 @@ Use in CI to guarantee a reproducible install from the committed lockfile.
 ## Virtual store
 - **`--disable-global-virtual-store`** — Force the shared global virtual store off for this invocation.
 
-  Packages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.
+  Packages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).
 
   **Aliases:** `--disable-gvs`
 - **`--enable-global-virtual-store`** — Force the shared global virtual store on for this invocation.

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1246,7 +1246,7 @@
             "name": "disable-global-virtual-store",
             "usage": "--disable-global-virtual-store",
             "help": "Force the shared global virtual store off for this invocation.",
-            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.",
+            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).",
             "help_first_line": "Force the shared global virtual store off for this invocation.",
             "short": [],
             "long": [
@@ -2710,7 +2710,7 @@
             "name": "disable-global-virtual-store",
             "usage": "--disable-global-virtual-store",
             "help": "Force the shared global virtual store off for this invocation.",
-            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.",
+            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).",
             "help_first_line": "Force the shared global virtual store off for this invocation.",
             "short": [],
             "long": [
@@ -4031,7 +4031,7 @@
             "name": "disable-global-virtual-store",
             "usage": "--disable-global-virtual-store",
             "help": "Force the shared global virtual store off for this invocation.",
-            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.",
+            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).",
             "help_first_line": "Force the shared global virtual store off for this invocation.",
             "short": [],
             "long": [
@@ -4387,7 +4387,7 @@
             "name": "disable-global-virtual-store",
             "usage": "--disable-global-virtual-store",
             "help": "Force the shared global virtual store off for this invocation.",
-            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.",
+            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).",
             "help_first_line": "Force the shared global virtual store off for this invocation.",
             "short": [],
             "long": [
@@ -5685,7 +5685,7 @@
             "name": "disable-global-virtual-store",
             "usage": "--disable-global-virtual-store",
             "help": "Force the shared global virtual store off for this invocation.",
-            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.",
+            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).",
             "help_first_line": "Force the shared global virtual store off for this invocation.",
             "short": [],
             "long": [
@@ -6166,7 +6166,7 @@
             "name": "disable-global-virtual-store",
             "usage": "--disable-global-virtual-store",
             "help": "Force the shared global virtual store off for this invocation.",
-            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.",
+            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).",
             "help_first_line": "Force the shared global virtual store off for this invocation.",
             "short": [],
             "long": [
@@ -6451,7 +6451,7 @@
             "name": "disable-global-virtual-store",
             "usage": "--disable-global-virtual-store",
             "help": "Force the shared global virtual store off for this invocation.",
-            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.",
+            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).",
             "help_first_line": "Force the shared global virtual store off for this invocation.",
             "short": [],
             "long": [
@@ -7790,7 +7790,7 @@
             "name": "disable-global-virtual-store",
             "usage": "--disable-global-virtual-store",
             "help": "Force the shared global virtual store off for this invocation.",
-            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.",
+            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).",
             "help_first_line": "Force the shared global virtual store off for this invocation.",
             "short": [],
             "long": [
@@ -8065,7 +8065,7 @@
             "name": "disable-global-virtual-store",
             "usage": "--disable-global-virtual-store",
             "help": "Force the shared global virtual store off for this invocation.",
-            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.",
+            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).",
             "help_first_line": "Force the shared global virtual store off for this invocation.",
             "short": [],
             "long": [
@@ -11590,7 +11590,7 @@
             "name": "disable-global-virtual-store",
             "usage": "--disable-global-virtual-store",
             "help": "Force the shared global virtual store off for this invocation.",
-            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.",
+            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).",
             "help_first_line": "Force the shared global virtual store off for this invocation.",
             "short": [],
             "long": [
@@ -11868,7 +11868,7 @@
             "name": "disable-global-virtual-store",
             "usage": "--disable-global-virtual-store",
             "help": "Force the shared global virtual store off for this invocation.",
-            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.",
+            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).",
             "help_first_line": "Force the shared global virtual store off for this invocation.",
             "short": [],
             "long": [
@@ -12420,7 +12420,7 @@
             "name": "disable-global-virtual-store",
             "usage": "--disable-global-virtual-store",
             "help": "Force the shared global virtual store off for this invocation.",
-            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.",
+            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).",
             "help_first_line": "Force the shared global virtual store off for this invocation.",
             "short": [],
             "long": [
@@ -13686,7 +13686,7 @@
             "name": "disable-global-virtual-store",
             "usage": "--disable-global-virtual-store",
             "help": "Force the shared global virtual store off for this invocation.",
-            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.",
+            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).",
             "help_first_line": "Force the shared global virtual store off for this invocation.",
             "short": [],
             "long": [
@@ -13958,7 +13958,7 @@
             "name": "disable-global-virtual-store",
             "usage": "--disable-global-virtual-store",
             "help": "Force the shared global virtual store off for this invocation.",
-            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.",
+            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).",
             "help_first_line": "Force the shared global virtual store off for this invocation.",
             "short": [],
             "long": [
@@ -14462,7 +14462,7 @@
             "name": "disable-global-virtual-store",
             "usage": "--disable-global-virtual-store",
             "help": "Force the shared global virtual store off for this invocation.",
-            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.",
+            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).",
             "help_first_line": "Force the shared global virtual store off for this invocation.",
             "short": [],
             "long": [
@@ -15865,7 +15865,7 @@
             "name": "disable-global-virtual-store",
             "usage": "--disable-global-virtual-store",
             "help": "Force the shared global virtual store off for this invocation.",
-            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.",
+            "help_long": "Force the shared global virtual store off for this invocation.\n\nPackages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).",
             "help_first_line": "Force the shared global virtual store off for this invocation.",
             "short": [],
             "long": [

--- a/docs/cli/dedupe.md
+++ b/docs/cli/dedupe.md
@@ -40,7 +40,7 @@ Re-resolve the lockfile to collapse duplicate versions
 ## Virtual store
 - **`--disable-global-virtual-store`** — Force the shared global virtual store off for this invocation.
 
-  Packages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.
+  Packages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).
 
   **Aliases:** `--disable-gvs`
 - **`--enable-global-virtual-store`** — Force the shared global virtual store on for this invocation.

--- a/docs/cli/deploy.md
+++ b/docs/cli/deploy.md
@@ -58,7 +58,7 @@ Deploy a workspace package into a target directory with deps inlined
 ## Virtual store
 - **`--disable-global-virtual-store`** — Force the shared global virtual store off for this invocation.
 
-  Packages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.
+  Packages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).
 
   **Aliases:** `--disable-gvs`
 - **`--enable-global-virtual-store`** — Force the shared global virtual store on for this invocation.

--- a/docs/cli/dlx.md
+++ b/docs/cli/dlx.md
@@ -50,7 +50,7 @@ Fetch a package into a throwaway environment and run its binary
 ## Virtual store
 - **`--disable-global-virtual-store`** — Force the shared global virtual store off for this invocation.
 
-  Packages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.
+  Packages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).
 
   **Aliases:** `--disable-gvs`
 - **`--enable-global-virtual-store`** — Force the shared global virtual store on for this invocation.

--- a/docs/cli/exec.md
+++ b/docs/cli/exec.md
@@ -66,7 +66,7 @@ Execute a locally installed binary
 ## Virtual store
 - **`--disable-global-virtual-store`** — Force the shared global virtual store off for this invocation.
 
-  Packages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.
+  Packages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).
 
   **Aliases:** `--disable-gvs`
 - **`--enable-global-virtual-store`** — Force the shared global virtual store on for this invocation.

--- a/docs/cli/fetch.md
+++ b/docs/cli/fetch.md
@@ -39,7 +39,7 @@ Download lockfile dependencies into the store without linking node_modules
 ## Virtual store
 - **`--disable-global-virtual-store`** — Force the shared global virtual store off for this invocation.
 
-  Packages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.
+  Packages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).
 
   **Aliases:** `--disable-gvs`
 - **`--enable-global-virtual-store`** — Force the shared global virtual store on for this invocation.

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -102,7 +102,7 @@ Install all dependencies
 ## Virtual store
 - **`--disable-global-virtual-store`** — Force the shared global virtual store off for this invocation.
 
-  Packages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.
+  Packages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).
 
   **Aliases:** `--disable-gvs`
 - **`--enable-global-virtual-store`** — Force the shared global virtual store on for this invocation.

--- a/docs/cli/remove.md
+++ b/docs/cli/remove.md
@@ -47,7 +47,7 @@ Remove a dependency
 ## Virtual store
 - **`--disable-global-virtual-store`** — Force the shared global virtual store off for this invocation.
 
-  Packages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.
+  Packages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).
 
   **Aliases:** `--disable-gvs`
 - **`--enable-global-virtual-store`** — Force the shared global virtual store on for this invocation.

--- a/docs/cli/restart.md
+++ b/docs/cli/restart.md
@@ -40,7 +40,7 @@ Restart a package (shortcut for `run restart`; falls back to `stop` + `start`)
 ## Virtual store
 - **`--disable-global-virtual-store`** — Force the shared global virtual store off for this invocation.
 
-  Packages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.
+  Packages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).
 
   **Aliases:** `--disable-gvs`
 - **`--enable-global-virtual-store`** — Force the shared global virtual store on for this invocation.

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -77,7 +77,7 @@ Run a script defined in package.json
 ## Virtual store
 - **`--disable-global-virtual-store`** — Force the shared global virtual store off for this invocation.
 
-  Packages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.
+  Packages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).
 
   **Aliases:** `--disable-gvs`
 - **`--enable-global-virtual-store`** — Force the shared global virtual store on for this invocation.

--- a/docs/cli/start.md
+++ b/docs/cli/start.md
@@ -40,7 +40,7 @@ Start a package (shortcut for `run start`)
 ## Virtual store
 - **`--disable-global-virtual-store`** — Force the shared global virtual store off for this invocation.
 
-  Packages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.
+  Packages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).
 
   **Aliases:** `--disable-gvs`
 - **`--enable-global-virtual-store`** — Force the shared global virtual store on for this invocation.

--- a/docs/cli/stop.md
+++ b/docs/cli/stop.md
@@ -40,7 +40,7 @@ Stop a package (shortcut for `run stop`)
 ## Virtual store
 - **`--disable-global-virtual-store`** — Force the shared global virtual store off for this invocation.
 
-  Packages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.
+  Packages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).
 
   **Aliases:** `--disable-gvs`
 - **`--enable-global-virtual-store`** — Force the shared global virtual store on for this invocation.

--- a/docs/cli/test.md
+++ b/docs/cli/test.md
@@ -41,7 +41,7 @@ Run the `test` script (shortcut for `run test`)
 ## Virtual store
 - **`--disable-global-virtual-store`** — Force the shared global virtual store off for this invocation.
 
-  Packages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.
+  Packages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).
 
   **Aliases:** `--disable-gvs`
 - **`--enable-global-virtual-store`** — Force the shared global virtual store on for this invocation.

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -77,7 +77,7 @@ Update dependencies
 ## Virtual store
 - **`--disable-global-virtual-store`** — Force the shared global virtual store off for this invocation.
 
-  Packages are materialized inside the project's virtual store instead of symlinked from `~/.cache/aube/virtual-store/`.
+  Packages are materialized inside the project's virtual store instead of symlinked from the shared store-adjacent tree (`~/.local/share/aube/store/v1/virtual-store/`).
 
   **Aliases:** `--disable-gvs`
 - **`--enable-global-virtual-store`** — Force the shared global virtual store on for this invocation.

--- a/docs/package-manager/global-virtual-store.md
+++ b/docs/package-manager/global-virtual-store.md
@@ -8,10 +8,18 @@ This is separate from the global content store:
 - The **global content store** (`$XDG_DATA_HOME/aube/store/v1/`) stores
   package files by BLAKE3 hash. Every install uses it.
 - The **global virtual store**
-  (`<cacheDir>/virtual-store/v1/`, defaulting to
-  `$XDG_CACHE_HOME/aube/virtual-store/v1/`, then
-  `~/.cache/aube/virtual-store/v1/`) stores package directory trees keyed by
-  dependency graph. Project `node_modules` entries symlink into it.
+  (`<storeDir>/v1/virtual-store/v1/`, defaulting to
+  `$XDG_DATA_HOME/aube/store/v1/virtual-store/v1/`, then
+  `~/.local/share/aube/store/v1/virtual-store/v1/`) stores package directory
+  trees keyed by dependency graph. Project `node_modules` entries symlink
+  into it.
+
+The virtual store sits next to the content store on purpose: entries are
+hardlinked out of the CAS (same volume by construction), and projects'
+`node_modules` symlinks point into it — so it must not live somewhere users
+routinely delete, the way a cache directory is. A virtual store created by an
+older aube release at `<cacheDir>/virtual-store/` keeps being used for as long
+as that directory exists, so existing project symlinks stay valid.
 
 ## Default behavior
 
@@ -40,16 +48,16 @@ project-b/
 ## With the global virtual store
 
 With the global virtual store enabled, aube builds the package tree once in the
-shared cache. Each project points directly at that shared tree:
+shared store-adjacent tree. Each project points directly at that shared tree:
 
 ```text
 project-a/
   node_modules/
-    react -> <cacheDir>/virtual-store/v1/react@18.2.0/<graph-hash>/node_modules/react
+    react -> <storeDir>/v1/virtual-store/v1/react@18.2.0/<graph-hash>/node_modules/react
 
 project-b/
   node_modules/
-    react -> <cacheDir>/virtual-store/v1/react@18.2.0/<graph-hash>/node_modules/react
+    react -> <storeDir>/v1/virtual-store/v1/react@18.2.0/<graph-hash>/node_modules/react
 ```
 
 The global virtual store still imports package files from the global content
@@ -119,26 +127,22 @@ aube install --disable-global-virtual-store
 
 ### Moving it off the default volume
 
-Two settings relocate the global virtual store, and neither requires moving
-`XDG_CACHE_HOME` (which would drag every other tool's cache along with it).
+The virtual store follows [`storeDir`](/settings/#setting-storedir), so moving
+the store moves it too:
+
+```sh
+export AUBE_STORE_DIR=/Volumes/Mini/dev/stores/aube
+```
 
 [`globalVirtualStoreDir`](/settings/#setting-globalvirtualstoredir) moves the
-virtual store on its own and leaves packument metadata where it is:
+virtual store on its own:
 
 ```sh
 export AUBE_GLOBAL_VIRTUAL_STORE_DIR=/Volumes/Mini/dev/aube-virtual-store
 export AUBE_STORE_DIR=/Volumes/Mini/dev/stores/aube
 ```
 
-[`cacheDir`](/settings/#setting-cachedir) moves the whole cache — virtual store
-and metadata together:
-
-```sh
-export AUBE_CACHE_DIR=/Volumes/Mini/dev/cache/aube
-export AUBE_STORE_DIR=/Volumes/Mini/dev/stores/aube
-```
-
-Either way, keep the virtual store on the *same* volume as `storeDir`. Its
+When splitting them, keep the virtual store on the *same* volume as `storeDir`. Its
 entries are hardlinked out of the content store, so a split across filesystems
 makes every global-virtual-store install fall back to a per-file copy. aube
 warns (`WARN_AUBE_GVS_CROSS_VOLUME`) when it detects that split:

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -134,7 +134,7 @@ Aube generates this page from [`settings.toml`](https://github.com/jdx/aube/blob
 | [`globalBinDir`](#setting-globalbindir) | `path` | Directory where global binaries are symlinked. |
 | [`npmrcAuthFile`](#setting-npmrcauthfile) | `path` | Path to an additional .npmrc file consulted for registry authentication tokens. |
 | [`stateDir`](#setting-statedir) | `path` | Directory for aube install-state files. |
-| [`cacheDir`](#setting-cachedir) | `path` | Directory for the global virtual store and cached package metadata. |
+| [`cacheDir`](#setting-cachedir) | `path` | Directory for cached package metadata. |
 | [`useStderr`](#setting-usestderr) | `bool` | Write all output to stderr instead of stdout. |
 | [`updateNotifier`](#setting-updatenotifier) | `bool` | Show an update notification when a newer aube is available. |
 | [`updateRewritesSpecifier`](#setting-updaterewritesspecifier) | `bool` | Rewrite caret/tilde manifest specifiers on `aube update` without `--latest`. |
@@ -1215,17 +1215,19 @@ Location of the shared virtual store used by every project.
 
 Relocates the global virtual store — the shared tree of materialized
 package directories that `node_modules/.aube/<dep>` symlinks into when
-`enableGlobalVirtualStore` is on. Unset, it lives at
-`<cacheDir>/virtual-store/`. Aube stores registry-managed entries in a
-versioned child directory below this root so older releases cannot share
-entries that a current `aube store prune` may remove.
+`enableGlobalVirtualStore` is on. Unset, it lives store-adjacent at
+`<storeDir>/v1/virtual-store/`, next to the CAS `files/` and `index/`
+directories — on the same volume as the content store (so the hardlink
+fast path always applies) and outside `cacheDir` (so deleting the cache
+never severs the symlinks every installed project points into it).
+Installs whose virtual store predates this default keep using the
+legacy `<cacheDir>/virtual-store/` tree for as long as it exists.
+Aube stores registry-managed entries in a versioned child directory
+below this root so older releases cannot share entries that a current
+`aube store prune` may remove.
 
 Set this when the global virtual store belongs somewhere other than
-the rest of the cache — typically to put it on the same volume as
-`storeDir` while leaving packument metadata on the system disk.
-Setting `cacheDir` moves the virtual store too, so reach for that one
-when you want the whole cache to travel together and this one when you
-want to split them.
+the store — for example a dedicated volume shared between machines.
 
 Entries in the global virtual store are hardlinked out of the content
 store, so keep this on the same volume as `storeDir`. When they land
@@ -2734,7 +2736,7 @@ Overrides the directory that holds the `.aube-state` install-state file. Default
 
 ### `cacheDir` {#setting-cachedir}
 
-Directory for the global virtual store and cached package metadata.
+Directory for cached package metadata.
 
 - Type: `path`
 - Default: `` platform cache dir (`$XDG_CACHE_HOME/aube`) ``
@@ -2748,23 +2750,22 @@ Overrides the cache directory. Unset, aube derives it per platform
 its own name to; this setting takes a complete path instead, so
 `AUBE_CACHE_DIR=/mnt/fast/aube` puts the cache directly there.
 
-The global virtual store (`<cacheDir>/virtual-store/`) and cached
-packument metadata (`<cacheDir>/packuments-v1/`,
-`<cacheDir>/packuments-full-v1/`) live under this directory. The
+Cached packument metadata (`<cacheDir>/packuments-v1/`,
+`<cacheDir>/packuments-full-v1/`) lives under this directory. The
 content-addressable store is *not* here — it is `storeDir`, which
-defaults under `$XDG_DATA_HOME` instead. A few smaller caches (the OSV
-advisory mirror, the bootstrapped `node-gyp`, git clones) still follow
-the platform cache dir regardless of this setting.
+defaults under `$XDG_DATA_HOME` instead, and the global virtual store
+defaults next to that store (`<storeDir>/v1/virtual-store/`), not under
+the cache; a virtual store created by an older aube at
+`<cacheDir>/virtual-store/` keeps being used for as long as it exists.
+A few smaller caches (the OSV advisory mirror, the bootstrapped
+`node-gyp`, git clones) still follow the platform cache dir regardless
+of this setting.
 
-Set this alongside `storeDir` when the store lives on a non-default
-volume. Entries in the global virtual store are hardlinked out of the
-CAS, so on installs with the global virtual store enabled, a `cacheDir`
-and `storeDir` split across filesystems degrades every install to a
-per-file copy and aube warns about it. Pointing both at the same volume
-(`AUBE_CACHE_DIR=/mnt/dev/cache/aube` plus
-`AUBE_STORE_DIR=/mnt/dev/stores/aube`) keeps the hardlink fast path.
-Use `globalVirtualStoreDir` to move only the virtual store and leave
-the metadata caches where they are.
+Once the virtual store no longer lives here, everything under this
+directory is regenerable: deleting it costs the next install some
+registry round-trips but breaks nothing. Use `globalVirtualStoreDir`
+to move only the virtual store and leave the metadata caches where
+they are.
 
 Examples:
 

--- a/test/gvs_ecosystem_slow.bats
+++ b/test/gvs_ecosystem_slow.bats
@@ -88,7 +88,7 @@ JS
 	refute_output --partial "disableGlobalVirtualStoreForPackages"
 	run realpath node_modules/parcel
 	assert_success
-	[[ "$output" == */aube/virtual-store/v1/* ]]
+	[[ "$output" == */virtual-store/v1/* ]]
 
 	run aube run build
 	assert_success

--- a/test/install.bats
+++ b/test/install.bats
@@ -1345,12 +1345,13 @@ JSON
 	rm "$victim"
 
 	# Wipe both node_modules AND the global virtual store. The GVS at
-	# `$XDG_CACHE_HOME/aube/virtual-store/` holds hardlinks back to the
+	# `<store>/v1/virtual-store/` (legacy installs: under
+	# `$XDG_CACHE_HOME/aube/virtual-store/`) holds hardlinks back to the
 	# (deleted) CAS path, and `ensure_in_virtual_store` short-circuits
 	# on `pkg_nm_dir.exists()` — leaving the GVS in place would let the
 	# materializer skip the broken package entirely and mask the very
 	# bug this test exists to catch.
-	rm -rf node_modules "$XDG_CACHE_HOME/aube/virtual-store"
+	rm -rf node_modules "$store_v1/virtual-store" "$XDG_CACHE_HOME/aube/virtual-store"
 
 	# Without the verified probe, this install would fail with
 	# `ERR_AUBE_MISSING_STORE_FILE` from the GVS prewarm path; with

--- a/test/modules_dir_settings.bats
+++ b/test/modules_dir_settings.bats
@@ -100,8 +100,8 @@ teardown() {
 	assert [ ! -e node_modules/.bin ]
 	# The project still references GVS entries through `.aube`, so pruning
 	# must include it in reachability even without top-level links.
-	assert_dir_exists "$HOME/.cache/aube/virtual-store/v1/.projects"
-	assert [ -n "$(find "$HOME/.cache/aube/virtual-store/v1/.projects" -type f -name '*.json' -print -quit)" ]
+	assert_dir_exists "$XDG_DATA_HOME/aube/store/v1/virtual-store/v1/.projects"
+	assert [ -n "$(find "$XDG_DATA_HOME/aube/store/v1/virtual-store/v1/.projects" -type f -name '*.json' -print -quit)" ]
 }
 
 @test "virtualStoreOnly=false (default) writes the usual top-level symlinks" {
@@ -209,7 +209,7 @@ teardown() {
 @test "modulesCacheMaxAge unlinks orphan symlinks without touching the target" {
 	# Defense for the cursor-bot review on PR #202: in
 	# global-virtual-store mode `.aube/<dep>` entries are symlinks
-	# into the shared `~/.cache/aube/virtual-store/`. On older
+	# into the shared store-adjacent virtual store. On older
 	# Linux kernels `remove_dir_all` could follow the symlink and
 	# recursively destroy the shared target, breaking other
 	# projects. The sweep must only unlink the local symlink.

--- a/test/nextjs_gvs_autodisable.bats
+++ b/test/nextjs_gvs_autodisable.bats
@@ -56,25 +56,28 @@ JSON
 	assert_output --partial "\`next\`"
 
 	# The whole point of the auto-disable: `.aube/<pkg>` must be a
-	# real directory, not a symlink into
-	# `~/.cache/aube/virtual-store/`. A symlink here is what trips
-	# Turbopack's filesystem-root check.
+	# real directory, not a symlink into the shared global virtual
+	# store. A symlink here is what trips Turbopack's
+	# filesystem-root check.
 	[ -d node_modules/.aube/is-odd@3.0.1 ]
 	[ ! -L node_modules/.aube/is-odd@3.0.1 ]
 	[ -L node_modules/next ]
 
 	# Regression guard: the fetch-pipelined prewarm task builds its
 	# own Linker and used to miss this override, so it would spend
-	# the fetch phase materializing packages into
-	# `$XDG_CACHE_HOME/aube/virtual-store/` even though the main
-	# linker ran in per-project mode and threw all of that work
-	# away. HOME is isolated in setup, so the shared virtual store
-	# stays empty on a clean run — no per-dep_path subdir under
-	# `virtual-store/` means prewarm correctly skipped the pour.
-	if [ -d "$XDG_CACHE_HOME/aube/virtual-store" ]; then
-		run find "$XDG_CACHE_HOME/aube/virtual-store" -mindepth 1 -maxdepth 1 -type d
-		assert_output ""
-	fi
+	# the fetch phase materializing packages into the shared global
+	# virtual store even though the main linker ran in per-project
+	# mode and threw all of that work away. HOME is isolated in
+	# setup, so the shared virtual store stays empty on a clean run
+	# — no per-dep_path subdir under `virtual-store/` means prewarm
+	# correctly skipped the pour. (Both the store-adjacent default
+	# and the legacy cache-dir location are checked.)
+	for gvs_root in "$XDG_DATA_HOME/aube/store/v1/virtual-store" "$XDG_CACHE_HOME/aube/virtual-store"; do
+		if [ -d "$gvs_root" ]; then
+			run find "$gvs_root" -mindepth 1 -maxdepth 1 -type d
+			assert_output ""
+		fi
+	done
 }
 
 @test "aube install warns when next is in devDependencies" {
@@ -153,7 +156,7 @@ JSON
 
 	run sed -n 's/.*"virtualStoreDir": "\(.*\)".*/\1/p' node_modules/.modules.yaml
 	assert_success
-	[[ "$output" == /*/aube/virtual-store/v1 ]]
+	[[ "$output" == /*/virtual-store/v1 ]]
 
 	rm node_modules/.modules.yaml
 	run aube install
@@ -182,7 +185,7 @@ JSON
 
 	run sed -n 's/.*"virtualStoreDir": "\(.*\)".*/\1/p' packages/app/node_modules/.modules.yaml
 	assert_success
-	[[ "$output" == /*/aube/virtual-store/v1 ]]
+	[[ "$output" == /*/virtual-store/v1 ]]
 }
 
 @test "disableGlobalVirtualStoreForPackages=[] opts out of the auto-disable" {

--- a/test/settings.bats
+++ b/test/settings.bats
@@ -195,11 +195,13 @@ _make_env_probe_project() {
 
 # --- relocating the global virtual store ---
 #
-# The global virtual store is the biggest thing under `cacheDir`, and
-# it hardlinks out of the CAS, so users who move `storeDir` to another
-# volume need to move this with it. Before these settings were honored
-# here, the only lever was `XDG_CACHE_HOME`. `cacheDir` moves the whole
-# cache; `globalVirtualStoreDir` moves only the virtual store.
+# The global virtual store hardlinks out of the CAS, so it defaults
+# store-adjacent (`<storeDir>/v1/virtual-store/`) — same volume as the
+# CAS by construction, and outside `cacheDir` so deleting the cache
+# never severs project symlinks. A tree created by an older aube at
+# `<cacheDir>/virtual-store/` stays authoritative for as long as it
+# exists (existing projects embed that path in their symlink farms).
+# `globalVirtualStoreDir` moves only the virtual store.
 
 # Assert `.aube/<dep_path>` is an absolute symlink into `$1`, the
 # expected global virtual store root.
@@ -211,30 +213,45 @@ _assert_links_into_gvs() {
 	[[ "$target" == "$gvs/"* ]]
 }
 
-@test "AUBE_CACHE_DIR relocates the global virtual store" {
+@test "global virtual store defaults next to the content store" {
+	_setup_basic_fixture
+
+	run aube install
+	assert_success
+
+	local gvs_default="$XDG_DATA_HOME/aube/store/v1/virtual-store"
+	assert_dir_exists "$gvs_default"
+	_assert_links_into_gvs "$gvs_default"
+	# Nothing lands under the cache dir — deleting the cache must never
+	# sever project symlinks.
+	[ ! -d "$HOME/.cache/aube/virtual-store" ]
+}
+
+@test "AUBE_CACHE_DIR no longer relocates the global virtual store" {
 	_setup_basic_fixture
 	local custom_cache="$TEST_TEMP_DIR/custom-cache"
 
 	AUBE_CACHE_DIR="$custom_cache" run aube install
 	assert_success
 
-	assert_dir_exists "$custom_cache/virtual-store"
-	# `.aube/<dep_path>` is a symlink into the relocated global store,
-	# not into the XDG default.
-	_assert_links_into_gvs "$custom_cache/virtual-store"
+	# The virtual store stays store-adjacent; only metadata follows
+	# `cacheDir`.
+	_assert_links_into_gvs "$XDG_DATA_HOME/aube/store/v1/virtual-store"
+	[ ! -d "$custom_cache/virtual-store" ]
 	[ ! -d "$HOME/.cache/aube/virtual-store" ]
 }
 
-@test "cacheDir in .npmrc relocates the global virtual store" {
+@test "a legacy cache-dir virtual store stays authoritative" {
 	_setup_basic_fixture
-	local custom_cache="$TEST_TEMP_DIR/npmrc-cache"
-	echo "cacheDir=$custom_cache" >>"$HOME/.npmrc"
+	# Simulate an install whose GVS predates the store-adjacent
+	# default: the legacy root exists, so projects out there embed it
+	# in their symlink farms and it must keep winning.
+	mkdir -p "$XDG_CACHE_HOME/aube/virtual-store"
 
 	run aube install
 	assert_success
-	assert_dir_exists "$custom_cache/virtual-store"
-	_assert_links_into_gvs "$custom_cache/virtual-store"
-	[ ! -d "$HOME/.cache/aube/virtual-store" ]
+	_assert_links_into_gvs "$XDG_CACHE_HOME/aube/virtual-store"
+	[ ! -d "$XDG_DATA_HOME/aube/store/v1/virtual-store" ]
 }
 
 @test "AUBE_GLOBAL_VIRTUAL_STORE_DIR relocates only the virtual store" {


### PR DESCRIPTION
## What

Two changes from the benchmark investigation's "third tier" (the robustness bug plus the fetch-concurrency hygiene item):

**1. The global virtual store now defaults store-adjacent** (`<storeDir>/v1/virtual-store/`, i.e. `~/.local/share/aube/store/v1/virtual-store/`) instead of `<cacheDir>/virtual-store/`.

The cache-relative default broke two ways in the real world:

- Deleting the cache (`rm -rf ~/.cache`, CI cache eviction, systemd-tmpfiles) severed the `node_modules/.aube` symlink farm of **every GVS-linked project at once** — even though a cache directory is exactly the thing users are entitled to delete. This is also what vlt's public benchmark surfaces as aube's worst rows (their harness wipes `~/.cache/aube` between variations).
- GVS entries hardlink out of the CAS, so whenever `cacheDir` and `storeDir` sat on different volumes, every install silently degraded to per-file copies (`WARN_AUBE_GVS_CROSS_VOLUME`). Store-adjacent means same volume by construction.

This is the same drift-class reasoning as the earlier index migration out of the cache dir (users who mount `aube store path` into containers now get the GVS too).

**Compatibility:** a virtual store created by an older aube at `<cacheDir>/virtual-store/` stays authoritative for as long as it exists — it cannot be renamed into place because existing projects embed its absolute path in their symlink farms, and dangling them is exactly the breakage this PR prevents. Once the legacy tree is gone (e.g. the user cleared their cache), the next install materializes into the durable location and projects re-link there. `globalVirtualStoreDir` still overrides everything, verbatim.

**2. The tarball `AdaptiveLimit` ceiling now derives from the tokio blocking-pool size** (previously a literal 256 against a 128-thread pool). Each streaming tarball import pins one blocking thread for its entire download (`ChunkReader` blocks on the chunk channel), so permits past the pool only opened sockets whose imports queued behind earlier finishers — slow-start reaches the ceiling within a couple of completions, parking up to half the fleet in that queue. An explicit `networkConcurrency` above the pool is still honored, and `AUBE_TOKIO_BLOCKING` moves both numbers together so they can't drift apart again.

## Benchmarks

Hermetic registry, 500 mbit / 50 ms throttle (same as `mise run bench`), gvs fixture (1225 pkgs), cold caches, frozen lockfile, trust policy off to isolate the fetch phase, n=5:

| binary | total | fetch phase |
|---|---|---|
| main | 2543±138 ms | 2189±125 ms |
| this PR | 2559±148 ms | 2199±137 ms |

No regression; the limiter cap removes the oversubscription regime rather than winning on this machine (8 cores — the AIMD converges under the pool here anyway). The GVS relocation costs nothing on install and is behavioral, not perf.

## Notes

- Complements https://github.com/jdx/aube/pull/1400 (freshness-path scaling); the trust-policy pre-pass — the dominant cold-install cost — is left for its own PR.
- Docs regenerated via `mise run render` (settings + CLI pages); the GVS doc page and settings.toml prose updated by hand.
- New unit tests cover the default resolution (store-adjacent, legacy-sticky, explicit override); bats tests updated to the new semantics plus a new legacy-stickiness test. Remaining local bats failures are a pre-existing broken `node` mise shim under the isolated test `$HOME`, unrelated to this change (present on a clean checkout).

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default GVS path changes where new installs symlink and what breaks when users delete caches; legacy stickiness limits breakage, but wrong resolution would dangle many projects' `node_modules/.aube` links.
> 
> **Overview**
> **Moves the default global virtual store (GVS) from the cache tree to `<storeDir>/v1/virtual-store/`**, so shared package trees sit on the same volume as the content store and survive `cacheDir` wipes. When `globalVirtualStoreDir` is unset, resolution goes through new `default_global_virtual_store_root` in `settings_context.rs`; **existing `<cacheDir>/virtual-store/` directories keep winning** until removed. Docs, settings prose, CLI help, embed tests, and bats reflect that **`AUBE_CACHE_DIR` no longer relocates GVS**.
> 
> **Tarball download concurrency** on the lockfile and streaming install paths no longer uses a fixed ceiling of 256. **`AdaptiveLimit` max is tied to `tokio_blocking_pool_size()`** (default 128, `AUBE_TOKIO_BLOCKING`), since each streaming import holds a blocking thread for the whole download; explicit `networkConcurrency` above the pool is still honored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c88dfe4a81e332954a318c2c15299292567a064e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The global virtual store now defaults to a location adjacent to the shared package store.
  * Existing virtual stores in the legacy cache location continue to be recognized.
  * Cache storage is now reserved for regenerable metadata.

* **Performance**
  * Package fetching concurrency now adapts to the available blocking-thread capacity.

* **Documentation**
  * Updated CLI help and configuration guides to reflect the new virtual-store location and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->