### PR TITLE
ci(release): stop routing release-plz's cargo through mbx

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -308,6 +308,17 @@ jobs:
       - uses: taiki-e/install-action@fcf5432d9f50d67e37ee6e29bdb7a224ff67b4a7 # v2.86.8
         with:
           tool: release-plz
+      # `release-plz update` shells out to `cargo package` inside temp
+      # checkouts of the commits it diffs against the published crates. On
+      # PATH `cargo` is mise's command wrapper, which mise.toml routes to mbx
+      # — and in those checkouts mise reads *that commit's* mise.toml, so it
+      # looks for the mbx version pinned back then, which was never installed
+      # on this runner. cargo then dies with "mbx" couldn't exec process and
+      # release-plz fails with "failed to determine next versions". Put the
+      # real cargo ahead of the wrapper. Steps that go through `mise run` keep
+      # using mbx: mise prepends its own wrapper dir there.
+      - name: Put the real cargo ahead of the mbx wrapper
+        run: dirname "$(mise which cargo)" >> "$GITHUB_PATH"
       - name: Configure git identity
         run: |
           git config user.name "release-plz[bot]"


### PR DESCRIPTION
The `release-plz PR` job has failed on every push to `main` since the mr-boxington 1.8.1 bump — [run 33976635522](https://github.com/aubepkg/aube/actions/runs/33976635522) is the latest:

```
failed to check package equality for `aube-codes` at commit 3e15639
  error while running `cargo package`: mise ERROR "mbx" couldn't exec process: No such file or directory
Error: failed to determine next versions
```

## Why

To compute the next version, `release-plz update` checks the commits it diffs against out into temp dirs and runs `cargo package --list` there. On `PATH` that `cargo` is mise's command wrapper, which `mise.toml` routes to mbx:

```toml
[wrappers.cargo]
command = "mbx"
```

In the temp checkout mise reads *that commit's* `mise.toml`, so it goes looking for the `mr-boxington` version pinned back then — which the runner never installed, because it installed the version pinned at HEAD. So the job breaks whenever the two pins disagree, which is why it went red at the 1.8.1 bump and has stayed red. `MBX_DISABLE: "1"` doesn't help; mbx never gets far enough to read it.

## Fix

Put the real cargo ahead of the wrapper on `PATH` before release-plz runs. Steps that go through `mise run` are untouched and still build via mbx, since mise prepends its own wrapper dir there — so the build cache keeps working where it actually pays. Routing a `cargo package --list` through mbx bought nothing anyway.

The `release-plz release` job doesn't install mise, so its cargo is already the plain one and needs no change.

## Context

Found while fixing the identical failure in [jdx/pitchfork#826](https://github.com/jdx/pitchfork/pull/826). `jdx/mise`, `jdx/hk` and `jdx/fnox` carry the same `[wrappers.cargo]` block but are not exposed: their `release-plz` tasks are hand-rolled git-cliff scripts that never invoke the release-plz binary, so nothing runs `cargo package` inside an old checkout.

Worth noting the trap is broader than release-plz — any tool that runs `cargo` inside a checkout of a different commit hits it, because mise resolves the wrapper's target against that checkout's `mise.toml`.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
