### PR TITLE
fix(config): redact credentials from command output

### DIFF
--- a/crates/aube/src/commands/config/list.rs
+++ b/crates/aube/src/commands/config/list.rs
@@ -1,6 +1,6 @@
 use super::{
-    ListLocation, literal_aliases, read_merged, read_single, setting_default_value,
-    setting_for_key, settings_meta, user_npmrc_path,
+    ListLocation, display_config_value, literal_aliases, read_merged, read_single,
+    setting_default_value, setting_for_key, settings_meta, user_npmrc_path,
 };
 use aube_settings::meta::SettingMeta;
 use miette::miette;
@@ -137,13 +137,14 @@ pub fn run(args: ListArgs) -> miette::Result<()> {
         let obj: serde_json::Map<String, serde_json::Value> = seen
             .into_iter()
             .map(|(k, v)| {
+                let display = display_config_value(&k, &v);
                 let value = if args.all {
                     serde_json::json!({
-                        "value": v,
+                        "value": display,
                         "default": defaults.contains(&k),
                     })
                 } else {
-                    serde_json::Value::String(v)
+                    serde_json::Value::String(display)
                 };
                 (k, value)
             })
@@ -153,10 +154,11 @@ pub fn run(args: ListArgs) -> miette::Result<()> {
         println!("{out}");
     } else {
         for (k, v) in &seen {
+            let display = display_config_value(k, v);
             if defaults.contains(k) {
-                println!("{k}={v} (default)");
+                println!("{k}={display} (default)");
             } else {
-                println!("{k}={v}");
+                println!("{k}={display}");
             }
         }
     }

--- a/crates/aube/src/commands/config/mod.rs
+++ b/crates/aube/src/commands/config/mod.rs
@@ -251,6 +251,38 @@ pub(super) fn is_npm_shared_key(key: &str) -> bool {
     setting_for_key(key).is_some_and(|meta| meta.npm_shared)
 }
 
+/// Redact credentials before config values cross the command-output boundary.
+///
+/// This follows npm's deliberately broad treatment of underscore-prefixed
+/// authentication fields and also covers the inline TLS private-key spelling
+/// accepted by aube's registry configuration. Non-secret URLs still pass
+/// through [`aube_util::url::redact_url`] so embedded userinfo is not echoed.
+pub(super) fn display_config_value(key: &str, value: &str) -> String {
+    let lower = key.to_ascii_lowercase();
+    let suffix = lower.rsplit_once(':').map_or(lower.as_str(), |(_, v)| v);
+    let is_protected_name = |name| {
+        matches!(
+            name,
+            "auth"
+                | "authtoken"
+                | "certfile"
+                | "email"
+                | "key"
+                | "keyfile"
+                | "password"
+                | "username"
+        )
+    };
+    if lower.starts_with('_')
+        || is_protected_name(&lower)
+        || (lower.starts_with("//") && (suffix.starts_with('_') || is_protected_name(suffix)))
+    {
+        "(protected)".to_string()
+    } else {
+        aube_util::url::redact_url(value)
+    }
+}
+
 pub(super) fn setting_for_key(key: &str) -> Option<&'static settings_meta::SettingMeta> {
     settings_meta::find(key).or_else(|| {
         settings_meta::all().iter().find(|meta| {
@@ -442,6 +474,28 @@ mod tests {
         assert_eq!(
             list::canonical_list_key("//registry.example.com/:_authToken"),
             "//registry.example.com/:_authToken"
+        );
+    }
+
+    #[test]
+    fn display_config_value_protects_credentials_and_redacts_urls() {
+        for key in [
+            "_authToken",
+            "//registry.example.com/:_authToken",
+            "//registry.example.com/:username",
+            "//registry.example.com/:_password",
+            "//registry.example.com/:key",
+            "email",
+        ] {
+            assert_eq!(display_config_value(key, "secret"), "(protected)");
+        }
+        assert_eq!(
+            display_config_value("registry", "https://example.com"),
+            "https://example.com"
+        );
+        assert_eq!(
+            display_config_value("proxy", "https://user:secret@example.com"),
+            "https://***@example.com"
         );
     }
 

--- a/crates/aube/src/commands/config/set.rs
+++ b/crates/aube/src/commands/config/set.rs
@@ -1,5 +1,6 @@
 use super::{
-    Location, NpmrcEdit, aube_config, is_npm_shared_key, resolve_aliases, setting_for_key,
+    Location, NpmrcEdit, aube_config, display_config_value, is_npm_shared_key, resolve_aliases,
+    setting_for_key,
 };
 use miette::miette;
 
@@ -97,7 +98,12 @@ pub(super) fn set_value(
         {
             aube_config::set_workspace_yaml_value(&path, meta, yaml_key, value)?;
             if report {
-                eprintln!("set {}={} ({})", yaml_key, value, path.display());
+                eprintln!(
+                    "set {}={} ({})",
+                    yaml_key,
+                    display_config_value(yaml_key, value),
+                    path.display()
+                );
             }
             return Ok(());
         }
@@ -105,7 +111,12 @@ pub(super) fn set_value(
         edit.set(meta, value)?;
         edit.save(&path)?;
         if report {
-            eprintln!("set {}={} ({})", meta.name, value, path.display());
+            eprintln!(
+                "set {}={} ({})",
+                meta.name,
+                display_config_value(meta.name, value),
+                path.display()
+            );
         }
         return Ok(());
     }
@@ -117,7 +128,12 @@ pub(super) fn set_value(
     edit.set_unknown(key, value);
     edit.save(&path)?;
     if report {
-        eprintln!("set {}={} ({})", key, value, path.display());
+        eprintln!(
+            "set {}={} ({})",
+            key,
+            display_config_value(key, value),
+            path.display()
+        );
     }
     Ok(())
 }
@@ -176,7 +192,12 @@ fn try_set_aube_map_entry(
         aube_manifest::workspace::upsert_map_entry(&cwd, meta.name, entry, yaml_value, json_value)
             .map_err(|e| miette!("failed to write {}.{entry}: {e}", meta.name))?;
     if report {
-        eprintln!("set {}.{entry}={value} ({})", meta.name, written.display());
+        let key = format!("{}.{entry}", meta.name);
+        eprintln!(
+            "set {key}={} ({})",
+            display_config_value(&key, value),
+            written.display()
+        );
     }
     Ok(Some(()))
 }
@@ -212,7 +233,12 @@ fn write_npmrc(key: &str, value: &str, location: Location, report: bool) -> miet
     edit.set(&write_key, value);
     edit.save(&path)?;
     if report {
-        eprintln!("set {}={} ({})", write_key, value, path.display());
+        eprintln!(
+            "set {}={} ({})",
+            write_key,
+            display_config_value(&write_key, value),
+            path.display()
+        );
     }
     sweep_stale_aube_config(key, &aliases, location)?;
     Ok(())

--- a/test/config.bats
+++ b/test/config.bats
@@ -267,6 +267,40 @@ TOML
 	assert_output --partial "auto-install-peers=false"
 }
 
+@test "config list protects credentials in text and JSON output" {
+	mkdir proj
+	cat >proj/.npmrc <<'EOF'
+//registry.example.com/:_authToken=token-secret
+//registry.example.com/:username=user-secret
+//registry.example.com/:_password=password-secret
+https-proxy=https://proxy-user:proxy-secret@proxy.example.com
+EOF
+	cd proj
+	run aube config list
+	assert_success
+	assert_output --partial "//registry.example.com/:_authToken=(protected)"
+	assert_output --partial "//registry.example.com/:username=(protected)"
+	assert_output --partial "//registry.example.com/:_password=(protected)"
+	assert_output --partial "https-proxy=https://***@proxy.example.com"
+	refute_output --partial "token-secret"
+	refute_output --partial "user-secret"
+	refute_output --partial "password-secret"
+	refute_output --partial "proxy-secret"
+
+	run bash -c 'aube config list --json | jq -r ".[\"//registry.example.com/:_authToken\"]"'
+	assert_success
+	assert_output "(protected)"
+}
+
+@test "config set does not echo credentials" {
+	run aube config set "//registry.example.com/:_authToken" token-secret
+	assert_success
+	assert_output --partial "//registry.example.com/:_authToken=(protected)"
+	refute_output --partial "token-secret"
+	run grep token-secret "$HOME/.npmrc"
+	assert_success
+}
+
 @test "config with no subcommand lists merged entries" {
 	mkdir proj
 	echo "registry=https://user.example.com/" >"$HOME/.npmrc"


### PR DESCRIPTION
## Summary

- render authentication credentials as `(protected)` in text and JSON config listings
- redact embedded URL credentials and keep `config set` from echoing secrets
- add regression coverage for tokens, usernames, passwords, proxy URLs, and persisted values

Addresses [Discussion #1482](https://github.com/aubepkg/aube/discussions/1482).

## Testing

- `cargo fmt --check`
- `MBX_DISABLE=1 cargo test -p aube commands::config::tests::display_config_value_protects_credentials_and_redacts_urls`
- `test/bats/bin/bats test/config.bats` (72 passed)
- `MBX_DISABLE=1 cargo clippy -p aube --all-targets --no-deps -- -D warnings`
- `MBX_DISABLE=1 cargo test`: all 841 aube unit tests pass; the run later stops in the untouched `facade_install_preserves_non_utf8_storage_paths` embed test with macOS `Illegal byte sequence`
- repository-wide clippy remains blocked by eight untouched `unused_assignments` errors in `crates/aube-lockfile/src/io.rs`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*