### PR TITLE
chore: release v2.2.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "ambient-id",
  "assert_cmd",
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "aube-codes"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "serde",
  "serde_json",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "aube-ffi"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "aube",
  "aube-codes",
@@ -311,7 +311,7 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "aube-node"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "aube",
  "aube-codes",
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "aube-runtime"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -484,7 +484,7 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "aube-util",
  "base64 0.23.1",
@@ -541,7 +541,7 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "aube-codes",
  "blake3",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "aube-codes",
  "aube-manifest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ inherits = "release"
 panic = "unwind"
 
 [workspace.package]
-version = "2.2.9"
+version = "2.2.10"
 edition = "2024"
 # Kept at the floor mise can build with (its distro packaging pins the
 # toolchain) so mise can embed the library crates. CI enforces this via

--- a/crates/aube-lockfile/CHANGELOG.md
+++ b/crates/aube-lockfile/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.10](https://github.com/aubepkg/aube/compare/aube-lockfile-v2.2.9...aube-lockfile-v2.2.10) - 2026-09-05
+
+### Other
+
+- Revert "fix(release): avoid major bumps for lockfile error variants" ([#1468](https://github.com/aubepkg/aube/pull/1468))
+
 ## [2.2.5](https://github.com/aubepkg/aube/compare/aube-lockfile-v2.2.4...aube-lockfile-v2.2.5) - 2026-09-03
 
 ### Fixed

--- a/crates/aube/CHANGELOG.md
+++ b/crates/aube/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.10](https://github.com/aubepkg/aube/compare/v2.2.9...v2.2.10) - 2026-09-05
+
+### Fixed
+
+- *(config)* redact credentials from command output ([#1483](https://github.com/aubepkg/aube/pull/1483))
+- *(config)* preserve comments and order in config.toml ([#1480](https://github.com/aubepkg/aube/pull/1480))
+
 ## [2.2.9](https://github.com/jdx/aube/compare/v2.2.8...v2.2.9) - 2026-09-04
 
 ### Fixed

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "2.2.9",
-  "releasedAt": "2026-09-04T02:18:24Z"
+  "version": "2.2.10",
+  "releasedAt": "2026-09-05T19:46:33Z"
 }


### PR DESCRIPTION
## 🤖 New release: `v2.2.10`

This PR bumps the workspace to `v2.2.10` and regenerates CHANGELOG entries, `aube.usage.kdl`, the CLI docs, and the benchmark results.

See the diff for the full set of changes, or the per-crate `CHANGELOG.md` files for the release notes that will ship.

---
Generated by the `release-plz-pr` workflow.
