### PR TITLE
fix(release): isolate arm64 pgo toolchain

### DIFF
--- a/.github/containers/release-arm64/Containerfile
+++ b/.github/containers/release-arm64/Containerfile
@@ -21,21 +21,21 @@ ARG PKG_CONFIG_VERSION=0.29.1-0ubuntu4
 ARG WGET_VERSION=1.20.3-1ubuntu2.1
 ARG XZ_UTILS_VERSION=5.2.4-1ubuntu1.1
 
-# The mounted repository has a broader developer tool list; missing task
-# tools must not make this focused release image install unsupported assets.
+# The mounted repository has a broader developer tool list. Keep runtime
+# auto-install disabled so this focused, non-root release image uses only the
+# system tools installed from its scoped config below.
 ENV DEBIAN_FRONTEND=noninteractive \
     MISE_CACHE_DIR=/mise/cache \
     MISE_CONFIG_DIR=/mise \
     MISE_DATA_DIR=/mise \
     MISE_INSTALL_PATH=/usr/local/bin/mise \
     MISE_SYSTEM_DATA_DIR=/usr/local/share/mise \
-    MISE_TASK_RUN_AUTO_INSTALL=false \
+    MISE_AUTO_INSTALL=false \
     MISE_TRUSTED_CONFIG_PATHS=/mise \
     MISE_YES=1 \
     CARGO_HOME=/usr/local/share/mise/cargo \
     RUSTUP_HOME=/usr/local/share/mise/rustup \
-    RUSTUP_TOOLCHAIN=1.97.0 \
-    PATH=/usr/local/share/mise/cargo/bin:/usr/local/share/mise/installs/node/24.14.0/bin:/mise/shims:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin
+    PATH=/usr/local/share/mise/cargo/bin:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,6 +344,20 @@ jobs:
           # can restore it but must not let an arbitrary ref poison it.
           cache-to: ${{ !fromJSON(inputs.dry_run || 'false') && inputs.ref == '' && github.ref == 'refs/heads/main' && 'type=gha,mode=max,scope=aube-release-arm64' || '' }}
 
+      - name: Smoke-test ARM64 PGO environment
+        shell: bash
+        run: |
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            --env HOME=/tmp \
+            --env MISE_CACHE_DIR=/tmp/mise-cache \
+            aube-release-arm64:local \
+            mise -C /mise exec -- bash -euo pipefail -c '
+              node --version
+              rustc --version
+              cargo --version
+            '
+
       - name: PGO build (Focal + LLD + BOLT)
         shell: bash
         env:
@@ -372,11 +386,12 @@ jobs:
             --env CARGO_HOME=/tmp/aube-home/.cargo \
             --env MISE_CACHE_DIR=/tmp/mise-cache \
             aube-release-arm64:local \
-            bash -euo pipefail -c '
+            mise -C /mise exec -- bash -euo pipefail -c '
+              cd /workspace
               # sed consumes the full stream; head can make ldd exit with
               # SIGPIPE (141), which pipefail incorrectly treats as a build failure.
               ldd --version | sed -n "1p"
-              mise run --skip-tools build:pgo
+              bash benchmarks/pgo.bash
             '
 
       - name: Validate glibc baseline


### PR DESCRIPTION
## Summary

- run the native ARM64 PGO build with the release images scoped mise configuration instead of the mounted repository configuration
- remove stale Node and Rust version pins from the container environment and disable runtime auto-install globally
- smoke-test Node, Rust, and Cargo as the non-root runtime user before starting the expensive PGO build

## Root cause

The image installed Node 24.20 and Rust 1.98 from its scoped mise.toml, but its runtime PATH and RUSTUP_TOOLCHAIN still referenced Node 24.14 and Rust 1.97. The missing Node path fell through to a project mise shim, which attempted to install Node 24.14 into read-only /mise.

## Verification

- git diff --check
- shellcheck benchmarks/pgo.bash
- release workflow dry run will exercise the branch on the native ARM64 runner
- local container build unavailable because no Docker daemon is running

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*