### PR TITLE
fix(release): avoid SIGPIPE in ARM64 PGO probe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -378,7 +378,9 @@ jobs:
             --env MISE_CACHE_DIR=/tmp/mise-cache \
             aube-release-arm64:local \
             bash -euo pipefail -c '
-              ldd --version | head -1
+              # sed consumes the full stream; head can make ldd exit with
+              # SIGPIPE (141), which pipefail incorrectly treats as a build failure.
+              ldd --version | sed -n "1p"
               mise run --skip-tools build:pgo
             '
 


### PR DESCRIPTION
## Summary

- replace the short-reading `head` probe with `sed`, which consumes the complete `ldd` output
- prevent `bash -o pipefail` from treating `ldd` SIGPIPE status 141 as an ARM64 PGO build failure
- document why the pipeline must not use `head`

This addresses the failure in the v2.2.3 release run: https://github.com/jdx/aube/actions/runs/33253836336

## Validation

- `actionlint .github/workflows/release.yml`
- `git diff --check`
- corrected `ldd` pipeline under `bash -euo pipefail`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ARM64 release build reliability by preventing false failures during environment version checks.
  - Release builds now complete successfully when strict shell error handling is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->