### PR TITLE
perf(install): validate trustPolicy from compact trust histories

### DIFF
--- a/crates/aube-registry/src/client/cache.rs
+++ b/crates/aube-registry/src/client/cache.rs
@@ -163,6 +163,35 @@ pub(super) fn packument_full_cache_path(
     Some(cache_dir.join(origin).join(format!("{safe_name}.json")))
 }
 
+/// Disk-cached compact trust history ([`crate::PackumentTrustHistory`])
+/// for the lockfile trust-policy validator. Same revalidation envelope
+/// as the packument caches, but the payload keeps only the `time` map
+/// and per-version trust evidence — orders of magnitude smaller than
+/// the raw full packument the validator previously cached.
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct CachedTrustHistory {
+    pub(super) etag: Option<String>,
+    pub(super) last_modified: Option<String>,
+    /// Unix epoch seconds when this entry was written
+    pub(super) fetched_at: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) max_age_secs: Option<u64>,
+    pub(super) history: crate::PackumentTrustHistory,
+}
+
+pub(super) fn read_cached_trust_history(path: &Path) -> Option<CachedTrustHistory> {
+    let content = std::fs::read(path).ok()?;
+    sonic_rs::from_slice(&content).ok()
+}
+
+pub(super) fn write_cached_trust_history(
+    path: &Path,
+    cached: &CachedTrustHistory,
+) -> std::io::Result<()> {
+    let json = sonic_rs::to_vec(cached).map_err(std::io::Error::other)?;
+    aube_util::fs_atomic::atomic_write(path, &json)
+}
+
 pub(super) fn read_cached_full_packument(path: &Path) -> Option<CachedFullPackument> {
     let content = std::fs::read(path).ok()?;
     sonic_rs::from_slice(&content).ok()

--- a/crates/aube-registry/src/client/packument.rs
+++ b/crates/aube-registry/src/client/packument.rs
@@ -364,6 +364,111 @@ impl RegistryClient {
         }
     }
 
