### PR TITLE
ci(perf): move benchmarks to dedicated runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,6 @@
 self-hosted-runner:
   labels:
+    - jdx-perf-v1
     - bamboo-perf
     - namespace-profile-endev-linux-amd64
     - namespace-profile-endev-linux-amd64-large

--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -76,6 +76,7 @@ jobs:
     needs: check
     if: needs.check.outputs.drift == 'true'
     outputs:
+      artifact_name: ${{ steps.dirty.outputs.artifact_name }}
       dirty: ${{ steps.dirty.outputs.dirty }}
     runs-on: [self-hosted, jdx-perf-v1]
     container:
@@ -97,11 +98,6 @@ jobs:
           cache: false
         env:
           MISE_LOCKED: "1"
-      - name: Restore hermetic bench registry cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/aube-bench/registry
-          key: aube-bench-registry-${{ runner.os }}-v1
       - name: Snapshot previous benchmarks
         run: cp benchmarks/results.json /tmp/bench-results-before.json
       - name: Refresh benchmarks
@@ -116,6 +112,7 @@ jobs:
       - name: Check for diff
         id: dirty
         run: |
+          echo "artifact_name=bench-refresh-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
           git add -A
           changed=$(git diff --cached --name-only)
           unexpected=$(printf '%s\n' "$changed" \
@@ -144,7 +141,7 @@ jobs:
         if: steps.dirty.outputs.dirty == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: bench-refresh-${{ github.run_id }}-${{ github.run_attempt }}
+          name: ${{ steps.dirty.outputs.artifact_name }}
           path: ${{ runner.temp }}/bench-refresh
           if-no-files-found: error
           retention-days: 1
@@ -165,7 +162,7 @@ jobs:
           persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: bench-refresh-${{ github.run_id }}-${{ github.run_attempt }}
+          name: ${{ needs.refresh.outputs.artifact_name }}
           path: ${{ runner.temp }}/bench-refresh
       - name: Validate and stage refreshed benchmarks
         env:

--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -72,7 +72,10 @@ jobs:
     name: Refresh benchmarks
     needs: check
     if: needs.check.outputs.drift == 'true'
-    runs-on: bamboo-perf
+    runs-on: [self-hosted, jdx-perf-v1]
+    container:
+      image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9
+      options: --cpuset-cpus 0-7
     timeout-minutes: 60
     permissions:
       contents: write
@@ -84,8 +87,8 @@ jobs:
           token: ${{ secrets.AUBE_GH_TOKEN }}
           submodules: recursive
           persist-credentials: false
-      # Compile inside this disposable VM. Restoring target/ can relabel a
-      # binary built on a different runner class as a Bamboo measurement.
+      # Compile inside the pinned job container. Restoring target/ could relabel
+      # a binary built on another runner class as a jdx-perf-v1 measurement.
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         env:
           MISE_LOCKED: "1"

--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -25,6 +25,9 @@ concurrency:
 
 env:
   CARGO_INCREMENTAL: "0"
+  # Rust 1.97.1 is part of the digest-pinned benchmark image.
+  MISE_DISABLE_TOOLS: rust
+  RUSTUP_TOOLCHAIN: 1.97.1
 
 jobs:
   # Gate: only run bench if `benchmarks/results.json` is pinned to an older
@@ -76,7 +79,7 @@ jobs:
       dirty: ${{ steps.dirty.outputs.dirty }}
     runs-on: [self-hosted, jdx-perf-v1]
     container:
-      image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9
+      image: ghcr.io/jdx/perf-runner@sha256:0f4ee40929472883a32cc29bcd4bd22068c4382b72697da299d6769475b263b5
       options: --cpuset-cpus 0-7
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -72,19 +72,19 @@ jobs:
     name: Refresh benchmarks
     needs: check
     if: needs.check.outputs.drift == 'true'
+    outputs:
+      dirty: ${{ steps.dirty.outputs.dirty }}
     runs-on: [self-hosted, jdx-perf-v1]
     container:
       image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9
       options: --cpuset-cpus 0-7
     timeout-minutes: 60
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-          token: ${{ secrets.AUBE_GH_TOKEN }}
           submodules: recursive
           persist-credentials: false
       # Compile inside the pinned job container. Restoring target/ could relabel
@@ -97,10 +97,6 @@ jobs:
         with:
           path: ~/.cache/aube-bench/registry
           key: aube-bench-registry-${{ runner.os }}-v1
-      - name: Configure git identity
-        run: |
-          git config user.name "release-plz[bot]"
-          git config user.email "release-plz+bot@users.noreply.github.com"
       - name: Snapshot previous benchmarks
         run: cp benchmarks/results.json /tmp/bench-results-before.json
       - name: Refresh benchmarks
@@ -115,36 +111,98 @@ jobs:
       - name: Check for diff
         id: dirty
         run: |
-          if git diff --quiet && [ -z "$(git status --porcelain)" ]; then
+          git add -A
+          changed=$(git diff --cached --name-only)
+          unexpected=$(printf '%s\n' "$changed" \
+            | grep -Ev '^(README\.md|benchmarks/results\.json)$' || true)
+          if [ -n "$unexpected" ]; then
+            echo "::error::bench:bump changed files outside the publication allowlist"
+            printf '%s\n' "$unexpected"
+            exit 1
+          fi
+          if git diff --cached --quiet; then
             echo "bench:bump produced no diff; skipping PR update."
             echo "dirty=false" >> "$GITHUB_OUTPUT"
           else
             echo "dirty=true" >> "$GITHUB_OUTPUT"
           fi
+          git reset --quiet
 
-      # Reuse the single `bench-refresh` branch across runs so the PR
-      # number is preserved. Always force-push — the previous bench commit
-      # is superseded by the new one, never additive.
-      - name: Force-push bench-refresh branch
+      - name: Package refreshed benchmarks
         if: steps.dirty.outputs.dirty == 'true'
+        run: |
+          mkdir -p "$RUNNER_TEMP/bench-refresh/benchmarks"
+          cp README.md "$RUNNER_TEMP/bench-refresh/README.md"
+          cp benchmarks/results.json "$RUNNER_TEMP/bench-refresh/benchmarks/results.json"
+          cp /tmp/bench_summary.md "$RUNNER_TEMP/bench-refresh/summary.md"
+      - name: Upload refreshed benchmarks
+        if: steps.dirty.outputs.dirty == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bench-refresh-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/bench-refresh
+          if-no-files-found: error
+          retention-days: 1
+
+  propose:
+    name: Propose refreshed benchmarks
+    needs: [check, refresh]
+    if: needs.refresh.outputs.dirty == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bench-refresh-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/bench-refresh
+      - name: Validate and stage refreshed benchmarks
+        env:
+          WORKSPACE: ${{ needs.check.outputs.workspace }}
+        run: |
+          cd "$RUNNER_TEMP/bench-refresh"
+          if find . -type l -print -quit | grep -q .; then
+            echo "::error::Refusing an artifact containing symbolic links"
+            exit 1
+          fi
+          actual=$(find . -type f -printf '%P\n' | sort)
+          expected=$(printf '%s\n' README.md benchmarks/results.json summary.md | sort)
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::Refusing an artifact outside the publication allowlist"
+            printf 'Expected:\n%s\nActual:\n%s\n' "$expected" "$actual"
+            exit 1
+          fi
+          jq -e --arg workspace "$WORKSPACE" \
+            '.versions.aube == $workspace' benchmarks/results.json >/dev/null
+          test "$(grep -c '<!-- BENCH_RATIOS:START -->' README.md)" -eq 1
+          test "$(grep -c '<!-- BENCH_RATIOS:END -->' README.md)" -eq 1
+
+          cd "$GITHUB_WORKSPACE"
+          git config core.hooksPath /dev/null
+          cp "$RUNNER_TEMP/bench-refresh/README.md" README.md
+          cp "$RUNNER_TEMP/bench-refresh/benchmarks/results.json" benchmarks/results.json
+      # Reuse one branch so the PR number is preserved. The previous benchmark
+      # commit is superseded by the new one, never additive.
+      - name: Force-push bench-refresh branch
         env:
           GITHUB_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}
           REPOSITORY: ${{ github.repository }}
         run: |
