### PR TITLE
fix(release): remove mbx check from arm64 image

### DIFF
--- a/.github/containers/release-arm64/Containerfile
+++ b/.github/containers/release-arm64/Containerfile
@@ -77,7 +77,6 @@ RUN mkdir -p "$CARGO_HOME" "$RUSTUP_HOME" \
 COPY mise.toml /mise/config.toml
 
 RUN mise install --system \
-    && mise exec -- mbx --version \
     && mise exec -- node --version \
     && mise exec -- rustc --version \
     && chmod -R a+rX /mise /usr/local/share/mise


### PR DESCRIPTION
## Summary

- remove the mbx version check from the focused ARM64 PGO release image
- keep the image toolchain aligned with its scoped mise configuration, which installs only Node and Rust
- unblock the missing aarch64-unknown-linux-gnu release artifact and final publish gate

## Verification

- git diff --check
- confirmed the container-scoped mise.toml contains only Node and Rust
- full container build unavailable because no local Docker daemon is running
- local mise validation unavailable because the installed mise 2026.6.13 is older than the repository-required 2026.8.16

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*