### PR TITLE
fix(bench): benchmark published release binary

### DIFF
--- a/.github/workflows/bench-refresh.yml
+++ b/.github/workflows/bench-refresh.yml
@@ -91,17 +91,46 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           persist-credentials: false
-      # Compile inside the pinned job container. Restoring target/ could relabel
-      # a binary built on another runner class as a jdx-perf-v1 measurement.
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         with:
           cache: false
         env:
           MISE_LOCKED: "1"
+      - name: Download released aube binary
+        id: released_aube
+        env:
+          VERSION: ${{ needs.check.outputs.workspace }}
+        run: |
+          case "$(uname -m)" in
+            x86_64) TARGET=x86_64-unknown-linux-gnu ;;
+            aarch64|arm64) TARGET=aarch64-unknown-linux-gnu ;;
+            *)
+              echo "::error::Unsupported benchmark runner architecture: $(uname -m)"
+              exit 1
+              ;;
+          esac
+          ARCHIVE="aube-v${VERSION}-${TARGET}.tar.gz"
+          DESTINATION="$RUNNER_TEMP/aube-release"
+          mkdir -p "$DESTINATION"
+          curl --fail --location --retry 3 \
+            --output "$DESTINATION/$ARCHIVE" \
+            "https://github.com/${GITHUB_REPOSITORY}/releases/download/v${VERSION}/${ARCHIVE}"
+          tar -xzf "$DESTINATION/$ARCHIVE" -C "$DESTINATION" aube
+          chmod +x "$DESTINATION/aube"
+          ACTUAL_VERSION=$("$DESTINATION/aube" --version | grep -Eo \
+            '[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.+-]+)?' | head -n1)
+          if [ "$ACTUAL_VERSION" != "$VERSION" ]; then
+            echo "::error::Downloaded aube $ACTUAL_VERSION, expected $VERSION"
+            exit 1
+          fi
+          echo "Benchmarking released aube $ACTUAL_VERSION from $ARCHIVE"
+          echo "bin=$DESTINATION/aube" >> "$GITHUB_OUTPUT"
       - name: Snapshot previous benchmarks
         run: cp benchmarks/results.json /tmp/bench-results-before.json
       - name: Refresh benchmarks
         run: mise run bench:bump
+        env:
+          AUBE_BIN: ${{ steps.released_aube.outputs.bin }}
       - name: Validate benchmark claims
         run: node benchmarks/validate-results.mts
       - name: Summarize benchmark changes
@@ -216,7 +245,7 @@ jobs:
           cat > /tmp/bench_body.md <<EOF
           ## 🤖 Refreshed benchmarks
 
