### PR TITLE
perf(store): serialize package indexes with sonic

### DIFF
--- a/crates/aube-store/Cargo.toml
+++ b/crates/aube-store/Cargo.toml
@@ -41,3 +41,7 @@ tempfile = "3"
 # Synthesize a napi `--compress` hybrid in the store-compression tests
 # (the gated import unwraps it back to the raw addon before CAS).
 zstd = { workspace = true }
+
+[[bench]]
+name = "index_serialization"
+harness = false

--- a/crates/aube-store/benches/index_serialization.rs
+++ b/crates/aube-store/benches/index_serialization.rs
@@ -1,0 +1,39 @@
+use aube_store::{PackageIndex, StoredFile};
+use std::hint::black_box;
+use std::path::PathBuf;
+use std::time::Instant;
+
+fn main() {
+    let mut index = PackageIndex::default();
+    for i in 0..64 {
+        index.insert(
+            format!("lib/components/component-{i}/index.js"),
+            StoredFile {
+                hex_hash: format!("{i:064x}"),
+                store_path: PathBuf::from(format!("/store/files/{:02x}/{i:062x}", i % 256)),
+                executable: i % 17 == 0,
+                size: Some(1024 + i),
+            },
+        );
+    }
+
+    const ITERATIONS: usize = 100_000;
+    let started = Instant::now();
+    for _ in 0..ITERATIONS {
+        black_box(serde_json::to_vec(black_box(&index)).unwrap());
+    }
+    let serde_json = started.elapsed();
+
+    let started = Instant::now();
+    for _ in 0..ITERATIONS {
+        black_box(sonic_rs::to_vec(black_box(&index)).unwrap());
+    }
+    let sonic = started.elapsed();
+
+    println!("serde_json: {serde_json:?}");
+    println!("sonic-rs:   {sonic:?}");
+    println!(
+        "speedup:    {:.2}x",
+        serde_json.as_secs_f64() / sonic.as_secs_f64()
+    );
+}

--- a/crates/aube-store/src/index.rs
+++ b/crates/aube-store/src/index.rs
@@ -262,8 +262,7 @@ impl Store {
                 "refusing to cache: invalid coordinate {name:?}@{version:?} or integrity {integrity:?}"
             ))
         })?;
-        let json =
-            serde_json::to_string(index).map_err(|e| Error::Tar(format!("serialize: {e}")))?;
+        let json = sonic_rs::to_vec(index).map_err(|e| Error::Tar(format!("serialize: {e}")))?;
         xx::file::write(&index_path, json).map_err(|e| Error::Xx(e.to_string()))?;
         trace!("cached index: {name}@{version}");
         Ok(())


### PR DESCRIPTION
## Summary

- serialize package indexes directly into byte vectors with the already-used `sonic-rs`
- avoid constructing an intermediate UTF-8 `String`
- add a focused release benchmark for representative 64-file indexes

This is stacked on #1423.

## Benchmark

`cargo bench -p aube-store --bench index_serialization`, 100,000 serializations of a representative 64-file package index:

| run | serde_json | sonic-rs | speedup |
|---|---:|---:|---:|
| 1 | 1.516s | 0.656s | 2.31× |
| 2 | 0.721s | 0.356s | 2.03× |

In the hermetic end-to-end cold benchmark, the candidate used 1.406s user CPU versus 1.546s for the adjacent baseline, but both runs contained filesystem outliers, so the focused benchmark is the primary evidence.

## Validation

- `cargo fmt --check`
- `cargo test -p aube-store` (114 passed)
- `cargo clippy -p aube-store --all-targets -- -D warnings`
- `cargo bench -p aube-store --bench index_serialization`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized cache-write serialization change with symmetric serde usage already on read; benchmark-only additions elsewhere.
> 
> **Overview**
> **Package index cache writes** now serialize with `sonic_rs::to_vec` instead of `serde_json::to_string`, matching the existing `sonic_rs::from_slice` read path and skipping an intermediate UTF-8 `String` before `xx::file::write`.
> 
> A new **`index_serialization`** bench (`harness = false`) compares `serde_json` vs `sonic-rs` on a 64-entry representative `PackageIndex` over 100k iterations to quantify the ~2× serialization speedup cited in the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86d5287b627c467eabe3927e673fa38abbbae040. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->