+          git config user.name "release-plz[bot]"
+          git config user.email "release-plz+bot@users.noreply.github.com"
           git checkout -B bench-refresh
-          git add -A
+          git add README.md benchmarks/results.json
           git commit -m "chore: refresh benchmarks"
-          # persist-credentials: false on checkout means we need to auth
-          # the push explicitly. Re-point origin (rather than pushing to
-          # a one-shot URL) so --force-with-lease has a remote-tracking
-          # ref to compare against; pushing to an unnamed URL leaves no
-          # tracking ref and git rejects every push with "stale info".
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
           git fetch origin bench-refresh || true
           git push --force-with-lease -u origin HEAD:refs/heads/bench-refresh
-
       - name: Create or update PR
-        if: steps.dirty.outputs.dirty == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}
           WORKSPACE: ${{ needs.check.outputs.workspace }}
@@ -158,7 +216,7 @@ jobs:
 
           \`benchmarks/results.json\` was pinned to aube \`${BENCH:-<unset>}\`; the workspace is now \`${WORKSPACE}\`. Re-ran \`mise run bench:bump\` on the hermetic Verdaccio registry (500mbit / 50ms per the mise task) and regenerated \`benchmarks/results.json\` plus the README \`BENCH_RATIOS\` block. The benchmark matrix pins aube's GVS mode via \`npm_config_enable_global_virtual_store=true|false\` (the auto-synthesized env alias for the \`enableGlobalVirtualStore\` setting), so GitHub Actions' inherited \`CI=true\` environment does not change whether aube runs with GVS enabled or disabled.
 
-          $(cat /tmp/bench_summary.md)
+          $(cat "$RUNNER_TEMP/bench-refresh/summary.md")
 
           **Review the numbers** before merging — if anything looks wildly off vs. the previous release, investigate before landing. Hermetic proxy jitter or an npmjs uplink hiccup can occasionally skew results.
 
@@ -166,6 +224,8 @@ jobs:
 
           ---
           Generated by the \`bench-refresh\` workflow.
+
+          *AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*
           EOF
           if [ -n "$EXISTING" ]; then
             gh pr edit "$EXISTING" --title "$TITLE" --body-file /tmp/bench_body.md

--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -90,6 +90,8 @@ jobs:
       # Compile inside the pinned job container. Restoring target/ could relabel
       # a binary built on another runner class as a jdx-perf-v1 measurement.
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          cache: false
         env:
           MISE_LOCKED: "1"
       - name: Restore hermetic bench registry cache

--- a/.github/workflows/perf-backfill.yml
+++ b/.github/workflows/perf-backfill.yml
@@ -40,10 +40,13 @@ jobs:
     # series and the ongoing one have to come from the same kind of machine.
     runs-on: [self-hosted, jdx-perf-v1]
     container:
-      image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9
+      image: ghcr.io/jdx/perf-runner@sha256:0f4ee40929472883a32cc29bcd4bd22068c4382b72697da299d6769475b263b5
       options: --cpuset-cpus 0-7
     timeout-minutes: 60
     env:
+      # Rust 1.97.1 is part of the digest-pinned benchmark image.
+      MISE_DISABLE_TOOLS: rust
+      RUSTUP_TOOLCHAIN: 1.97.1
       TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-aube-rust1.97.1
     permissions:
       contents: read # listing releases and downloading assets; no write here
@@ -67,8 +70,8 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@6ab972a'
-            echo 'image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9'
+            echo 'environment-revision: perf-runner@34a523e'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:0f4ee40929472883a32cc29bcd4bd22068c4382b72697da299d6769475b263b5'
             uname -a
             lscpu
             mise --version

--- a/.github/workflows/perf-backfill.yml
+++ b/.github/workflows/perf-backfill.yml
@@ -57,6 +57,8 @@ jobs:
           persist-credentials: false
 
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          cache: false
         env:
           MISE_LOCKED: "1"
 

--- a/.github/workflows/perf-backfill.yml
+++ b/.github/workflows/perf-backfill.yml
@@ -38,10 +38,13 @@ jobs:
     # Same runner class as perf.yml. Absolute instruction counts shift between
     # machine types by more than a real regression does, so the backfilled
     # series and the ongoing one have to come from the same kind of machine.
-    runs-on: bamboo-perf
+    runs-on: [self-hosted, jdx-perf-v1]
+    container:
+      image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922
+      options: --cpuset-cpus 0-7
     timeout-minutes: 60
     env:
-      TAK_RUNNER: bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1
+  TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-aube-rust1.97.1
     permissions:
       contents: read # listing releases and downloading assets; no write here
     steps:
@@ -57,13 +60,27 @@ jobs:
         env:
           MISE_LOCKED: "1"
 
-      - name: Install valgrind
+      - name: Runner metadata
         run: |
-          command -v valgrind || {
-            sudo apt-get update
-            sudo apt-get install -y --no-install-recommends valgrind
-          }
-          valgrind --version
+          {
+            echo '### Runner metadata'
+            echo '```text'
+            echo 'environment-revision: perf-runner@d7c0e81'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
+            uname -a
+            lscpu
+            mise --version
+            rustc --version
+            cargo --version
+            valgrind --version
+            for zone in /sys/class/thermal/thermal_zone*/temp; do
+              [ -r "$zone" ] && printf '%s: %s\n' "$zone" "$(cat "$zone")"
+            done
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Verify valgrind
+        run: valgrind --version
 
       # `sbom` rather than tak's default of `--version`. aube's `-V` is
       # documented as "print version and check for updates", and a subject that
