### PR TITLE
chore: release v2.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "aube-codes"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "aube-ffi"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "aube",
  "aube-codes",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "aube-node"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "aube",
  "aube-codes",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "aube-runtime"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "aube-util",
  "base64 0.23.1",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "aube-codes",
  "blake3",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "aube-codes",
  "aube-manifest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ inherits = "release"
 panic = "unwind"
 
 [workspace.package]
-version = "2.2.3"
+version = "2.2.4"
 edition = "2024"
 # Kept at the floor mise can build with (its distro packaging pins the
 # toolchain) so mise can embed the library crates. CI enforces this via

--- a/crates/aube-codes/CHANGELOG.md
+++ b/crates/aube-codes/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.4](https://github.com/jdx/aube/compare/aube-codes-v2.2.3...aube-codes-v2.2.4) - 2026-08-31
+
+### Other
+
+- refresh benchmarks for v2.2.3 ([#1417](https://github.com/jdx/aube/pull/1417))
+
 ## [2.2.1](https://github.com/jdx/aube/compare/aube-codes-v2.2.0...aube-codes-v2.2.1) - 2026-08-29
 
 ### Other

--- a/crates/aube-linker/CHANGELOG.md
+++ b/crates/aube-linker/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.4](https://github.com/jdx/aube/compare/aube-linker-v2.2.3...aube-linker-v2.2.4) - 2026-08-31
+
+### Other
+
+- refresh benchmarks for v2.2.3 ([#1417](https://github.com/jdx/aube/pull/1417))
+
 ## [2.2.1](https://github.com/jdx/aube/compare/aube-linker-v2.2.0...aube-linker-v2.2.1) - 2026-08-29
 
 ### Other

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.4](https://github.com/jdx/aube/compare/aube-lockfile-v2.2.3...aube-lockfile-v2.2.4) - 2026-08-31
+
+### Other
+
+- refresh benchmarks for v2.2.3 ([#1417](https://github.com/jdx/aube/pull/1417))
+
 ## [2.2.1](https://github.com/jdx/aube/compare/aube-lockfile-v2.2.0...aube-lockfile-v2.2.1) - 2026-08-29
 
 ### Fixed

--- a/crates/aube-manifest/CHANGELOG.md
+++ b/crates/aube-manifest/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.4](https://github.com/jdx/aube/compare/aube-manifest-v2.2.3...aube-manifest-v2.2.4) - 2026-08-31
+
+### Other
+
+- refresh benchmarks for v2.2.3 ([#1417](https://github.com/jdx/aube/pull/1417))
+
 ## [2.2.1](https://github.com/jdx/aube/compare/aube-manifest-v2.2.0...aube-manifest-v2.2.1) - 2026-08-29
 
 ### Fixed

--- a/crates/aube-registry/CHANGELOG.md
+++ b/crates/aube-registry/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.4](https://github.com/jdx/aube/compare/aube-registry-v2.2.3...aube-registry-v2.2.4) - 2026-08-31
+
+### Other
+
+- refresh benchmarks for v2.2.3 ([#1417](https://github.com/jdx/aube/pull/1417))
+
 ## [2.2.1](https://github.com/jdx/aube/compare/aube-registry-v2.2.0...aube-registry-v2.2.1) - 2026-08-29
 
 ### Other

--- a/crates/aube-resolver/CHANGELOG.md
+++ b/crates/aube-resolver/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.4](https://github.com/jdx/aube/compare/aube-resolver-v2.2.3...aube-resolver-v2.2.4) - 2026-08-31
+
+### Other
+
+- refresh benchmarks for v2.2.3 ([#1417](https://github.com/jdx/aube/pull/1417))
+
 ## [2.2.1](https://github.com/jdx/aube/compare/aube-resolver-v2.2.0...aube-resolver-v2.2.1) - 2026-08-29
 
 ### Fixed

--- a/crates/aube-runtime/CHANGELOG.md
+++ b/crates/aube-runtime/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.4](https://github.com/jdx/aube/compare/aube-runtime-v2.2.3...aube-runtime-v2.2.4) - 2026-08-31
+
+### Other
+
+- refresh benchmarks for v2.2.3 ([#1417](https://github.com/jdx/aube/pull/1417))
+
 ## [2.2.1](https://github.com/jdx/aube/compare/aube-runtime-v2.2.0...aube-runtime-v2.2.1) - 2026-08-29
 
 ### Other

--- a/crates/aube-scripts/CHANGELOG.md
+++ b/crates/aube-scripts/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.4](https://github.com/jdx/aube/compare/aube-scripts-v2.2.3...aube-scripts-v2.2.4) - 2026-08-31
+
+### Other
+
+- refresh benchmarks for v2.2.3 ([#1417](https://github.com/jdx/aube/pull/1417))
+
 ## [2.2.1](https://github.com/jdx/aube/compare/aube-scripts-v2.2.0...aube-scripts-v2.2.1) - 2026-08-29
 
 ### Other

--- a/crates/aube-settings/CHANGELOG.md
+++ b/crates/aube-settings/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.4](https://github.com/jdx/aube/compare/aube-settings-v2.2.3...aube-settings-v2.2.4) - 2026-08-31
+
+### Fixed
+
+- *(install)* trust locked packages without revalidation ([#1418](https://github.com/jdx/aube/pull/1418))
+
+### Other
+
+- refresh benchmarks for v2.2.3 ([#1417](https://github.com/jdx/aube/pull/1417))
+
 ## [2.2.1](https://github.com/jdx/aube/compare/aube-settings-v2.2.0...aube-settings-v2.2.1) - 2026-08-29
 
 ### Fixed

--- a/crates/aube-store/CHANGELOG.md
+++ b/crates/aube-store/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.4](https://github.com/jdx/aube/compare/aube-store-v2.2.3...aube-store-v2.2.4) - 2026-08-31
+
+### Other
+
+- *(store)* publish Linux CAS files by descriptor ([#1419](https://github.com/jdx/aube/pull/1419))
+- refresh benchmarks for v2.2.3 ([#1417](https://github.com/jdx/aube/pull/1417))
+
 ## [2.2.1](https://github.com/jdx/aube/compare/aube-store-v2.2.0...aube-store-v2.2.1) - 2026-08-29
 
 ### Other

--- a/crates/aube-util/CHANGELOG.md
+++ b/crates/aube-util/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.4](https://github.com/jdx/aube/compare/aube-util-v2.2.3...aube-util-v2.2.4) - 2026-08-31
+
+### Other
+
+- refresh benchmarks for v2.2.3 ([#1417](https://github.com/jdx/aube/pull/1417))
+
 ## [2.2.1](https://github.com/jdx/aube/compare/aube-util-v2.2.0...aube-util-v2.2.1) - 2026-08-29
 
 ### Other

--- a/crates/aube-workspace/CHANGELOG.md
+++ b/crates/aube-workspace/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.4](https://github.com/jdx/aube/compare/aube-workspace-v2.2.3...aube-workspace-v2.2.4) - 2026-08-31
+
+### Other
+
+- refresh benchmarks for v2.2.3 ([#1417](https://github.com/jdx/aube/pull/1417))
+
 ## [2.2.1](https://github.com/jdx/aube/compare/aube-workspace-v2.2.0...aube-workspace-v2.2.1) - 2026-08-29
 
 ### Other

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.4](https://github.com/jdx/aube/compare/v2.2.3...v2.2.4) - 2026-08-31
+
+### Fixed
+
+- *(install)* trust locked packages without revalidation ([#1418](https://github.com/jdx/aube/pull/1418))
+
+### Other
+
+- refresh benchmarks for v2.2.3 ([#1417](https://github.com/jdx/aube/pull/1417))
+
 ## [2.2.3](https://github.com/jdx/aube/compare/v2.2.2...v2.2.3) - 2026-08-29
 
 ### Fixed

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "2.2.3",
-  "releasedAt": "2026-08-29T11:16:05Z"
+  "version": "2.2.4",
+  "releasedAt": "2026-08-31T14:02:44Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v2.2.4`

This PR bumps the workspace to `v2.2.4` and regenerates CHANGELOG entries, `aube.usage.kdl`, the CLI docs, and the benchmark results.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The release bundles install trust-policy behavior (#1418) and Linux store/CAS publishing (#1419), which affect supply-chain checks and artifact layout even though this PR is mostly version bumps.
> 
> **Overview**
> **Release PR** that cuts **v2.2.4** across the workspace: `[workspace.package].version` and every `aube-*` entry in `Cargo.lock` move **2.2.3 → 2.2.4**, and `release.json` records the new version and release timestamp.
> 
> Per-crate **CHANGELOG** sections document what ships in this tag: **#1418** fixes install so **lockfile-resolved packages are trusted without revalidation** (main `aube` / `aube-settings`); **#1419** changes **Linux CAS publishing to use file descriptors** (`aube-store`); **#1417** refreshes benchmark results (noted on all crates). No application Rust changes appear in this diff—only release metadata and notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5551d305e19aa3d7e1b22c1017e27604b19cf866. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->