### PR TITLE
fix(bench): align aube script policy with other managers

### DIFF
--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -307,7 +307,9 @@ for i in "${!TOOLS[@]}"; do
 
 	case "$tool" in
 	aube)
-		cd "$dir" && HOME="$home" XDG_CACHE_HOME="$cache" XDG_DATA_HOME="$home/.local/share" "$bin" install
+		# Aube's built-in trusted-dependency list can allow known-safe
+		# install scripts; opt out explicitly to match every other PM.
+		cd "$dir" && HOME="$home" XDG_CACHE_HOME="$cache" XDG_DATA_HOME="$home/.local/share" "$bin" install --ignore-scripts
 		;;
 	npm)
 		# `--legacy-peer-deps` is the only way npm tolerates the
@@ -465,7 +467,7 @@ AUBE_ENV_GVS_ON="$AUBE_ENV npm_config_enable_global_virtual_store=true"
 cmd_template() {
 	case "$1:$2" in
 	gvs-warm:aube | gvs-cold:aube)
-		echo "cd {project} && $AUBE_ENV_GVS_ON {bin} install --frozen-lockfile >/dev/null 2>&1"
+		echo "cd {project} && $AUBE_ENV_GVS_ON {bin} install --frozen-lockfile --ignore-scripts >/dev/null 2>&1"
 		;;
 	gvs-warm:bun | gvs-cold:bun)
 		echo "cd {project} && $BUN_BASE --frozen-lockfile >/dev/null 2>&1"


### PR DESCRIPTION
## Summary

- pass `--ignore-scripts` during the Aube benchmark populate step
- pass `--ignore-scripts` in timed warm- and cold-cache Aube installs
- align Aube with npm, pnpm, Bun, Yarn, Deno, and vlt script policy in the benchmark matrix

## Why

The benchmark already disables dependency lifecycle scripts for every other package manager. Aube normally skips scripts, but its built-in trusted-dependency list allows known-safe packages such as `@parcel/watcher` to run. That added dependency lifecycle and bin-relink work to the Aube sample while Bun and the other managers skipped it.

## Benchmark

Hermetic registry, 500mbit bandwidth, 50ms latency, 10 runs and 3 warmups:

| Manager | Fresh cold install |
|---|---:|
| Aube | 1.067s ± 0.037s |
| Bun | 1.430s ± 0.012s |

Aube is about 1.34x faster in this run. The phase sample no longer includes dependency lifecycle work, and `link_bins` fell from roughly 20ms to 4ms.

## Validation

- `bash -n benchmarks/bench.sh`
- `shellcheck benchmarks/bench.sh`
- `shfmt -d benchmarks/bench.sh`
- `git diff --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only benchmark harness flags and comments; no production install or resolver behavior changes.
> 
> **Overview**
> Benchmark comparisons were skewed because **Aube** could still run lifecycle scripts for packages on its trusted-dependency allowlist while npm, pnpm, Bun, and the rest of the matrix already skipped scripts.
> 
> This PR adds **`--ignore-scripts`** to Aube’s **populate** warm install and to the timed **`gvs-warm` / `gvs-cold`** frozen-lockfile install commands in `bench.sh`, with a short comment explaining the trusted-deps behavior. **`install-test`** is unchanged (it still exercises script dispatch via `aube test`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb8748636c0bd2c1644e728f894c4f53f74a22ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->