@@ -90,7 +107,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LIMIT: ${{ inputs.limit }}
         run: |
-          tak backfill --bench release-graph --limit "$LIMIT" -- \
+          taskset -c 0-3 tak backfill --bench release-graph --limit "$LIMIT" -- \
             -C "$GITHUB_WORKSPACE/fixtures/medium" sbom
 
       # A bundle is how the notes reach the publish job: it carries the ref and

--- a/.github/workflows/perf-backfill.yml
+++ b/.github/workflows/perf-backfill.yml
@@ -40,7 +40,7 @@ jobs:
     # series and the ongoing one have to come from the same kind of machine.
     runs-on: [self-hosted, jdx-perf-v1]
     container:
-      image: ghcr.io/jdx/perf-runner@sha256:8935770e7f656f7b0bcd0204328aa3d6998b32d8bb04084851731b30df56941b
+      image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9
       options: --cpuset-cpus 0-7
     timeout-minutes: 60
     env:
@@ -66,7 +66,7 @@ jobs:
             echo '### Runner metadata'
             echo '```text'
             echo 'environment-revision: perf-runner@6ab972a'
-            echo 'image: ghcr.io/jdx/perf-runner@sha256:8935770e7f656f7b0bcd0204328aa3d6998b32d8bb04084851731b30df56941b'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9'
             uname -a
             lscpu
             mise --version

--- a/.github/workflows/perf-backfill.yml
+++ b/.github/workflows/perf-backfill.yml
@@ -40,7 +40,7 @@ jobs:
     # series and the ongoing one have to come from the same kind of machine.
     runs-on: [self-hosted, jdx-perf-v1]
     container:
-      image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922
+      image: ghcr.io/jdx/perf-runner@sha256:8935770e7f656f7b0bcd0204328aa3d6998b32d8bb04084851731b30df56941b
       options: --cpuset-cpus 0-7
     timeout-minutes: 60
     env:
@@ -65,8 +65,8 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@78e4231'
-            echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
+            echo 'environment-revision: perf-runner@6ab972a'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:8935770e7f656f7b0bcd0204328aa3d6998b32d8bb04084851731b30df56941b'
             uname -a
             lscpu
             mise --version

--- a/.github/workflows/perf-backfill.yml
+++ b/.github/workflows/perf-backfill.yml
@@ -44,7 +44,7 @@ jobs:
       options: --cpuset-cpus 0-7
     timeout-minutes: 60
     env:
-  TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-aube-rust1.97.1
+      TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-aube-rust1.97.1
     permissions:
       contents: read # listing releases and downloading assets; no write here
     steps:
@@ -65,7 +65,7 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@d7c0e81'
+            echo 'environment-revision: perf-runner@78e4231'
             echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
             uname -a
             lscpu

--- a/.github/workflows/perf-pr-preflight.yml
+++ b/.github/workflows/perf-pr-preflight.yml
@@ -1,0 +1,14 @@
+name: perf-pr-preflight
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  complete:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "The default-branch controller will independently validate this pull request."

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -195,6 +195,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
+      checks: write # attach the regression gate to the measured PR head SHA
       pull-requests: write
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -227,6 +228,29 @@ jobs:
             gh api --method POST "repos/$GH_REPO/issues/$PR_NUMBER/comments" \
               --field body="$(cat /tmp/tak-comment.md)"
           fi
