### PR TITLE
fix(release): avoid major bumps for lockfile error variants

### DIFF
--- a/crates/aube-lockfile/Cargo.toml
+++ b/crates/aube-lockfile/Cargo.toml
@@ -10,6 +10,12 @@ homepage.workspace = true
 readme.workspace = true
 include = ["src/**/*.rs"]
 
+[package.metadata.cargo-semver-checks.lints]
+# Lockfile errors are intended to grow as more invalid formats are diagnosed.
+# Keep additions visible in semver-check output without forcing a workspace-wide
+# major release for every new diagnostic variant.
+enum_variant_added = "warn"
+
 [dependencies]
 aube-codes = { workspace = true }
 aube-manifest = { workspace = true }


### PR DESCRIPTION
## Summary

- downgrade `enum_variant_added` to warning-only for `aube-lockfile`
- keep all other cargo-semver-checks API compatibility checks enforced
- allow new lockfile diagnostic variants without forcing a workspace-wide major release

## Validation

- `cargo-semver-checks 0.49.0 semver-checks --baseline-version 2.2.4 --package aube-lockfile` (222 passed, 1 warning, 0 failures; no semver update required)
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*