### PR TITLE
perf(store): direct-write Linux CAS under install lock

### DIFF
--- a/crates/aube-store/src/cas.rs
+++ b/crates/aube-store/src/cas.rs
@@ -8,7 +8,7 @@ thread_local! {
     static B3_HASHER: RefCell<blake3::Hasher> = RefCell::new(blake3::Hasher::new());
 }
 
-/// Per-shard mutex array used by the macOS CAS fast path to serialize
+/// Per-shard mutex array used by the Linux/macOS CAS fast path to serialize
 /// concurrent writers within a single process. Indexed by the first
 /// byte of the file's BLAKE3 hash (matching the on-disk 2-char shard
 /// layout), so two threads writing the same hash always collide; threads
@@ -17,12 +17,8 @@ thread_local! {
 /// per install, and a static avoids carrying 256 mutexes in every cheap
 /// `Store::clone()` along the fetch pipeline.
 ///
-/// macOS-gated rather than `not(linux)` because the fast-path block
-/// itself uses `OpenOptionsExt::mode`, which only exists on Unix —
-/// Windows would fail to compile under `not(linux)`. Linux already has
-/// `O_TMPFILE + linkat` (atomic-by-construction, faster than either
-/// alternative); Windows keeps the tempfile + persist_noclobber path.
-#[cfg(target_os = "macos")]
+/// Windows keeps the tempfile + persist_noclobber path.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 static FAST_PATH_SHARD_LOCKS: [std::sync::Mutex<()>; 256] =
     [const { std::sync::Mutex::new(()) }; 256];
 
@@ -240,7 +236,7 @@ impl Store {
                     let disabled = *O_TMPFILE_DISABLED.get_or_init(|| {
                         aube_util::env::embedder_env("DISABLE_O_TMPFILE").is_some()
                     });
-                    if !disabled {
+                    if !disabled && !this.fast_path.load(Ordering::Acquire) {
                         match try_o_tmpfile_publish(path, bytes) {
                             Ok(outcome) => return Ok(outcome),
                             Err(OTmpfileFallback::Unsupported) => {}
@@ -249,7 +245,7 @@ impl Store {
                     }
                 }
 
-                // macOS fast path: direct O_CREAT|O_EXCL at the final
+                // Linux/macOS fast path: direct O_CREAT|O_EXCL at the final
                 // content-addressed path, no tempfile dance. Caller (the
                 // install command) flips `fast_path` on only after
                 // acquiring an exclusive store-level lock against other
@@ -271,10 +267,10 @@ impl Store {
                 //
                 // On APFS the fast path is ~2.25x faster than
                 // tempfile+chmod+persist (~64µs/file vs ~145µs/file in
-                // isolation). macOS-gated rather than `not(linux)`
-                // because `OpenOptionsExt::mode` is unix-only — Windows
-                // keeps the tempfile path.
-                #[cfg(target_os = "macos")]
+                // isolation). Linux also uses it while the install owns
+                // the exclusive store lock; contended installs retain the
+                // atomic O_TMPFILE path. Windows keeps named tempfiles.
+                #[cfg(any(target_os = "linux", target_os = "macos"))]
                 if this.fast_path.load(Ordering::Acquire) {
                     use std::io::Write;
                     use std::os::unix::fs::OpenOptionsExt;
@@ -381,7 +377,7 @@ impl Store {
                 // orders and clobbered each other's recovery. The
                 // fast-path branch above re-enables it under an
                 // exclusive store lock.
-                let _ = this; // suppress unused warning on Linux
+                let _ = this; // suppress unused warning on non-Unix targets
                 let parent = path.parent().ok_or_else(|| {
                     Error::Io(path.to_path_buf(), std::io::ErrorKind::NotFound.into())
                 })?;
@@ -466,7 +462,7 @@ impl Store {
         // The macOS byte importer publishes directly into the final path while
         // holding this same shard lock. Hold it through publication and any
         // recovery so a streamed writer cannot unlink an in-progress file.
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         let _shard_guard = hex_hash
             .get(..2)
             .and_then(|shard| u8::from_str_radix(shard, 16).ok())
@@ -475,7 +471,7 @@ impl Store {
                     .lock()
                     .unwrap_or_else(|poisoned| poisoned.into_inner())
             });
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         let mut recovery_lock = None;
 
         let mut retried_missing_parent = false;
@@ -506,7 +502,7 @@ impl Store {
                     // before deciding the entry is torn. The in-process shard
                     // mutex above separately serializes recovery threads in
                     // this process.
-                    #[cfg(target_os = "macos")]
+                    #[cfg(any(target_os = "linux", target_os = "macos"))]
                     if !self.fast_path.load(Ordering::Acquire)
                         && !cas_file_matches_len(&store_path, len)
                         && recovery_lock.is_none()
@@ -616,26 +612,22 @@ impl Store {
                 format!(r#"{{"size":{}}}"#, content.len())
             });
         }
-        // The macOS fast path verifies the file size inline under its
+        // The Linux/macOS fast path verifies the file size inline under its
         // shard mutex before returning `AlreadyExisted`, so this
         // recovery only needs to run when we took the tempfile path.
         // Skipping it there also prevents a race where the recovery
         // unlinks a file that another in-process thread is concurrently
         // re-creating after observing the same crashed-predecessor.
         //
-        // `cfg!(target_os = "macos")` matches the cfg gate on the only
-        // code path that flips `fast_path` to true (and on the inline
-        // recovery inside `create_cas_file`). Without the cfg!, a future
-        // caller setting the flag on Linux would silently disable this
-        // recovery — the Linux O_TMPFILE branch has no inline
-        // length-check substitute, so torn CAS files would be accepted.
-        let fast_path_handled_recovery =
-            cfg!(target_os = "macos") && self.fast_path.load(Ordering::Acquire);
+        // The target check matches the cfg gate on the only code path that
+        // flips `fast_path` to true and the inline recovery above.
+        let fast_path_handled_recovery = (cfg!(target_os = "linux") || cfg!(target_os = "macos"))
+            && self.fast_path.load(Ordering::Acquire);
         if outcome == CasWriteOutcome::AlreadyExisted && !fast_path_handled_recovery {
             // A length mismatch from this branch can mean either
             //   (a) a crashed predecessor left a torn file (the recovery
             //       case this code was originally written for), or
-            //   (b) on macOS, another *process* is currently writing to
+            //   (b) on Linux/macOS, another *process* is currently writing to
             //       the same path via the fast path (no atomic publish
             //       at the final path, so its in-progress fd is visible
             //       by name to other writers).

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -46,7 +46,7 @@ use sha1::Sha1;
 use sha2::{Digest as _, Sha256, Sha384, Sha512};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -180,7 +180,7 @@ impl Store {
         }
     }
 
-    /// Enable the macOS direct-write fast path for CAS imports. Bypasses
+    /// Enable the Linux/macOS direct-write fast path for CAS imports. Bypasses
     /// the tempfile + persist_noclobber pattern and writes straight to
     /// the final content-addressed path, saving ~80µs/file on APFS. The
     /// caller MUST hold an exclusive lock against the store for the
@@ -188,14 +188,9 @@ impl Store {
     /// concurrent installer can observe a partial file and the
     /// `AlreadyExisted` recovery dance can clobber an in-flight write.
     ///
-    /// macOS-gated rather than just declared inert on other platforms.
-    /// On Linux the `O_TMPFILE+linkat` path has no inline length-check
-    /// recovery — that recovery only lives inside the macOS fast-path
-    /// branch — so the outer skip in `import_bytes` (also macOS-gated
-    /// via `cfg!`) must never see the flag set on Linux. Removing the
-    /// method on non-macOS platforms makes that mismatch a build error
-    /// rather than a silent acceptance of torn CAS files.
-    #[cfg(target_os = "macos")]
+    /// Unix-gated because the implementation relies on `OpenOptionsExt`.
+    /// Windows retains the named-tempfile publication path.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     pub fn enable_fast_path(&self) {
         self.fast_path.store(true, Ordering::Release);
     }

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -752,7 +752,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     if let Err(e) = store.ensure_shards_exist() {
         tracing::debug!("ensure_shards_exist failed (slow path will cover): {e}");
     }
-    // macOS fast-path gate: take an exclusive `try_lock` on
+    // Linux/macOS fast-path gate: take an exclusive `try_lock` on
     // `<store>/v1/.install.lock`. If we get it, no other aube install is
     // running against this store right now, so the CAS write path can
     // skip the tempfile + persist_noclobber dance and write straight to
@@ -762,13 +762,13 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     // back to the safe tempfile path — concurrent installers still
     // proceed, just at the existing speed.
     //
-    // Linux is unaffected: `create_cas_file` always uses O_TMPFILE+linkat
-    // there, which is already atomic-by-construction and faster than
-    // both options. Windows keeps the tempfile path; the fast-path branch
+    // Linux normally uses atomic O_TMPFILE+linkat, but direct writes save
+    // the anonymous-file publication syscall while this lock excludes other
+    // aube writers. Windows keeps the tempfile path; the fast-path branch
     // in `aube-store` is unix-only (`OpenOptionsExt::mode`), so gating
-    // the lock acquisition on macOS too avoids opening a lock file that
+    // the lock acquisition on Unix too avoids opening a lock file that
     // nothing would consult.
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     let _store_lock = {
         let lock_dir = store
             .root()


### PR DESCRIPTION
## Summary

- extend the existing exclusive-lock CAS fast path from macOS to Linux
- write new CAS objects directly to their final paths when this install owns the store lock
- retain atomic O_TMPFILE publication whenever another installer holds the lock
- share the existing per-shard synchronization and torn-entry recovery across Linux and macOS

This is stacked on #1421.

## Benchmark

Hermetic `gvs-cold`, 500mbit bandwidth / 50ms latency, 10 measured runs and 3 warmups. A/B/A sequence:

| run | revision | wall time | install total | fetch | aggregate system CPU |
|---|---|---:|---:|---:|---:|
| A1 | candidate | 2.612s ± 0.131s | 2429ms | 2046ms | 15.564s |
| B | #1421 baseline | 2.690s ± 0.060s | 2528ms | 2160ms | 15.951s |
| A2 | candidate | 2.697s ± 0.278s | 2421ms | 2054ms | 15.271s |

The candidate average is 2.655s, 1.3% faster than the sandwiched baseline, with 3.3% less aggregate system CPU. The measured install work is consistently lower in both candidate runs. An earlier baseline run reached 2.526s, so this is intentionally presented as a modest improvement rather than a large headline gain.

## Validation

- `cargo fmt --check`
- `cargo test -p aube-store` (114 passed)
- `cargo test -p aube --lib commands::install` (116 passed)
- `cargo clippy -p aube-store -p aube --all-targets -- -D warnings`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrent CAS write semantics on Linux (fast direct writes vs O_TMPFILE) and relies on the install lock plus shard mutexes for correctness; mistakes could cause torn entries or recovery races under contention.
> 
> **Overview**
> Extends the **exclusive `.install.lock` CAS fast path** from macOS-only to **Linux and macOS**. When an install holds that lock, it calls `Store::enable_fast_path()` and writes new CAS objects **directly to their final paths** (`O_CREAT|O_EXCL`) instead of tempfile + `persist_noclobber`, reusing the existing **256-way shard mutexes** and inline torn-entry recovery.
> 
> On **Linux**, `create_cas_file` now **skips `O_TMPFILE+linkat` while `fast_path` is set**; if the lock is contended (another installer running), behavior stays on the atomic anonymous-file path. **`enable_fast_path`**, install lock acquisition, and the `import_bytes` recovery skip are all gated with `cfg(any(linux, macos))` so Linux cannot silently accept torn CAS entries when the flag is on. Windows is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d50f44a2b27fd19f04cbaf6ace6d6f14a297135. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->