+
+      - name: Publish the pull request check
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          status=$(cat /tmp/tak-out/status 2>/dev/null || echo 2)
+          if [ "$status" -eq 0 ]; then
+            conclusion=success
+            title='Instruction counts passed'
+          else
+            conclusion=failure
+            title='Instruction-count regression or measurement failure'
+          fi
+          test -f /tmp/tak-out/report.md || echo 'The comparison did not produce a report.' > /tmp/tak-out/report.md
+          jq -n --arg head_sha "$HEAD_SHA" --arg conclusion "$conclusion" \
+            --arg title "$title" --arg details_url "$RUN_URL" \
+            --rawfile summary /tmp/tak-out/report.md \
+            '{name:"perf / instruction-count",head_sha:$head_sha,status:"completed",conclusion:$conclusion,details_url:$details_url,output:{title:$title,summary:$summary}}' \
+            | gh api --method POST "repos/$GH_REPO/check-runs" --input -
 
       - name: Fail on a regression
         if: always()

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -82,7 +82,7 @@ jobs:
     # the report would say "nothing was compared" instead of anything useful.
     runs-on: [self-hosted, jdx-perf-v1]
     container:
-      image: ghcr.io/jdx/perf-runner@sha256:8935770e7f656f7b0bcd0204328aa3d6998b32d8bb04084851731b30df56941b
+      image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9
       options: --cpuset-cpus 0-7
     timeout-minutes: 40
     permissions:
@@ -118,7 +118,7 @@ jobs:
             echo '### Runner metadata'
             echo '```text'
             echo 'environment-revision: perf-runner@6ab972a'
-            echo 'image: ghcr.io/jdx/perf-runner@sha256:8935770e7f656f7b0bcd0204328aa3d6998b32d8bb04084851731b30df56941b'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9'
             uname -a
             lscpu
             mise --version

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -13,16 +13,17 @@ name: perf-pr
 # main contributes to the history — a branch's numbers are not the trunk's, and
 # a series that mixes them cannot be read.
 
-on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
-  workflow_dispatch:
+on: # zizmor: ignore[dangerous-triggers] validates live PR metadata before any self-hosted job
+  workflow_run:
+    workflows: [perf-pr-preflight]
+    types: [completed]
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 env:
@@ -31,13 +32,50 @@ env:
   TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-aube-rust1.97.1
 
 jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    outputs:
+      authorized: ${{ steps.pr.outputs.authorized }}
+      base_ref: ${{ steps.pr.outputs.base_ref }}
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+      pr_number: ${{ steps.pr.outputs.pr_number }}
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - id: pr
+        name: Validate the pull request from the trusted default branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          TRIGGER_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          TRIGGER_EVENT: ${{ github.event.workflow_run.event }}
+          TRIGGER_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          exec 3>>"$GITHUB_OUTPUT"
+          echo 'authorized=false' >&3
+          [ "$TRIGGER_EVENT" = pull_request ] || exit 0
+          [ "$TRIGGER_CONCLUSION" = success ] || exit 0
+          [[ "$PR_NUMBER" =~ ^[0-9]+$ ]] || exit 0
+          pr="$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER")"
+          [ "$(jq -r .state <<<"$pr")" = open ] || exit 0
+          [ "$(jq -r .user.login <<<"$pr")" = jdx ] || exit 0
+          [ "$(jq -r .head.repo.full_name <<<"$pr")" = "$REPOSITORY" ] || exit 0
+          [ "$(jq -r .base.repo.full_name <<<"$pr")" = "$REPOSITORY" ] || exit 0
+          head_ref="$(jq -r .head.ref <<<"$pr")"
+          [[ "$head_ref" != release-plz-* ]] || exit 0
+          head_sha="$(jq -r .head.sha <<<"$pr")"
+          [ "$head_sha" = "$TRIGGER_SHA" ] || exit 0
+          echo 'authorized=true' >&3
+          echo "base_ref=$(jq -r .base.ref <<<"$pr")" >&3
+          echo "head_sha=$head_sha" >&3
+          echo "pr_number=$PR_NUMBER" >&3
+
   compare:
     name: Compare instruction counts
-    # release-plz PRs only contain generated release metadata and changelogs.
-    # Measuring them repeats the same binary already measured on main. Restrict
-    # the exemption to release-plz branches in this repository so a fork cannot
-    # bypass the comparison by choosing the same branch prefix.
-    if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'jdx' && github.event.pull_request.head.repo.full_name == github.repository && !startsWith(github.head_ref, 'release-plz-')
+    needs: authorize
+    if: needs.authorize.outputs.authorized == 'true'
     # Same runner class as perf.yml and perf-backfill.yml. Absolute counts shift
     # between machine types by more than a real regression does, so a comparison
     # across runner classes is not a comparison — tak refuses to make one, and
@@ -49,7 +87,6 @@ jobs:
     timeout-minutes: 40
     permissions:
       contents: read
-      pull-requests: write # the sticky comment
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -58,7 +95,7 @@ jobs:
           # for the run, changes whenever main advances, and measuring it would
           # attribute a number to a commit nobody can check out. It would also
           # make the footer below name a commit the measurement is not of.
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ needs.authorize.outputs.head_sha }}
           # Needed twice over: to find the merge base, and for the sparkline,
           # which walks twenty commits of trunk history.
           fetch-depth: 0
@@ -77,7 +114,7 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@d7c0e81'
+            echo 'environment-revision: perf-runner@78e4231'
             echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
             uname -a
             lscpu
@@ -104,7 +141,7 @@ jobs:
       - name: Find the base commit
         id: base
         env:
-          BASE_REF: ${{ github.base_ref }}
+          BASE_REF: ${{ needs.authorize.outputs.base_ref }}
         run: |
           git fetch --quiet origin "$BASE_REF"
           # The merge base, not the branch tip: comparing against a moving
@@ -128,31 +165,59 @@ jobs:
           cat /tmp/tak-report.md
           cat /tmp/tak-report.md >> "$GITHUB_STEP_SUMMARY"
 
