### PR TITLE
perf(store): skip initialized writer lease locking

### DIFF
--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -344,6 +344,13 @@ impl Store {
     /// Acquire the shared writer lease and perform any pending legacy-index
     /// migration. The lease is retained by this `Store` and all of its clones.
     pub fn prepare_for_write(&self) -> Result<(), Error> {
+        // `migration_done` is set only after the shared lease has been stored
+        // in `maintenance.shared` and migration has completed. Once visible,
+        // the Arc-owned lease remains live for every Store clone, so hot CAS
+        // and index writes can skip the maintenance mutex entirely.
+        if self.migration_done.get().is_some() {
+            return Ok(());
+        }
         let mut shared = self.maintenance.shared.lock().map_err(|_| {
             Error::Io(
                 self.maintenance_lock_path(),


### PR DESCRIPTION
## Summary

- return immediately from `prepare_for_write` after shared lease initialization and migration complete
- use the existing Arc-shared `migration_done` OnceLock as the acquire/release synchronization point
- avoid taking the maintenance mutex for every CAS object and package-index write

A 1,226-package cold install performs roughly 38,700 CAS file imports, so this removes tens of thousands of uncontended mutex lock/unlock pairs. The retained shared lock file still lives in the Arc-owned maintenance state, preserving prune exclusion.

This is stacked on #1424.

## Benchmark

Hermetic `gvs-cold`, 500mbit bandwidth / 50ms latency, 10 measured runs and 3 warmups:

| run | revision | wall time | install total | fetch | aggregate system CPU |
|---|---|---:|---:|---:|---:|
| A1 | candidate | 2.598s ± 0.346s | 2358ms | 1997ms | 11.820s |
| B | #1424 baseline | 3.403s ± 0.436s | 4243ms | 3670ms | 18.574s |
| A2 | candidate | 2.360s ± 0.390s | 2400ms | 2034ms | 11.037s |

The middle baseline was anomalously slow, so the full sandwich gap should not be treated as the expected improvement. A separate earlier #1424 run was 2.623s with 16.697s system CPU; compared with the two candidate runs averaged together, the conservative signal is 5.5% lower wall time and 31.5% lower system CPU.

## Validation

- `cargo fmt --check`
- `cargo test -p aube-store` (114 passed)
- `cargo clippy -p aube-store --all-targets -- -D warnings`
- existing maintenance-lock concurrency test remains green

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches writer-lease and migration ordering; incorrect fast-path could skip lease acquisition or migration, though `OnceLock` is only set after the existing init path completes and tests cover maintenance-lock concurrency.
> 
> **Overview**
> **`Store::prepare_for_write`** now returns immediately when the shared **`migration_done`** `OnceLock` is already set, instead of locking **`maintenance.shared`** on every call.
> 
> After the first successful pass (shared `.maintenance.lock` lease held in Arc state and legacy index migration finished), hot **CAS** imports and **package-index** writes no longer pay an uncontended mutex round-trip. The on-disk shared lease and prune exclusion behavior are unchanged because the lease file handle stays alive in shared maintenance state across **`Store`** clones.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4129f35f20e937000678c5b5ee8bc54e60580ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->