### PR TITLE
ci: back mbx with the GitHub Actions cache alone

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,13 +1,7 @@
 name: Set up mbx
-description: Select the trusted jdx server or fork-safe GitHub cache backend
+description: Set up mbx with the GitHub Actions cache backend
 
 inputs:
-  backend:
-    description: Explicit backend for structurally trusted or untrusted callers
-    default: auto
-  mirror-github-cache:
-    description: Mirror a trusted main build into the restore-only cache used by fork PRs
-    default: "false"
   cache-links:
     description: Cache native links; "auto" enables this on Linux
     default: auto
@@ -18,20 +12,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Restore the fork PR cache mirror
-      if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
+    - uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
       with:
         version: 0.6.0
         backend: github
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}
-    - uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
-      with:
-        version: 0.6.0
-        cache-links: ${{ inputs.cache-links }}
-        toolchain: ${{ inputs.toolchain }}
-        backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
-        server-url: https://cache.mise.jdx.dev
-        namespace: jdx/aube
-        oidc-audience: https://cache.mise.jdx.dev

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -11,9 +11,6 @@ on:
       trusted:
         required: true
         type: boolean
-      mbx-backend:
-        required: true
-        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -52,9 +49,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/mbx
-        with:
-          backend: ${{ inputs.mbx-backend }}
-          mirror-github-cache: "true"
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5 # zizmor: ignore[cache-poisoning] PRs restore only; saves are restricted to main
         with:
           cache_save: ${{ github.ref == 'refs/heads/main' }}
@@ -80,8 +74,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/mbx
-        with:
-          backend: ${{ inputs.mbx-backend }}
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5 # zizmor: ignore[cache-poisoning] PRs restore only; saves are restricted to main
         with:
           cache_save: ${{ github.ref == 'refs/heads/main' }}
@@ -127,8 +119,6 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
       - uses: ./.github/actions/mbx
-        with:
-          backend: ${{ inputs.mbx-backend }}
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5 # zizmor: ignore[cache-poisoning] PRs restore only; saves are restricted to main
         with:
           cache_save: false
@@ -325,9 +315,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/mbx
-        with:
-          backend: ${{ inputs.mbx-backend }}
-          mirror-github-cache: "true"
       - run: mbx build --workspace
       - run: mbx test --workspace
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
     uses: ./.github/workflows/ci-impl.yml
     with:
       trusted: true
-      mbx-backend: server
 
   untrusted:
     if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
@@ -26,7 +25,6 @@ jobs:
     uses: ./.github/workflows/ci-impl.yml
     with:
       trusted: false
-      mbx-backend: github
 
   final:
     name: final

--- a/.github/workflows/docs-impl.yml
+++ b/.github/workflows/docs-impl.yml
@@ -6,9 +6,6 @@ on:
       trusted:
         required: true
         type: boolean
-      mbx-backend:
-        required: true
-        type: string
 
 env:
   CARGO_INCREMENTAL: "0"
@@ -29,8 +26,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/mbx
-        with:
-          backend: ${{ inputs.mbx-backend }}
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
       - name: Build aube
         run: mbx build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,6 @@ jobs:
     uses: ./.github/workflows/docs-impl.yml
     with:
       trusted: true
-      mbx-backend: server
 
   untrusted:
     if: ${{ github.actor != 'jdx' }}
@@ -36,7 +35,6 @@ jobs:
     uses: ./.github/workflows/docs-impl.yml
     with:
       trusted: false
-      mbx-backend: github
 
   docs:
     name: docs

--- a/.github/workflows/ffi-impl.yml
+++ b/.github/workflows/ffi-impl.yml
@@ -18,9 +18,6 @@ on:
       trusted:
         required: true
         type: boolean
-      mbx-backend:
-        required: true
-        type: string
     secrets:
       AUBE_GH_TOKEN:
         required: false
@@ -83,8 +80,6 @@ jobs:
         with: { node-version: "24", package-manager-cache: false }
       - uses: ./.github/actions/mbx
         if: github.event_name != 'release' && inputs.tag == '' && !inputs.draft_phase
