### PR TITLE
fix(release-plz): resolve cargo through rustup

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -318,7 +318,11 @@ jobs:
       # real cargo ahead of the wrapper. Steps that go through `mise run` keep
       # using mbx: mise prepends its own wrapper dir there.
       - name: Put the real cargo ahead of the mbx wrapper
-        run: dirname "$(mise which cargo)" >> "$GITHUB_PATH"
+        run: |
+          # Rust is managed by rustup, not mise. Keep the lookup separate so
+          # a failure stops this step instead of being masked by dirname.
+          cargo_path=$(rustup which cargo)
+          dirname "$cargo_path" >> "$GITHUB_PATH"
       - name: Configure git identity
         run: |
           git config user.name "release-plz[bot]"


### PR DESCRIPTION
The release PR workflow fails while release-plz compares historical packages because Cargo still resolves to the mise/mbx wrapper. The existing bypass uses `mise which cargo`, but Rust is managed by Rustup; that lookup fails and `dirname` masks its exit status.

Resolve Cargo with `rustup which cargo` in a separate assignment before adding its directory to `GITHUB_PATH`. A failed lookup now stops the step, and a successful lookup puts the real Cargo ahead of the wrapper for release-plz's historical checkouts.

Fixes the failure in [this workflow run](https://github.com/aubepkg/aube/actions/runs/33984164839/job/101354546394).

Validation: actionlint, ShellCheck, and git diff --check passed. Shell smoke checks confirmed real Cargo takes precedence over a failing wrapper and a failed Rustup lookup exits immediately without writing GITHUB_PATH. The full release workflow has not been rerun.

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*
