### PR TITLE
ci: enforce conventional commits

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,27 @@
+name: conventional-commits
+
+on: # zizmor: ignore[dangerous-triggers] reads only the PR title and executes no untrusted code
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check pull request title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|security|style|test)(\([[:alnum:]][[:alnum:]./_-]*(, ?[[:alnum:]][[:alnum:]./_-]*)*\))?!?: [[:lower:]](.*[[:graph:]])?$'
+          if [[ ! "$PR_TITLE" =~ $pattern ]]; then
+            echo "::error title=Invalid pull request title::The title does not match the required format."
+            printf 'Received title: %q\n' "$PR_TITLE"
+            echo "Use: <type>[optional scope][optional !]: <description starting lowercase>"
+            exit 1
+          fi

--- a/.rules
+++ b/.rules
@@ -127,7 +127,7 @@ when_to_use_release:
 
 commits:
   format: <type>(<scope>): <description>
-  style: conventional commits — lowercase after colon, imperative mood, concise, subject typically <=80 chars (p95 in history is 73), usually no body
+  style: conventional commits — start the description lowercase, use imperative mood, keep it concise, subject typically <=80 chars (p95 in history is 73), usually no body
   why: PR titles drive release-plz version bumps (feat→minor, fix→patch, BREAKING CHANGE/`!` →major, others→no bump). enforced by .github/workflows/semantic-pr-lint.yml on PR title via amannn/action-semantic-pull-request
   types[12]: fix, feat, refactor, chore, docs, style, test, perf, build, ci, revert, security
   scope_optional: true (omit for repo-wide changes like `chore: release v1.2.0`)
@@ -140,6 +140,7 @@ commits:
   body_rules: reserve body for breaking changes, security fixes, benchmark tables, non-obvious WHY. wrap 72, use - not *
   pr_numbers: never type (#NN) yourself, GitHub squash-merge appends them automatically
   pr_titles: must match the same `<type>(<scope>): <desc>` format — the lint workflow blocks merges that don't
+  validation: CI checks the PR title on creation and edits; intermediate commits are not checked because PRs are squash-merged
   forbidden[2]:
     - "[codex]" or tool-branding prefix in subject
     - emoji in commit subject


### PR DESCRIPTION
## Summary

- document or connect the repository’s Conventional Commits policy for pull request titles
- validate the title on creation and every edit with the repository’s allowed types
- use a permissionless `pull_request_target` workflow with no checkout, so pull request code cannot bypass the check
- intentionally ignore intermediate commit subjects because pull requests are squash-merged using their titles

## Testing

- `actionlint .github/workflows/conventional-commits.yml`
- exercised valid, breaking-change, invalid-type, uppercase-description, and trailing-space title cases locally

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*