### PR TITLE
chore: adopt mr-boxington 1.1 cargo shim

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
     - uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
       with:
-        version: 0.6.0
+        version: 1.1.0
         backend: github
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,14 +1,6 @@
 name: Set up mbx
 description: Set up mbx with the GitHub Actions cache backend
 
-inputs:
-  cache-links:
-    description: Cache native links; "auto" enables this on Linux
-    default: auto
-  toolchain:
-    description: Rust toolchain named explicitly by the build
-    required: false
-
 runs:
   using: composite
   steps:
@@ -17,5 +9,3 @@ runs:
         version: 1.1.0
         backend: github
         cache-generation: v2
-        cache-links: ${{ inputs.cache-links }}
-        toolchain: ${{ inputs.toolchain }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -12,9 +12,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
+    - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
       with:
         version: 1.1.0
         backend: github
+        cache-generation: v2
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}

--- a/.rules
+++ b/.rules
@@ -11,7 +11,7 @@ project:
 mbx:
   policy: mise installs mbx 1.1 and activates its transparent Cargo shim; use ordinary cargo commands
   fallback: prefix the exact equivalent cargo command from CONTRIBUTING.md with MBX_DISABLE=1 without weakening or skipping the check
-  report: if bypassed Cargo succeeds, surface the mismatch and recommend https://github.com/jdx/mr-boxington/discussions with repository and commit, OS, mbx --version, mbx doctor, and both commands and outputs
+  report: if bypassed Cargo succeeds, surface the mismatch and recommend https://github.com/jdx/mr-boxington/discussions with repository and commit, OS, mbx --version, mbx doctor, and both commands and outputs; redact secrets, absolute cache paths, remote URLs, namespaces, and other sensitive or identifying details
   agent_boundary: do not permanently disable the shim and do not post externally without user authorization
 
 layout:

--- a/.rules
+++ b/.rules
@@ -9,10 +9,10 @@ project:
   error_codes: every error/warning carries a stable ERR_AUBE_*/WARN_AUBE_* identifier from aube-codes crate; bespoke exit codes for a curated subset; see error_codes section below for conventions
 
 mbx:
-  policy: compilation-heavy mise tasks and hk checks use mbx
-  fallback: rerun the exact equivalent cargo command from CONTRIBUTING.md without weakening or skipping the check
-  report: if Cargo succeeds, surface the mismatch and recommend https://github.com/jdx/mr-boxington/discussions with repository and commit, OS, mbx --version, both commands and outputs, cache summary, and MBX_BYPASS_LOG details
-  agent_boundary: do not silently make Cargo permanent and do not post externally without user authorization
+  policy: mise installs mbx 1.1 and activates its transparent Cargo shim; use ordinary cargo commands
+  fallback: prefix the exact equivalent cargo command from CONTRIBUTING.md with MBX_DISABLE=1 without weakening or skipping the check
+  report: if bypassed Cargo succeeds, surface the mismatch and recommend https://github.com/jdx/mr-boxington/discussions with repository and commit, OS, mbx --version, mbx doctor, and both commands and outputs
+  agent_boundary: do not permanently disable the shim and do not post externally without user authorization
 
 layout:
   global_store: $XDG_DATA_HOME/aube/store/v1/ (contains files/ for CAS shards + index/ for cached package indexes; falls back to ~/.local/share/aube/store/v1/). `aube store path` prints this v1/ dir, matching `pnpm store path` granularity. The legacy index location at $XDG_CACHE_HOME/aube/index/ is migrated in-place on the first store open after upgrade.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,4 +19,6 @@ MBX_DISABLE=1 cargo clippy --all-targets -- -D warnings
 If bypassed Cargo succeeds where the shim fails, or mbx introduces a papercut, please start a
 [mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions).
 Include the repository and commit, operating system, `mbx --version`,
