### PR TITLE
perf(linker): resolve hardlinks relative to package dirs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,6 +320,7 @@ dependencies = [
  "glob",
  "hex",
  "junction",
+ "libc",
  "miette",
  "pathdiff",
  "rayon",

--- a/crates/aube-linker/Cargo.toml
+++ b/crates/aube-linker/Cargo.toml
@@ -30,6 +30,7 @@ diffy = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
 tempfile = "3"
+libc = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 junction = { workspace = true }

--- a/crates/aube-linker/src/hoisted.rs
+++ b/crates/aube-linker/src/hoisted.rs
@@ -794,11 +794,18 @@ fn materialize_hoisted_plan(
             std::fs::create_dir_all(parent).map_err(|e| Error::Io(parent.clone(), e))?;
         }
 
+        // Match the isolated materializer's Linux fast path: resolve every
+        // destination relative to one open package directory.
+        #[cfg(target_os = "linux")]
+        let pkg_dir_fd = std::fs::File::open(&pkg_dir).ok();
+        #[cfg(not(target_os = "linux"))]
+        let pkg_dir_fd: Option<std::fs::File> = None;
+
         for (rel_path, stored) in index {
             // Key already validated in the parent-collection loop
             // above. The index is immutable between the two loops.
             let target = pkg_dir.join(rel_path);
-            if let Err(e) = linker.link_file_fresh(stored, rel_path, &target, None) {
+            if let Err(e) = linker.link_file_fresh(stored, rel_path, &target, pkg_dir_fd.as_ref()) {
                 if let Error::MissingStoreFile { .. } = &e {
                     crate::invalidate_stale_index_for_package(&linker.store, pkg);
                 }

--- a/crates/aube-linker/src/hoisted.rs
+++ b/crates/aube-linker/src/hoisted.rs
@@ -798,7 +798,7 @@ fn materialize_hoisted_plan(
             // Key already validated in the parent-collection loop
             // above. The index is immutable between the two loops.
             let target = pkg_dir.join(rel_path);
-            if let Err(e) = linker.link_file_fresh(stored, rel_path, &target) {
+            if let Err(e) = linker.link_file_fresh(stored, rel_path, &target, None) {
                 if let Error::MissingStoreFile { .. } = &e {
                     crate::invalidate_stale_index_for_package(&linker.store, pkg);
                 }

--- a/crates/aube-linker/src/materialize.rs
+++ b/crates/aube-linker/src/materialize.rs
@@ -616,6 +616,15 @@ impl Linker {
             std::fs::create_dir_all(parent).map_err(|e| Error::Io(parent.clone(), e))?;
         }
 
+        // Linux can resolve every destination relative to one open package
+        // directory instead of walking the long GVS staging path per file.
+        // Failure to open is harmless: `link_file_fresh` retains the portable
+        // full-path operation and its existing copy fallback.
+        #[cfg(target_os = "linux")]
+        let pkg_nm_dir_fd = std::fs::File::open(&pkg_nm_dir).ok();
+        #[cfg(not(target_os = "linux"))]
+        let pkg_nm_dir_fd: Option<std::fs::File> = None;
+
         // `materialize_into` always writes into a fresh location
         // (either a `.tmp-<pid>-...` staging dir for the global virtual
         // store or a per-project `.aube/<dep_path>` just created by
@@ -628,7 +637,8 @@ impl Linker {
             // above. The index is immutable between the two loops.
             let target = pkg_nm_dir.join(rel_path);
 
-            if let Err(e) = self.link_file_fresh(stored, rel_path, &target) {
+            if let Err(e) = self.link_file_fresh(stored, rel_path, &target, pkg_nm_dir_fd.as_ref())
+            {
                 if let Error::MissingStoreFile { .. } = &e {
                     invalidate_stale_index_for_package(&self.store, pkg);
                 }
@@ -793,6 +803,7 @@ impl Linker {
         stored: &StoredFile,
         rel_path: &str,
         dst: &Path,
+        dst_dir: Option<&std::fs::File>,
     ) -> Result<(), Error> {
         #[cfg(target_os = "macos")]
         const SMALL_FILE_COPY_MAX: u64 = 16 * 1024;
@@ -909,7 +920,48 @@ impl Linker {
                 }
             }
             LinkStrategy::Hardlink => {
-                if let Err(e) = std::fs::hard_link(&stored.store_path, dst) {
+                #[cfg(target_os = "linux")]
+                let hardlink_result = if let Some(dst_dir) = dst_dir {
+                    use std::ffi::CString;
+                    use std::os::fd::AsRawFd;
+                    use std::os::unix::ffi::OsStrExt;
+
+                    let source = CString::new(stored.store_path.as_os_str().as_bytes());
+                    let relative = CString::new(rel_path.as_bytes());
+                    match (source, relative) {
+                        (Ok(source), Ok(relative)) => {
+                            // SAFETY: both C strings live through the call and
+                            // `dst_dir` owns a valid package-directory fd.
+                            let result = unsafe {
+                                libc::linkat(
+                                    libc::AT_FDCWD,
+                                    source.as_ptr(),
+                                    dst_dir.as_raw_fd(),
+                                    relative.as_ptr(),
+                                    0,
+                                )
+                            };
+                            if result == 0 {
+                                Ok(())
+                            } else {
+                                Err(std::io::Error::last_os_error())
+                            }
+                        }
+                        _ => Err(std::io::Error::new(
+                            std::io::ErrorKind::InvalidInput,
+                            "hardlink path contains nul",
+                        )),
+                    }
+                } else {
+                    std::fs::hard_link(&stored.store_path, dst)
+                };
+                #[cfg(not(target_os = "linux"))]
+                let hardlink_result = {
+                    let _ = dst_dir;
+                    std::fs::hard_link(&stored.store_path, dst)
+                };
+
+                if let Err(e) = hardlink_result {
                     if !stored.store_path.exists() {
                         return Err(missing_source());
                     }

--- a/crates/aube-linker/src/tests.rs
+++ b/crates/aube-linker/src/tests.rs
@@ -732,7 +732,7 @@ fn test_link_file_fresh_hardlink_short_circuits_when_source_missing() {
 
     let linker = Linker::new_with_gvs(&store, LinkStrategy::Hardlink, true);
     let err = linker
-        .link_file_fresh(&stored, "hello.txt", &dst)
+        .link_file_fresh(&stored, "hello.txt", &dst, None)
         .expect_err("source missing must fail");
     assert!(
         matches!(
@@ -805,7 +805,7 @@ fn realized_inode_matches_source_on_reflink_failure(strategy: LinkStrategy) -> b
         // Hold the guard across the materialize so a sibling test can't flip
         // the global flag mid-call; the flag is restored on drop, panic-safe.
         let _forced = ForcedReflinkFailure::engage();
-        linker.link_file_fresh(&stored, "payload.bin", &dst)
+        linker.link_file_fresh(&stored, "payload.bin", &dst, None)
     };
     result.expect("a reflink strategy must still materialize the file via its fallback");
 


### PR DESCRIPTION
## Summary

- open each freshly created package directory once on Linux
- publish CAS hardlinks relative to that directory descriptor
- retain the portable full-path hardlink and copy fallbacks

## Benchmark

Hermetic `gvs-cold`, 500mbit bandwidth / 50ms latency, 10 measured runs and 3 warmups:

| revision | wall time | aggregate system CPU |
|---|---:|---:|
| #1419 baseline | 3.291s ± 0.676s | 20.886s |
| candidate | 2.857s ± 0.343s | 16.822s |

That adjacent reverse-order pair is 434ms / 13.2% faster in wall time and uses 19.5% less system CPU. A preceding baseline run was 2.970s ± 0.394s, which still puts the candidate 3.8% ahead.

## Validation

- `cargo fmt --check`
- `cargo test -p aube-linker` (123 passed)
- `cargo clippy --all-targets -- -D warnings`
- full `cargo test`: 840 core tests passed; one CLI e2e initially failed because the ambient mise `node` shim was invalid
- the exact failed e2e passed after placing the repository Node 24 install on `PATH`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the hot-path file-linking implementation on Linux (including `unsafe` `linkat`), though behavior should match prior hardlink/copy fallbacks when the fd fast path is unavailable.
> 
> **Overview**
> Speeds up **Linux** package materialization by hardlinking CAS files into each package directory via **`linkat`** with a single open directory fd and **relative** destination paths, instead of repeating full GVS staging paths on every file.
> 
> **Hoisted** and **isolated** materializers now open each package directory once (best-effort) and pass that handle into **`link_file_fresh`**, which gains an optional **`dst_dir`** argument. Non-Linux builds and failed opens keep **`std::fs::hard_link`** plus the existing **EXDEV / missing-source copy** fallbacks. Tests pass **`None`** for the new parameter where the fd path is not exercised.
> 
> Adds a **`libc`** workspace dependency for the Linux syscall path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86203f7e5919d1ee873ab2d882f8319f9de54092. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved package materialization on Linux by creating hardlinks more efficiently, reducing repeated path traversal.
  * Preserved existing fallback behavior on other platforms and for alternate file-copy strategies.

* **Bug Fixes**
  * Updated file-linking workflows and tests to support the improved hardlink handling without changing visible behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->