-      # Skipped for pull requests from forks, which get a read-only token. The
-      # comparison and the gate still run there; only the comment is missing.
+      - name: Package the report
+        if: always()
+        env:
+          BASE_SHA: ${{ steps.base.outputs.sha }}
+          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+        run: |
+          mkdir -p /tmp/tak-out
+          if [ -f /tmp/tak-report.md ]; then
+            cp /tmp/tak-report.md /tmp/tak-out/report.md
+          else
+            echo "The comparison never ran — an earlier step failed." > /tmp/tak-out/report.md
+          fi
+          cp /tmp/tak-gate-status /tmp/tak-out/status 2>/dev/null || echo 2 > /tmp/tak-out/status
+          printf '%s %s\n' "${HEAD_SHA:0:12}" "${BASE_SHA:0:12}" > /tmp/tak-out/shas
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: always()
+        with:
+          name: tak-report
+          path: /tmp/tak-out
+          retention-days: 1
+          if-no-files-found: error
+
+  report:
+    name: Report and gate
+    needs: [authorize, compare]
+    if: always() && needs.authorize.outputs.authorized == 'true' && needs.compare.result != 'cancelled'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: tak-report
+          path: /tmp/tak-out
+
       - name: Comment on the pull request
-        if: github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE_SHA: ${{ steps.base.outputs.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
         run: |
           marker='<!-- aube-perf-pr -->'
-          # The backticks below are markdown, not command substitution, and
-          # single quotes are what keeps them literal.
+          read -r head_sha base_sha < /tmp/tak-out/shas
           # shellcheck disable=SC2016
           {
             printf '%s\n' "$marker"
             printf '### Instruction counts\n\n'
-            cat /tmp/tak-report.md
-            printf '\n<sub>`%s` vs `%s` · measured on this runner, not pushed to the history.</sub>\n' \
-              "${HEAD_SHA:0:12}" "${BASE_SHA:0:12}"
+            cat /tmp/tak-out/report.md
+            printf '\n<sub>`%s` vs `%s` · measured on the runner, not pushed to the history.</sub>\n' \
+              "$head_sha" "$base_sha"
           } > /tmp/tak-comment.md
-
-          # One comment per pull request, edited in place. A new comment on
-          # every push buries the conversation under numbers.
           existing="$(gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" --paginate \
             --jq ".[] | select(.body | contains(\"$marker\")) | .id" | tail -n1)"
           if [ -n "$existing" ]; then
@@ -163,19 +228,12 @@ jobs:
               --field body="$(cat /tmp/tak-comment.md)"
           fi
 
-      # `always()` because a step that fails stops the ones after it, and the
-      # gate is the reason this workflow exists. Without it, a `gh api` hiccup
-      # in the comment step would skip the gate entirely: the job would still go
-      # red, but for the wrong reason and with no regression error to read.
       - name: Fail on a regression
         if: always()
         run: |
-          if [ ! -f /tmp/tak-gate-status ]; then
-            echo "::error::the comparison never ran — nothing was gated"
-            exit 1
-          fi
-          status=$(cat /tmp/tak-gate-status)
-          if [ "$status" -ne 0 ]; then
-            echo "::error::an instruction count rose beyond the gate — see the table in the comment or the job summary"
-            exit "$status"
-          fi
+          status=$(cat /tmp/tak-out/status)
+          case "$status" in
+            0) ;;
+            2) echo "::error::the comparison never ran — nothing was gated"; exit 1 ;;
+            *) echo "::error::an instruction count rose beyond the gate"; exit "$status" ;;
+          esac

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -108,7 +108,7 @@ jobs:
       # a binary built on another runner class as a jdx-perf-v1 measurement.
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         with:
-          cache_save: false
+          cache: false
         env:
           MISE_LOCKED: "1"
 

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -82,7 +82,7 @@ jobs:
     # the report would say "nothing was compared" instead of anything useful.
     runs-on: [self-hosted, jdx-perf-v1]
     container:
-      image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922
+      image: ghcr.io/jdx/perf-runner@sha256:8935770e7f656f7b0bcd0204328aa3d6998b32d8bb04084851731b30df56941b
       options: --cpuset-cpus 0-7
     timeout-minutes: 40
     permissions:
@@ -117,8 +117,8 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@78e4231'
-            echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
+            echo 'environment-revision: perf-runner@6ab972a'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:8935770e7f656f7b0bcd0204328aa3d6998b32d8bb04084851731b30df56941b'
             uname -a
             lscpu
             mise --version

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -14,7 +14,7 @@ name: perf-pr
 # a series that mixes them cannot be read.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
 
@@ -28,7 +28,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  TAK_RUNNER: bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1
+  TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-aube-rust1.97.1
 
 jobs:
   compare:
@@ -37,12 +37,15 @@ jobs:
     # Measuring them repeats the same binary already measured on main. Restrict
     # the exemption to release-plz branches in this repository so a fork cannot
     # bypass the comparison by choosing the same branch prefix.
-    if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'jdx' && !(startsWith(github.head_ref, 'release-plz-') && github.event.pull_request.head.repo.full_name == github.repository)
+    if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'jdx' && github.event.pull_request.head.repo.full_name == github.repository && !startsWith(github.head_ref, 'release-plz-')
     # Same runner class as perf.yml and perf-backfill.yml. Absolute counts shift
     # between machine types by more than a real regression does, so a comparison
     # across runner classes is not a comparison — tak refuses to make one, and
     # the report would say "nothing was compared" instead of anything useful.
-    runs-on: bamboo-perf
+    runs-on: [self-hosted, jdx-perf-v1]
+    container:
+      image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922
+      options: --cpuset-cpus 0-7
     timeout-minutes: 40
     permissions:
       contents: read
