### PR TITLE
fix: update packslip action to v1.1.1

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -176,7 +176,7 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: jdx/packslip@a6eddff2d884891faa2efbec374b48e7053df2c4 # v1.0.1
+      - uses: jdx/packslip@a0d434ad57571c62dbd0ab5095b4eff607a71fd3 # v1.1.1
         with:
           tag: ${{ needs.release-plz-release.outputs.tag }}
           download: aube-*.tar.gz aube-*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -770,7 +770,7 @@ jobs:
       # The jobs that built these archives already attested them as they went,
       # which is the stronger claim; attesting again here would only add a
       # second statement about the same digests.
-      - uses: jdx/packslip@433c0c0f033e64c22f12433471768c255ef2bd93 # v0.3.0
+      - uses: jdx/packslip@a0d434ad57571c62dbd0ab5095b4eff607a71fd3 # v1.1.1
         with:
           tag: ${{ inputs.tag }}
           artifacts: dist/aube-v*.tar.gz dist/aube-v*.zip


### PR DESCRIPTION
Update both release workflow pins to packslip v1.1.1. The older action failed to upload the signed packslip in jobs without a checkout because `gh release upload` inferred the repository from Git; the updated action explicitly passes `--repo`.

Validation: verified the v1.1.1 tag resolves to the pinned commit, inspected the upstream upload fix and supported inputs, and ran `git diff --check`. Release publishing was not run locally.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-6; version: unavailable.*
