### PR TITLE
perf(store): serialize package indexes with sonic

### DIFF
--- a/crates/aube-store/Cargo.toml
+++ b/crates/aube-store/Cargo.toml
@@ -41,3 +41,7 @@ tempfile = "3"
 # Synthesize a napi `--compress` hybrid in the store-compression tests
 # (the gated import unwraps it back to the raw addon before CAS).
 zstd = { workspace = true }
+
+[[bench]]
+name = "index_serialization"
+harness = false

--- a/crates/aube-store/benches/index_serialization.rs
+++ b/crates/aube-store/benches/index_serialization.rs
@@ -1,0 +1,39 @@
+use aube_store::{PackageIndex, StoredFile};
+use std::hint::black_box;
+use std::path::PathBuf;
+use std::time::Instant;
+
+fn main() {
+    let mut index = PackageIndex::default();
+    for i in 0..64 {
+        index.insert(
+            format!("lib/components/component-{i}/index.js"),
+            StoredFile {
+                hex_hash: format!("{i:064x}"),
+                store_path: PathBuf::from(format!("/store/files/{:02x}/{i:062x}", i % 256)),
+                executable: i % 17 == 0,
+                size: Some(1024 + i),
+            },
+        );
+    }
+
+    const ITERATIONS: usize = 100_000;
+    let started = Instant::now();
+    for _ in 0..ITERATIONS {
+        black_box(serde_json::to_vec(black_box(&index)).unwrap());
+    }
+    let serde_json = started.elapsed();
+
+    let started = Instant::now();
+    for _ in 0..ITERATIONS {
+        black_box(sonic_rs::to_vec(black_box(&index)).unwrap());
+    }
+    let sonic = started.elapsed();
+
+    println!("serde_json: {serde_json:?}");
+    println!("sonic-rs:   {sonic:?}");
+    println!(
+        "speedup:    {:.2}x",
+        serde_json.as_secs_f64() / sonic.as_secs_f64()
+    );
+}

--- a/crates/aube-store/benches/index_serialization.rs
+++ b/crates/aube-store/benches/index_serialization.rs
@@ -17,18 +17,45 @@ fn main() {
         );
     }
 
-    const ITERATIONS: usize = 100_000;
-    let started = Instant::now();
-    for _ in 0..ITERATIONS {
-        black_box(serde_json::to_vec(black_box(&index)).unwrap());
+    const WARMUP_ITERATIONS: usize = 1_000;
+    for iteration in 0..WARMUP_ITERATIONS {
+        if iteration % 2 == 0 {
+            black_box(serde_json::to_vec(black_box(&index)).unwrap());
+            black_box(sonic_rs::to_vec(black_box(&index)).unwrap());
+        } else {
+            black_box(sonic_rs::to_vec(black_box(&index)).unwrap());
+            black_box(serde_json::to_vec(black_box(&index)).unwrap());
+        }
     }
-    let serde_json = started.elapsed();
 
-    let started = Instant::now();
-    for _ in 0..ITERATIONS {
-        black_box(sonic_rs::to_vec(black_box(&index)).unwrap());
+    const ROUNDS: usize = 20;
+    const ITERATIONS_PER_ROUND: usize = 5_000;
+    let measure_serde_json = || {
+        let started = Instant::now();
+        for _ in 0..ITERATIONS_PER_ROUND {
+            black_box(serde_json::to_vec(black_box(&index)).unwrap());
+        }
+        started.elapsed()
+    };
+    let measure_sonic = || {
+        let started = Instant::now();
+        for _ in 0..ITERATIONS_PER_ROUND {
+            black_box(sonic_rs::to_vec(black_box(&index)).unwrap());
+        }
+        started.elapsed()
+    };
+
+    let mut serde_json = std::time::Duration::ZERO;
+    let mut sonic = std::time::Duration::ZERO;
+    for round in 0..ROUNDS {
+        if round % 2 == 0 {
+            serde_json += measure_serde_json();
+            sonic += measure_sonic();
+        } else {
+            sonic += measure_sonic();
+            serde_json += measure_serde_json();
+        }
     }
-    let sonic = started.elapsed();
 
     println!("serde_json: {serde_json:?}");
     println!("sonic-rs:   {sonic:?}");

--- a/crates/aube-store/src/index.rs
+++ b/crates/aube-store/src/index.rs
@@ -262,8 +262,7 @@ impl Store {
                 "refusing to cache: invalid coordinate {name:?}@{version:?} or integrity {integrity:?}"
             ))
         })?;
-        let json =
-            serde_json::to_string(index).map_err(|e| Error::Tar(format!("serialize: {e}")))?;
+        let json = sonic_rs::to_vec(index).map_err(|e| Error::Tar(format!("serialize: {e}")))?;
         xx::file::write(&index_path, json).map_err(|e| Error::Xx(e.to_string()))?;
         trace!("cached index: {name}@{version}");
         Ok(())


### PR DESCRIPTION
## Summary

- serialize package indexes directly into byte vectors with the already-used `sonic-rs`
- avoid constructing an intermediate UTF-8 `String`
- add a focused release benchmark for representative 64-file indexes

This is stacked on #1421. It replaces #1424 after removing the withdrawn #1423 dependency.

## Benchmark

`cargo bench -p aube-store --bench index_serialization`, with 1,000 symmetric warm-up iterations followed by 20 alternating-order rounds (100,000 measured serializations total) of a representative 64-file package index:

| serde_json | sonic-rs | speedup |
|---:|---:|---:|
| 628.5ms | 355.1ms | 1.77× |

Warm-up and order alternation prevent CPU-frequency, allocator-state, and cache-warmth bias from systematically favoring either serializer. The focused serializer benchmark is the primary evidence because end-to-end cold runs contain substantially more filesystem variance.

## Validation

- `cargo fmt --check`
- `cargo test -p aube-store` (114 passed)
- `cargo clippy -p aube-store --all-targets -- -D warnings`
- `cargo bench -p aube-store --bench index_serialization`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized write-path serializer swap for on-disk cache JSON; load path already used sonic-rs, and format remains JSON bytes.
> 
> **Overview**
> **Package index cache writes** now serialize with `sonic_rs::to_vec` instead of `serde_json::to_string`, matching the existing `sonic_rs::from_slice` read path and writing UTF-8 bytes directly to disk without an intermediate `String`.
> 
> A new **`index_serialization`** bench (`harness = false`) compares `serde_json` vs `sonic-rs` on a representative 64-file `PackageIndex`, with warm-up and alternating measurement order to reduce timing bias.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d87cfe3b48ec4cdf00a1fbf303bf7f6ab86a3e28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved package index serialization performance when saving cached indexes.
  * Reduced serialization overhead while preserving the existing cache output and error handling.

* **Benchmarks**
  * Added benchmarks comparing serialization performance across supported JSON serializers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->