### PR TITLE
chore: release v2.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "aube-codes"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "aube-ffi"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "aube",
  "aube-codes",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -364,7 +364,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "aube-node"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "aube",
  "aube-codes",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "aube-runtime"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "aube-util",
  "base64 0.23.1",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "aube-codes",
  "blake3",
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "aube-codes",
  "aube-manifest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ inherits = "release"
 panic = "unwind"
 
 [workspace.package]
-version = "2.2.4"
+version = "2.2.5"
 edition = "2024"
 # Kept at the floor mise can build with (its distro packaging pins the
 # toolchain) so mise can embed the library crates. CI enforces this via

--- a/crates/aube-codes/CHANGELOG.md
+++ b/crates/aube-codes/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.5](https://github.com/aubepkg/aube/compare/aube-codes-v2.2.4...aube-codes-v2.2.5) - 2026-09-03
+
+### Fixed
+
+- *(lockfile)* reject pre-v9 pnpm lockfiles instead of installing nothing ([#1456](https://github.com/aubepkg/aube/pull/1456))
+
+### Other
+
+- move routine workflows to GitHub-hosted runners ([#1469](https://github.com/aubepkg/aube/pull/1469))
+- move project to aubepkg and aube.sh ([#1460](https://github.com/aubepkg/aube/pull/1460))
+- fix prose and content in docs and cli help ([#1455](https://github.com/aubepkg/aube/pull/1455))
+- refresh benchmarks for v2.2.4 ([#1434](https://github.com/aubepkg/aube/pull/1434))
+
 ## [2.2.4](https://github.com/jdx/aube/compare/aube-codes-v2.2.3...aube-codes-v2.2.4) - 2026-08-31
 
 ### Other

--- a/crates/aube-linker/CHANGELOG.md
+++ b/crates/aube-linker/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.5](https://github.com/aubepkg/aube/compare/aube-linker-v2.2.4...aube-linker-v2.2.5) - 2026-09-03
+
+### Other
+
+- move routine workflows to GitHub-hosted runners ([#1469](https://github.com/aubepkg/aube/pull/1469))
+- move project to aubepkg and aube.sh ([#1460](https://github.com/aubepkg/aube/pull/1460))
+- refresh benchmarks for v2.2.4 ([#1434](https://github.com/aubepkg/aube/pull/1434))
+
 ## [2.2.4](https://github.com/jdx/aube/compare/aube-linker-v2.2.3...aube-linker-v2.2.4) - 2026-08-31
 
 ### Other

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.5](https://github.com/aubepkg/aube/compare/aube-lockfile-v2.2.4...aube-lockfile-v2.2.5) - 2026-09-03
+
+### Fixed
+
+- *(release)* avoid major bumps for lockfile error variants ([#1463](https://github.com/aubepkg/aube/pull/1463))
+- *(lockfile)* reject pre-v9 pnpm lockfiles instead of installing nothing ([#1456](https://github.com/aubepkg/aube/pull/1456))
+
+### Other
+
+- move routine workflows to GitHub-hosted runners ([#1469](https://github.com/aubepkg/aube/pull/1469))
+- move project to aubepkg and aube.sh ([#1460](https://github.com/aubepkg/aube/pull/1460))
+- refresh benchmarks for v2.2.4 ([#1434](https://github.com/aubepkg/aube/pull/1434))
+
 ## [2.2.4](https://github.com/jdx/aube/compare/aube-lockfile-v2.2.3...aube-lockfile-v2.2.4) - 2026-08-31
 
 ### Other

--- a/crates/aube-manifest/CHANGELOG.md
+++ b/crates/aube-manifest/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.5](https://github.com/aubepkg/aube/compare/aube-manifest-v2.2.4...aube-manifest-v2.2.5) - 2026-09-03
+
+### Other
+
+- move routine workflows to GitHub-hosted runners ([#1469](https://github.com/aubepkg/aube/pull/1469))
+- move project to aubepkg and aube.sh ([#1460](https://github.com/aubepkg/aube/pull/1460))
+- fix prose and content in docs and cli help ([#1455](https://github.com/aubepkg/aube/pull/1455))
+- refresh benchmarks for v2.2.4 ([#1434](https://github.com/aubepkg/aube/pull/1434))
+
 ## [2.2.4](https://github.com/jdx/aube/compare/aube-manifest-v2.2.3...aube-manifest-v2.2.4) - 2026-08-31
 
 ### Other

--- a/crates/aube-registry/CHANGELOG.md
+++ b/crates/aube-registry/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.5](https://github.com/aubepkg/aube/compare/aube-registry-v2.2.4...aube-registry-v2.2.5) - 2026-09-03
+
+### Other
+
+- move routine workflows to GitHub-hosted runners ([#1469](https://github.com/aubepkg/aube/pull/1469))
+- move project to aubepkg and aube.sh ([#1460](https://github.com/aubepkg/aube/pull/1460))
+- fix prose and content in docs and cli help ([#1455](https://github.com/aubepkg/aube/pull/1455))
+- refresh benchmarks for v2.2.4 ([#1434](https://github.com/aubepkg/aube/pull/1434))
+
 ## [2.2.4](https://github.com/jdx/aube/compare/aube-registry-v2.2.3...aube-registry-v2.2.4) - 2026-08-31
 
 ### Other

--- a/crates/aube-resolver/CHANGELOG.md
+++ b/crates/aube-resolver/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.5](https://github.com/aubepkg/aube/compare/aube-resolver-v2.2.4...aube-resolver-v2.2.5) - 2026-09-03
+
+### Other
+
+- move routine workflows to GitHub-hosted runners ([#1469](https://github.com/aubepkg/aube/pull/1469))
+- move project to aubepkg and aube.sh ([#1460](https://github.com/aubepkg/aube/pull/1460))
+- refresh benchmarks for v2.2.4 ([#1434](https://github.com/aubepkg/aube/pull/1434))
+
 ## [2.2.4](https://github.com/jdx/aube/compare/aube-resolver-v2.2.3...aube-resolver-v2.2.4) - 2026-08-31
 
 ### Other

--- a/crates/aube-runtime/CHANGELOG.md
+++ b/crates/aube-runtime/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.5](https://github.com/aubepkg/aube/compare/aube-runtime-v2.2.4...aube-runtime-v2.2.5) - 2026-09-03
+
+### Other
+
+- move routine workflows to GitHub-hosted runners ([#1469](https://github.com/aubepkg/aube/pull/1469))
+- move project to aubepkg and aube.sh ([#1460](https://github.com/aubepkg/aube/pull/1460))
+- refresh benchmarks for v2.2.4 ([#1434](https://github.com/aubepkg/aube/pull/1434))
+
 ## [2.2.4](https://github.com/jdx/aube/compare/aube-runtime-v2.2.3...aube-runtime-v2.2.4) - 2026-08-31
 
 ### Other

--- a/crates/aube-scripts/CHANGELOG.md
+++ b/crates/aube-scripts/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.5](https://github.com/aubepkg/aube/compare/aube-scripts-v2.2.4...aube-scripts-v2.2.5) - 2026-09-03
+
+### Other
+
+- move routine workflows to GitHub-hosted runners ([#1469](https://github.com/aubepkg/aube/pull/1469))
+- move project to aubepkg and aube.sh ([#1460](https://github.com/aubepkg/aube/pull/1460))
+- refresh benchmarks for v2.2.4 ([#1434](https://github.com/aubepkg/aube/pull/1434))
+
 ## [2.2.4](https://github.com/jdx/aube/compare/aube-scripts-v2.2.3...aube-scripts-v2.2.4) - 2026-08-31
 
 ### Other

--- a/crates/aube-settings/CHANGELOG.md
+++ b/crates/aube-settings/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.5](https://github.com/aubepkg/aube/compare/aube-settings-v2.2.4...aube-settings-v2.2.5) - 2026-09-03
+
+### Other
+
+- move routine workflows to GitHub-hosted runners ([#1469](https://github.com/aubepkg/aube/pull/1469))
+- move project to aubepkg and aube.sh ([#1460](https://github.com/aubepkg/aube/pull/1460))
+- fix prose and content in docs and cli help ([#1455](https://github.com/aubepkg/aube/pull/1455))
+- refresh benchmarks for v2.2.4 ([#1434](https://github.com/aubepkg/aube/pull/1434))
+
 ## [2.2.4](https://github.com/jdx/aube/compare/aube-settings-v2.2.3...aube-settings-v2.2.4) - 2026-08-31
 
 ### Fixed

--- a/crates/aube-store/CHANGELOG.md
+++ b/crates/aube-store/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.5](https://github.com/aubepkg/aube/compare/aube-store-v2.2.4...aube-store-v2.2.5) - 2026-09-03
+
+### Other
+
+- move routine workflows to GitHub-hosted runners ([#1469](https://github.com/aubepkg/aube/pull/1469))
+- move project to aubepkg and aube.sh ([#1460](https://github.com/aubepkg/aube/pull/1460))
+- *(store)* direct-write Linux CAS under install lock ([#1430](https://github.com/aubepkg/aube/pull/1430))
+- refresh benchmarks for v2.2.4 ([#1434](https://github.com/aubepkg/aube/pull/1434))
+
 ## [2.2.4](https://github.com/jdx/aube/compare/aube-store-v2.2.3...aube-store-v2.2.4) - 2026-08-31
 
 ### Other

--- a/crates/aube-util/CHANGELOG.md
+++ b/crates/aube-util/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.5](https://github.com/aubepkg/aube/compare/aube-util-v2.2.4...aube-util-v2.2.5) - 2026-09-03
+
+### Other
+
+- move routine workflows to GitHub-hosted runners ([#1469](https://github.com/aubepkg/aube/pull/1469))
+- move project to aubepkg and aube.sh ([#1460](https://github.com/aubepkg/aube/pull/1460))
+- refresh benchmarks for v2.2.4 ([#1434](https://github.com/aubepkg/aube/pull/1434))
+
 ## [2.2.4](https://github.com/jdx/aube/compare/aube-util-v2.2.3...aube-util-v2.2.4) - 2026-08-31
 
 ### Other

--- a/crates/aube-workspace/CHANGELOG.md
+++ b/crates/aube-workspace/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.5](https://github.com/aubepkg/aube/compare/aube-workspace-v2.2.4...aube-workspace-v2.2.5) - 2026-09-03
+
+### Other
+
+- move routine workflows to GitHub-hosted runners ([#1469](https://github.com/aubepkg/aube/pull/1469))
+- move project to aubepkg and aube.sh ([#1460](https://github.com/aubepkg/aube/pull/1460))
+- refresh benchmarks for v2.2.4 ([#1434](https://github.com/aubepkg/aube/pull/1434))
+
 ## [2.2.4](https://github.com/jdx/aube/compare/aube-workspace-v2.2.3...aube-workspace-v2.2.4) - 2026-08-31
 
 ### Other

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.5](https://github.com/aubepkg/aube/compare/v2.2.4...v2.2.5) - 2026-09-03
+
+### Other
+
+- move routine workflows to GitHub-hosted runners ([#1469](https://github.com/aubepkg/aube/pull/1469))
+- move project to aubepkg and aube.sh ([#1460](https://github.com/aubepkg/aube/pull/1460))
+- fix prose and content in docs and cli help ([#1455](https://github.com/aubepkg/aube/pull/1455))
+- *(store)* direct-write Linux CAS under install lock ([#1430](https://github.com/aubepkg/aube/pull/1430))
+- refresh benchmarks for v2.2.4 ([#1434](https://github.com/aubepkg/aube/pull/1434))
+
 ## [2.2.4](https://github.com/jdx/aube/compare/v2.2.3...v2.2.4) - 2026-08-31
 
 ### Fixed

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "2.2.4",
-  "releasedAt": "2026-08-31T14:02:44Z"
+  "version": "2.2.5",
+  "releasedAt": "2026-09-03T20:05:48Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v2.2.5`

This PR bumps the workspace to `v2.2.5` and regenerates CHANGELOG entries, `aube.usage.kdl`, the CLI docs, and the benchmark results.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.
