### PR TITLE
ci: use runner-provided rust

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,0 @@
-[toolchain]
-channel = "1.98"
-profile = "minimal"
-components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Summary

- remove the repository-wide Rust 1.98 toolchain pin
- let CI use the Rust toolchain provided by the GitHub Actions runner
- leave the declared MSRV unchanged

## Validation

- `actionlint`
- `git diff --check`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the project-specific Rust toolchain pin and component configuration.
  * Builds now use the default Rust toolchain environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->