### PR TITLE
fix(release): mount writable home for arm64 pgo builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -358,10 +358,12 @@ jobs:
           AUBE_PGO_USE_LLD: "1"
           AUBE_PGO_LLVM_VERSION: ${{ env.LLVM_VERSION }}
         run: |
-          mkdir -p "$HOME/.cargo/registry" "$HOME/.cargo/git"
+          container_home="$RUNNER_TEMP/aube-home"
+          mkdir -p "$container_home/.cargo" "$HOME/.cargo/registry" "$HOME/.cargo/git"
           docker run --rm \
             --user "$(id -u):$(id -g)" \
             --volume "$GITHUB_WORKSPACE:/workspace" \
+            --volume "$container_home:/tmp/aube-home" \
             --volume "$HOME/.cargo/registry:/tmp/aube-home/.cargo/registry" \
             --volume "$HOME/.cargo/git:/tmp/aube-home/.cargo/git" \
             --workdir /workspace \


### PR DESCRIPTION
## Summary
- mount a runner-owned temporary home into the ARM64 PGO container
- keep the existing Cargo registry and git cache mounts nested inside it
- allow the non-root container user to write mise state and Cargo metadata

## Context
The v2.2.1 release failed because `HOME=/tmp/aube-home` was backed only by nested Docker mounts, leaving the home directory itself root-owned and unwritable. Mise failed while creating `~/.local/state/mise/trusted-configs`.

Failed job: https://github.com/jdx/aube/actions/runs/33229976192/job/99041610331

After merging, manually dispatch `release.yml` for `v2.2.1` with `dry_run=false`, verify the release assets, and publish the draft release. Rerunning the original job would continue using the old workflow revision.

## Validation
- `git diff --check`
- `mise exec -- actionlint -color`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to Docker volume mounts in `release.yml`; no application or release artifact logic is modified.
> 
> **Overview**
> Fixes failing **ARM64 Linux PGO** release builds where the Docker step sets `HOME=/tmp/aube-home` but only nested Cargo cache bind-mounts existed, leaving the home directory itself non-writable for the non-root `--user` container process.
> 
> The workflow now creates a runner-owned directory under `$RUNNER_TEMP/aube-home`, bind-mounts it as `/tmp/aube-home`, and still nests the existing `~/.cargo/registry` and `~/.cargo/git` mounts under that home so **mise** can write state (e.g. trusted configs) and Cargo metadata during `mise run build:pgo`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8b120398f1dec01f2412db4eb2d7d77d6cb21cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the PGO build process for ARM64 Linux releases by ensuring required build data persists correctly during containerized builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->