### PR TITLE
fix(install): repair stale cached node-gyp

### DIFF
--- a/crates/aube/src/commands/install/node_gyp_bootstrap.rs
+++ b/crates/aube/src/commands/install/node_gyp_bootstrap.rs
@@ -76,6 +76,29 @@ fn node_gyp_binary(bin_dir: &Path) -> Option<PathBuf> {
         .find(|path| path.is_file())
 }
 
+/// Resolve a cached binary all the way through an aube-generated wrapper.
+///
+/// Isolated installs use regular shell/cmd wrappers rather than symlinks so
+/// they can inject `NODE_PATH`. The wrapper itself remains a valid file after
+/// its virtual-store target disappears, which made the cache fast path accept
+/// a broken node-gyp install. Unknown regular files are retained for forward
+/// compatibility; only wrappers we can decode are held to target existence.
+fn cached_node_gyp_binary(bin_dir: &Path) -> Option<PathBuf> {
+    BINARY_NAMES
+        .iter()
+        .map(|name| bin_dir.join(name))
+        .find(|path| {
+            if !path.is_file() {
+                return false;
+            }
+            match aube_linker::sys::resolve_bin_shim(path) {
+                Ok(Some(shim)) => shim.target.is_file(),
+                Ok(None) => true,
+                Err(_) => false,
+            }
+        })
+}
+
 fn tool_root() -> miette::Result<PathBuf> {
     let cache = aube_store::dirs::cache_dir()
         .ok_or_else(|| miette!("could not resolve cache dir for node-gyp bootstrap"))?;
@@ -86,7 +109,7 @@ pub(crate) async fn ensure_cached(project_dir: &Path) -> miette::Result<PathBuf>
     let root = tool_root()?;
     let tool_dir = root.join(BUCKET);
     let bin_dir = tool_dir.join("node_modules").join(".bin");
-    if node_gyp_bin_exists(&bin_dir) {
+    if cached_node_gyp_binary(&bin_dir).is_some() {
         return Ok(bin_dir);
     }
     let tool_dir_blocking = tool_dir.clone();
@@ -104,7 +127,7 @@ pub(crate) async fn ensure_cached(project_dir: &Path) -> miette::Result<PathBuf>
     let lock = crate::commands::take_project_lock(&tool_dir)?;
     // Re-check under the lock: another process may have raced us between the
     // check above and acquisition.
-    if node_gyp_bin_exists(&bin_dir) {
+    if cached_node_gyp_binary(&bin_dir).is_some() {
         return Ok(bin_dir);
     }
 
@@ -126,7 +149,7 @@ pub(crate) async fn ensure_cached(project_dir: &Path) -> miette::Result<PathBuf>
             )
         })?;
 
