### PR TITLE
fix(release): mount cached arm64 build target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -363,6 +363,7 @@ jobs:
           docker run --rm \
             --user "$(id -u):$(id -g)" \
             --volume "$GITHUB_WORKSPACE:/workspace" \
+            --volume "$GITHUB_WORKSPACE/target:/workspace/target" \
             --volume "$container_home:/tmp/aube-home" \
             --volume "$HOME/.cargo/registry:/tmp/aube-home/.cargo/registry" \
             --volume "$HOME/.cargo/git:/tmp/aube-home/.cargo/git" \


### PR DESCRIPTION
## Summary
- bind the Namespace-cached target directory explicitly into the ARM64 PGO container
- preserve the PGO+BOLT binary across the container boundary for validation and archiving

## Context
The writable-home fix allowed the ARM64 PGO+BOLT build to complete, but Namespace mounts `${{ github.workspace }}/target` as a separate cache mount. The parent workspace bind did not expose that nested mount inside Docker, so the completed binary remained in a container-only target directory and the following host step could not find it.

Failed job: https://github.com/jdx/aube/actions/runs/33236593555/job/99059126945

## Validation
- `git diff --check`
- `mise exec -- actionlint -color`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Docker volume wiring for the ARM64 PGO job; no application or release-upload logic changes beyond making the existing host steps find the binary.
> 
> **Overview**
> Fixes ARM64 Linux PGO release builds where **glibc validation and tarball steps could not see the built binary** after the in-container `mise run build:pgo` finished.
> 
> The `upload-assets-pgo-arm64-linux` job already restores Namespace cache for `${{ github.workspace }}/target`, but that path is a **separate mount** from the workspace root. A single `--volume "$GITHUB_WORKSPACE:/workspace"` bind does not propagate that nested mount into Docker, so artifacts landed in a container-only `target` tree. The PR adds an explicit **`--volume "$GITHUB_WORKSPACE/target:/workspace/target"`** on the `docker run` so PGO+BOLT output and the cached target directory are the same on the host for **Validate glibc baseline**, **Archive PGO binaries**, and upload/attest steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b6f447cb3a87522b1c5c78e84c853c2c77f5985. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the ARM64 PGO Docker build configuration for more reliable build output handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->