### PR TITLE
chore: release v2.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "aube-codes"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "aube-ffi"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "aube",
  "aube-codes",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "aube-node"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "aube",
  "aube-codes",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "aube-runtime"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "aube-util",
  "base64 0.23.1",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "aube-codes",
  "blake3",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "aube-codes",
  "aube-manifest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ inherits = "release"
 panic = "unwind"
 
 [workspace.package]
-version = "2.2.2"
+version = "2.2.3"
 edition = "2024"
 # Kept at the floor mise can build with (its distro packaging pins the
 # toolchain) so mise can embed the library crates. CI enforces this via

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.3](https://github.com/jdx/aube/compare/v2.2.2...v2.2.3) - 2026-08-29
+
+### Fixed
+
+- *(release)* mount cached arm64 build target ([#1412](https://github.com/jdx/aube/pull/1412))
+
 ## [2.2.2](https://github.com/jdx/aube/compare/v2.2.1...v2.2.2) - 2026-08-29
 
 ### Fixed

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "2.2.2",
-  "releasedAt": "2026-08-29T05:23:01Z"
+  "version": "2.2.3",
+  "releasedAt": "2026-08-29T11:16:05Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v2.2.3`

This PR bumps the workspace to `v2.2.3` and regenerates CHANGELOG entries, `aube.usage.kdl`, the CLI docs, and the benchmark results.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical semver patch release; the only documented change is release-pipeline/CI caching for arm64 builds, not install or resolver logic.
> 
> **Overview**
> Cuts **v2.2.3** by bumping the workspace and every `aube-*` crate from `2.2.2` to `2.2.3`, syncing `Cargo.lock`, and updating `release.json` with the new version and release timestamp.
> 
> The shipped note in `crates/aube/CHANGELOG.md` is a **release CI fix**: mount the cached **arm64** build target ([#1412](https://github.com/jdx/aube/pull/1412)). No application/runtime behavior changes appear in this diff beyond versioning and release metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed9edf49fdc9b4273441612c4825a5b575eee285. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->