@@ -61,26 +64,42 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      # Compile inside this disposable VM. Restoring target/ can relabel a
-      # binary built on a different runner class as a Bamboo measurement.
+      # Compile inside the pinned job container. Restoring target/ could relabel
+      # a binary built on another runner class as a jdx-perf-v1 measurement.
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         with:
           cache_save: false
         env:
           MISE_LOCKED: "1"
 
-      - name: Install valgrind
+      - name: Runner metadata
         run: |
-          command -v valgrind || {
-            sudo apt-get update
-            sudo apt-get install -y --no-install-recommends valgrind
-          }
-          valgrind --version
+          {
+            echo '### Runner metadata'
+            echo '```text'
+            echo 'environment-revision: perf-runner@d7c0e81'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
+            uname -a
+            lscpu
+            mise --version
+            rustc --version
+            cargo --version
+            valgrind --version
+            for zone in /sys/class/thermal/thermal_zone*/temp; do
+              [ -r "$zone" ] && printf '%s: %s\n' "$zone" "$(cat "$zone")"
+            done
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Verify valgrind
+        run: valgrind --version
 
       # `--record` writes a git note locally and nothing more. There is no
       # `tak push` in this workflow and there should never be one.
       - name: Measure this pull request
-        run: mise run perf:record
+        run: |
+          cargo build --release
+          taskset -c 0-3 mise run perf:record
 
       - name: Find the base commit
         id: base

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -29,6 +29,9 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
+  # Rust 1.97.1 is part of the digest-pinned benchmark image.
+  MISE_DISABLE_TOOLS: rust
+  RUSTUP_TOOLCHAIN: 1.97.1
   TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-aube-rust1.97.1
 
 jobs:
@@ -82,7 +85,7 @@ jobs:
     # the report would say "nothing was compared" instead of anything useful.
     runs-on: [self-hosted, jdx-perf-v1]
     container:
-      image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9
+      image: ghcr.io/jdx/perf-runner@sha256:0f4ee40929472883a32cc29bcd4bd22068c4382b72697da299d6769475b263b5
       options: --cpuset-cpus 0-7
     timeout-minutes: 40
     permissions:
@@ -117,8 +120,8 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@6ab972a'
-            echo 'image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9'
+            echo 'environment-revision: perf-runner@34a523e'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:0f4ee40929472883a32cc29bcd4bd22068c4382b72697da299d6769475b263b5'
             uname -a
             lscpu
             mise --version

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -23,7 +23,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.pull_requests[0].number }}
   cancel-in-progress: true
 
 env:
@@ -87,6 +87,9 @@ jobs:
     timeout-minutes: 40
     permissions:
       contents: read
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -37,7 +37,7 @@ jobs:
     # that wanders between runners is unreadable.
     runs-on: [self-hosted, jdx-perf-v1]
     container:
-      image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922
+      image: ghcr.io/jdx/perf-runner@sha256:8935770e7f656f7b0bcd0204328aa3d6998b32d8bb04084851731b30df56941b
       options: --cpuset-cpus 0-7
     timeout-minutes: 30
     permissions:
@@ -62,8 +62,8 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@78e4231'
-            echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
+            echo 'environment-revision: perf-runner@6ab972a'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:8935770e7f656f7b0bcd0204328aa3d6998b32d8bb04084851731b30df56941b'
             uname -a
             lscpu
             mise --version

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -27,7 +27,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  TAK_RUNNER: bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1
+  TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-aube-rust1.97.1
 
 jobs:
   measure:
@@ -35,17 +35,20 @@ jobs:
     # Pinned to one runner class on purpose. Absolute instruction counts shift
     # between machine types by more than a real regression does, so a series
     # that wanders between runners is unreadable.
-    runs-on: bamboo-perf
+    runs-on: [self-hosted, jdx-perf-v1]
+    container:
+      image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922
+      options: --cpuset-cpus 0-7
     timeout-minutes: 30
     permissions:
-      contents: write # pushing refs/notes/tak is a write to this repository
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      # Compile inside this disposable VM. Restoring target/ can relabel a
-      # binary built on a different runner class as a Bamboo measurement.
+      # Compile inside the pinned job container. Restoring target/ could relabel
+      # a binary built on another runner class as a jdx-perf-v1 measurement.
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         env:
           MISE_LOCKED: "1"
@@ -54,35 +57,77 @@ jobs:
       # to ~0.02% run-to-run where wall clock on this same hardware moves by
       # 4-20%. Without it tak still records timing, but the series stops being
       # precise enough to detect anything.
-      - name: Install valgrind
+      - name: Runner metadata
         run: |
