### PR TITLE
perf(store): direct-write Linux CAS under install lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,6 +320,7 @@ dependencies = [
  "glob",
  "hex",
  "junction",
+ "libc",
  "miette",
  "pathdiff",
  "rayon",

--- a/crates/aube-linker/Cargo.toml
+++ b/crates/aube-linker/Cargo.toml
@@ -30,6 +30,7 @@ diffy = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
 tempfile = "3"
+libc = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 junction = { workspace = true }

--- a/crates/aube-linker/src/hoisted.rs
+++ b/crates/aube-linker/src/hoisted.rs
@@ -794,11 +794,18 @@ fn materialize_hoisted_plan(
             std::fs::create_dir_all(parent).map_err(|e| Error::Io(parent.clone(), e))?;
         }
 
+        // Match the isolated materializer's Linux fast path: resolve every
+        // destination relative to one open package directory.
+        #[cfg(target_os = "linux")]
+        let pkg_dir_fd = std::fs::File::open(&pkg_dir).ok();
+        #[cfg(not(target_os = "linux"))]
+        let pkg_dir_fd: Option<std::fs::File> = None;
+
         for (rel_path, stored) in index {
             // Key already validated in the parent-collection loop
             // above. The index is immutable between the two loops.
             let target = pkg_dir.join(rel_path);
-            if let Err(e) = linker.link_file_fresh(stored, rel_path, &target, None) {
+            if let Err(e) = linker.link_file_fresh(stored, rel_path, &target, pkg_dir_fd.as_ref()) {
                 if let Error::MissingStoreFile { .. } = &e {
                     crate::invalidate_stale_index_for_package(&linker.store, pkg);
                 }

--- a/crates/aube-linker/src/hoisted.rs
+++ b/crates/aube-linker/src/hoisted.rs
@@ -798,7 +798,7 @@ fn materialize_hoisted_plan(
             // Key already validated in the parent-collection loop
             // above. The index is immutable between the two loops.
             let target = pkg_dir.join(rel_path);
-            if let Err(e) = linker.link_file_fresh(stored, rel_path, &target) {
+            if let Err(e) = linker.link_file_fresh(stored, rel_path, &target, None) {
                 if let Error::MissingStoreFile { .. } = &e {
                     crate::invalidate_stale_index_for_package(&linker.store, pkg);
                 }

--- a/crates/aube-linker/src/materialize.rs
+++ b/crates/aube-linker/src/materialize.rs
@@ -616,6 +616,15 @@ impl Linker {
             std::fs::create_dir_all(parent).map_err(|e| Error::Io(parent.clone(), e))?;
         }
 
+        // Linux can resolve every destination relative to one open package
+        // directory instead of walking the long GVS staging path per file.
+        // Failure to open is harmless: `link_file_fresh` retains the portable
+        // full-path operation and its existing copy fallback.
+        #[cfg(target_os = "linux")]
+        let pkg_nm_dir_fd = std::fs::File::open(&pkg_nm_dir).ok();
+        #[cfg(not(target_os = "linux"))]
+        let pkg_nm_dir_fd: Option<std::fs::File> = None;
+
         // `materialize_into` always writes into a fresh location
         // (either a `.tmp-<pid>-...` staging dir for the global virtual
         // store or a per-project `.aube/<dep_path>` just created by
@@ -628,7 +637,8 @@ impl Linker {
             // above. The index is immutable between the two loops.
             let target = pkg_nm_dir.join(rel_path);
 
-            if let Err(e) = self.link_file_fresh(stored, rel_path, &target) {
+            if let Err(e) = self.link_file_fresh(stored, rel_path, &target, pkg_nm_dir_fd.as_ref())
+            {
                 if let Error::MissingStoreFile { .. } = &e {
                     invalidate_stale_index_for_package(&self.store, pkg);
                 }
@@ -793,6 +803,7 @@ impl Linker {
         stored: &StoredFile,
         rel_path: &str,
         dst: &Path,
+        dst_dir: Option<&std::fs::File>,
     ) -> Result<(), Error> {
         #[cfg(target_os = "macos")]
         const SMALL_FILE_COPY_MAX: u64 = 16 * 1024;
@@ -909,7 +920,48 @@ impl Linker {
                 }
             }
             LinkStrategy::Hardlink => {
-                if let Err(e) = std::fs::hard_link(&stored.store_path, dst) {
+                #[cfg(target_os = "linux")]
+                let hardlink_result = if let Some(dst_dir) = dst_dir {
+                    use std::ffi::CString;
+                    use std::os::fd::AsRawFd;
+                    use std::os::unix::ffi::OsStrExt;
+
+                    let source = CString::new(stored.store_path.as_os_str().as_bytes());
+                    let relative = CString::new(rel_path.as_bytes());
+                    match (source, relative) {
+                        (Ok(source), Ok(relative)) => {
+                            // SAFETY: both C strings live through the call and
+                            // `dst_dir` owns a valid package-directory fd.
+                            let result = unsafe {
+                                libc::linkat(
+                                    libc::AT_FDCWD,
+                                    source.as_ptr(),
+                                    dst_dir.as_raw_fd(),
+                                    relative.as_ptr(),
+                                    0,
+                                )
+                            };
+                            if result == 0 {
+                                Ok(())
+                            } else {
+                                Err(std::io::Error::last_os_error())
+                            }
+                        }
+                        _ => Err(std::io::Error::new(
+                            std::io::ErrorKind::InvalidInput,
+                            "hardlink path contains nul",
+                        )),
+                    }
+                } else {
+                    std::fs::hard_link(&stored.store_path, dst)
+                };
+                #[cfg(not(target_os = "linux"))]
+                let hardlink_result = {
+                    let _ = dst_dir;
+                    std::fs::hard_link(&stored.store_path, dst)
+                };
+
+                if let Err(e) = hardlink_result {
                     if !stored.store_path.exists() {
                         return Err(missing_source());
                     }

--- a/crates/aube-linker/src/tests.rs
+++ b/crates/aube-linker/src/tests.rs
@@ -732,7 +732,7 @@ fn test_link_file_fresh_hardlink_short_circuits_when_source_missing() {
 
     let linker = Linker::new_with_gvs(&store, LinkStrategy::Hardlink, true);
     let err = linker
-        .link_file_fresh(&stored, "hello.txt", &dst)
+        .link_file_fresh(&stored, "hello.txt", &dst, None)
         .expect_err("source missing must fail");
     assert!(
         matches!(
@@ -805,7 +805,7 @@ fn realized_inode_matches_source_on_reflink_failure(strategy: LinkStrategy) -> b
         // Hold the guard across the materialize so a sibling test can't flip
         // the global flag mid-call; the flag is restored on drop, panic-safe.
         let _forced = ForcedReflinkFailure::engage();
-        linker.link_file_fresh(&stored, "payload.bin", &dst)
+        linker.link_file_fresh(&stored, "payload.bin", &dst, None)
     };
     result.expect("a reflink strategy must still materialize the file via its fallback");
 

--- a/crates/aube-store/src/cas.rs
+++ b/crates/aube-store/src/cas.rs
@@ -8,7 +8,7 @@ thread_local! {
     static B3_HASHER: RefCell<blake3::Hasher> = RefCell::new(blake3::Hasher::new());
 }
 
-/// Per-shard mutex array used by the macOS CAS fast path to serialize
+/// Per-shard mutex array used by the Linux/macOS CAS fast path to serialize
 /// concurrent writers within a single process. Indexed by the first
 /// byte of the file's BLAKE3 hash (matching the on-disk 2-char shard
 /// layout), so two threads writing the same hash always collide; threads
@@ -17,12 +17,8 @@ thread_local! {
 /// per install, and a static avoids carrying 256 mutexes in every cheap
 /// `Store::clone()` along the fetch pipeline.
 ///
-/// macOS-gated rather than `not(linux)` because the fast-path block
-/// itself uses `OpenOptionsExt::mode`, which only exists on Unix —
-/// Windows would fail to compile under `not(linux)`. Linux already has
-/// `O_TMPFILE + linkat` (atomic-by-construction, faster than either
-/// alternative); Windows keeps the tempfile + persist_noclobber path.
-#[cfg(target_os = "macos")]
+/// Windows keeps the tempfile + persist_noclobber path.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 static FAST_PATH_SHARD_LOCKS: [std::sync::Mutex<()>; 256] =
     [const { std::sync::Mutex::new(()) }; 256];
 
@@ -240,7 +236,7 @@ impl Store {
                     let disabled = *O_TMPFILE_DISABLED.get_or_init(|| {
                         aube_util::env::embedder_env("DISABLE_O_TMPFILE").is_some()
                     });
-                    if !disabled {
+                    if !disabled && !this.fast_path.load(Ordering::Acquire) {
                         match try_o_tmpfile_publish(path, bytes) {
                             Ok(outcome) => return Ok(outcome),
                             Err(OTmpfileFallback::Unsupported) => {}
@@ -249,7 +245,7 @@ impl Store {
                     }
                 }
 
-                // macOS fast path: direct O_CREAT|O_EXCL at the final
+                // Linux/macOS fast path: direct O_CREAT|O_EXCL at the final
                 // content-addressed path, no tempfile dance. Caller (the
                 // install command) flips `fast_path` on only after
                 // acquiring an exclusive store-level lock against other
@@ -271,10 +267,10 @@ impl Store {
                 //
                 // On APFS the fast path is ~2.25x faster than
                 // tempfile+chmod+persist (~64µs/file vs ~145µs/file in
-                // isolation). macOS-gated rather than `not(linux)`
-                // because `OpenOptionsExt::mode` is unix-only — Windows
-                // keeps the tempfile path.
-                #[cfg(target_os = "macos")]
+                // isolation). Linux also uses it while the install owns
+                // the exclusive store lock; contended installs retain the
+                // atomic O_TMPFILE path. Windows keeps named tempfiles.
+                #[cfg(any(target_os = "linux", target_os = "macos"))]
                 if this.fast_path.load(Ordering::Acquire) {
                     use std::io::Write;
                     use std::os::unix::fs::OpenOptionsExt;
@@ -381,7 +377,7 @@ impl Store {
                 // orders and clobbered each other's recovery. The
                 // fast-path branch above re-enables it under an
                 // exclusive store lock.
-                let _ = this; // suppress unused warning on Linux
+                let _ = this; // suppress unused warning on non-Unix targets
                 let parent = path.parent().ok_or_else(|| {
                     Error::Io(path.to_path_buf(), std::io::ErrorKind::NotFound.into())
                 })?;
@@ -466,7 +462,7 @@ impl Store {
         // The macOS byte importer publishes directly into the final path while
         // holding this same shard lock. Hold it through publication and any
         // recovery so a streamed writer cannot unlink an in-progress file.
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         let _shard_guard = hex_hash
             .get(..2)
             .and_then(|shard| u8::from_str_radix(shard, 16).ok())
@@ -475,7 +471,7 @@ impl Store {
                     .lock()
                     .unwrap_or_else(|poisoned| poisoned.into_inner())
             });
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         let mut recovery_lock = None;
 
         let mut retried_missing_parent = false;
@@ -506,7 +502,7 @@ impl Store {
                     // before deciding the entry is torn. The in-process shard
                     // mutex above separately serializes recovery threads in
                     // this process.
-                    #[cfg(target_os = "macos")]
+                    #[cfg(any(target_os = "linux", target_os = "macos"))]
                     if !self.fast_path.load(Ordering::Acquire)
                         && !cas_file_matches_len(&store_path, len)
                         && recovery_lock.is_none()
@@ -616,26 +612,22 @@ impl Store {
                 format!(r#"{{"size":{}}}"#, content.len())
             });
         }
-        // The macOS fast path verifies the file size inline under its
+        // The Linux/macOS fast path verifies the file size inline under its
         // shard mutex before returning `AlreadyExisted`, so this
         // recovery only needs to run when we took the tempfile path.
         // Skipping it there also prevents a race where the recovery
         // unlinks a file that another in-process thread is concurrently
         // re-creating after observing the same crashed-predecessor.
         //
-        // `cfg!(target_os = "macos")` matches the cfg gate on the only
-        // code path that flips `fast_path` to true (and on the inline
-        // recovery inside `create_cas_file`). Without the cfg!, a future
-        // caller setting the flag on Linux would silently disable this
-        // recovery — the Linux O_TMPFILE branch has no inline
-        // length-check substitute, so torn CAS files would be accepted.
-        let fast_path_handled_recovery =
-            cfg!(target_os = "macos") && self.fast_path.load(Ordering::Acquire);
+        // The target check matches the cfg gate on the only code path that
+        // flips `fast_path` to true and the inline recovery above.
+        let fast_path_handled_recovery = (cfg!(target_os = "linux") || cfg!(target_os = "macos"))
+            && self.fast_path.load(Ordering::Acquire);
         if outcome == CasWriteOutcome::AlreadyExisted && !fast_path_handled_recovery {
             // A length mismatch from this branch can mean either
             //   (a) a crashed predecessor left a torn file (the recovery
             //       case this code was originally written for), or
-            //   (b) on macOS, another *process* is currently writing to
+            //   (b) on Linux/macOS, another *process* is currently writing to
             //       the same path via the fast path (no atomic publish
             //       at the final path, so its in-progress fd is visible
             //       by name to other writers).

--- a/crates/aube-store/src/cas.rs
+++ b/crates/aube-store/src/cas.rs
@@ -639,6 +639,29 @@ impl Store {
             if !cas_file_matches_len(&store_path, content.len() as u64) {
                 wait_for_cas_file_len(&store_path, content.len() as u64);
             }
+            // An unlocked writer may have observed a direct writer's
+            // in-progress final path. Coordinate with that writer before
+            // deciding the entry is torn, then recheck under the lock.
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
+            let _recovery_lock = if !cas_file_matches_len(&store_path, content.len() as u64) {
+                let lock_dir = self
+                    .root
+                    .parent()
+                    .map(Path::to_path_buf)
+                    .unwrap_or_else(|| self.root.clone());
+                std::fs::create_dir_all(&lock_dir).map_err(|e| Error::Io(lock_dir.clone(), e))?;
+                let lock_path = lock_dir.join(".install.lock");
+                let file = std::fs::OpenOptions::new()
+                    .create(true)
+                    .truncate(false)
+                    .write(true)
+                    .open(&lock_path)
+                    .map_err(|e| Error::Io(lock_path.clone(), e))?;
+                file.lock().map_err(|e| Error::Io(lock_path, e))?;
+                Some(file)
+            } else {
+                None
+            };
             if !cas_file_matches_len(&store_path, content.len() as u64) {
                 let _ = xx::file::remove_file(&store_path);
                 self.create_cas_file(&store_path, Some(content))?;

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -46,7 +46,7 @@ use sha1::Sha1;
 use sha2::{Digest as _, Sha256, Sha384, Sha512};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -180,7 +180,7 @@ impl Store {
         }
     }
 
-    /// Enable the macOS direct-write fast path for CAS imports. Bypasses
+    /// Enable the Linux/macOS direct-write fast path for CAS imports. Bypasses
     /// the tempfile + persist_noclobber pattern and writes straight to
     /// the final content-addressed path, saving ~80µs/file on APFS. The
     /// caller MUST hold an exclusive lock against the store for the
@@ -188,14 +188,9 @@ impl Store {
     /// concurrent installer can observe a partial file and the
     /// `AlreadyExisted` recovery dance can clobber an in-flight write.
     ///
-    /// macOS-gated rather than just declared inert on other platforms.
-    /// On Linux the `O_TMPFILE+linkat` path has no inline length-check
-    /// recovery — that recovery only lives inside the macOS fast-path
-    /// branch — so the outer skip in `import_bytes` (also macOS-gated
-    /// via `cfg!`) must never see the flag set on Linux. Removing the
-    /// method on non-macOS platforms makes that mismatch a build error
-    /// rather than a silent acceptance of torn CAS files.
-    #[cfg(target_os = "macos")]
+    /// Unix-gated because the implementation relies on `OpenOptionsExt`.
+    /// Windows retains the named-tempfile publication path.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     pub fn enable_fast_path(&self) {
         self.fast_path.store(true, Ordering::Release);
     }

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -518,6 +518,61 @@ mod tests {
         contender.try_lock().unwrap();
     }
 
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn unlocked_import_waits_for_direct_writer_before_recovery() {
+        use std::io::Write;
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("v1/files");
+        let store = Store::at(root);
+        store.ensure_shards_exist().unwrap();
+
+        let content = b"a direct writer may still be filling this CAS object";
+        let hex_hash = blake3_hex(content);
+        let store_path = store.file_path_from_hex(&hex_hash);
+        let lock_path = tmp.path().join("v1/.install.lock");
+        let lock = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(&lock_path)
+            .unwrap();
+        lock.try_lock().unwrap();
+
+        let mut partial = std::fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&store_path)
+            .unwrap();
+        partial.write_all(&content[..1]).unwrap();
+        partial.flush().unwrap();
+
+        let import_store = store.clone();
+        let (finished_tx, finished_rx) = mpsc::channel();
+        let importer = std::thread::spawn(move || {
+            let result = import_store.import_bytes(content, false);
+            finished_tx.send(()).unwrap();
+            result
+        });
+
+        assert!(matches!(
+            finished_rx.recv_timeout(Duration::from_millis(200)),
+            Err(mpsc::RecvTimeoutError::Timeout)
+        ));
+
+        partial.write_all(&content[1..]).unwrap();
+        partial.flush().unwrap();
+        drop(partial);
+        drop(lock);
+
+        finished_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        let stored = importer.join().unwrap().unwrap();
+        assert_eq!(std::fs::read(stored.store_path).unwrap(), content);
+    }
+
     #[test]
     fn migrate_legacy_index_dir_relocates_files_and_subdirs() {
         let tmp = tempfile::tempdir().unwrap();

--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -105,12 +105,13 @@ pub struct Store {
     maintenance: Arc<MaintenanceState>,
     migration_done: Arc<OnceLock<()>>,
     /// When set, `create_cas_file` writes directly to the final
-    /// content-addressed path on non-Linux platforms instead of the
-    /// tempfile-then-rename dance. Caller must guarantee no concurrent
-    /// installer is writing into this store — typically via an exclusive
-    /// file lock taken at install start. Linux is unaffected because the
-    /// O_TMPFILE+linkat path is already atomic-by-construction.
+    /// content-addressed path on Linux/macOS instead of using atomic
+    /// publication. The paired lock file remains owned by every clone of
+    /// this state, so detached blocking imports cannot outlive the exclusive
+    /// store lock that makes direct writes safe.
     fast_path: Arc<AtomicBool>,
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    fast_path_lock: Arc<Mutex<Option<std::fs::File>>>,
 }
 
 impl Store {
@@ -153,6 +154,8 @@ impl Store {
             maintenance: Arc::new(MaintenanceState::default()),
             migration_done: Arc::new(OnceLock::new()),
             fast_path: Arc::new(AtomicBool::new(false)),
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
+            fast_path_lock: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -177,21 +180,26 @@ impl Store {
             maintenance: Arc::new(MaintenanceState::default()),
             migration_done: Arc::new(OnceLock::new()),
             fast_path: Arc::new(AtomicBool::new(false)),
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
+            fast_path_lock: Arc::new(Mutex::new(None)),
         }
     }
 
     /// Enable the Linux/macOS direct-write fast path for CAS imports. Bypasses
     /// the tempfile + persist_noclobber pattern and writes straight to
     /// the final content-addressed path, saving ~80µs/file on APFS. The
-    /// caller MUST hold an exclusive lock against the store for the
-    /// duration any thread might invoke `import_bytes`; otherwise a
-    /// concurrent installer can observe a partial file and the
-    /// `AlreadyExisted` recovery dance can clobber an in-flight write.
+    /// `lock` MUST already hold the store's exclusive install lock. The
+    /// store takes ownership so the lock remains held until all clones used
+    /// by blocking imports are dropped.
     ///
     /// Unix-gated because the implementation relies on `OpenOptionsExt`.
     /// Windows retains the named-tempfile publication path.
     #[cfg(any(target_os = "linux", target_os = "macos"))]
-    pub fn enable_fast_path(&self) {
+    pub fn enable_fast_path(&self, lock: std::fs::File) {
+        *self
+            .fast_path_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(lock);
         self.fast_path.store(true, Ordering::Release);
     }
 
@@ -470,7 +478,44 @@ mod tests {
             maintenance: Arc::new(MaintenanceState::default()),
             migration_done: Arc::new(OnceLock::new()),
             fast_path: Arc::new(AtomicBool::new(false)),
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
+            fast_path_lock: Arc::new(Mutex::new(None)),
         }
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn fast_path_lock_lives_until_last_store_clone_drops() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("v1/files");
+        std::fs::create_dir_all(&root).unwrap();
+        let lock_path = tmp.path().join("v1/.install.lock");
+        let lock = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(&lock_path)
+            .unwrap();
+        lock.try_lock().unwrap();
+
+        let store = Store::at(root);
+        store.enable_fast_path(lock);
+        let blocking_import_store = store.clone();
+        drop(store);
+
+        let contender = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(&lock_path)
+            .unwrap();
+        assert!(matches!(
+            contender.try_lock(),
+            Err(std::fs::TryLockError::WouldBlock)
+        ));
+
+        drop(blocking_import_store);
+        contender.try_lock().unwrap();
     }
 
     #[test]

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -757,10 +757,10 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     // running against this store right now, so the CAS write path can
     // skip the tempfile + persist_noclobber dance and write straight to
     // the final content-addressed path (`Store::enable_fast_path`). The
-    // guard is held in `_store_lock` for the rest of this `run` call;
-    // dropping it at function exit releases the lock. Contention falls
-    // back to the safe tempfile path — concurrent installers still
-    // proceed, just at the existing speed.
+    // `Store` takes ownership of the guard so blocking imports retain it
+    // even if their Tokio parent is aborted during error unwinding.
+    // Contention falls back to the safe tempfile path — concurrent
+    // installers still proceed, just at the existing speed.
     //
     // Linux normally uses atomic O_TMPFILE+linkat, but direct writes save
     // the anonymous-file publication syscall while this lock excludes other
@@ -769,7 +769,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     // the lock acquisition on Unix too avoids opening a lock file that
     // nothing would consult.
     #[cfg(any(target_os = "linux", target_os = "macos"))]
-    let _store_lock = {
+    {
         let lock_dir = store
             .root()
             .parent()
@@ -785,19 +785,16 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
         {
             Ok(file) => match file.try_lock() {
                 Ok(()) => {
-                    store.enable_fast_path();
+                    store.enable_fast_path(file);
                     tracing::debug!("CAS fast path enabled (exclusive store lock acquired)");
-                    Some(file)
                 }
                 Err(std::fs::TryLockError::WouldBlock) => {
                     tracing::debug!(
                         "another aube install is using this store; staying on tempfile path"
                     );
-                    None
                 }
                 Err(std::fs::TryLockError::Error(e)) => {
                     tracing::debug!("store lock probe failed ({e}); staying on tempfile path");
-                    None
                 }
             },
             Err(e) => {
@@ -805,7 +802,6 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
                     "could not open store lock at {} ({e}); staying on tempfile path",
                     lock_path.display()
                 );
-                None
             }
         }
     };

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -752,7 +752,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     if let Err(e) = store.ensure_shards_exist() {
         tracing::debug!("ensure_shards_exist failed (slow path will cover): {e}");
     }
-    // macOS fast-path gate: take an exclusive `try_lock` on
+    // Linux/macOS fast-path gate: take an exclusive `try_lock` on
     // `<store>/v1/.install.lock`. If we get it, no other aube install is
     // running against this store right now, so the CAS write path can
     // skip the tempfile + persist_noclobber dance and write straight to
@@ -762,13 +762,13 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
     // back to the safe tempfile path — concurrent installers still
     // proceed, just at the existing speed.
     //
-    // Linux is unaffected: `create_cas_file` always uses O_TMPFILE+linkat
-    // there, which is already atomic-by-construction and faster than
-    // both options. Windows keeps the tempfile path; the fast-path branch
+    // Linux normally uses atomic O_TMPFILE+linkat, but direct writes save
+    // the anonymous-file publication syscall while this lock excludes other
+    // aube writers. Windows keeps the tempfile path; the fast-path branch
     // in `aube-store` is unix-only (`OpenOptionsExt::mode`), so gating
-    // the lock acquisition on macOS too avoids opening a lock file that
+    // the lock acquisition on Unix too avoids opening a lock file that
     // nothing would consult.
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     let _store_lock = {
         let lock_dir = store
             .root()


### PR DESCRIPTION
## Summary

- extend the existing exclusive-lock CAS fast path from macOS to Linux
- write new CAS objects directly to their final paths when this install owns the store lock
- retain atomic O_TMPFILE publication whenever another installer holds the lock
- retain the exclusive lock in Arc-shared Store state so detached blocking imports cannot outlive it
- make unlocked torn-entry recovery acquire and recheck under the same cross-process lock before unlinking
- cover both lock-lifetime and competing-recovery races with regression tests

This is stacked on #1421 and supersedes #1423. It carries forward the fixes pushed to that closed branch in b52e5ac1, plus the recovery-race regression in f9992f3f.

## Benchmark

Hermetic `gvs-cold`, 500mbit bandwidth / 50ms latency, 10 measured runs and 3 warmups. A/B/A sequence:

| run | revision | wall time | install total | fetch | aggregate system CPU |
|---|---|---:|---:|---:|---:|
| A1 | candidate | 2.612s ± 0.131s | 2429ms | 2046ms | 15.564s |
| B | #1421 baseline | 2.690s ± 0.060s | 2528ms | 2160ms | 15.951s |
| A2 | candidate | 2.697s ± 0.278s | 2421ms | 2054ms | 15.271s |

The candidate average is 2.655s, 1.3% faster than the sandwiched baseline, with 3.3% less aggregate system CPU. The measured install work is consistently lower in both candidate runs. An earlier baseline run reached 2.526s, so this is intentionally presented as a modest improvement rather than a large headline gain.

## Review fixes carried forward

- unlocked importers cannot unlink a live direct-write inode: they acquire `.install.lock` and recheck under the lock before recovery
- detached `spawn_blocking` imports cannot outlive the safety lock: the locked file is owned by Arc-shared Store state
- regression tests exercise both the Store-clone lifetime and the competing recovery path

## Validation

- `cargo fmt --check`
- `cargo test -p aube-store` (116 passed)
- `cargo clippy -p aube-store -p aube --all-targets -- -D warnings`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrent CAS publication, cross-process locking, and torn-file recovery on Linux/macOS—high-impact store correctness paths, but gated on exclusive install locks with new regression tests.
> 
> **Overview**
> **Extends the exclusive-install-lock CAS fast path from macOS to Linux**, writing new objects straight to their final content-addressed paths when this install owns `.install.lock`, and **skipping `O_TMPFILE+linkat` on Linux only while `fast_path` is active**. If another installer holds the lock, Linux keeps the atomic `O_TMPFILE` path.
> 
> **`Store::enable_fast_path` now takes the locked install file** and stores it in shared `Store` state so every clone (including detached `spawn_blocking` imports) keeps the exclusive lock until the last clone drops—install no longer holds a local guard that can be released during unwinding.
> 
> **Torn-entry recovery is tightened for cross-process direct writes**: slow-path importers wait on `.install.lock` and recheck length before unlinking, matching the tempfile publish path and avoiding clobbering an in-flight direct writer. Per-shard in-process mutexes apply on both Linux and macOS for the fast path.
> 
> **Regression tests** cover install-lock lifetime across `Store` clones and an unlocked importer waiting on a partial direct write before recovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9992f3f546447f15bb8349eef581b7d69335e76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->