### PR TITLE
chore: release v2.2.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "2.2.6"
+version = "2.2.7"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "aube-codes"
-version = "2.2.6"
+version = "2.2.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "aube-ffi"
-version = "2.2.6"
+version = "2.2.7"
 dependencies = [
  "aube",
  "aube-codes",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "2.2.6"
+version = "2.2.7"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "2.2.6"
+version = "2.2.7"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -364,7 +364,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "2.2.6"
+version = "2.2.7"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "aube-node"
-version = "2.2.6"
+version = "2.2.7"
 dependencies = [
  "aube",
  "aube-codes",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "2.2.6"
+version = "2.2.7"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "2.2.6"
+version = "2.2.7"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "aube-runtime"
-version = "2.2.6"
+version = "2.2.7"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "2.2.6"
+version = "2.2.7"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "2.2.6"
+version = "2.2.7"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "2.2.6"
+version = "2.2.7"
 dependencies = [
  "aube-util",
  "base64 0.23.1",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "2.2.6"
+version = "2.2.7"
 dependencies = [
  "aube-codes",
  "blake3",
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "2.2.6"
+version = "2.2.7"
 dependencies = [
  "aube-codes",
  "aube-manifest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ inherits = "release"
 panic = "unwind"
 
 [workspace.package]
-version = "2.2.6"
+version = "2.2.7"
 edition = "2024"
 # Kept at the floor mise can build with (its distro packaging pins the
 # toolchain) so mise can embed the library crates. CI enforces this via

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.7](https://github.com/jdx/aube/compare/v2.2.6...v2.2.7) - 2026-09-03
+
+### Fixed
+
+- *(release)* remove mbx check from arm64 image ([#1473](https://github.com/jdx/aube/pull/1473))
+
 ## [2.2.6](https://github.com/jdx/aube/compare/v2.2.5...v2.2.6) - 2026-09-03
 
 ### Fixed

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "2.2.6",
-  "releasedAt": "2026-09-03T22:05:03Z"
+  "version": "2.2.7",
+  "releasedAt": "2026-09-03T23:59:06Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v2.2.7`

This PR bumps the workspace to `v2.2.7` and regenerates CHANGELOG entries, `aube.usage.kdl`, the CLI docs, and the benchmark results.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.
