### PR TITLE
fix(release): create arm64 target before mounting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -368,7 +368,9 @@ jobs:
           AUBE_PGO_LLVM_VERSION: ${{ env.LLVM_VERSION }}
         run: |
           container_home="$RUNNER_TEMP/aube-home"
-          mkdir -p "$container_home/.cargo" "$HOME/.cargo/registry" "$HOME/.cargo/git"
+          # Docker creates missing bind-mount sources as root. Create target as
+          # the runner user so the non-root container can write PGO artifacts.
+          mkdir -p "$GITHUB_WORKSPACE/target" "$container_home/.cargo" "$HOME/.cargo/registry" "$HOME/.cargo/git"
           docker run --rm \
             --user "$(id -u):$(id -g)" \
             --volume "$GITHUB_WORKSPACE:/workspace" \
@@ -388,6 +390,7 @@ jobs:
             aube-release-arm64:local \
             mise -C /mise exec -- bash -euo pipefail -c '
               cd /workspace
+              test -w target
               # sed consumes the full stream; head can make ldd exit with
               # SIGPIPE (141), which pipefail incorrectly treats as a build failure.
               ldd --version | sed -n "1p"


### PR DESCRIPTION
## Summary

- create the host-side `target` directory before Docker bind-mounts it
- verify the non-root ARM64 build container can write to that directory before starting PGO

## Why

Docker creates a missing bind-mount source as root. The ARM64 release job runs the container as the runner UID, so `benchmarks/pgo.bash` failed when creating `target/pgo-data`.

## Validation

- `git diff --check`
- [full release dry run passed](https://github.com/aubepkg/aube/actions/runs/33826868093), including ARM64 GNU PGO, BOLT, glibc validation, archive, and artifact upload

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*