-`mbx doctor`, and both commands and their output.
+`mbx doctor`, and both commands and their output. Before posting, redact
+secrets, absolute cache paths, remote URLs, namespaces, and other sensitive or
+identifying details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,19 +4,19 @@ See the [contributing guide](https://aube.jdx.dev/contributing).
 
 ## mbx build cache
 
-The normal `mise run build`, `mise run test`, and `mise run lint` workflows use
-[mbx](https://mr-boxington.jdx.dev) for compilation-heavy Cargo work. If mbx
-appears to be the problem, use the equivalent Cargo commands to unblock
-yourself without skipping or weakening the check:
+`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.1 and activates
+its transparent Cargo shim. The normal `mise run build`, `mise run test`, and
+`mise run lint` workflows therefore use the cache while invoking Cargo
+normally. To bypass mbx without skipping or weakening a check, prefix the
+equivalent Cargo command with `MBX_DISABLE=1`:
 
 ```sh
-cargo build
-cargo test
-cargo clippy --all-targets -- -D warnings
+MBX_DISABLE=1 cargo build
+MBX_DISABLE=1 cargo test
+MBX_DISABLE=1 cargo clippy --all-targets -- -D warnings
 ```
 
-If Cargo succeeds where mbx fails, or mbx introduces a papercut, please start a
+If bypassed Cargo succeeds where the shim fails, or mbx introduces a papercut, please start a
 [mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions).
-Include the repository and commit, operating system, `mbx --version`, both
-commands and their output, the mbx cache summary, and an `MBX_BYPASS_LOG` when
-relevant (for example, `MBX_BYPASS_LOG=mbx-bypasses.log mise run build`).
+Include the repository and commit, operating system, `mbx --version`,
+`mbx doctor`, and both commands and their output.

--- a/hk.pkl
+++ b/hk.pkl
@@ -14,7 +14,7 @@ local linters = new Mapping<String, Step> {
     ["actionlint"] = Builtins.actionlint
     ["cargo-fmt"] = Builtins.cargo_fmt
     ["cargo-clippy"] = (Builtins.cargo_clippy) {
-        check = "mbx clippy --manifest-path {{workspace_indicator}} --quiet -- -D warnings"
+        check = "cargo clippy --manifest-path {{workspace_indicator}} --quiet -- -D warnings"
     }
     ["shfmt"] = (Builtins.shfmt) {
         glob = List("**/*.bats", "**/*.sh", "**/*.bash")

--- a/mise.lock
+++ b/mise.lock
@@ -148,47 +148,6 @@ checksum = "sha256:e437443331865218763d44089680f4d36547353e8c3c8b394c24859203e6c
 url = "https://github.com/foresterre/cargo-msrv/releases/download/v0.19.3/cargo-msrv-x86_64-pc-windows-msvc-v0.19.3.zip"
 url_api = "https://api.github.com/repos/foresterre/cargo-msrv/releases/assets/380851496"
 
-[[tools."github:jdx/mr-boxington"]]
-version = "0.6.0"
-backend = "github:jdx/mr-boxington"
-
-[tools."github:jdx/mr-boxington"."platforms.linux-arm64"]
-checksum = "sha256:019c98cdf8ff28e8967919ea9a549b2a7d05f8636957fc443d2fe7d00d22a5ac"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792954"
-provenance = "github-attestations"
-
-[tools."github:jdx/mr-boxington"."platforms.linux-arm64-musl"]
-checksum = "sha256:019c98cdf8ff28e8967919ea9a549b2a7d05f8636957fc443d2fe7d00d22a5ac"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792954"
-provenance = "github-attestations"
-
-[tools."github:jdx/mr-boxington"."platforms.linux-x64"]
-checksum = "sha256:156bb820fd035f846b6efb5d7210a3b816ec8842005c904f4bf40fe0a1be245e"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792966"
-provenance = "github-attestations"
-provenance_verified = true
-
-[tools."github:jdx/mr-boxington"."platforms.linux-x64-musl"]
-checksum = "sha256:156bb820fd035f846b6efb5d7210a3b816ec8842005c904f4bf40fe0a1be245e"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792966"
-provenance = "github-attestations"
-
-[tools."github:jdx/mr-boxington"."platforms.macos-arm64"]
-checksum = "sha256:bbd19a27974cdbfe7fa4a6ffef3cb29150b12ccdf3a17d2dc1e0afdd09675f25"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792953"
-provenance = "github-attestations"
-
-[tools."github:jdx/mr-boxington"."platforms.windows-x64"]
-checksum = "sha256:4a0958560ecba3253cd1d4459abf6b05b70e739e40f207ac1c17df4cd6a9e8e7"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792956"
-provenance = "github-attestations"
-
 [[tools."github:jdx/tak"]]
 version = "0.0.8"
 backend = "github:jdx/tak"
@@ -257,6 +216,47 @@ url = "https://github.com/jdx/hk/releases/download/v1.44.3/hk-aarch64-apple-darw
 [tools.hk."platforms.windows-x64"]
 checksum = "sha256:c59c6bf1c45157903ce58a5572257a959ca5e3895b6b9cbfb808a744d4858fb9"
 url = "https://github.com/jdx/hk/releases/download/v1.44.3/hk-x86_64-pc-windows-msvc.zip"
+
+[[tools.mr-boxington]]
+version = "1.1.0"
+backend = "github:jdx/mr-boxington"
+
+[tools.mr-boxington."platforms.linux-arm64"]
+checksum = "sha256:ded60221f2217a6e0abfe0ba3583674bae63e5a7b696c4fa145827a3a0e352af"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232514"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.linux-arm64-musl"]
+checksum = "sha256:70a882277389bd6e6b606fc291083a857a7ef0c742b60ba5a7822cc49fe7c4ac"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232511"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.linux-x64"]
+checksum = "sha256:8e718ff25e71057f758d02f3039481258cd531be914afd3f77198811d0113a74"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232519"
+provenance = "github-attestations"
+provenance_verified = true
+
+[tools.mr-boxington."platforms.linux-x64-musl"]
+checksum = "sha256:9f590a0fd0fc0a5896791257863980fe9c6035458414575749cc43e68e7ff0cf"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232518"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.macos-arm64"]
+checksum = "sha256:da96661534480fff35ec78e598124d208ac1f2624c6d3c287c9ae2a5852b0b29"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232513"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.windows-x64"]
+checksum = "sha256:4adbb02bf97f00644d2e1e3930e154df39a07df1e574e0829b5d6e34474a3c95"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232517"
+provenance = "github-attestations"
 
 [[tools.node]]
 version = "24.14.0"

--- a/mise.toml
+++ b/mise.toml
@@ -7,7 +7,7 @@ cargo.binstall_native = true
 
 [tools]
 actionlint = "latest"
-"github:jdx/mr-boxington" = "latest"
+mr-boxington = { version = "1.1.0", postinstall = "mbx setup --yes" }
 usage = "6.4.0"
 communique = "latest"
 "github:bnjbvr/cargo-machete" = "latest"
@@ -50,10 +50,10 @@ run = "hk fix --all --slow"
 run = "mise x cargo:cargo-fixit@0.1.15 -- cargo fixit --clippy --all-targets --allow-dirty --allow-staged"
 
 [tasks.build]
-run = "mbx build"
+run = "cargo build"
 
 [tasks.test]
-run = "mbx test"
+run = "cargo test"
 
 [tasks."docs:dev"]
 depends = ["build"]

--- a/mise.toml
+++ b/mise.toml
@@ -142,7 +142,7 @@ dir = "{{config_root}}"
 # work-stealing races do not move the install count by 10%+ between runs.
 env = { npm_config_enable_global_virtual_store = "true", TOKIO_WORKER_THREADS = "1", RAYON_NUM_THREADS = "1", AUBE_LINK_CONCURRENCY = "1" }
 run = [
-  "cargo build --release",
+  "MBX_DISABLE=1 cargo build --release",
   "./target/release/aube -C fixtures/medium install --frozen-lockfile",
   "tak run",
 ]
@@ -154,7 +154,7 @@ run = [
 dir = "{{config_root}}"
 env = { npm_config_enable_global_virtual_store = "true", TOKIO_WORKER_THREADS = "1", RAYON_NUM_THREADS = "1", AUBE_LINK_CONCURRENCY = "1" }
 run = [
-  "cargo build --release",
+  "MBX_DISABLE=1 cargo build --release",
   "./target/release/aube -C fixtures/medium install --frozen-lockfile",
   "tak run --record",
 ]

--- a/mise.toml
+++ b/mise.toml
@@ -136,16 +136,20 @@ run = [
 # The store warm-up is the one networked step. It has to happen before tak runs
 # because the install benchmark uses --offline, and it is outside the
 # measurement on purpose — nothing tak times ever touches the registry.
+[tasks."perf:build"]
+env = { MBX_DISABLE = "1" }
+run = "cargo build --release"
+
 [tasks.perf]
 dir = "{{config_root}}"
 # Cachegrind aggregates instructions from every worker. Pin the pools so idle
 # work-stealing races do not move the install count by 10%+ between runs.
 env = { npm_config_enable_global_virtual_store = "true", TOKIO_WORKER_THREADS = "1", RAYON_NUM_THREADS = "1", AUBE_LINK_CONCURRENCY = "1" }
 run = [
-  "MBX_DISABLE=1 cargo build --release",
   "./target/release/aube -C fixtures/medium install --frozen-lockfile",
   "tak run",
 ]
+depends = ["perf:build"]
 
 # Same measurement, appended to refs/notes/tak for this commit. Run by the
 # `perf` workflow on every push to main; the notes are what the history is.
@@ -154,10 +158,10 @@ run = [
 dir = "{{config_root}}"
 env = { npm_config_enable_global_virtual_store = "true", TOKIO_WORKER_THREADS = "1", RAYON_NUM_THREADS = "1", AUBE_LINK_CONCURRENCY = "1" }
 run = [
-  "MBX_DISABLE=1 cargo build --release",
   "./target/release/aube -C fixtures/medium install --frozen-lockfile",
   "tak run --record",
 ]
+depends = ["perf:build"]
 
 [tasks."build:pgo"]
 dir = "{{config_root}}"

--- a/mise.toml
+++ b/mise.toml
@@ -7,7 +7,7 @@ cargo.binstall_native = true
 
 [tools]
 actionlint = "latest"
-mr-boxington = { version = "1.1.0", postinstall = "mbx setup --yes" }
+mr-boxington = { version = "1.1.0", postinstall = "mbx setup --global" }
 usage = "6.4.0"
 communique = "latest"
 "github:bnjbvr/cargo-machete" = "latest"


### PR DESCRIPTION
## Summary

- adopt the `mr-boxington` mise shorthand at 1.1.0 with the setup post-install hook
- run compilation-heavy tasks through ordinary `cargo` commands and the transparent shim
- refresh the locked release and contributor/agent guidance

## Validation

- `MISE_LOCKED=1 mise install mr-boxington`
- `mise exec -- mbx --version` (`mbx 1.1.0`)
- `mise tasks ls`
- `git diff --check`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and CI-cache configuration only; application code and runtime behavior are unchanged aside from how Cargo is invoked locally and in updated workflows.
> 
> **Overview**
> **Upgrades mbx to 1.1.0** and shifts day-to-day builds from explicit `mbx build` / `mbx test` to normal **`cargo`** calls, relying on **`mbx setup --global`** (mise postinstall) for transparent caching.
> 
> **mise** pins `mr-boxington` 1.1.0 with postinstall setup, refreshes **mise.lock**, and splits **`perf:build`** as a release compile with **`MBX_DISABLE=1`** so benchmark timings are not cache-skewed. **hk**’s clippy step now runs **`cargo clippy`** instead of **`mbx clippy`**.
> 
> The **GitHub composite action** bumps **mr-boxington-action** to 1.1.0, drops the old `cache-links` / `toolchain` inputs, and sets **`cache-generation: v2`**. **CONTRIBUTING.md** and **`.rules`** document bypass via **`MBX_DISABLE=1`**, **`mbx doctor`**, and redaction when reporting shim issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73a16dd88a398d72fcb00e544737c96f6cbc993b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgraded build caching tools to version 1.1.0.
  * Added transparent caching for standard Cargo build and test commands.
  * Added automated setup for the caching tool.
  * Added support for cache generation v2.
  * Improved performance workflow build handling.

* **Documentation**
  * Updated contributor troubleshooting and cache bypass guidance.
  * Added `mbx doctor` diagnostic instructions.
  * Added guidance to redact secrets and sensitive details from troubleshooting reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->