### PR TITLE
ci(release): publish a signed packslip with each release

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -158,6 +158,41 @@ jobs:
       CERTIFICATES_P12: ${{ secrets.CERTIFICATES_P12 }}
       CERTIFICATES_P12_PASS: ${{ secrets.CERTIFICATES_P12_PASS }}
 
+  # The packslip is this release's signed inventory: every CLI archive's
+  # digest, the executable inside it, and the workflow identity that signed
+  # for all of it, so an installer can check a download against
+  # github.com/jdx/aube's identity rather than a key this project would have
+  # to hold. `upload-assets` already attests each archive's build provenance
+  # with actions/attest-build-provenance, so `attest: link` only links those
+  # statements instead of attesting a second time. The FFI libraries stay out
+  # — nothing installs a binary directly from them the way it does from these
+  # archives. See https://packslip.dev.
+  packslip:
+    name: Publish the packslip
+    needs: [release-plz-release, upload-assets]
+    if: ${{ needs.release-plz-release.outputs.tag != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Download release assets
+        env:
+          GH_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}
+          TAG: ${{ needs.release-plz-release.outputs.tag }}
+        run: |
+          mkdir -p dist
+          gh release download "$TAG" --repo "${{ github.repository }}" --dir dist --clobber \
+            --pattern 'aube-*.tar.gz' --pattern 'aube-*.zip'
+          ls -la dist
+      - uses: jdx/packslip@0121abf6972fe6ca13633233402439a715f4cc0e # v1.0.0
+        with:
+          tag: ${{ needs.release-plz-release.outputs.tag }}
+          artifacts: dist/aube-*.tar.gz dist/aube-*.zip
+          bin: aube
+          attest: link
+          token: ${{ secrets.AUBE_GH_TOKEN }}
+
   # Flip the draft release to non-draft once *every* asset uploaded
   # cleanly and Communiqué has written the final notes. With immutable
   # GitHub releases enabled, a published release can't have its assets
@@ -171,7 +206,7 @@ jobs:
   # happen after confirming the Communiqué notes are present too.
   publish-release:
     name: Publish release
-    needs: [release-plz-release, upload-assets, upload-ffi-assets, enhance-release]
+    needs: [release-plz-release, upload-assets, upload-ffi-assets, enhance-release, packslip]
     if: ${{ needs.release-plz-release.outputs.tag != '' }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -176,19 +176,10 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - name: Download release assets
-        env:
-          GH_TOKEN: ${{ secrets.AUBE_GH_TOKEN }}
-          TAG: ${{ needs.release-plz-release.outputs.tag }}
-        run: |
-          mkdir -p dist
-          gh release download "$TAG" --repo "${{ github.repository }}" --dir dist --clobber \
-            --pattern 'aube-*.tar.gz' --pattern 'aube-*.zip'
-          ls -la dist
-      - uses: jdx/packslip@0121abf6972fe6ca13633233402439a715f4cc0e # v1.0.0
+      - uses: jdx/packslip@a6eddff2d884891faa2efbec374b48e7053df2c4 # v1.0.1
         with:
           tag: ${{ needs.release-plz-release.outputs.tag }}
-          artifacts: dist/aube-*.tar.gz dist/aube-*.zip
+          download: aube-*.tar.gz aube-*.zip
           bin: aube
           attest: link
           token: ${{ secrets.AUBE_GH_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a `packslip` job to `release-plz.yml` that runs after `upload-assets` and before the draft release is published, signing an inventory of the CLI archives (`aube-*.tar.gz` / `aube-*.zip`).
- `upload-assets` already attests each archive's build provenance with `actions/attest-build-provenance`, so this uses `attest: link` rather than attesting a second time.
- The FFI libraries from `upload-ffi-assets` stay out of the packslip — nothing installs a binary directly from them the way it does from the CLI archives, matching the precedent in jdx/hk (which excludes its Pkl package for the same reason).
- Pinned to `jdx/packslip` v1.0.0 (the format's first stable release) rather than starting from an older tag.

## Test plan
- [ ] `actionlint .github/workflows/release-plz.yml` (ran locally, clean)
- [ ] Next tagged release runs the `packslip` job successfully and uploads `packslip.sigstore.json` before `publish-release` flips the draft live

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*AI-assisted — Tool: Claude Code; model: anthropic/claude-sonnet-5; version: unavailable.*
