### PR TITLE
fix(install): verify the already-linked shortcut against the expected target

### DIFF
--- a/crates/aube/src/commands/install/fetch.rs
+++ b/crates/aube/src/commands/install/fetch.rs
@@ -389,8 +389,8 @@ pub(in crate::commands) async fn fetch_packages(
 ) -> miette::Result<(BTreeMap<String, aube_store::PackageIndex>, usize, usize)> {
     // Eager-client caller (`aube fetch`): the command only exists to
     // download tarballs, so there's no point deferring construction.
-    // `skip_already_linked_shortcut=true` because `aube fetch`'s entire
-    // job is to verify/populate the global store — it must not be
+    // No already-linked shortcut because `aube fetch`'s entire job is
+    // to verify/populate the global store — it must not be
     // short-circuited by a stale `node_modules/.aube/<dep>` from a
     // prior install, which could leave the store empty on a setup
     // that wipes the global aube store but not `node_modules/` (e.g.
@@ -426,7 +426,7 @@ pub(in crate::commands) async fn fetch_packages(
         &aube_dir,
         &packument_cache_dir(),
         /*materialize_tx=*/ None,
-        /*skip_already_linked_shortcut=*/ true,
+        /*already_linked_shortcut=*/ None,
         /*force_index_dep_paths=*/ &std::collections::BTreeSet::new(),
         virtual_store_dir_max_length,
         ignore_scripts,
@@ -467,23 +467,26 @@ pub(super) async fn fetch_packages_with_root<F>(
     // batch finishes. None keeps batch-then-return for `aube fetch`.
     // Sender drops on function exit so consumer sees channel close.
     materialize_tx: Option<tokio::sync::mpsc::Sender<(String, aube_store::PackageIndex)>>,
-    // When true, every package classifies as `Cached` or `NeedsFetch`
-    // based on `store.load_index`, regardless of whether
-    // `.aube/<dep>` already exists on disk. Callers pass true when
-    // either:
+    // The virtual-store layout the linker will produce, when the
+    // already-linked shortcut is in play. `Some` lets a package whose
+    // `.aube/<dep>` entry already matches what the linker expects skip
+    // the store index entirely; `None` disables the shortcut, so every
+    // package classifies as `Cached` or `NeedsFetch` through
+    // `store.load_index_verified` regardless of what is on disk.
     //
-    //   - the linker will need a verified index for packages this
-    //     shortcut would skip (`link_workspace`); or
-    //   - the caller needs `load_index` to actually run as its store
-    //     verification step (`aube fetch`, which treats the act of
-    //     walking the store-file existence check as the operation's
-    //     primary side effect).
+    // Callers pass `None` when either:
     //
-    // Both cases share the same implementation: skip the `.aube/`
-    // existence check entirely so every package goes through
-    // `store.load_index` → either `Cached` (store has it) or
-    // `NeedsFetch` (store is missing the file, download fresh).
-    skip_already_linked_shortcut: bool,
+    //   - the shortcut has not been turned on for that install shape
+    //     yet. Workspaces are the live case: `link_workspace`'s step 1b
+    //     mirrors `link_all`'s state machine exactly, so the
+    //     classification below is as sound there as it is here, but
+    //     switching monorepos over is a perf change that wants its own
+    //     measurement rather than a ride on a correctness fix; or
+    //   - the caller needs the verified index load to actually run as
+    //     its store verification step (`aube fetch`, which treats the
+    //     act of walking the store-file existence check as the
+    //     operation's primary side effect).
+    already_linked_shortcut: Option<&super::materialize::VirtualStorePlan>,
     // Packages selected for project-local compatibility materialization
     // need an index even when their prior GVS entry still exists.
     force_index_dep_paths: &std::collections::BTreeSet<String>,
@@ -507,8 +510,8 @@ where
 {
     let packument_cache_dir = packument_cache_dir.to_path_buf();
     // No-op fast path: for every package whose per-project
-    // `node_modules/.aube/<dep_path>` entry already resolves to an
-    // existing target, skip the package-index load entirely. The
+    // `node_modules/.aube/<dep_path>` entry is already the one the
+    // linker will accept, skip the package-index load entirely. The
     // linker's only consumer of a `PackageIndex` is
     // `materialize_into` — if the package is already materialized
     // (either as a real directory here in per-project mode, or as a
@@ -519,50 +522,27 @@ where
     // fixture drops from ~38 ms of parallel index reads to a handful
     // of `stat(2)`s.
     //
-    // Two call sites disable the fast path entirely via
-    // `skip_already_linked_shortcut=true`:
+    // "The one the linker will accept" is what
+    // `VirtualStorePlan::entry_is_current` decides, and it is stricter
+    // than mere resolvability. Under the global virtual store the
+    // local `.aube/<dep_path>` name is keyed by dep_path alone while
+    // the shared subdir folds in graph hashes (`aube_dir_entry_name`
+    // vs `virtual_store_subdir`), so a build-state change moves the
+    // expected target while the entry keeps resolving to the old one.
+    // A shortcut keyed on resolvability alone would classify that
+    // package `AlreadyLinked`; `classify_entry_state` would then report
+    // `Stale`, the linker would need an index it was never handed, and
+    // its fallback is the *unverified* `store.load_index` — which
+    // happily returns a stale index whose CAS shards are gone, failing
+    // the link instead of re-fetching. Comparing against the expected
+    // subdir keeps that case self-healing: it misses the shortcut,
+    // takes the verified index load below, and a stale index drops to
+    // `NeedsFetch` so the tarball is re-downloaded while the network is
+    // still available. The linker has no such option — only fetch can
+    // re-download, which is why the check belongs here.
     //
-    //   - **Workspace installs.** The shortcut's precondition ("the
-    //     entry resolves") is weaker than what the linker actually
-    //     needs ("the entry resolves *to the target this graph
-    //     expects*"). The local `.aube/<dep_path>` name is keyed by
-    //     dep_path alone, while the global virtual-store subdir folds
-    //     in graph hashes (`virtual_store_subdir` vs
-    //     `aube_dir_entry_name`), so a build-state change moves the
-    //     expected target while the entry keeps resolving to the old
-    //     one. `classify_entry_state` then reports `Stale`, the linker
-    //     needs an index it was never handed, and its fallback is the
-    //     *unverified* `store.load_index` — which happily returns a
-    //     stale index whose CAS shards are gone, failing the link
-    //     instead of re-fetching. Verifying every package here keeps
-    //     that self-healing (a stale index drops to `NeedsFetch` and
-    //     the tarball is re-downloaded while the network is still
-    //     available; the linker has no such option).
-    //
-    //     Enabling the shortcut for workspaces is worth doing — it is
-    //     a stat per store file per package on every repeat install of
-    //     a monorepo — but only once the classification compares
-    //     against the expected virtual-store subdir, which needs the
-    //     graph hashes that are currently computed inside the
-    //     concurrent prewarm task rather than before this call.
-    //
-    //   - **`aube fetch`.** The command exists to populate the
-    //     global store (typical use: Docker layer caching, warming
-    //     a CI mirror, or recovering from a wiped aube store).
-    //     If `node_modules/.aube/<dep>` happens to exist from a
-    //     previous install, the `AlreadyLinked` shortcut would skip
-    //     both `load_index` and the tarball fetch — which silently
-    //     leaves the store empty even though the user explicitly
-    //     asked for it to be repopulated. Disabling the shortcut
-    //     makes every package flow through `store.load_index`,
-    //     which does a first-file existence check on the CAS and
-    //     correctly downgrades to `NeedsFetch` when the store entry
-    //     has been wiped.
-    //
-    // `Path::exists` follows symlinks, so a per-project entry pointing
-    // at a global virtual-store target that no longer exists correctly
-    // falls through to the slow path. The linker re-derives the entry
-    // name through `aube_dir_entry_name(dep_path)`, which is just
+    // The linker re-derives the entry name through
+    // `aube_dir_entry_name(dep_path)`, which is just
     // `dep_path_to_filename(dep_path, max_length)` — we take the max
     // length as a parameter (instead of reaching for
     // `DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH`) so the fast path checks
@@ -593,9 +573,16 @@ where
         .par_iter()
         .filter(|(_, pkg)| pkg.local_source.is_none())
         .map(|(dep_path, pkg)| {
-            if !skip_already_linked_shortcut && !force_index_dep_paths.contains(dep_path) {
+            // `force_index_dep_paths` is the project-local closure the
+            // linker materializes as real directories rather than
+            // shared-store symlinks, so its freshness test is a
+            // different one; those always take the verified path.
+            if let Some(plan) = already_linked_shortcut
+                && !force_index_dep_paths.contains(dep_path)
+            {
                 let entry_name = dep_path_to_filename(dep_path, virtual_store_dir_max_length);
-                if aube_dir.join(&entry_name).exists() {
+                let entry = aube_dir.join(&entry_name);
+                if plan.entry_is_current(&entry, dep_path, virtual_store_dir_max_length) {
                     return (dep_path.clone(), pkg, CheckResult::AlreadyLinked);
                 }
             }

--- a/crates/aube/src/commands/install/materialize.rs
+++ b/crates/aube/src/commands/install/materialize.rs
@@ -1,8 +1,8 @@
+use aube_lockfile::dep_path_filename::dep_path_to_filename;
 use miette::{Context, IntoDiagnostic, miette};
 
 // Inputs for the GVS-prewarm materializer task. Built once before
 // fetch starts, moved into spawned task.
-#[allow(clippy::too_many_arguments)]
 pub(super) struct GvsPrewarmInputs {
     pub graph: std::sync::Arc<aube_lockfile::LockfileGraph>,
     pub store: std::sync::Arc<aube_store::Store>,
@@ -11,10 +11,180 @@ pub(super) struct GvsPrewarmInputs {
     pub link_strategy: aube_linker::LinkStrategy,
     pub link_concurrency: Option<usize>,
     pub patches: aube_linker::Patches,
+    pub use_global_virtual_store_override: Option<bool>,
+    pub virtual_store_plan: VirtualStorePlan,
+}
+
+/// Where this install materializes package trees, decided before the
+/// fetch phase starts.
+///
+/// The fetch phase's already-linked shortcut skips a package's store
+/// index whenever its `node_modules/.aube/<dep_path>` entry is one the
+/// linker will accept as-is, and deciding that needs the layout. Under
+/// the global virtual store the local entry name is keyed by dep_path
+/// alone (`aube_dir_entry_name`) while the shared subdir folds in graph
+/// hashes (`virtual_store_subdir`), so a build-state change moves the
+/// expected target while the entry keeps *resolving* to the old one.
+/// The linker classifies such an entry `Stale`, needs a `PackageIndex`
+/// the fetch phase never handed it, and its only fallback is the
+/// *unverified* `store.load_index` — which returns a stale index whose
+/// CAS shards are gone and fails the link. The linker cannot
+/// re-download; only fetch can. So the comparison happens there,
+/// against these hashes, and a package that fails it falls through to
+/// the verified index load that re-fetches when the store has drifted.
+#[derive(Clone)]
+pub(super) enum VirtualStorePlan {
+    /// `.aube/<dep_path>` entries are symlinks into the shared store at
+    /// `virtual_store`, under subdir names derived from `hashes`.
+    Global {
+        virtual_store: std::path::PathBuf,
+        hashes: std::sync::Arc<aube_lockfile::graph_hash::GraphHashes>,
+    },
+    /// `.aube/<dep_path>` entries are per-project directories keyed by
+    /// dep_path alone, so their existence *is* the linker's freshness
+    /// test and there is no shared target to compare against.
+    PerProject,
+}
+
+impl VirtualStorePlan {
+    /// Whether `entry` is a `node_modules/.aube/<dep_path>` the linker
+    /// will reuse without a `PackageIndex`. Mirrors `aube-linker`'s own
+    /// freshness tests: `classify_entry_state` under the global virtual
+    /// store (the stored target must be the subdir this graph expects
+    /// *and* still exist) and the plain existence check the per-project
+    /// materializer uses.
+    pub(super) fn entry_is_current(
+        &self,
+        entry: &std::path::Path,
+        dep_path: &str,
+        virtual_store_dir_max_length: usize,
+    ) -> bool {
+        match self {
+            Self::Global {
+                virtual_store,
+                hashes,
+            } => {
+                let expected = virtual_store.join(dep_path_to_filename(
+                    &hashes.hashed_dep_path(dep_path),
+                    virtual_store_dir_max_length,
+                ));
+                // `read_link` then `exists`: the link has to name the
+                // target this graph expects, and that target has to be
+                // there. `exists` follows the link, so a dangling entry
+                // is a miss.
+                matches!(std::fs::read_link(entry), Ok(target) if target == expected)
+                    && entry.exists()
+            }
+            Self::PerProject => entry.exists(),
+        }
+    }
+
+    /// The graph hashes, when this install uses the global virtual
+    /// store. `None` in per-project mode, where nothing reads them.
+    fn hashes(&self) -> Option<&std::sync::Arc<aube_lockfile::graph_hash::GraphHashes>> {
+        match self {
+            Self::Global { hashes, .. } => Some(hashes),
+            Self::PerProject => None,
+        }
+    }
+}
+
+/// Everything [`plan_virtual_store`] needs to name each package's
+/// virtual-store subdir. Mirrors the inputs the link phase folds into
+/// `compute_graph_hashes_full`, minus the per-package content
+/// fingerprints — those depend on trees the fetch phase hasn't imported
+/// yet, so a source-backed dep and its ancestors simply miss the
+/// already-linked shortcut and take the verified path instead.
+pub(super) struct VirtualStorePlanInputs<'a> {
+    pub graph: &'a std::sync::Arc<aube_lockfile::LockfileGraph>,
+    pub store: &'a aube_store::Store,
+    pub link_strategy: aube_linker::LinkStrategy,
+    pub virtual_store_dir_max_length: usize,
+    pub use_global_virtual_store_override: Option<bool>,
     pub patch_hashes: std::collections::BTreeMap<String, String>,
     pub node_version: Option<String>,
     pub build_policy: std::sync::Arc<aube_scripts::BuildPolicy>,
-    pub use_global_virtual_store_override: Option<bool>,
+}
+
+/// Decide the virtual-store layout and, under the global virtual
+/// store, compute the graph hashes that name every package's subdir.
+///
+/// This runs before the fetch phase rather than inside the prewarm
+/// task that overlaps it, because the already-linked shortcut needs the
+/// hashes to classify an entry correctly (see [`VirtualStorePlan`]).
+/// The prewarm and link phases then reuse the same `Arc` instead of
+/// repeating the walk, so the only cost is that on the lockfile-reuse
+/// path the walk no longer hides behind the fetch tail. Measured on a
+/// warm install of the 1.4k-package medium fixture (debug build): the
+/// fetch phase goes 5.1 ms -> 7.7 ms, the prewarm loses the matching
+/// 1.7 ms `hash_await`, and total install time is unchanged inside
+/// run-to-run noise. The cold-resolve path pays nothing at all — its
+/// tarball fetch is already in flight by the time this is called.
+pub(super) async fn plan_virtual_store(
+    inputs: VirtualStorePlanInputs<'_>,
+) -> miette::Result<VirtualStorePlan> {
+    let VirtualStorePlanInputs {
+        graph,
+        store,
+        link_strategy,
+        virtual_store_dir_max_length,
+        use_global_virtual_store_override,
+        patch_hashes,
+        node_version,
+        build_policy,
+    } = inputs;
+
+    // Probe linker built exactly the way the prewarm and link phases
+    // build theirs, so all three agree on whether the global virtual
+    // store is in play.
+    let mut probe = aube_linker::Linker::new(store, link_strategy)
+        .with_virtual_store_dir_max_length(virtual_store_dir_max_length);
+    if let Some(enabled) = use_global_virtual_store_override {
+        probe = probe.with_use_global_virtual_store(enabled);
+    }
+    if !probe.uses_global_virtual_store() {
+        return Ok(VirtualStorePlan::PerProject);
+    }
+    let virtual_store = store.virtual_store_dir();
+
+    let engine = node_version
+        .as_deref()
+        .map(aube_lockfile::graph_hash::engine_name_default);
+    let graph = graph.clone();
+    aube_util::diag::instant(
+        aube_util::diag::Category::Materialize,
+        "hash_compute_spawn",
+        None,
+    );
+    // CPU-bound BLAKE3 walk over every package; keep it off the tokio
+    // worker so the caller's remaining setup keeps making progress.
+    let hashes = tokio::task::spawn_blocking(move || {
+        let _diag = aube_util::diag::Span::new(
+            aube_util::diag::Category::Materialize,
+            "graph_hash_compute",
+        );
+        let allow = |pkg: &aube_lockfile::LockedPackage| {
+            super::package_build_is_allowed(&build_policy, pkg)
+        };
+        let patch_hash_fn = |name: &str, version: &str| -> Option<String> {
+            let key = format!("{name}@{version}");
+            patch_hashes.get(&key).cloned()
+        };
+        aube_lockfile::graph_hash::compute_graph_hashes_with_patches(
+            &graph,
+            &allow,
+            engine.as_ref(),
+            &patch_hash_fn,
+        )
+    })
+    .await
+    .into_diagnostic()
+    .wrap_err("graph_hash compute task failed")?;
+
+    Ok(VirtualStorePlan::Global {
+        virtual_store,
+        hashes: std::sync::Arc::new(hashes),
+    })
 }
 
 /// Initial capacity for the (canonical_key, PackageIndex) channel
@@ -103,64 +273,21 @@ pub(super) async fn run_gvs_prewarm_materializer(
         link_strategy,
         link_concurrency,
         patches,
-        patch_hashes,
-        node_version,
-        build_policy,
         use_global_virtual_store_override,
+        virtual_store_plan,
     } = inputs;
 
-    let engine = node_version
-        .as_deref()
-        .map(aube_lockfile::graph_hash::engine_name_default);
-
-    // Build a probe linker without graph_hashes to check GVS mode
-    // first. compute_graph_hashes_with_patches walks every package
-    // BLAKE3-style, expensive on huge graphs. Skip it when GVS is
-    // off so per-project installs and cold CI (CI=true gates GVS)
-    // don't pay for hashes nothing reads.
+    // Same builder state `plan_virtual_store` probed with, so
+    // `virtual_store_plan` and this linker agree on the layout.
     let mut probe = aube_linker::Linker::new(store.as_ref(), link_strategy)
         .with_virtual_store_dir_max_length(virtual_store_dir_max_length);
     if let Some(enabled) = use_global_virtual_store_override {
         probe = probe.with_use_global_virtual_store(enabled);
     }
-    if !probe.uses_global_virtual_store() {
+    let Some(graph_hashes_arc) = virtual_store_plan.hashes().cloned() else {
         return run_aube_dir_materializer(probe, graph, cwd, link_concurrency, materialize_rx)
             .await;
-    }
-
-    // Hash compute walks every package BLAKE3-style. spawn_blocking
-    // pushes it off the tokio worker so the canonical_to_contextualized
-    // build below + nested_link_targets walk + first materialize_rx
-    // recv keep making progress in parallel. compute_graph_hashes_with_patches
-    // is CPU-bound and was previously blocking the executor.
-    let graph_for_hash = graph.clone();
-    let build_policy_for_hash = build_policy.clone();
-    let engine_for_hash = engine.clone();
-    let patch_hashes_for_hash = patch_hashes.clone();
-    aube_util::diag::instant(
-        aube_util::diag::Category::Materialize,
-        "hash_compute_spawn",
-        None,
-    );
-    let hash_handle = tokio::task::spawn_blocking(move || {
-        let _diag = aube_util::diag::Span::new(
-            aube_util::diag::Category::Materialize,
-            "graph_hash_compute",
-        );
-        let allow = |pkg: &aube_lockfile::LockedPackage| {
-            super::package_build_is_allowed(&build_policy_for_hash, pkg)
-        };
-        let patch_hash_fn = |name: &str, version: &str| -> Option<String> {
-            let key = format!("{name}@{version}");
-            patch_hashes_for_hash.get(&key).cloned()
-        };
-        aube_lockfile::graph_hash::compute_graph_hashes_with_patches(
-            &graph_for_hash,
-            &allow,
-            engine_for_hash.as_ref(),
-            &patch_hash_fn,
-        )
-    });
+    };
 
     let nested_link_targets =
         aube_linker::build_nested_link_targets(&cwd, &graph).map(std::sync::Arc::new);
@@ -200,19 +327,11 @@ pub(super) async fn run_gvs_prewarm_materializer(
     // final content-ful path.
     let content_affected = aube_lockfile::graph_hash::content_affected_dep_paths(&graph);
 
-    let _diag_hash_wait =
-        aube_util::diag::Span::new(aube_util::diag::Category::Materialize, "hash_await");
-    let graph_hashes = hash_handle
-        .await
-        .into_diagnostic()
-        .wrap_err("graph_hash compute task failed")?;
-    drop(_diag_hash_wait);
     aube_util::diag::instant(
         aube_util::diag::Category::Materialize,
         "drain_rx_begin",
         None,
     );
-    let graph_hashes_arc = std::sync::Arc::new(graph_hashes);
     let mut linker = probe.with_graph_hashes((*graph_hashes_arc).clone());
     if !patches.is_empty() {
         linker = linker.with_patches(patches);

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -72,7 +72,8 @@ use lockfile_dir::{
     parse_lockfile_dir_remapped_with_kind_and_options, write_lockfile_dir_remapped,
 };
 use materialize::{
-    GvsPrewarmInputs, combine_install_pipeline_errors, materialize_channel, spawn_gvs_prewarm,
+    GvsPrewarmInputs, VirtualStorePlanInputs, combine_install_pipeline_errors, materialize_channel,
+    plan_virtual_store, spawn_gvs_prewarm,
 };
 pub(crate) use settings::PeerDependencyRules;
 pub(crate) use settings::resolve_catalog_prune;
@@ -1207,26 +1208,39 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
             let (lock_patches, lock_patch_hashes) =
                 crate::patches::load_patches_for_linker(&cwd, &graph.patched_dependencies)?;
             let (lock_materialize_tx, lock_materialize_rx) = materialize_channel();
-            let lock_materialize_graph = filter_graph_for_install(
+            let lock_materialize_graph = std::sync::Arc::new(filter_graph_for_install(
                 &cwd,
                 &workspace_packages,
                 &graph,
                 &opts,
                 has_workspace && !link_all_workspace_importers,
                 false,
-            )?;
+            )?);
+            // Hoisted out of the prewarm task (where it used to run
+            // concurrently with fetch) because the already-linked
+            // shortcut below cannot classify an entry without it. The
+            // prewarm and link phases reuse the same hashes.
+            let lock_virtual_store_plan = plan_virtual_store(VirtualStorePlanInputs {
+                graph: &lock_materialize_graph,
+                store: &store,
+                link_strategy: lock_strategy,
+                virtual_store_dir_max_length,
+                use_global_virtual_store_override,
+                patch_hashes: lock_patch_hashes,
+                node_version: lock_node_version,
+                build_policy: lock_build_policy,
+            })
+            .await?;
             let lock_prewarm_inputs = GvsPrewarmInputs {
-                graph: std::sync::Arc::new(lock_materialize_graph),
+                graph: lock_materialize_graph,
                 store: store.clone(),
                 cwd: cwd.clone(),
                 virtual_store_dir_max_length,
                 link_strategy: lock_strategy,
                 link_concurrency: link_concurrency_setting,
                 patches: lock_patches,
-                patch_hashes: lock_patch_hashes,
-                node_version: lock_node_version,
-                build_policy: lock_build_policy,
                 use_global_virtual_store_override,
+                virtual_store_plan: lock_virtual_store_plan.clone(),
             };
             let lock_materialize_handle =
                 spawn_gvs_prewarm(lock_prewarm_inputs, lock_materialize_rx);
@@ -1249,8 +1263,9 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
                 &aube_dir,
                 &packument_cache_dir,
                 Some(lock_materialize_tx),
-                /*skip_already_linked_shortcut=*/
-                has_workspace || explicit_store_dir_override,
+                /*already_linked_shortcut=*/
+                (!(has_workspace || explicit_store_dir_override))
+                    .then_some(&lock_virtual_store_plan),
                 &lock_project_local_dep_paths,
                 virtual_store_dir_max_length,
                 opts.ignore_scripts,
@@ -2012,6 +2027,20 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
             let materialize_strategy = resolve_link_strategy(&cwd, &settings_ctx, planned_gvs)?;
             let (materialize_patches, materialize_patch_hashes) =
                 crate::patches::load_patches_for_linker(&cwd, &graph.patched_dependencies)?;
+            // Shared with the catch-up fetch below, which needs it to
+            // classify already-linked packages the same way the linker
+            // will.
+            let materialize_virtual_store_plan = plan_virtual_store(VirtualStorePlanInputs {
+                graph: &materialize_graph_arc,
+                store: &store,
+                link_strategy: materialize_strategy,
+                virtual_store_dir_max_length,
+                use_global_virtual_store_override,
+                patch_hashes: materialize_patch_hashes,
+                node_version: node_version_for_prewarm.clone(),
+                build_policy: build_policy_for_prewarm.clone(),
+            })
+            .await?;
             let materialize_inputs = GvsPrewarmInputs {
                 graph: materialize_graph_arc.clone(),
                 store: store.clone(),
@@ -2020,10 +2049,8 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
                 link_strategy: materialize_strategy,
                 link_concurrency: link_concurrency_setting,
                 patches: materialize_patches,
-                patch_hashes: materialize_patch_hashes,
-                node_version: node_version_for_prewarm.clone(),
-                build_policy: build_policy_for_prewarm.clone(),
                 use_global_virtual_store_override,
+                virtual_store_plan: materialize_virtual_store_plan.clone(),
             };
             aube_util::diag::instant(
                 aube_util::diag::Category::Install,
@@ -2299,8 +2326,9 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
                         &aube_dir,
                         &packument_cache_dir,
                         /*materialize_tx=*/ None,
-                        /*skip_already_linked_shortcut=*/
-                        has_workspace || explicit_store_dir_override,
+                        /*already_linked_shortcut=*/
+                        (!(has_workspace || explicit_store_dir_override))
+                            .then_some(&materialize_virtual_store_plan),
                         &project_local_dep_paths,
                         virtual_store_dir_max_length,
                         opts.ignore_scripts,

--- a/test/install_reuse_regressions.bats
+++ b/test/install_reuse_regressions.bats
@@ -58,6 +58,28 @@ _assert_installed_is_odd() {
 	assert_output --partial '3.0.1'
 }
 
+_setup_single_fixture() {
+	cat >package.json <<'JSON'
+{
+  "name": "single-root",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "is-odd": "3.0.1"
+  }
+}
+JSON
+}
+
+# Single-project counterpart of `_assert_installed_is_odd`: the root
+# importer's own `node_modules/` is the tree under test.
+_assert_installed_is_odd_root() {
+	run cat node_modules/is-odd/package.json
+	assert_success
+	assert_output --partial '"is-odd"'
+	assert_output --partial '3.0.1'
+}
+
 @test "workspace install rebuilds a removed virtual store entry" {
 	# The shortcut keys off `Path::exists`, which follows symlinks, so a
 	# `.aube/<dep>` entry whose target is gone must NOT classify as
@@ -181,6 +203,55 @@ _assert_installed_is_odd() {
 	assert_file_exists "$victim"
 	assert_dir_exists "$expected"
 	_assert_installed_is_odd
+}
+
+@test "install self-heals a stale index when the entry resolves elsewhere" {
+	# Non-workspace form of the test above, and the one the shortcut is
+	# actually enabled for. It used to fail with "failed to link
+	# node_modules" on every retry: the shortcut classified the package
+	# `AlreadyLinked` because its `.aube/<dep>` entry merely *resolved*,
+	# so the linker was handed no index, found the entry `Stale` against
+	# the target this graph expects, and fell back to the *unverified*
+	# `store.load_index` — a stale index whose CAS shards are gone. Only
+	# the fetch phase can re-download, so nothing recovered.
+	#
+	# The shortcut now compares the entry's target against the expected
+	# virtual-store subdir, so this package misses it, takes the verified
+	# index load, drops to `NeedsFetch`, and the store, the expected
+	# target and the link are all restored.
+	_setup_single_fixture
+
+	run aube install
+	assert_success
+
+	entry="node_modules/.aube/is-odd@3.0.1"
+	expected="$(readlink "$entry")"
+	[ -n "$expected" ]
+
+	store_v1="$(aube store path)"
+	index="$(find "$store_v1/index" -name 'is-odd@*' -print -quit)"
+	[ -n "$index" ]
+	# Remove a NON-first CAS shard so the cheap first-file probe inside
+	# `load_index` still succeeds and only the verified walk catches it.
+	victim="$(grep -o '"store_path":"[^"]*"' "$index" | sed -n '2p' | sed 's/.*":"//;s/"$//')"
+	[ -n "$victim" ]
+	rm -f "$victim"
+
+	# Point the entry at a directory that exists but is not the target
+	# this graph expects, and remove the expected target.
+	decoy="$TEST_TEMP_DIR/decoy"
+	mkdir -p "$decoy/node_modules"
+	cp -r "$expected/node_modules/is-odd" "$decoy/node_modules/" 2>/dev/null || true
+	rm -rf "${expected:?}"
+	rm -f "$entry"
+	ln -s "$decoy" "$entry"
+	[ -e "$entry" ]
+
+	run aube install
+	assert_success
+	assert_file_exists "$victim"
+	assert_dir_exists "$expected"
+	_assert_installed_is_odd_root
 }
 
 @test "workspace install with a changed store-dir produces a correct tree" {


### PR DESCRIPTION
## The bug

A non-workspace `aube install` could fail with `failed to link node_modules` and never self-heal — every retry took the same broken path.

The fetch phase's already-linked shortcut classified a package `AlreadyLinked` whenever its `node_modules/.aube/<dep_path>` entry merely *resolved*. But the local entry name is keyed by dep_path alone (`aube_dir_entry_name`) while the virtual-store subdir folds in graph hashes (`virtual_store_subdir`), so a build-state change moves the expected target while the entry keeps resolving to the old one. `classify_entry_state` then reports `Stale`, the linker needs a `PackageIndex` it was never handed, and its only fallback is the *unverified* `store.load_index` — which returns a stale index whose CAS shards are gone:

```
× failed to link node_modules
╰─▶ cached package index references a missing CAS shard … (file: "LICENSE").
    The store and its index cache are out of sync — rerun the install to re-fetch the tarball.
```

The advice in that message was wrong: rerunning hit the same shortcut. Verification has to happen at fetch time because only fetch can re-download.

## The fix

`fetch_packages_with_root`'s shortcut now compares the entry's resolved target against the virtual-store subdir this graph expects, via `VirtualStorePlan::entry_is_current` — mirroring the linker's own freshness tests (`classify_entry_state` under GVS, the plain existence check in per-project mode, which is unchanged). A package that fails the comparison misses the shortcut, takes the verified index load, drops to `NeedsFetch`, and is re-downloaded.

That needs the graph hashes before fetch rather than inside the prewarm task that overlaps it, so `plan_virtual_store` computes them up front and the prewarm and link phases reuse the same `Arc`. `node_version`, `build_policy` and `patch_hashes` drop out of `GvsPrewarmInputs` as a result. The `skip_already_linked_shortcut: bool` parameter collapses into `already_linked_shortcut: Option<&VirtualStorePlan>` so one value carries the whole decision.

Hash divergence between the precomputed set and the link phase's (a source-backed dep's content fingerprint, a differently-filtered graph) can only *miss* the shortcut, never produce a false match.

## Cost

Measured via `AUBE_DIAG_FILE` on a warm install of the 1.4k-package medium fixture, debug build:

| | before | after |
| --- | --- | --- |
| `install_phase/fetch` | 5.1 ms | 7.7 ms |
| `materialize/hash_await` | 1.7 ms | gone |
| `install/total` | 109 ms | 105 ms |

Total is unchanged inside run-to-run noise. The cold-resolve path pays nothing at all — its tarball fetch is already in flight when the plan is built.

## Testing

- New `install self-heals a stale index when the entry resolves elsewhere` in `test/install_reuse_regressions.bats`, the non-workspace counterpart to the workspace case added in #1400. Confirmed it fails on the unmodified binary with the exact production error above, and passes with the fix.
- `cargo test` green (839 + all crate suites); `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.
- bats sweep over install / reuse / gvs / fetch / hoisted / ci / patch and workspace / filter / dedupe / local_deps / git_deps / lifecycle / allow_builds. The failures present are a broken mise `node` shim under bats' isolated `HOME`; I ran the same suites against unmodified crates for comparison and got an identical failure set, plus the new test failing there. No regressions.

## Not in scope

Workspaces keep the shortcut disabled. `link_workspace`'s step 1b mirrors `link_all`'s state machine, so the new classification is sound there too and #1400's stated blocker is gone — but switching monorepos over is a perf change that wants its own measurement rather than a ride on a correctness fix. Only the now-stale comment explaining the exclusion was updated.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core install fetch/link coordination and GVS freshness semantics; incorrect shortcut logic could skip re-fetch or over-fetch, though workspace paths remain on the disabled shortcut and hash mismatch only misses the fast path.
> 
> **Overview**
> Fixes a **non-workspace install** failure where `node_modules/.aube/<dep>` still *resolved* but pointed at the wrong global virtual-store subdir after graph/build-state drift. The fetch phase treated that as **AlreadyLinked**, skipped handing an index to the linker, and the linker fell back to **unverified** `load_index` on a stale CAS — producing repeatable `failed to link node_modules` with no self-heal on retry.
> 
> The shortcut now uses **`VirtualStorePlan::entry_is_current`**: under GVS it checks the symlink target matches the **hashed** subdir this graph expects (and still exists); per-project mode keeps a plain existence check. **`plan_virtual_store`** runs **before fetch** to compute those graph hashes (moved out of the GVS prewarm overlap); prewarm/link reuse the same `Arc`. The old `skip_already_linked_shortcut` bool becomes **`already_linked_shortcut: Option<&VirtualStorePlan>`** (`None` for `aube fetch` and workspaces, where the shortcut stays off). Adds a bats regression for single-root self-heal when the entry resolves to a decoy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe8de1d21f7039cbfe6825593732eaa6e2c84d02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved package reinstall detection by verifying that existing links point to the correct virtual-store targets.
  - Ensured reinstallations recover correctly when package links or stored data are stale or redirected.
  - Standardized virtual-store planning before package fetching and prewarming for more reliable installs.

- **Tests**
  - Added coverage for repairing stale package links and restoring missing store data in single-project installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->