-          \`benchmarks/results.json\` was pinned to aube \`${BENCH:-<unset>}\`; the workspace is now \`${WORKSPACE}\`. Re-ran \`mise run bench:bump\` on the hermetic Verdaccio registry (500mbit / 50ms per the mise task) and regenerated \`benchmarks/results.json\` plus the README \`BENCH_RATIOS\` block. The benchmark matrix pins aube's GVS mode via \`npm_config_enable_global_virtual_store=true|false\` (the auto-synthesized env alias for the \`enableGlobalVirtualStore\` setting), so GitHub Actions' inherited \`CI=true\` environment does not change whether aube runs with GVS enabled or disabled.
+          \`benchmarks/results.json\` was pinned to aube \`${BENCH:-<unset>}\`; the workspace is now \`${WORKSPACE}\`. Downloaded the published aube \`v${WORKSPACE}\` archive, then re-ran \`mise run bench:bump\` on the hermetic Verdaccio registry (500mbit / 50ms per the mise task) and regenerated \`benchmarks/results.json\` plus the README \`BENCH_RATIOS\` block. The benchmark matrix pins aube's GVS mode via \`npm_config_enable_global_virtual_store=true|false\` (the auto-synthesized env alias for the \`enableGlobalVirtualStore\` setting), so GitHub Actions' inherited \`CI=true\` environment does not change whether aube runs with GVS enabled or disabled.
 
           $(cat "$RUNNER_TEMP/bench-refresh/summary.md")
 

--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -5,7 +5,8 @@ set -euo pipefail
 # and vlt install performance.
 #
 # Prerequisites:
-#   - aube built in release mode: cargo build --release
+#   - aube built in release mode: cargo build --release, or AUBE_BIN set
+#     to an executable released binary
 #   - benchmark dependencies from mise (use `mise run bench` or
 #     `mise run bench:bump`; missing package managers are skipped with
 #     a warning rather than failing the whole run)
@@ -31,6 +32,7 @@ set -euo pipefail
 #   BENCH_SCENARIOS — comma-separated scenario keys to run
 #                     (default: all)
 #   BENCH_PHASES — set to 0 to skip aube phase timing samples
+#   AUBE_BIN     — override the aube executable to benchmark
 #
 #   BENCH_HERMETIC=1 — route all registry traffic through a local
 #                      Verdaccio instance pre-populated from npmjs. This
@@ -48,7 +50,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-AUBE_BIN="$REPO_DIR/target/release/aube"
+AUBE_BIN="${AUBE_BIN:-$REPO_DIR/target/release/aube}"
 PNPM_BIN="$(command -v pnpm || true)"
 YARN_BIN="$(command -v yarn || true)"
 NPM_BIN="$(command -v npm || true)"
@@ -80,8 +82,8 @@ if ! command -v hyperfine &>/dev/null; then
 fi
 
 if [ ! -f "$AUBE_BIN" ]; then
-	echo "error: aube release binary not found at $AUBE_BIN" >&2
-	echo "Run: cargo build --release" >&2
+	echo "error: aube binary not found at $AUBE_BIN" >&2
+	echo "Run: cargo build --release, or set AUBE_BIN to a released binary" >&2
 	exit 1
 fi
 

--- a/mise.toml
+++ b/mise.toml
@@ -101,7 +101,7 @@ run = [
 ]
 
 # Regenerate `benchmarks/results.json` (and the markdown summary) by
-# re-running the full hyperfine scenario matrix with a release build
+# re-running the full hyperfine scenario matrix with a release-mode binary
 # and 10 runs × 3 warmups, then writing the structured output into
 # the repo in-place. Commit the updated JSON and the chart on the
 # VitePress benchmarks page picks it up automatically — the page's
@@ -120,7 +120,7 @@ env = {
   AUBE_FORCE_METADATA_PRIMER = "true",
 }
 run = [
-  "cargo build --release",
+  "if [ -z \"${AUBE_BIN:-}\" ]; then cargo build --release; fi",
   "mise x aqua:sharkdp/hyperfine@latest github:pnpm/pnpm@latest npm:@yarnpkg/cli-dist@latest bun@latest deno@latest npm:vlt@latest node@24 -- bash benchmarks/bench.sh",
   "node benchmarks/update-readme.mts",
 ]


### PR DESCRIPTION
## Summary

- download the matching published aube release artifact before bench-refresh runs
- reject draft releases and verify the downloaded binary reports the workspace version
- let the benchmark harness honor AUBE_BIN while preserving source builds for local runs without an override
- record the published artifact source in generated benchmark PR descriptions

## Validation

- `actionlint .github/workflows/bench-refresh.yml`
- `shellcheck benchmarks/bench.sh`
- `mise tasks`
- downloaded the v2.2.4 x86_64 Linux release archive and verified `aube --version` reports 2.2.4

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect benchmark automation and how the aube executable is selected in CI; no runtime product, auth, or data-path changes.
> 
> **Overview**
> **Bench refresh CI** now downloads the matching **GitHub release** `aube` tarball for the workspace version (x86_64 or aarch64), checks `aube --version` against that version, and runs `mise run bench:bump` with **`AUBE_BIN`** pointing at the extracted binary instead of relying on a runner-local `cargo build --release`.
> 
> The **benchmark harness** (`benchmarks/bench.sh`) accepts **`AUBE_BIN`** to override the default `target/release/aube`; **`bench:bump`** in `mise.toml` only runs `cargo build --release` when `AUBE_BIN` is unset. Generated bench-refresh PR text notes that numbers come from the published artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 311b819eb7a99a40f38c1eff11d7946dda7f3cdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved benchmark refreshes by using the published release binary when available.
  * Added support for specifying a custom executable for benchmark runs.
  * Updated benchmark commands and messages to clarify release-mode binary usage.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->