### PR TITLE
perf(store): skip initialized writer lease locking

### DIFF
--- a/crates/aube-store/Cargo.toml
+++ b/crates/aube-store/Cargo.toml
@@ -45,3 +45,7 @@ zstd = { workspace = true }
 [[bench]]
 name = "index_serialization"
 harness = false
+
+[[bench]]
+name = "writer_lease"
+harness = false

--- a/crates/aube-store/benches/writer_lease.rs
+++ b/crates/aube-store/benches/writer_lease.rs
@@ -1,0 +1,21 @@
+use aube_store::Store;
+use std::hint::black_box;
+use std::time::Instant;
+
+fn main() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = Store::at(tmp.path().join("store/v1/files"));
+    store.prepare_for_write().unwrap();
+
+    const ITERATIONS: usize = 5_000_000;
+    let started = Instant::now();
+    for _ in 0..ITERATIONS {
+        black_box(&store).prepare_for_write().unwrap();
+    }
+    let elapsed = started.elapsed();
+    println!("{ITERATIONS} prepared writes: {elapsed:?}");
+    println!(
+        "per prepared write: {:.2}ns",
+        elapsed.as_nanos() as f64 / ITERATIONS as f64
+    );
+}

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -344,6 +344,13 @@ impl Store {
     /// Acquire the shared writer lease and perform any pending legacy-index
     /// migration. The lease is retained by this `Store` and all of its clones.
     pub fn prepare_for_write(&self) -> Result<(), Error> {
+        // `migration_done` is set only after the shared lease has been stored
+        // in `maintenance.shared` and migration has completed. Once visible,
+        // the Arc-owned lease remains live for every Store clone, so hot CAS
+        // and index writes can skip the maintenance mutex entirely.
+        if self.migration_done.get().is_some() {
+            return Ok(());
+        }
         let mut shared = self.maintenance.shared.lock().map_err(|_| {
             Error::Io(
                 self.maintenance_lock_path(),


### PR DESCRIPTION
## Summary

- return immediately from `prepare_for_write` after shared lease initialization and migration complete
- use the existing Arc-shared `migration_done` OnceLock as the acquire/release synchronization point
- avoid taking the maintenance mutex for every CAS object and package-index write
- add a focused release benchmark for the initialized writer path

The retained shared lock file still lives in the Arc-owned maintenance state, preserving prune exclusion.

This is stacked on #1427. It replaces #1426 after removing the withdrawn #1423 dependency.

## Benchmark

Focused `cargo bench -p aube-store --bench writer_lease`, 5,000,000 initialized `prepare_for_write` calls:

| implementation | total | per call |
|---|---:|---:|
| maintenance mutex | 17.257ms | 3.45ns |
| OnceLock fast path | 9.671ms | 1.93ns |

That is a 1.79× speedup for the exact hot operation. A safe-base hermetic cold comparison was wall-neutral within noise (2.773s candidate vs 2.737s baseline) while aggregate system CPU fell from 17.591s to 16.270s (7.5%); no larger end-to-end claim is intended.

## Validation

- `cargo fmt --check`
- `cargo test -p aube-store` (114 passed)
- `cargo clippy -p aube-store --all-targets -- -D warnings`
- `cargo bench -p aube-store --bench writer_lease`
- existing maintenance-lock concurrency test remains green

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches writer-lease synchronization used on every store write; incorrect fast-path ordering could weaken prune/maintenance locking, though the existing concurrency test and `OnceLock` gating after lease+migration mitigate that.
> 
> **Overview**
> **`Store::prepare_for_write`** now returns immediately when the Arc-shared **`migration_done`** `OnceLock` is already set, so repeated CAS and package-index writes no longer take the maintenance **`Mutex`** on every call.
> 
> The first call still acquires the shared **`.maintenance.lock`** file, runs legacy index migration, and records completion in **`migration_done`**; the Arc-held lock file stays alive for clones, so prune exclusion behavior is unchanged.
> 
> Adds a **`writer_lease`** release benchmark (`cargo bench -p aube-store --bench writer_lease`) that stress-tests 5M initialized **`prepare_for_write`** calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9c1ee9759d8621d3f6d5a96d8e8a7c119cb7b46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved repeated write preparation after legacy index migration, reducing unnecessary overhead on subsequent operations.
* **Benchmarking**
  * Added a benchmark to measure write-preparation performance across repeated calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->