-    if !node_gyp_bin_exists(&bin_dir) {
+    if cached_node_gyp_binary(&bin_dir).is_none() {
         return Err(miette!(
             "node-gyp bootstrap into {} reported success but left no node-gyp binary in {}",
             tool_dir.display(),
@@ -512,6 +535,36 @@ mod tests {
 
         assert_eq!(node_gyp_binary(&dir), Some(exe.clone()));
         assert!(exe.is_file());
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn cached_wrapper_requires_its_target() {
+        let dir = tempdir();
+        let bin_dir = dir.join("node_modules/.bin");
+        let target = dir.join("node_modules/node-gyp/bin/node-gyp.js");
+        std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+        std::fs::write(&target, "#!/usr/bin/env node\n").unwrap();
+        aube_linker::create_bin_shim(
+            &bin_dir,
+            "node-gyp",
+            &target,
+            aube_linker::BinShimOptions {
+                prefer_symlinked_executables: Some(false),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert!(node_gyp_bin_exists(&bin_dir));
+        assert!(cached_node_gyp_binary(&bin_dir).is_some());
+
+        std::fs::remove_file(target).unwrap();
+        assert!(
+            node_gyp_bin_exists(&bin_dir),
+            "the wrapper itself should still exist"
+        );
+        assert!(cached_node_gyp_binary(&bin_dir).is_none());
         let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/crates/aube/src/commands/install/node_gyp_bootstrap.rs
+++ b/crates/aube/src/commands/install/node_gyp_bootstrap.rs
@@ -84,19 +84,21 @@ fn node_gyp_binary(bin_dir: &Path) -> Option<PathBuf> {
 /// a broken node-gyp install. Unknown regular files are retained for forward
 /// compatibility; only wrappers we can decode are held to target existence.
 fn cached_node_gyp_binary(bin_dir: &Path) -> Option<PathBuf> {
-    BINARY_NAMES
-        .iter()
-        .map(|name| bin_dir.join(name))
-        .find(|path| {
-            if !path.is_file() {
-                return false;
-            }
-            match aube_linker::sys::resolve_bin_shim(path) {
-                Ok(Some(shim)) => shim.target.is_file(),
-                Ok(None) => true,
-                Err(_) => false,
-            }
-        })
+    let mut opaque_binary = None;
+    for path in BINARY_NAMES.iter().map(|name| bin_dir.join(name)) {
+        if !path.is_file() {
+            continue;
+        }
+        match aube_linker::sys::resolve_bin_shim(&path) {
+            // A decoded aube wrapper is authoritative. On Windows it has
+            // opaque extensionless/PowerShell siblings, which must not make a
+            // stale `.cmd` wrapper look healthy after its target disappears.
+            Ok(Some(shim)) => return shim.target.is_file().then_some(path),
+            Ok(None) => opaque_binary.get_or_insert(path),
+            Err(_) => continue,
+        };
+    }
+    opaque_binary
 }
 
 fn tool_root() -> miette::Result<PathBuf> {

--- a/crates/aube/src/commands/install/node_gyp_bootstrap.rs
+++ b/crates/aube/src/commands/install/node_gyp_bootstrap.rs
@@ -85,20 +85,24 @@ fn node_gyp_binary(bin_dir: &Path) -> Option<PathBuf> {
 /// compatibility; only wrappers we can decode are held to target existence.
 fn cached_node_gyp_binary(bin_dir: &Path) -> Option<PathBuf> {
     let mut opaque_binary = None;
+    let mut stale_wrapper = false;
     for path in BINARY_NAMES.iter().map(|name| bin_dir.join(name)) {
         if !path.is_file() {
             continue;
         }
         match aube_linker::sys::resolve_bin_shim(&path) {
-            // A decoded aube wrapper is authoritative. On Windows it has
-            // opaque extensionless/PowerShell siblings, which must not make a
-            // stale `.cmd` wrapper look healthy after its target disappears.
-            Ok(Some(shim)) => return shim.target.is_file().then_some(path),
-            Ok(None) => opaque_binary.get_or_insert(path),
+            // A decoded live wrapper wins. Record stale wrappers so their
+            // opaque Windows siblings cannot make the cache look healthy,
+            // while still allowing a later decoded live wrapper to win.
+            Ok(Some(shim)) if shim.target.is_file() => return Some(path),
+            Ok(Some(_)) => stale_wrapper = true,
+            Ok(None) => {
+                opaque_binary.get_or_insert(path);
+            }
             Err(_) => continue,
         };
     }
-    opaque_binary
+    (!stale_wrapper).then_some(opaque_binary).flatten()
 }
 
 fn tool_root() -> miette::Result<PathBuf> {
@@ -537,6 +541,37 @@ mod tests {
 
         assert_eq!(node_gyp_binary(&dir), Some(exe.clone()));
         assert!(exe.is_file());
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn live_decoded_wrapper_wins_over_an_earlier_stale_wrapper() {
+        let dir = tempdir();
+        let target = dir.join("target/node-gyp.js");
+        std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+        std::fs::write(&target, "#!/usr/bin/env node\n").unwrap();
+        aube_linker::create_bin_shim(
+            &dir,
+            "node-gyp",
+            &target,
+            aube_linker::BinShimOptions::default(),
+        )
+        .unwrap();
+        std::fs::remove_file(target).unwrap();
+        let live_target = dir.join("live.js");
+        std::fs::write(&live_target, "#!/usr/bin/env node\n").unwrap();
+        let shell_wrapper = dir.join("node-gyp");
+        std::fs::write(
+            &shell_wrapper,
+            format!(
+                "#!/bin/sh\n{}live.js\n",
+                aube_linker::sys::POSIX_SHIM_MARKER_PREFIX
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(cached_node_gyp_binary(&dir), Some(shell_wrapper));
         let _ = std::fs::remove_dir_all(dir);
     }
 

--- a/test/node_gyp_bootstrap.bats
+++ b/test/node_gyp_bootstrap.bats
@@ -73,6 +73,25 @@ JSON
 	assert_file_exists "$XDG_CACHE_HOME/aube/tools/node-gyp/v12/node_modules/.bin/node-gyp"
 }
 
+@test "bootstrap repairs a cached node-gyp whose virtual store was deleted" {
+	if [ -z "${AUBE_TEST_REGISTRY:-}" ]; then
+		skip "AUBE_TEST_REGISTRY not set (Verdaccio not running)"
+	fi
+
+	run aube __node-gyp-bootstrap "$PWD"
+	assert_success
+	assert_file_exists "$output"
+
+	# Isolated installs write a regular .bin wrapper. Deleting its target
+	# used to leave the wrapper looking healthy to the bootstrap fast path.
+	rm -rf "$XDG_CACHE_HOME/aube/virtual-store"
+	run aube __node-gyp-bootstrap "$PWD"
+	assert_success
+	assert_file_exists "$output"
+	run "$output" --help
+	assert_success
+}
+
 @test "dep lifecycle does not bootstrap node-gyp unless invoked" {
 	if [ -z "${AUBE_TEST_REGISTRY:-}" ]; then
 		skip "AUBE_TEST_REGISTRY not set (Verdaccio not running)"


### PR DESCRIPTION
## Summary

- validate aube-generated cached node-gyp wrappers through their resolved targets
- bypass the cache fast path when the virtual-store target is missing
- cover automatic recovery after deleting the global virtual store

Closes the aube-owned node-gyp portion of https://github.com/jdx/aube/discussions/1405. The mise-owned legacy tool-tree detection is being handled separately.

## Validation

- `cargo test -p aube cached_wrapper_requires_its_target`
- `mise run build`
- `mise run test:bats test/node_gyp_bootstrap.bats`
- `mise run lint`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to node-gyp bootstrap cache validation in the install path; no auth or data-handling changes.
> 
> **Overview**
> Fixes the node-gyp bootstrap **cache fast path** treating leftover `.bin` wrappers as healthy after their virtual-store targets are gone.
> 
> **`ensure_cached`** now uses **`cached_node_gyp_binary`**, which decodes aube shims via **`resolve_bin_shim`** and only accepts a cache hit when a decoded wrapper’s target still exists (or the entry is an undecodable opaque binary with no stale decoded wrappers). Stale wrappers force a re-bootstrap instead of returning a broken path.
> 
> Adds unit tests for stale vs live wrappers and a Bats case that deletes the virtual store and confirms bootstrap repairs the cache and **`node-gyp --help`** works.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68af3b18a72f33e6fda071a5e2c3791b747b5f47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node-gyp cache validation to detect missing wrapper targets.
  * Automatically repairs cached node-gyp installations when their underlying files are removed.
  * Ensured cached binaries remain functional after virtual-store cleanup.
  * Prevented stale cached wrappers from being treated as valid installations.
  * Improved recovery when multiple cached node-gyp wrappers are present, selecting a working installation when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->