-          command -v valgrind || {
-            sudo apt-get update
-            sudo apt-get install -y --no-install-recommends valgrind
-          }
-          valgrind --version
+          {
+            echo '### Runner metadata'
+            echo '```text'
+            echo 'environment-revision: perf-runner@d7c0e81'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
+            uname -a
+            lscpu
+            mise --version
+            rustc --version
+            cargo --version
+            valgrind --version
+            for zone in /sys/class/thermal/thermal_zone*/temp; do
+              [ -r "$zone" ] && printf '%s: %s\n' "$zone" "$(cat "$zone")"
+            done
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Verify valgrind
+        run: valgrind --version
 
       - name: Measure and record
-        run: mise run perf:record
-
-      # persist-credentials: false means the push needs its own auth. Same
-      # pattern as bench-refresh.yml: re-point origin rather than pushing to a
-      # one-shot URL, so tak's retry path has a remote to fetch from when it
-      # loses a race.
-      #
-      # Only main publishes. workflow_dispatch can be pointed at any branch or
-      # tag, and refs/notes/tak is a shared baseline that should hold main's
-      # history and nothing else. Gating the push rather than the whole job
-      # means a dispatch on a branch still measures and still prints its
-      # numbers in the summary — it just keeps them local.
-      - name: Push measurements
+        run: |
+          cargo build --release
+          taskset -c 0-3 mise run perf:record
+      - name: Package measurement note
         if: github.ref == 'refs/heads/main'
+        run: |
+          mkdir -p /tmp/tak-out
+          git notes --ref=tak show HEAD > /tmp/tak-out/note
+          git rev-parse HEAD > /tmp/tak-out/sha
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: github.ref == 'refs/heads/main'
+        with:
+          name: tak-measurement
+          path: /tmp/tak-out
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Summary
+        run: tak history >> "$GITHUB_STEP_SUMMARY"
+
+  publish:
+    name: Publish measurement note
+    needs: measure
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: tak-measurement
+          path: /tmp/tak-out
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Publish refs/notes/tak
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
-          tak push
-
-      - name: Summary
-        run: tak history >> "$GITHUB_STEP_SUMMARY"
+          sha=$(cat /tmp/tak-out/sha)
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin refs/notes/tak:refs/notes/tak || true
+          git notes --ref=tak add -f -F /tmp/tak-out/note "$sha"
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git" refs/notes/tak

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -128,6 +128,25 @@ jobs:
           sha=$(cat /tmp/tak-out/sha)
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch origin refs/notes/tak:refs/notes/tak || true
-          git notes --ref=tak add -f -F /tmp/tak-out/note "$sha"
-          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git" refs/notes/tak
+          git fetch origin +refs/notes/tak:refs/notes/tak-remote || true
+          if git rev-parse --verify --quiet refs/notes/tak-remote >/dev/null; then
+            git update-ref refs/notes/tak refs/notes/tak-remote
+          fi
+          {
+            git notes --ref=tak show "$sha" 2>/dev/null || true
+            cat /tmp/tak-out/note
+          } | LC_ALL=C sort -u > /tmp/tak-out/merged-note
+          git notes --ref=tak add -f -F /tmp/tak-out/merged-note "$sha"
+
+          remote="https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
+          for attempt in 1 2 3 4 5; do
+            if git push --quiet "$remote" refs/notes/tak:refs/notes/tak; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              echo "::error::could not publish refs/notes/tak after five attempts"
+              exit 1
+            fi
+            git fetch --quiet "$remote" +refs/notes/tak:refs/notes/tak-remote
+            git notes --ref=tak merge -s cat_sort_uniq refs/notes/tak-remote
+          done

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -62,7 +62,7 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@d7c0e81'
+            echo 'environment-revision: perf-runner@78e4231'
             echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
             uname -a
             lscpu

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -50,6 +50,8 @@ jobs:
       # Compile inside the pinned job container. Restoring target/ could relabel
       # a binary built on another runner class as a jdx-perf-v1 measurement.
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          cache: false
         env:
           MISE_LOCKED: "1"
 

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -37,7 +37,7 @@ jobs:
     # that wanders between runners is unreadable.
     runs-on: [self-hosted, jdx-perf-v1]
     container:
-      image: ghcr.io/jdx/perf-runner@sha256:8935770e7f656f7b0bcd0204328aa3d6998b32d8bb04084851731b30df56941b
+      image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9
       options: --cpuset-cpus 0-7
     timeout-minutes: 30
     permissions:
@@ -63,7 +63,7 @@ jobs:
             echo '### Runner metadata'
             echo '```text'
             echo 'environment-revision: perf-runner@6ab972a'
-            echo 'image: ghcr.io/jdx/perf-runner@sha256:8935770e7f656f7b0bcd0204328aa3d6998b32d8bb04084851731b30df56941b'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9'
             uname -a
             lscpu
             mise --version

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -27,6 +27,9 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
+  # Rust 1.97.1 is part of the digest-pinned benchmark image.
+  MISE_DISABLE_TOOLS: rust
+  RUSTUP_TOOLCHAIN: 1.97.1
   TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-aube-rust1.97.1
 
 jobs:
@@ -37,7 +40,7 @@ jobs:
     # that wanders between runners is unreadable.
     runs-on: [self-hosted, jdx-perf-v1]
     container:
-      image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9
+      image: ghcr.io/jdx/perf-runner@sha256:0f4ee40929472883a32cc29bcd4bd22068c4382b72697da299d6769475b263b5
       options: --cpuset-cpus 0-7
     timeout-minutes: 30
     permissions:
@@ -64,8 +67,8 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@6ab972a'
-            echo 'image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9'
+            echo 'environment-revision: perf-runner@34a523e'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:0f4ee40929472883a32cc29bcd4bd22068c4382b72697da299d6769475b263b5'
             uname -a
             lscpu
             mise --version

--- a/mise.lock
+++ b/mise.lock
@@ -149,44 +149,44 @@ url = "https://github.com/foresterre/cargo-msrv/releases/download/v0.19.3/cargo-
 url_api = "https://api.github.com/repos/foresterre/cargo-msrv/releases/assets/380851496"
 
 [[tools."github:jdx/tak"]]
-version = "0.0.8"
+version = "0.0.9"
 backend = "github:jdx/tak"
 
 [tools."github:jdx/tak"."platforms.linux-arm64"]
-checksum = "sha256:d3b5ee39a9be283586fcc1f40fffbe4003d0fce79905462f9e798ec488e148dd"
-url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283627"
+checksum = "sha256:9069450a581d5918c7f40fe4120f054a71835da322604becb42b7acb5bd1e0a1"
+url = "https://github.com/jdx/tak/releases/download/v0.0.9/tak-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/537992902"
 provenance = "github-attestations"
 
 [tools."github:jdx/tak"."platforms.linux-arm64-musl"]
-checksum = "sha256:a3261a9ffe9fcb2c997687d1d044107ff311429e0d7385ec98e92c6ea1935e2c"
-url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283626"
+checksum = "sha256:0caa3b6b66fe98298714a90e6de0690402a417f5b3c34d9aa9c912edf69a18f1"
+url = "https://github.com/jdx/tak/releases/download/v0.0.9/tak-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/537992901"
 provenance = "github-attestations"
 
 [tools."github:jdx/tak"."platforms.linux-x64"]
-checksum = "sha256:8def2146c565a331e2de9abebda238c22bb868335dc139db9a76aff1de1339c4"
-url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283644"
+checksum = "sha256:dfb0020b976d679af5a7504190ffbcb201c0e11b2f7788901fd6f60740cd87d4"
+url = "https://github.com/jdx/tak/releases/download/v0.0.9/tak-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/537992912"
 provenance = "github-attestations"
-provenance_verified = true
 
 [tools."github:jdx/tak"."platforms.linux-x64-musl"]
-checksum = "sha256:442c866a7572936f639c39edb32042a2f60d78a9dd86116a429f6e31cc9840fe"
-url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283646"
+checksum = "sha256:c761a4dbf695dc493744c79de0f3ab67a1698ee5af9afd35f6d019af36145420"
+url = "https://github.com/jdx/tak/releases/download/v0.0.9/tak-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/537992915"
 provenance = "github-attestations"
 
 [tools."github:jdx/tak"."platforms.macos-arm64"]
-checksum = "sha256:fbd5e2c3366f085cb8ce71362bcdc05fbf549e7787bd401ae085a1dee09bdb22"
-url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283628"
+checksum = "sha256:be4690bad41265946803d11f145c22e01368164e7f1fe49befef8789259c9471"
+url = "https://github.com/jdx/tak/releases/download/v0.0.9/tak-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/537992905"
 provenance = "github-attestations"
+provenance_verified = true
 
 [tools."github:jdx/tak"."platforms.windows-x64"]
-checksum = "sha256:fd3157419889dc558c87e5779f89d123dc909bfc4f7557c970dcb95d71a97d1b"
-url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283641"
+checksum = "sha256:a15f62ea6fa0051f8ae01fca58da26c550ae95fd9d7eccaa167ca53d6f2262b3"
+url = "https://github.com/jdx/tak/releases/download/v0.0.9/tak-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/537992910"
 provenance = "github-attestations"
 
 [[tools.hk]]

--- a/mise.toml
+++ b/mise.toml
@@ -19,7 +19,7 @@ communique = "latest"
 # TODO: switch to plain `tak = "0.0.4"` once a mise release ships the registry
 # entry from jdx/mise#11307 — the shorthand exists on main but the registry is
 # compiled in, so it is not usable until then.
-"github:jdx/tak" = "v0.0.8"
+"github:jdx/tak" = "v0.0.9"
 hk = "latest"
 node = "24"
 pitchfork = "latest"


### PR DESCRIPTION
## Summary

- route main and authorized pull-request benchmarks through `[self-hosted, jdx-perf-v1]`
- serialize benchmark work on the host and keep write credentials off measurement jobs
- pin Tak 0.0.9 through its checksum-verified GitHub release artifacts; no Cargo compilation is used
- retain GitHub-hosted jobs for publishing notes and enforcing the regression gate

## Security

- only same-repository pull requests authored by `jdx` can dispatch measurements
- controlling workflows remain on the default branch and check out the exact authorized head SHA
- actions and the benchmark container are digest-pinned; credentials and caches are disabled on the self-hosted job

## Validation

- `actionlint` on each changed workflow
- `mise lock github:jdx/tak --dry-run --json`
- installed the prebuilt release asset and confirmed `tak 0.0.9`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Testing**
  - Improved measurement consistency with pinned runners, containers, and CPU allocation.
  - Added diagnostics for runner environment, toolchain, and thermal conditions.
  - Performance comparisons now clearly report successful runs, regressions, and incomplete comparisons.
  - Results are packaged and published more reliably with retry support.
  - Standardized benchmark refresh execution on the dedicated performance environment.

- **CI Improvements**
  - Added automated preflight validation and safeguards for performance pull requests.
  - Improved benchmark refresh validation and artifact-based publishing.

- **Chores**
  - Updated the pinned `tak` tool version to v0.0.9.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI security boundaries (workflow_run gating, token placement) and the hardware baseline for all perf/bench numbers; misconfiguration could skip checks or publish bad notes, but measurement jobs no longer hold write credentials.
> 
> **Overview**
> Benchmark and instruction-count CI moves from **`bamboo-perf`** to **`[self-hosted, jdx-perf-v1]`** inside a digest-pinned **`ghcr.io/jdx/perf-runner`** container (`--cpuset-cpus 0-7`), with Rust **1.97.1** from the image (`MISE_DISABLE_TOOLS: rust`, mise cache off) and **`taskset -c 0-3`** around tak runs. **`TAK_RUNNER`** is renamed to the new machine id; **`tak`** is bumped to **v0.0.9** in `mise.toml` / `mise.lock`.
> 
> **`perf-pr`** no longer runs on `pull_request` directly: **`perf-pr-preflight`** fires on PR events, then **`perf-pr`** runs on `workflow_run` with an **`authorize`** job that re-fetches PR metadata (same-repo, `jdx`, non-`release-plz-*`, head SHA match) before any self-hosted work. Measurement stays read-only on the runner; a **`report`** job on GitHub-hosted Ubuntu posts the sticky comment, publishes a **`perf / instruction-count`** check on the head SHA, and fails the workflow on regression.
> 
> **`perf`** and **`bench-refresh`** split **measure/refresh** (artifacts only, `contents: read`) from **publish/propose** (write token on `ubuntu-latest`), with allowlist validation on benchmark artifacts and retrying **`refs/notes/tak`** push via merge instead of in-job `tak push`. Valgrind install steps are dropped in favor of the image plus runner metadata in the job summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f340ffb94ed3bc8fcf4b929573c385ed206de5f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->