+    /// Fetch the compact trust history (`time` map plus per-version trust
+    /// evidence) for a package, backed by its own small on-disk cache.
+    ///
+    /// The lockfile trust-policy validator calls this once per package
+    /// *name* in the locked graph. It hits the same full-packument
+    /// endpoint as [`Self::fetch_packument_with_time_cached`], but
+    /// decodes only the fields the no-downgrade check reads and caches
+    /// that compact shape instead of the multi-megabyte raw document —
+    /// cold validations skip the `serde_json::Value` round-trip and the
+    /// full-packument cache write, warm revalidations re-read kilobytes
+    /// instead of megabytes per name.
+    pub async fn fetch_trust_history_cached(
+        &self,
+        name: &str,
+        cache_dir: &Path,
+    ) -> Result<crate::PackumentTrustHistory, Error> {
+        let cache_registry_url = self.config.registry_for(name).to_string();
+        // Same per-origin/name file layout as the packument caches;
+        // only the cache root differs (`trust-history-v1/`).
+        let cache_path = packument_full_cache_path(cache_dir, name, &cache_registry_url)
+            .ok_or_else(|| Error::InvalidName(name.to_string()))?;
+        let force_cache = self.force_cache();
+        let cached = read_cached_trust_history(&cache_path);
+        if let Some(c) = &cached
+            && (force_cache || cached_is_fresh(c.fetched_at, c.max_age_secs))
+        {
+            return Ok(c.history.clone());
+        }
+        if self.network_mode == NetworkMode::Offline {
+            // A stale entry beats failing outright: offline installs
+            // can't revalidate anything, and the caller already decided
+            // offline installs may proceed.
+            if let Some(c) = cached {
+                return Ok(c.history);
+            }
+            return Err(Error::Offline(format!("trust history for {name}")));
+        }
+
+        let (url, registry_url) = self.packument_url(name);
+        let etag = cached.as_ref().and_then(|c| c.etag.clone());
+        let last_modified = cached.as_ref().and_then(|c| c.last_modified.clone());
+        let resp = self
+            .send_metadata_with_retry(&format!("trust history {name}"), || {
+                let mut req = self
+                    .authed_get_for_package(&url, registry_url, name)
+                    .header("Accept", PACKUMENT_FULL_ACCEPT);
+                if let Some(ref etag) = etag {
+                    req = req.header("If-None-Match", etag);
+                }
+                if let Some(ref lm) = last_modified {
+                    req = req.header("If-Modified-Since", lm);
+                }
+                req
+            })
+            .await?;
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(Error::NotFound(name.to_string()));
+        }
+        if resp.status() == reqwest::StatusCode::NOT_MODIFIED {
+            if let Some(mut c) = cached {
+                c.max_age_secs = parse_cache_control_max_age(&resp).or(c.max_age_secs);
+                c.fetched_at = now_secs();
+                if let Err(e) = write_cached_trust_history(&cache_path, &c) {
+                    tracing::warn!(
+                        code = aube_codes::warnings::WARN_AUBE_PACKUMENT_CACHE_WRITE,
+                        "failed to write trust-history cache {}: {e}",
+                        cache_path.display()
+                    );
+                }
+                return Ok(c.history);
+            }
+            // 304 without a cached entry means we never sent conditional
+            // headers — a misbehaving registry. Treat as a hard error
+            // rather than parsing the empty body.
+            return Err(Error::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("registry returned 304 for unconditional trust-history request: {name}"),
+            )));
+        }
+        let resp = resp.error_for_status()?;
+        check_body_cap(
+            &resp,
+            self.fetch_policy.packument_max_bytes,
+            "packument-trust-history",
+        )?;
+        let (etag, last_modified) = extract_cache_headers(&resp);
+        let max_age_secs = parse_cache_control_max_age(&resp);
+        let history: crate::PackumentTrustHistory = parse_full_response(resp).await?;
+        let cached = CachedTrustHistory {
+            etag,
+            last_modified,
+            fetched_at: now_secs(),
+            max_age_secs,
+            history,
+        };
+        if let Err(e) = write_cached_trust_history(&cache_path, &cached) {
+            tracing::warn!(
+                code = aube_codes::warnings::WARN_AUBE_PACKUMENT_CACHE_WRITE,
+                "failed to write trust-history cache {}: {e}",
+                cache_path.display()
+            );
+        }
+        Ok(cached.history)
+    }
+
     pub(super) async fn revalidate_full_packument_typed(
         &self,
         name: &str,

--- a/crates/aube-registry/src/client/packument.rs
+++ b/crates/aube-registry/src/client/packument.rs
@@ -405,8 +405,16 @@ impl RegistryClient {
         let (url, registry_url) = self.packument_url(name);
         let etag = cached.as_ref().and_then(|c| c.etag.clone());
         let last_modified = cached.as_ref().and_then(|c| c.last_modified.clone());
-        let resp = self
-            .send_metadata_with_retry(&format!("trust history {name}"), || {
+        let label = format!("trust history {name}");
+        let started = std::time::Instant::now();
+        // Single attempt loop covering send *and* body decode, matching
+        // `fetch_packument_full_cached`: a truncated or malformed body on
+        // an otherwise-successful response is retriable, and letting it
+        // through would abort trust validation for the whole install.
+        let max_attempts = self.fetch_policy.retries.saturating_add(1);
+        for attempt in 0..max_attempts {
+            let is_last = attempt + 1 >= max_attempts;
+            let resp = match {
                 let mut req = self
                     .authed_get_for_package(&url, registry_url, name)
                     .header("Accept", PACKUMENT_FULL_ACCEPT);
@@ -417,56 +425,107 @@ impl RegistryClient {
                     req = req.header("If-Modified-Since", lm);
                 }
                 req
-            })
-            .await?;
-        if resp.status() == reqwest::StatusCode::NOT_FOUND {
-            return Err(Error::NotFound(name.to_string()));
-        }
-        if resp.status() == reqwest::StatusCode::NOT_MODIFIED {
-            if let Some(mut c) = cached {
-                c.max_age_secs = parse_cache_control_max_age(&resp).or(c.max_age_secs);
-                c.fetched_at = now_secs();
-                if let Err(e) = write_cached_trust_history(&cache_path, &c) {
-                    tracing::warn!(
-                        code = aube_codes::warnings::WARN_AUBE_PACKUMENT_CACHE_WRITE,
-                        "failed to write trust-history cache {}: {e}",
-                        cache_path.display()
-                    );
-                }
-                return Ok(c.history);
             }
-            // 304 without a cached entry means we never sent conditional
-            // headers — a misbehaving registry. Treat as a hard error
-            // rather than parsing the empty body.
-            return Err(Error::Io(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("registry returned 304 for unconditional trust-history request: {name}"),
-            )));
+            .send()
+            .await
+            {
+                Ok(resp) if is_retriable_status(resp.status()) && !is_last => {
+                    let wait = retry_after_from(&resp)
+                        .unwrap_or_else(|| self.fetch_policy.backoff_for_attempt(attempt + 1));
+                    tracing::warn!(
+                        attempt = attempt + 1,
+                        max_attempts,
+                        backoff_ms = wait.as_millis() as u64,
+                        status = resp.status().as_u16(),
+                        label,
+                        code = aube_codes::warnings::WARN_AUBE_HTTP_RETRY_TRANSIENT,
+                        "retrying HTTP request after transient failure",
+                    );
+                    tokio::time::sleep(wait).await;
+                    continue;
+                }
+                Ok(resp) => resp,
+                Err(_) if !is_last => {
+                    let wait = self.fetch_policy.backoff_for_attempt(attempt + 1);
+                    tokio::time::sleep(wait).await;
+                    continue;
+                }
+                Err(e) => return Err(e.into()),
+            };
+
+            if resp.status() == reqwest::StatusCode::NOT_FOUND {
+                self.maybe_record_slow_metadata(&label, started);
+                return Err(Error::NotFound(name.to_string()));
+            }
+            if resp.status() == reqwest::StatusCode::NOT_MODIFIED {
+                if let Some(mut c) = cached {
+                    c.max_age_secs = parse_cache_control_max_age(&resp).or(c.max_age_secs);
+                    c.fetched_at = now_secs();
+                    if let Err(e) = write_cached_trust_history(&cache_path, &c) {
+                        tracing::warn!(
+                            code = aube_codes::warnings::WARN_AUBE_PACKUMENT_CACHE_WRITE,
+                            "failed to write trust-history cache {}: {e}",
+                            cache_path.display()
+                        );
+                    }
+                    self.maybe_record_slow_metadata(&label, started);
+                    return Ok(c.history);
+                }
+                // 304 without a cached entry means we never sent
+                // conditional headers — a misbehaving registry. Treat as
+                // a hard error rather than parsing the empty body.
+                return Err(Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(
+                        "registry returned 304 for unconditional trust-history request: {name}"
+                    ),
+                )));
+            }
+
+            let resp = resp.error_for_status()?;
+            check_body_cap(
+                &resp,
+                self.fetch_policy.packument_max_bytes,
+                "packument-trust-history",
+            )?;
+            let (etag, last_modified) = extract_cache_headers(&resp);
+            let max_age_secs = parse_cache_control_max_age(&resp);
+            match parse_full_response::<crate::PackumentTrustHistory>(resp).await {
+                Ok(history) => {
+                    let to_cache = CachedTrustHistory {
+                        etag,
+                        last_modified,
+                        fetched_at: now_secs(),
+                        max_age_secs,
+                        history,
+                    };
+                    if let Err(e) = write_cached_trust_history(&cache_path, &to_cache) {
+                        tracing::warn!(
+                            code = aube_codes::warnings::WARN_AUBE_PACKUMENT_CACHE_WRITE,
+                            "failed to write trust-history cache {}: {e}",
+                            cache_path.display()
+                        );
+                    }
+                    self.maybe_record_slow_metadata(&label, started);
+                    return Ok(to_cache.history);
+                }
+                Err(err) if !is_last => {
+                    let wait = self.fetch_policy.backoff_for_attempt(attempt + 1);
+                    tracing::warn!(
+                        attempt = attempt + 1,
+                        max_attempts,
+                        backoff_ms = wait.as_millis() as u64,
+                        label,
+                        error = %err,
+                        code = aube_codes::warnings::WARN_AUBE_HTTP_RETRY_TRANSIENT,
+                        "retrying HTTP request after body read failure",
+                    );
+                    tokio::time::sleep(wait).await;
+                }
+                Err(err) => return Err(err),
+            }
         }
-        let resp = resp.error_for_status()?;
-        check_body_cap(
-            &resp,
-            self.fetch_policy.packument_max_bytes,
-            "packument-trust-history",
-        )?;
-        let (etag, last_modified) = extract_cache_headers(&resp);
-        let max_age_secs = parse_cache_control_max_age(&resp);
-        let history: crate::PackumentTrustHistory = parse_full_response(resp).await?;
-        let cached = CachedTrustHistory {
-            etag,
-            last_modified,
-            fetched_at: now_secs(),
-            max_age_secs,
-            history,
-        };
-        if let Err(e) = write_cached_trust_history(&cache_path, &cached) {
-            tracing::warn!(
-                code = aube_codes::warnings::WARN_AUBE_PACKUMENT_CACHE_WRITE,
-                "failed to write trust-history cache {}: {e}",
-                cache_path.display()
-            );
-        }
-        Ok(cached.history)
+        unreachable!("retry loop exited without returning; max_attempts was {max_attempts}")
     }
 
     pub(super) async fn revalidate_full_packument_typed(

--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -214,7 +214,9 @@ pub struct Packument {
 /// trust-downgrade policies for an exact version. Deserializing this shape
 /// skips dependency maps and distribution metadata for every historical
 /// release, avoiding the large retained heap of a full [`Packument`].
-#[derive(Debug, Clone, Deserialize)]
+/// Serializable so the lockfile trust-policy validator can persist it in
+/// its compact on-disk cache (`trust-history-v1/`).
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PackumentTrustHistory {
     #[serde(default, deserialize_with = "non_string_tolerant_map")]
     pub time: BTreeMap<String, String>,
@@ -359,20 +361,25 @@ struct TolerantStringMap(
     #[serde(deserialize_with = "non_string_tolerant_map")] BTreeMap<String, String>,
 );
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct VersionTrustMetadata {
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub approver: Option<serde_json::Value>,
-    #[serde(default, rename = "_npmUser", deserialize_with = "npm_user_tolerant")]
+    #[serde(
+        default,
+        rename = "_npmUser",
+        deserialize_with = "npm_user_tolerant",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub npm_user: Option<NpmUser>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dist: Option<VersionTrustDist>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct VersionTrustDist {
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub attestations: Option<Attestations>,
 }
 

--- a/crates/aube-resolver/src/lib.rs
+++ b/crates/aube-resolver/src/lib.rs
@@ -35,7 +35,8 @@ pub use primer::{
 pub use semver_util::{PickResult, pick_version_for_add};
 pub use trust::{
     MissingTimeDetails as MissingTrustTimeDetails, PriorTrustEvidence, TrustCheckError,
-    TrustDowngradeDetails, check_no_downgrade, evidence_for, strongest_prior_evidence,
+    TrustDowngradeDetails, check_no_downgrade, check_no_downgrade_history, evidence_for,
+    strongest_prior_evidence,
 };
 pub use trust::{PackageVersionPolicy, TrustEvidence, TrustExcludeParseError, TrustExcludeRules};
 pub use types::{

--- a/crates/aube-resolver/src/trust.rs
+++ b/crates/aube-resolver/src/trust.rs
@@ -306,20 +306,68 @@ pub fn check_no_downgrade_compact(
     exclude: &TrustExcludeRules,
     ignore_after_minutes: Option<u64>,
 ) -> Result<(), TrustCheckError> {
+    check_no_downgrade_over_history(
+        &packument.name,
+        &packument.time,
+        picked_version,
+        evidence_for(picked_meta),
+        history,
+        exclude,
+        ignore_after_minutes,
+    )
+}
+
+/// Trust-policy check over a standalone compact trust history — no full
+/// [`Packument`] or [`VersionMetadata`] in hand. Used by the lockfile
+/// validator, which fetches [`aube_registry::PackumentTrustHistory`]
+/// per name; `history.versions` here *includes* the picked version
+/// (the shared loop skips it when ranking prior evidence).
+pub fn check_no_downgrade_history(
+    name: &str,
+    history: &aube_registry::PackumentTrustHistory,
+    picked_version: &str,
+    picked_meta: &aube_registry::VersionTrustMetadata,
+    exclude: &TrustExcludeRules,
+    ignore_after_minutes: Option<u64>,
+) -> Result<(), TrustCheckError> {
+    check_no_downgrade_over_history(
+        name,
+        &history.time,
+        picked_version,
+        compact_evidence_for(picked_meta),
+        &history.versions,
+        exclude,
+        ignore_after_minutes,
+    )
+}
+
+/// Shared core for the compact-history trust checks: rank the strongest
+/// prior evidence in `history` and reject a picked version that weakens
+/// it. `history` may or may not contain `picked_version` itself — the
+/// ranking loop always skips it.
+fn check_no_downgrade_over_history(
+    name: &str,
+    time: &std::collections::BTreeMap<String, String>,
+    picked_version: &str,
+    picked_evidence: Option<TrustEvidence>,
+    history: &std::collections::BTreeMap<String, aube_registry::VersionTrustMetadata>,
+    exclude: &TrustExcludeRules,
+    ignore_after_minutes: Option<u64>,
+) -> Result<(), TrustCheckError> {
     let picked_parsed = node_semver::Version::parse(picked_version).ok();
     if let Some(ref version) = picked_parsed {
-        if exclude.matches(&packument.name, version) {
+        if exclude.matches(name, version) {
             return Ok(());
         }
-    } else if exclude.matches_name_only(&packument.name) {
+    } else if exclude.matches_name_only(name) {
         return Ok(());
     }
-    if packument.time.is_empty() {
+    if time.is_empty() {
         return Ok(());
     }
-    let Some(picked_time) = packument.time.get(picked_version) else {
+    let Some(picked_time) = time.get(picked_version) else {
         return Err(TrustCheckError::MissingTime(MissingTimeDetails {
-            name: packument.name.clone(),
+            name: name.to_string(),
             version: picked_version.to_string(),
         }));
     };
@@ -340,7 +388,7 @@ pub fn check_no_downgrade_compact(
         if version == picked_version {
             continue;
         }
-        let Some(published_at) = packument.time.get(version) else {
+        let Some(published_at) = time.get(version) else {
             continue;
         };
         if published_at >= picked_time {
@@ -374,12 +422,11 @@ pub fn check_no_downgrade_compact(
     let Some(prior) = strongest else {
         return Ok(());
     };
-    let current = evidence_for(picked_meta);
-    if current.map_or(0, TrustEvidence::rank) < prior.evidence.rank() {
+    if picked_evidence.map_or(0, TrustEvidence::rank) < prior.evidence.rank() {
         return Err(TrustCheckError::Downgrade(TrustDowngradeDetails {
-            name: packument.name.clone(),
+            name: name.to_string(),
             picked_version: picked_version.to_string(),
-            current_evidence: current,
+            current_evidence: picked_evidence,
             prior_evidence: prior.evidence,
             prior_version: prior.version,
         }));
@@ -1039,6 +1086,67 @@ mod tests {
         };
         assert_eq!(details.prior_version, "2.0.0");
         assert_eq!(details.prior_evidence, TrustEvidence::Provenance);
+    }
+
+    #[test]
+    fn standalone_history_detects_downgrade_and_skips_picked_version() {
+        let trust_meta =
+            |dist: Option<aube_registry::VersionTrustDist>| aube_registry::VersionTrustMetadata {
+                approver: None,
+                npm_user: None,
+                dist,
+            };
+        let provenance_dist = aube_registry::VersionTrustDist {
+            attestations: Some(Attestations {
+                provenance: Some(serde_json::json!({
+                    "predicateType": "https://slsa.dev/provenance/v1"
+                })),
+            }),
+        };
+        // Unlike the compact map, the standalone history includes the
+        // picked version itself — the ranking loop must skip it even
+        // when it carries evidence.
+        let history = aube_registry::PackumentTrustHistory {
+            time: BTreeMap::from([
+                ("2.0.0".to_string(), "2025-02-01T00:00:00.000Z".to_string()),
+                ("3.0.0".to_string(), "2025-03-01T00:00:00.000Z".to_string()),
+            ]),
+            versions: BTreeMap::from([
+                ("2.0.0".to_string(), trust_meta(Some(provenance_dist))),
+                ("3.0.0".to_string(), trust_meta(None)),
+            ]),
+        };
+
+        let picked = &history.versions["3.0.0"];
+        let err = check_no_downgrade_history(
+            "foo",
+            &history,
+            "3.0.0",
+            picked,
+            &TrustExcludeRules::default(),
+            None,
+        )
+        .expect_err("prior provenance must block a downgrade");
+        let TrustCheckError::Downgrade(details) = err else {
+            panic!("expected Downgrade");
+        };
+        assert_eq!(details.name, "foo");
+        assert_eq!(details.prior_version, "2.0.0");
+        assert_eq!(details.prior_evidence, TrustEvidence::Provenance);
+        assert_eq!(details.current_evidence, None);
+
+        // Same history, but picking the version that carries the
+        // evidence: no prior outranks it, so the check passes.
+        let picked = &history.versions["2.0.0"];
+        check_no_downgrade_history(
+            "foo",
+            &history,
+            "2.0.0",
+            picked,
+            &TrustExcludeRules::default(),
+            None,
+        )
+        .expect("strongest evidence so far must pass");
     }
 
     #[test]

--- a/crates/aube-settings/settings.toml
+++ b/crates/aube-settings/settings.toml
@@ -2742,7 +2742,8 @@ its own name to; this setting takes a complete path instead, so
 
 The global virtual store (`<cacheDir>/virtual-store/`) and cached
 packument metadata (`<cacheDir>/packuments-v1/`,
-`<cacheDir>/packuments-full-v1/`) live under this directory. The
+`<cacheDir>/packuments-full-v1/`, and the `trustPolicy` trust histories
+in `<cacheDir>/trust-history-v1/`) live under this directory. The
 content-addressable store is *not* here — it is `storeDir`, which
 defaults under `$XDG_DATA_HOME` instead. A few smaller caches (the OSV
 advisory mirror, the bootstrapped `node-gyp`, git clones) still follow

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -104,6 +104,10 @@ use workspace::{
 const TRUST_POLICY_VALIDATION_CACHE_DIR: &str = "trust-policy-v1";
 const TRUST_POLICY_VALIDATION_CACHE_TTL: std::time::Duration =
     std::time::Duration::from_secs(5 * 60);
+/// Compact per-name trust histories (`aube_registry::PackumentTrustHistory`)
+/// cached by the lockfile trust-policy validator. Regenerable from the
+/// registry, like the packument caches it sits next to.
+const TRUST_HISTORY_CACHE_DIR: &str = "trust-history-v1";
 
 #[cfg(test)]
 mod reentrancy_tests {
@@ -278,31 +282,53 @@ fn apply_computed_integrities(
     }
 }
 
+/// Validate the locked graph against `trustPolicy=no-downgrade` using
+/// compact per-name trust histories. No-op when the policy is off, the
+/// install is offline, or a fresh stamp already covers this graph.
+///
+/// Runs to completion before the fetch phase, like it always has —
+/// overlapping it with tarball downloads was tried and reverted: on a
+/// bandwidth-shared link the extra concurrent metadata traffic inflates
+/// tarball RTTs enough to destabilize the adaptive fetch limiter.
+/// Revisit once the fetch-phase contention issues (blocking-pool
+/// ceiling, CUSUM shrink) are addressed.
+///
+/// `stamp_lockfile_file` additionally records a stamp keyed on the
+/// active lockfile's raw bytes, which the install fast path consults
+/// (see `startup::trust_policy_requires_validation`). Pass `true` only
+/// when `graph` is exactly the parse of that file — no member-lockfile
+/// merging, no `lockfileDir` remap — so a file-keyed hit can never
+/// cover packages this validation didn't see.
 async fn validate_lockfile_trust_policy(
     cwd: &std::path::Path,
     settings_ctx: &aube_settings::ResolveCtx<'_>,
     graph: &aube_lockfile::LockfileGraph,
     network_mode: aube_registry::NetworkMode,
     policy: &aube_resolver::DependencyPolicy,
+    stamp_lockfile_file: bool,
 ) -> miette::Result<()> {
     let Some(cache_key) = trust_policy_validation_cache_key(cwd, graph, network_mode, policy)
     else {
         return Ok(());
     };
     let cache_dir = super::resolved_cache_dir_with_ctx(cwd, settings_ctx);
+    let file_stamp_key = if stamp_lockfile_file {
+        lockfile_trust_policy_file_stamp_key(cwd, settings_ctx, network_mode)
+    } else {
+        None
+    };
     if trust_policy_validation_cache_hit(&cache_dir, &cache_key) {
         tracing::debug!("trustPolicy=no-downgrade: reused lockfile validation cache");
+        if let Some(key) = &file_stamp_key {
+            record_lockfile_trust_policy_validation(&cache_dir, key);
+        }
         return Ok(());
     }
 
-    let client = std::sync::Arc::new(make_client(cwd).with_network_mode(network_mode));
-    let full_cache_dir = cache_dir.join("packuments-full-v1");
-    let concurrency = default_lockfile_network_concurrency().max(1);
-    let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(concurrency));
-    let mut seen = std::collections::BTreeSet::new();
-    let mut checks: tokio::task::JoinSet<Result<(), aube_resolver::Error>> =
-        tokio::task::JoinSet::new();
-
+    // One compact trust-history fetch per registry name covers every
+    // locked version of that name.
+    let mut by_name: std::collections::BTreeMap<String, std::collections::BTreeSet<String>> =
+        std::collections::BTreeMap::new();
     for dep_path in reachable_package_dep_paths(graph) {
         let Some(pkg) = graph.packages.get(&dep_path) else {
             continue;
@@ -310,14 +336,22 @@ async fn validate_lockfile_trust_policy(
         if pkg.local_source.is_some() {
             continue;
         }
-        let name = pkg.registry_name().to_string();
-        let version = pkg.version.clone();
-        if !seen.insert((name.clone(), version.clone())) {
-            continue;
-        }
+        by_name
+            .entry(pkg.registry_name().to_string())
+            .or_default()
+            .insert(pkg.version.clone());
+    }
 
+    let client = std::sync::Arc::new(make_client(cwd).with_network_mode(network_mode));
+    let trust_cache_dir = cache_dir.join(TRUST_HISTORY_CACHE_DIR);
+    let concurrency = default_lockfile_network_concurrency().max(1);
+    let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(concurrency));
+    let mut checks: tokio::task::JoinSet<Result<(), aube_resolver::Error>> =
+        tokio::task::JoinSet::new();
+
+    for (name, versions) in by_name {
         let client = client.clone();
-        let full_cache_dir = full_cache_dir.clone();
+        let trust_cache_dir = trust_cache_dir.clone();
         let exclude = policy.trust_policy_exclude.clone();
         let ignore_after = policy.trust_policy_ignore_after;
         let semaphore = semaphore.clone();
@@ -325,17 +359,25 @@ async fn validate_lockfile_trust_policy(
             let _permit = semaphore.acquire_owned().await.map_err(|e| {
                 aube_resolver::Error::Registry(name.clone(), format!("trust check cancelled: {e}"))
             })?;
-            let packument = client
-                .fetch_packument_with_time_cached(&name, &full_cache_dir)
+            let history = client
+                .fetch_trust_history_cached(&name, &trust_cache_dir)
                 .await
                 .map_err(|e| aube_resolver::Error::Registry(name.clone(), e.to_string()))?;
-            let picked = packument.versions.get(&version).ok_or_else(|| {
-                aube_resolver::Error::Registry(
-                    name.clone(),
-                    format!("registry packument has no metadata for {name}@{version}"),
+            for version in versions {
+                let picked = history.versions.get(&version).ok_or_else(|| {
+                    aube_resolver::Error::Registry(
+                        name.clone(),
+                        format!("registry packument has no metadata for {name}@{version}"),
+                    )
+                })?;
+                aube_resolver::check_no_downgrade_history(
+                    &name,
+                    &history,
+                    &version,
+                    picked,
+                    &exclude,
+                    ignore_after,
                 )
-            })?;
-            aube_resolver::check_no_downgrade(&packument, &version, picked, &exclude, ignore_after)
                 .map_err(|e| match e {
                     aube_resolver::TrustCheckError::Downgrade(d) => {
                         aube_resolver::Error::TrustDowngrade(Box::new(d))
@@ -343,7 +385,9 @@ async fn validate_lockfile_trust_policy(
                     aube_resolver::TrustCheckError::MissingTime(d) => {
                         aube_resolver::Error::TrustCheckMissingTime(Box::new(d))
                     }
-                })
+                })?;
+            }
+            Ok(())
         });
     }
 
@@ -353,7 +397,95 @@ async fn validate_lockfile_trust_policy(
     }
 
     record_lockfile_trust_policy_validation(&cache_dir, &cache_key);
+    if let Some(key) = &file_stamp_key {
+        record_lockfile_trust_policy_validation(&cache_dir, key);
+    }
     Ok(())
+}
+
+/// Cache key for the file-content trust-policy stamp the install fast
+/// path consults. Hashes the active lockfile's raw bytes plus every
+/// non-graph input the graph-shaped key hashes — the file bytes subsume
+/// the graph, so any lockfile edit (and any registry/policy change)
+/// produces a different key. Returns `None` when no lockfile exists or
+/// it can't be read.
+fn lockfile_trust_policy_file_stamp_key(
+    cwd: &std::path::Path,
+    settings_ctx: &aube_settings::ResolveCtx<'_>,
+    network_mode: aube_registry::NetworkMode,
+) -> Option<String> {
+    let lockfile_path = crate::state::active_lockfile_path(cwd)?;
+    let bytes = std::fs::read(&lockfile_path).ok()?;
+
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"aube:trust-policy-validation-file:v1\0");
+    hasher.update(env!("CARGO_PKG_VERSION").as_bytes());
+    hasher.update(b"\0network=");
+    hasher.update(format!("{network_mode:?}").as_bytes());
+    hasher.update(b"\0ignore_after=");
+    hasher.update(
+        format!(
+            "{:?}",
+            aube_settings::resolved::trust_policy_ignore_after(settings_ctx)
+        )
+        .as_bytes(),
+    );
+    // Raw (unparsed) exclude rules: both the record site and the fast
+    // path read the same resolved setting strings, so the two sides
+    // can't drift the way parsed-rule formatting could.
+    hasher.update(b"\0exclude=");
+    for rule in aube_settings::resolved::trust_policy_exclude(settings_ctx) {
+        hasher.update(rule.as_bytes());
+        hasher.update(b"\x1e");
+    }
+
+    let config = super::load_npm_config(cwd);
+    hasher.update(b"\0registry=");
+    hasher.update(config.registry.as_bytes());
+    hasher.update(b"\0scoped_registries=");
+    for (scope, url) in config.scoped_registries {
+        hasher.update(scope.as_bytes());
+        hasher.update(b"\x1f");
+        hasher.update(url.as_bytes());
+        hasher.update(b"\x1e");
+    }
+
+    hasher.update(b"\0lockfile=");
+    hasher.update(
+        lockfile_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("")
+            .as_bytes(),
+    );
+    hasher.update(b"\x1f");
+    hasher.update(blake3::hash(&bytes).to_hex().as_bytes());
+
+    Some(hasher.finalize().to_hex().to_string())
+}
+
+/// True when a trust-policy validation stamp keyed on the active
+/// lockfile's current content is within its TTL — the full pipeline
+/// would skip validation anyway, so the install fast path may proceed
+/// without it.
+///
+/// Callers must still gate on `state::check_needs_install`. The graph
+/// this stamp covers had platform rules applied
+/// (`resolve::apply_lockfile_graph_platform_rules`), whose inputs —
+/// the root manifest, workspace YAML, and resolved settings — are
+/// exactly what the state check hashes. Keeping both conditions means
+/// a widened `supportedArchitectures` re-runs validation instead of
+/// riding a stamp that never saw the newly-included packages.
+pub(super) fn lockfile_trust_policy_file_stamp_fresh(
+    cwd: &std::path::Path,
+    settings_ctx: &aube_settings::ResolveCtx<'_>,
+    network_mode: aube_registry::NetworkMode,
+) -> bool {
+    let Some(key) = lockfile_trust_policy_file_stamp_key(cwd, settings_ctx, network_mode) else {
+        return false;
+    };
+    let cache_dir = super::resolved_cache_dir_with_ctx(cwd, settings_ctx);
+    trust_policy_validation_cache_hit(&cache_dir, &key)
 }
 
 fn trust_policy_validation_cache_key(
@@ -1136,6 +1268,8 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
                 &graph,
                 opts.network_mode,
                 &dependency_policy,
+                /*stamp_lockfile_file=*/
+                lockfile_dir == cwd && (shared_workspace_lockfile || !has_workspace),
             )
             .await?;
             control::check_cancelled()?;
@@ -2764,6 +2898,71 @@ mod trust_policy_validation_cache_tests {
             )
             .is_none()
         );
+    }
+
+    #[test]
+    fn trust_policy_file_stamp_tracks_lockfile_bytes_and_registry() {
+        let dir = tempfile::tempdir().unwrap();
+        write_project_npmrc(dir.path(), "https://registry.npmjs.org/");
+        let online = aube_registry::NetworkMode::Online;
+
+        // No lockfile on disk -> no key, and consulting can't be fresh.
+        crate::commands::with_settings_ctx(dir.path(), |ctx| {
+            assert!(lockfile_trust_policy_file_stamp_key(dir.path(), ctx, online).is_none());
+            assert!(!lockfile_trust_policy_file_stamp_fresh(
+                dir.path(),
+                ctx,
+                online
+            ));
+        });
+
+        std::fs::write(
+            dir.path().join("aube-lock.yaml"),
+            "lockfileVersion: '9.0'\n",
+        )
+        .unwrap();
+        let key = crate::commands::with_settings_ctx(dir.path(), |ctx| {
+            lockfile_trust_policy_file_stamp_key(dir.path(), ctx, online).unwrap()
+        });
+
+        // Recording the key makes the fast-path consult fresh...
+        crate::commands::with_settings_ctx(dir.path(), |ctx| {
+            let cache_dir = crate::commands::resolved_cache_dir_with_ctx(dir.path(), ctx);
+            record_lockfile_trust_policy_validation(&cache_dir, &key);
+            assert!(lockfile_trust_policy_file_stamp_fresh(
+                dir.path(),
+                ctx,
+                online
+            ));
+        });
+
+        // ...until the lockfile bytes change.
+        std::fs::write(
+            dir.path().join("aube-lock.yaml"),
+            "lockfileVersion: '9.0'\n# drift\n",
+        )
+        .unwrap();
+        crate::commands::with_settings_ctx(dir.path(), |ctx| {
+            let changed = lockfile_trust_policy_file_stamp_key(dir.path(), ctx, online).unwrap();
+            assert_ne!(key, changed);
+            assert!(!lockfile_trust_policy_file_stamp_fresh(
+                dir.path(),
+                ctx,
+                online
+            ));
+        });
+
+        // A registry change invalidates too, same as the graph key.
+        std::fs::write(
+            dir.path().join("aube-lock.yaml"),
+            "lockfileVersion: '9.0'\n",
+        )
+        .unwrap();
+        write_project_npmrc(dir.path(), "https://registry.example.test/");
+        crate::commands::with_settings_ctx(dir.path(), |ctx| {
+            let changed = lockfile_trust_policy_file_stamp_key(dir.path(), ctx, online).unwrap();
+            assert_ne!(key, changed);
+        });
     }
 
     #[test]

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -404,18 +404,34 @@ async fn validate_lockfile_trust_policy(
 }
 
 /// Cache key for the file-content trust-policy stamp the install fast
-/// path consults. Hashes the active lockfile's raw bytes plus every
-/// non-graph input the graph-shaped key hashes — the file bytes subsume
-/// the graph, so any lockfile edit (and any registry/policy change)
-/// produces a different key. Returns `None` when no lockfile exists or
-/// it can't be read.
+/// path consults. Hashes **every** lockfile present in the project plus
+/// every non-graph input the graph-shaped key hashes — the file bytes
+/// subsume the graph, so any lockfile edit (and any registry/policy
+/// change) produces a different key. Returns `None` when the project has
+/// no lockfile at all.
+///
+/// Hashing all of them rather than just the one this install parsed is
+/// deliberate: which lockfile wins depends on the embedder
+/// (`canonical_lockfile_always_wins`), and a foreign-first embedder in a
+/// project that also has an `aube-lock.yaml` would otherwise let an edit
+/// to the file it actually parsed ride a stamp keyed on the other one.
+/// Over-invalidating costs a revalidation; under-invalidating skips a
+/// security check.
 fn lockfile_trust_policy_file_stamp_key(
     cwd: &std::path::Path,
     settings_ctx: &aube_settings::ResolveCtx<'_>,
     network_mode: aube_registry::NetworkMode,
 ) -> Option<String> {
-    let lockfile_path = crate::state::active_lockfile_path(cwd)?;
-    let bytes = std::fs::read(&lockfile_path).ok()?;
+    let mut lockfiles: Vec<(String, [u8; 32])> = Vec::new();
+    for name in lockfile_stamp_candidate_names(cwd) {
+        let Ok(bytes) = std::fs::read(cwd.join(&name)) else {
+            continue;
+        };
+        lockfiles.push((name, *blake3::hash(&bytes).as_bytes()));
+    }
+    if lockfiles.is_empty() {
+        return None;
+    }
 
     let mut hasher = blake3::Hasher::new();
     hasher.update(b"aube:trust-policy-validation-file:v1\0");
@@ -450,18 +466,50 @@ fn lockfile_trust_policy_file_stamp_key(
         hasher.update(b"\x1e");
     }
 
-    hasher.update(b"\0lockfile=");
-    hasher.update(
-        lockfile_path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("")
-            .as_bytes(),
-    );
-    hasher.update(b"\x1f");
-    hasher.update(blake3::hash(&bytes).to_hex().as_bytes());
+    hasher.update(b"\0lockfiles=");
+    for (name, digest) in &lockfiles {
+        hasher.update(name.as_bytes());
+        hasher.update(b"\x1f");
+        hasher.update(digest);
+        hasher.update(b"\x1e");
+    }
 
     Some(hasher.finalize().to_hex().to_string())
+}
+
+/// Every lockfile basename that could be the one an install parses, in
+/// no particular order — the stamp key hashes all of them that exist, so
+/// precedence doesn't matter here. Mirrors `aube-lockfile`'s candidate
+/// set, including the branch-lockfile variants.
+fn lockfile_stamp_candidate_names(cwd: &std::path::Path) -> Vec<String> {
+    let basename = aube_util::embedder().lockfile_basename;
+    let stem = basename.rsplit_once('.').map_or(basename, |(s, _)| s);
+    let branch = aube_lockfile::aube_lock_filename(cwd);
+    let pnpm_branch = branch
+        .strip_prefix(&format!("{stem}."))
+        .map(|rest| format!("pnpm-lock.{rest}"));
+
+    let mut names = vec![basename.to_string()];
+    if branch != basename {
+        names.push(branch);
+    }
+    if let Some(pnpm_branch) = pnpm_branch
+        && pnpm_branch != "pnpm-lock.yaml"
+    {
+        names.push(pnpm_branch);
+    }
+    names.extend(
+        [
+            "pnpm-lock.yaml",
+            "bun.lock",
+            "yarn.lock",
+            "npm-shrinkwrap.json",
+            "package-lock.json",
+        ]
+        .into_iter()
+        .map(String::from),
+    );
+    names
 }
 
 /// True when a trust-policy validation stamp keyed on the active
@@ -2963,6 +3011,62 @@ mod trust_policy_validation_cache_tests {
             let changed = lockfile_trust_policy_file_stamp_key(dir.path(), ctx, online).unwrap();
             assert_ne!(key, changed);
         });
+    }
+
+    #[test]
+    fn trust_policy_file_stamp_tracks_every_lockfile_present() {
+        // Which lockfile an install parses depends on the embedder, so
+        // the stamp must notice an edit to *any* of them — otherwise a
+        // foreign-first embedder could ride a stamp keyed on the aube
+        // lockfile while installing a changed foreign graph.
+        let dir = tempfile::tempdir().unwrap();
+        write_project_npmrc(dir.path(), "https://registry.npmjs.org/");
+        let online = aube_registry::NetworkMode::Online;
+        let key_of = || {
+            crate::commands::with_settings_ctx(dir.path(), |ctx| {
+                lockfile_trust_policy_file_stamp_key(dir.path(), ctx, online)
+            })
+        };
+
+        std::fs::write(
+            dir.path().join("aube-lock.yaml"),
+            "lockfileVersion: '9.0'\n",
+        )
+        .unwrap();
+        let aube_only = key_of().unwrap();
+
+        // Adding a foreign lockfile changes the key...
+        std::fs::write(
+            dir.path().join("pnpm-lock.yaml"),
+            "lockfileVersion: '9.0'\n",
+        )
+        .unwrap();
+        let with_pnpm = key_of().unwrap();
+        assert_ne!(aube_only, with_pnpm);
+
+        // ...and so does editing it while the aube lockfile stands still.
+        std::fs::write(
+            dir.path().join("pnpm-lock.yaml"),
+            "lockfileVersion: '9.0'\n# drift\n",
+        )
+        .unwrap();
+        assert_ne!(with_pnpm, key_of().unwrap());
+
+        // Same for the other supported formats.
+        for name in [
+            "bun.lock",
+            "yarn.lock",
+            "npm-shrinkwrap.json",
+            "package-lock.json",
+        ] {
+            let before = key_of().unwrap();
+            std::fs::write(dir.path().join(name), "{}\n").unwrap();
+            assert_ne!(
+                before,
+                key_of().unwrap(),
+                "{name} must affect the stamp key"
+            );
+        }
     }
 
     #[test]

--- a/crates/aube/src/commands/install/startup.rs
+++ b/crates/aube/src/commands/install/startup.rs
@@ -169,11 +169,21 @@ fn trust_policy_requires_validation(cwd: &Path, opts: &InstallOptions) -> bool {
     let files = crate::commands::FileSources::load(cwd);
     let raw_workspace = aube_manifest::workspace::load_raw(cwd).unwrap_or_default();
     let ctx = files.ctx(&raw_workspace, &opts.env_snapshot, &opts.cli_flags);
-    aube_settings::resolved::paranoid(&ctx)
-        || matches!(
-            aube_settings::resolved::trust_policy(&ctx),
-            aube_settings::resolved::TrustPolicy::NoDowngrade
-        )
+    // `paranoid` bundles more than trustPolicy (strict advisory checks,
+    // strict store integrity, ...), so it always takes the full pipeline.
+    if aube_settings::resolved::paranoid(&ctx) {
+        return true;
+    }
+    if !matches!(
+        aube_settings::resolved::trust_policy(&ctx),
+        aube_settings::resolved::TrustPolicy::NoDowngrade
+    ) {
+        return false;
+    }
+    // Validation already ran for this exact lockfile content within the
+    // stamp TTL — the full pipeline would reuse that stamp and do no
+    // network work, so the warm fast path may skip it the same way.
+    !super::lockfile_trust_policy_file_stamp_fresh(cwd, &ctx, opts.network_mode)
 }
 
 pub(super) fn emit_up_to_date(cwd: &Path) {

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -1069,6 +1069,13 @@ pub fn remove_state(project_dir: &Path) -> Result<(), std::io::Error> {
 ///
 /// Returns the display name (for messages) plus the resolved path, if
 /// any exists.
+/// Path of the lockfile [`check_needs_install`] treats as active, if
+/// any. The install fast path keys the trust-policy file stamp on this
+/// same file so both checks agree on which lockfile governs the project.
+pub(crate) fn active_lockfile_path(project_dir: &Path) -> Option<PathBuf> {
+    active_lockfile(project_dir).1
+}
+
 fn active_lockfile(project_dir: &Path) -> (String, Option<PathBuf>) {
     let basename = aube_util::embedder().lockfile_basename;
     let stem = basename.rsplit_once('.').map_or(basename, |(s, _)| s);

--- a/crates/aube/src/state.rs
+++ b/crates/aube/src/state.rs
@@ -1069,13 +1069,6 @@ pub fn remove_state(project_dir: &Path) -> Result<(), std::io::Error> {
 ///
 /// Returns the display name (for messages) plus the resolved path, if
 /// any exists.
-/// Path of the lockfile [`check_needs_install`] treats as active, if
-/// any. The install fast path keys the trust-policy file stamp on this
-/// same file so both checks agree on which lockfile governs the project.
-pub(crate) fn active_lockfile_path(project_dir: &Path) -> Option<PathBuf> {
-    active_lockfile(project_dir).1
-}
-
 fn active_lockfile(project_dir: &Path) -> (String, Option<PathBuf>) {
     let basename = aube_util::embedder().lockfile_basename;
     let stem = basename.rsplit_once('.').map_or(basename, |(s, _)| s);

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -2750,7 +2750,8 @@ its own name to; this setting takes a complete path instead, so
 
 The global virtual store (`<cacheDir>/virtual-store/`) and cached
 packument metadata (`<cacheDir>/packuments-v1/`,
-`<cacheDir>/packuments-full-v1/`) live under this directory. The
+`<cacheDir>/packuments-full-v1/`, and the `trustPolicy` trust histories
+in `<cacheDir>/trust-history-v1/`) live under this directory. The
 content-addressable store is *not* here — it is `storeDir`, which
 defaults under `$XDG_DATA_HOME` instead. A few smaller caches (the OSV
 advisory mirror, the bootstrapped `node-gyp`, git clones) still follow


### PR DESCRIPTION
## Why

Profiling the cold-install gap against [benchmarks.vlt.sh](https://benchmarks.vlt.sh/) turned up an unexpected dominant cost: the lockfile trust-policy validator, not the download pipeline.

`trustPolicy=no-downgrade` is the default, and on any cold cache `validate_lockfile_trust_policy` fetched a **full** packument for every package name in the locked graph, then round-tripped each one through `serde_json::Value` — parse to `Value`, re-serialize into `packuments-full-v1/`, then `from_value` into a typed `Packument`. On the gvs benchmark fixture that is ~482 MiB of JSON decoded, re-encoded, and written to disk, all to read `time` plus three per-version evidence fields.

An A/B against the hermetic registry made the scale clear (1225 packages, 500mbit/50ms, cold caches):

| | total | resolve phase |
|---|---|---|
| default (`no-downgrade`) | ~9.1s | ~6.2s |
| `trust_policy=off` | ~2.9s | ~16ms |

## What changed

**Decode and cache only what the check reads.** `PackumentTrustHistory` already existed for the resolver's compact path; this points the lockfile validator at it too, via a new `fetch_trust_history_cached` that decodes the response in a single streaming pass (no `Value`) and caches that compact shape in `trust-history-v1/` with the same ETag/`Cache-Control` revalidation envelope as the packument caches. The graph is grouped by registry name, so one fetch covers every locked version of a package.

`check_no_downgrade_compact` and the new `check_no_downgrade_history` now share one ranking core — the only difference is whether the picked version appears in the history map (the loop skips it either way).

**Let the install fast path see a fresh stamp.** `trustPolicy != off` previously made every online `aube install` ineligible for the warm no-op path, *before* the state check ran — so the default configuration could never reach it. It now consults a validation stamp keyed on the active lockfile's bytes: if validation already ran for this exact lockfile within the TTL, the full pipeline would have reused that stamp and done no network work, so the fast path may skip it too.

The fast path still requires `check_needs_install`, and that is load-bearing rather than incidental: the validated graph has platform rules applied, and the manifest / workspace YAML / settings that drive that filtering are exactly what the state check hashes. A widened `supportedArchitectures` therefore re-validates instead of riding a stamp that never saw the newly-included packages. There's a comment on `lockfile_trust_policy_file_stamp_fresh` saying so.

## Measured

Same fixture and harness, median of 5 interleaved runs, baseline = `main` binary:

| | before | after |
|---|---|---|
| resolve phase | 6.1s | 5.4s |
| cache on disk | 739 MB | 381 MB |

Wire bytes are **unchanged** — the check still needs a full packument body per name — so what's left is request latency across ~1100 metadata GETs, not parsing. That's the next thing to go after, along with the fetch-phase items below; this PR deliberately stops at the parse/serialize/disk half.

## Not in scope

Follow-ups this analysis turned up, filed here so they aren't lost:

- **Durable per-version evidence.** A 5-minute stamp means real users re-validate the whole closure constantly. Persisting validated `(name, version)` evidence would make this incremental and would cut the wire cost this PR leaves untouched — the largest remaining win in this area.
- **Metadata request latency.** What's left of the resolve phase is ~1100 metadata GETs at 50ms, bounded by `default_lockfile_network_concurrency()` rather than bandwidth. Worth a look, though it shares a default with the resolver's packument fetches, so it isn't a one-line change.

(The virtual-store relocation and the tarball concurrency ceiling from the same investigation went out as #1401, which you closed — not repeating them here.)

## Testing

- `cargo test` — full suite green.
- `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` — clean.
- `mise run test:bats test/pnpm_install_misc.bats` — all 7 `trustPolicy` tests pass, including *"lockfile reuse still validates trust evidence"*, the case this PR reworks. (Tests 7–10 in that file fail identically on `main` in this environment — a broken `node` shim under bats' isolated `HOME`, unrelated.)
- New unit tests: `standalone_history_detects_downgrade_and_skips_picked_version` (resolver) and `trust_policy_file_stamp_tracks_lockfile_bytes_and_registry` (CLI — covers no-lockfile, byte drift, and registry change).

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the trust-policy validation and install fast-path gating paths; stamp keying is deliberately conservative, but any bug could skip or weaken no-downgrade checks.
> 
> **Overview**
> Lockfile **`trustPolicy=no-downgrade`** validation no longer pulls and caches **full packuments** per locked `(name, version)`. It now fetches **one compact trust history per registry name** via **`fetch_trust_history_cached`**, decodes only `PackumentTrustHistory`, and persists it under **`trust-history-v1/`** with the same ETag/`Cache-Control` revalidation envelope as packument caches—avoiding the `serde_json::Value` round-trip and multi‑MB **`packuments-full-v1/`** writes on cold runs.
> 
> The install validator groups locked versions by name and runs **`check_no_downgrade_history`**; resolver trust checks share a new **`check_no_downgrade_over_history`** core with the existing compact path.
> 
> **Install fast path:** when `no-downgrade` is on, online installs can skip re-validation if a **file-content stamp** (lockfile bytes, registry/scoped registries, trust exclude/ignore settings, network mode) is still within the existing validation TTL—only when validation would have been a cache hit anyway. Stamps hash **every** candidate lockfile in the project so edits to a non-primary lockfile cannot bypass checks.
> 
> Docs/settings note the new cache subdirectory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e74a960a55f33b78f5e10deed4677b2aca877425. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->