-        with:
-          backend: ${{ inputs.mbx-backend }}
       - name: Install Rust target
         shell: bash
         run: rustup target add '${{ matrix.target }}'

--- a/.github/workflows/ffi.yml
+++ b/.github/workflows/ffi.yml
@@ -81,7 +81,6 @@ jobs:
       draft_phase: ${{ inputs.draft_phase || false }}
       publish_packages: ${{ inputs.publish_packages || false }}
       trusted: true
-      mbx-backend: server
     secrets:
       AUBE_GH_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}
       CERTIFICATES_P12: ${{ secrets.CERTIFICATES_P12 }}
@@ -97,7 +96,6 @@ jobs:
       draft_phase: false
       publish_packages: false
       trusted: false
-      mbx-backend: github
 
   packages:
     name: packages

--- a/.github/workflows/node-addon-impl.yml
+++ b/.github/workflows/node-addon-impl.yml
@@ -10,9 +10,6 @@ on:
       trusted:
         required: true
         type: boolean
-      mbx-backend:
-        required: true
-        type: string
     secrets:
       CERTIFICATES_P12:
         required: false
@@ -73,8 +70,6 @@ jobs:
         with: { node-version: "24", package-manager-cache: false }
       - uses: ./.github/actions/mbx
         if: github.event_name != 'release' && inputs.tag == ''
-        with:
-          backend: ${{ inputs.mbx-backend }}
       - name: Install Rust target
         shell: bash
         run: rustup target add '${{ matrix.target }}'

--- a/.github/workflows/node-addon.yml
+++ b/.github/workflows/node-addon.yml
@@ -62,7 +62,6 @@ jobs:
     with:
       tag: ${{ inputs.tag || '' }}
       trusted: true
-      mbx-backend: server
     secrets:
       CERTIFICATES_P12: ${{ secrets.CERTIFICATES_P12 }}
       CERTIFICATES_P12_PASS: ${{ secrets.CERTIFICATES_P12_PASS }}
@@ -75,7 +74,6 @@ jobs:
     with:
       tag: ""
       trusted: false
-      mbx-backend: github
 
   packages:
     name: packages


### PR DESCRIPTION
Retires the remote cache server from CI: every job now uses mbx's GitHub Actions cache backend. Removes the backend-selection expression, the `mbx-backend` workflow plumbing, the fork-PR cache mirror, and the server-warming workflow — all of which existed to route trusted builds at cache.mise.jdx.dev. mbx itself stays.

`id-token: write` grants are left in place where they may serve Pages deploys or attestations; they can be tightened separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change with no application code; main risk is slower or colder Rust caches on trusted Namespace runners after dropping the remote mbx server.
> 
> **Overview**
> **CI now routes all `mbx` setup through the GitHub Actions cache backend** instead of choosing between `cache.mise.jdx.dev` for trusted runs and GHA cache for untrusted/fork PRs.
> 
> The composite **`.github/actions/mbx`** action is simplified: it always passes `backend: github` to `mr-boxington-action`, drops the `backend` and `mirror-github-cache` inputs, removes the main-branch **fork PR cache mirror** step, and stops configuring `server-url`, `namespace`, and OIDC audience for the remote cache.
> 
> Across **ci**, **docs**, **ffi**, and **node-addon** workflows, the reusable `mbx-backend` input and every caller passing `server` vs `github` are removed; jobs invoke `./.github/actions/mbx` with no backend overrides (including dropping `mirror-github-cache` on build/windows CI jobs).
> 
> Trusted/untrusted job split, OIDC assertions for untrusted jobs, and `id-token: write` on trusted jobs are unchanged for non-mbx reasons (Pages, attestations, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1b8a494d1288d3916a89567b860352407d8f124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI/CD Improvements**
  * Standardized build, test, documentation, FFI, and addon workflows on the GitHub Actions cache backend.
  * Removed backend-selection and cache-mirroring configuration from workflow interfaces.
  * Simplified trusted and untrusted workflow execution by eliminating backend-specific parameters.
  * Updated FFI workflow configuration to use a trusted-mode flag instead of backend selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->