### PR TITLE
chore: release v2.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "aube-codes"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "aube-ffi"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "aube",
  "aube-codes",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "aube-node"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "aube",
  "aube-codes",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "aube-runtime"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "aube-util",
  "base64 0.23.1",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "aube-codes",
  "blake3",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "aube-codes",
  "aube-manifest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ inherits = "release"
 panic = "unwind"
 
 [workspace.package]
-version = "2.2.1"
+version = "2.2.2"
 edition = "2024"
 # Kept at the floor mise can build with (its distro packaging pins the
 # toolchain) so mise can embed the library crates. CI enforces this via

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.2](https://github.com/jdx/aube/compare/v2.2.1...v2.2.2) - 2026-08-29
+
+### Fixed
+
+- *(release)* mount writable home for arm64 pgo builds ([#1409](https://github.com/jdx/aube/pull/1409))
+
 ## [2.2.1](https://github.com/jdx/aube/compare/v2.2.0...v2.2.1) - 2026-08-29
 
 ### Fixed

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "2.2.1",
-  "releasedAt": "2026-08-29T02:08:47Z"
+  "version": "2.2.2",
+  "releasedAt": "2026-08-29T05:23:01Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v2.2.2`

This PR bumps the workspace to `v2.2.2` and regenerates CHANGELOG entries, `aube.usage.kdl`, the CLI docs, and the benchmark results.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog/metadata updates only; no product logic changes in the diff.
> 
> **Overview**
> **Release `v2.2.2`** — bumps the workspace and all `aube-*` crates from `2.2.1` to `2.2.2`, updates `release.json`, and records the release in `crates/aube/CHANGELOG.md`.
> 
> User-facing notes for this tag: **fix release CI** by mounting a writable home directory for **arm64 PGO builds** ([#1409](https://github.com/jdx/aube/pull/1409)). No application/runtime code changes appear in this diff; it is the `release-plz` packaging PR for that fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 299f644850780ac81567d61faac434b9074cc983. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->