### PR TITLE
ci(release): publish a signed packslip with each release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -732,3 +732,48 @@ jobs:
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: ${{ steps.archive.outputs.path }}
+
+  # The packslip is this release's signed inventory: every archive's digest,
+  # the three multicall executables inside it, the shared objects it needs
+  # from the host, and the workflow identity that signed for all of it. An
+  # installer checks a download against jdx/aube's identity rather than
+  # against a key this project would have to hold. See https://packslip.dev.
+  #
+  # Its own job because the four upload jobs above each write straight to the
+  # release; one document covering the whole release can only be written once
+  # every one of them has landed. The FFI library and header from ffi.yml are
+  # not artifacts anyone installs an executable from, so they stay out.
+  packslip:
+    name: Publish the packslip
+    needs:
+      - upload-assets
+      - upload-assets-musl-arm64
+      - upload-assets-pgo-arm64-linux
+      - upload-assets-pgo
+    if: ${{ !fromJSON(inputs.dry_run || 'false') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Download the release archives
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}
+          TAG: ${{ inputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          mkdir -p dist
+          gh release download "$TAG" --repo "$REPO" --dir dist --clobber \
+            --pattern 'aube-v*.tar.gz' --pattern 'aube-v*.zip'
+          ls -la dist
+      # The jobs that built these archives already attested them as they went,
+      # which is the stronger claim; attesting again here would only add a
+      # second statement about the same digests.
+      - uses: jdx/packslip@433c0c0f033e64c22f12433471768c255ef2bd93 # v0.3.0
+        with:
+          tag: ${{ inputs.tag }}
+          artifacts: dist/aube-v*.tar.gz dist/aube-v*.zip
+          bin: aube aubr aubx
+          attest: "false"
+          token: ${{ secrets.AUBE_GH_TOKEN }}


### PR DESCRIPTION
Part of adopting [packslip](https://packslip.dev) across the jdx.dev CLIs.

Each release now publishes `packslip.sigstore.json` beside the archives — one signed document listing:

- every archive's sha256 and sha512
- the three multicall executables inside each one (`aube`, `aubr`, `aubx`; `.exe` on Windows)
- the shared objects each build needs from the host, read out of the binaries
- the source repo, tag, and commit

signed keylessly with this workflow's OIDC identity, so an installer verifies a download against the identity `github.com/jdx/aube` instead of a signing key this project would have to hold and rotate.

### Changes

- A new `packslip` job needing all four upload jobs. It has to be its own job: each of them writes straight to the release, so none sees the whole thing, and one document covering all of it can only be written once every one has landed. Skipped on a dry run, where nothing is uploaded.
- No change to `release-plz.yml`: it already grants `upload-assets` `id-token: write`.

`attest: false` on purpose — the jobs that built the archives already run `actions/attest-build-provenance` on them as they go, which is the stronger claim. Attesting again in a later job would only add a second statement about the same digests. The cost is that the packslip carries no `provenance` links; the action can only emit those when it does the attesting itself, which is worth a follow-up input on the action.

The FFI assets from `ffi.yml` (`libaube-*.{so,dylib,dll}`, `aube.h`) stay out of the `artifacts` glob. Nobody installs an executable from them, and packslip reads a bare `libaube-aarch64-apple-darwin.dylib` next to `aube-v2.2.9-aarch64-apple-darwin.tar.gz` as a second artifact claiming the same platform.

### Verification

Rehearsed end to end against the real v2.2.9 assets. The multicall shims ship as symlinks in the tarballs and as duplicate binaries in the zips; packslip resolves all three either way:

```
aube-v2.2.9-aarch64-apple-darwin.tar.gz      | darwin  aarch64  -    tar.gz | aube, aubr, aubx
aube-v2.2.9-aarch64-unknown-linux-gnu.tar.gz | linux   aarch64  gnu  tar.gz | aube, aubr, aubx
aube-v2.2.9-x86_64-pc-windows-msvc.zip       | windows x86_64   -    zip    | aube.exe, aubr.exe, aubx.exe
```

with `vcruntime140.dll` and `vcruntime140_1.dll` picked up as host requirements on the Windows builds. `zizmor --offline` reports no findings on the changed workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
