### PR TITLE
ci(perf): move benchmarks to namespace runners

### DIFF
--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -72,7 +72,7 @@ jobs:
     name: Refresh benchmarks
     needs: check
     if: needs.check.outputs.drift == 'true'
-    runs-on: bamboo-perf
+    runs-on: namespace-profile-endev-linux-amd64
     timeout-minutes: 60
     permissions:
       contents: write
@@ -85,7 +85,7 @@ jobs:
           submodules: recursive
           persist-credentials: false
       # Compile inside this disposable VM. Restoring target/ can relabel a
-      # binary built on a different runner class as a Bamboo measurement.
+      # binary built on a different runner class as a Namespace measurement.
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         env:
           MISE_LOCKED: "1"

--- a/.github/workflows/perf-backfill.yml
+++ b/.github/workflows/perf-backfill.yml
@@ -38,10 +38,10 @@ jobs:
     # Same runner class as perf.yml. Absolute instruction counts shift between
     # machine types by more than a real regression does, so the backfilled
     # series and the ongoing one have to come from the same kind of machine.
-    runs-on: bamboo-perf
+    runs-on: namespace-profile-endev-linux-amd64
     timeout-minutes: 60
     env:
-      TAK_RUNNER: bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1
+      TAK_RUNNER: namespace-endev-linux-amd64-rust1.97.1
     permissions:
       contents: read # listing releases and downloading assets; no write here
     steps:

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -28,7 +28,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  TAK_RUNNER: bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1
+  TAK_RUNNER: namespace-endev-linux-amd64-rust1.97.1
 
 jobs:
   compare:
@@ -42,7 +42,7 @@ jobs:
     # between machine types by more than a real regression does, so a comparison
     # across runner classes is not a comparison — tak refuses to make one, and
     # the report would say "nothing was compared" instead of anything useful.
-    runs-on: bamboo-perf
+    runs-on: namespace-profile-endev-linux-amd64
     timeout-minutes: 40
     permissions:
       contents: read
@@ -62,7 +62,7 @@ jobs:
           persist-credentials: false
 
       # Compile inside this disposable VM. Restoring target/ can relabel a
-      # binary built on a different runner class as a Bamboo measurement.
+      # binary built on a different runner class as a Namespace measurement.
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         with:
           cache_save: false

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -27,7 +27,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  TAK_RUNNER: bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1
+  TAK_RUNNER: namespace-endev-linux-amd64-rust1.97.1
 
 jobs:
   measure:
@@ -35,7 +35,7 @@ jobs:
     # Pinned to one runner class on purpose. Absolute instruction counts shift
     # between machine types by more than a real regression does, so a series
     # that wanders between runners is unreadable.
-    runs-on: bamboo-perf
+    runs-on: namespace-profile-endev-linux-amd64
     timeout-minutes: 30
     permissions:
       contents: write # pushing refs/notes/tak is a write to this repository
@@ -45,7 +45,7 @@ jobs:
           persist-credentials: false
 
       # Compile inside this disposable VM. Restoring target/ can relabel a
-      # binary built on a different runner class as a Bamboo measurement.
+      # binary built on a different runner class as a Namespace measurement.
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         env:
           MISE_LOCKED: "1"


### PR DESCRIPTION
## Summary

- move scheduled, PR, backfill, and benchmark-refresh workloads from `bamboo-perf` to `namespace-profile-endev-linux-amd64`
- assign Namespace measurements a new `TAK_RUNNER` identity so they cannot compare against Bamboo results
- update runner-specific workflow comments

## Context

A Bamboo aube benchmark VM reached 13.9 GiB and was killed by the host OOM killer. The dedicated `jdx-perf-01` appliance has only 16 GB of physical memory, so it does not provide enough safety margin for this workload. This PR keeps the benchmark jobs on managed Namespace runners instead.

This supersedes the runner destination in #1420. After merging, run `perf` on `main` once to seed the new Namespace Tak series before enabling PR comparisons.

## Validation

- `actionlint .github/workflows/*.yml`
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the pinned runner and `TAK_RUNNER` identity for all tak-backed perf gates and main history, so comparisons stay invalid until the new series is seeded on `main`.
> 
> **Overview**
> Moves **all performance and benchmark refresh jobs** off the `bamboo-perf` self-hosted label onto **`namespace-profile-endev-linux-amd64`**, covering `perf.yml`, `perf-pr.yml`, `perf-backfill.yml`, and the `refresh` job in `bench-refresh.yml`.
> 
> Sets **`TAK_RUNNER`** from `bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1` to **`namespace-endev-linux-amd64-rust1.97.1`** on the perf workflows so new measurements are tagged separately and **tak will not compare them against the old Bamboo series**. Workflow comments that warned about cross-runner binary relabeling now refer to **Namespace** instead of Bamboo.
> 
> **Follow-up after merge:** run `perf` on `main` once to start the Namespace instruction-count series before PR comparisons are meaningful again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8418434289583c620bcff449fb44208da7499eaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated performance and benchmarking workflows to run on Namespace infrastructure.
  * Standardized runner configuration across refresh, backfill, pull request, and performance measurement jobs.
  * Updated workflow labels and comments to reflect the new measurement environment.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->