### PR TITLE
chore(release): improve sponsor message

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -232,9 +232,9 @@ jobs:
 
           ## 💚 Sponsor aube
 
-          aube is maintained by [@jdx](https://github.com/jdx), an open source developer for [**entire.io**](https://entire.io), the title sponsor of the [jdx.dev](https://jdx.dev) open source tools including [mise](https://mise.jdx.dev/). Work on aube is funded by sponsors.
+          aube is built and maintained by [@jdx](https://github.com/jdx), an open source developer at [**entire.io**](https://entire.io/), the title sponsor of his open source work.
 
-          If aube is saving your team install time or CI minutes, please consider [sponsoring at jdx.dev](https://jdx.dev/sponsors.html). Individual and company sponsorships are what keep the project fast, free, and independent.
+          If aube saves your team install time or CI minutes, please consider becoming an [individual or company sponsor](https://jdx.dev/sponsors.html). Your support funds ongoing development and helps keep aube fast, free, and independent.
           EOF
           } > /tmp/release-notes.md
           gh release edit "$TAG" --notes-file /tmp/release-notes.md


### PR DESCRIPTION
## Summary

- clarify Entire's sponsorship of jdx's open source work
- link the sponsorship call to action directly to the individual and company sponsor page
- tighten the release-note copy while preserving each CLI's tailored message

## Testing

- git diff --check
- parsed the updated workflow as YAML

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to appended GitHub release notes; no runtime, auth, or release mechanics affected.
> 
> **Overview**
> Updates the **Sponsor aube** footer that the `enhance-release` job appends after Communiqué generates release notes.
> 
> The intro now describes [@jdx](https://github.com/jdx) as building and maintaining aube at **entire.io** as title sponsor of his open source work, instead of the longer jdx.dev/mise framing. The CTA links directly to [individual or company sponsor](https://jdx.dev/sponsors.html) with tightened wording about funding development and keeping aube free.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8be10b69ecff85f5ef6684777e5a55b519023027. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GitHub release notes with revised sponsor messaging.
  * Clarified the project’s maintenance and sponsorship information.
  * Added an invitation for individual and company sponsorship to support ongoing development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->