### PR TITLE
fix(store): bound parallel CAS imports on all platforms

### DIFF
--- a/crates/aube-store/src/lib.rs
+++ b/crates/aube-store/src/lib.rs
@@ -2120,6 +2120,46 @@ mod tests {
     }
 
     #[test]
+    fn concurrent_tarball_imports_preserve_contents_and_executable_bits() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("files"));
+        store.ensure_shards_exist().unwrap();
+        let gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        let mut archive = tar::Builder::new(gz);
+        // Cross the parallel-import threshold, with duplicate content to
+        // exercise competing CAS writers as multiple archives share a pool.
+        for i in 0..48 {
+            let content = format!("module.exports = {};\n", i % 8);
+            let mut header = tar::Header::new_gnu();
+            header.set_path(format!("package/lib/{i}.js")).unwrap();
+            header.set_size(content.len() as u64);
+            header.set_mode(if i % 3 == 0 { 0o755 } else { 0o644 });
+            header.set_cksum();
+            archive.append(&header, content.as_bytes()).unwrap();
+        }
+        let tarball = archive.into_inner().unwrap().finish().unwrap();
+
+        std::thread::scope(|scope| {
+            for _ in 0..6 {
+                scope.spawn(|| {
+                    let index = store.import_tarball(&tarball).unwrap();
+                    assert_eq!(index.len(), 48);
+                    for i in 0..48 {
+                        let stored = &index[&format!("lib/{i}.js")];
+                        let content = format!("module.exports = {};\n", i % 8);
+                        assert_eq!(
+                            std::fs::read(&stored.store_path).unwrap(),
+                            content.as_bytes()
+                        );
+                        assert_eq!(stored.hex_hash, blake3_hex(content.as_bytes()));
+                        assert_eq!(stored.executable, i % 3 == 0);
+                    }
+                });
+            }
+        });
+    }
+
+    #[test]
     fn test_import_tarball_streams_large_entry_into_cas() {
         let dir = tempfile::tempdir().unwrap();
         let store = Store::at(dir.path().join("files"));

--- a/crates/aube-store/src/tarball.rs
+++ b/crates/aube-store/src/tarball.rs
@@ -3,8 +3,7 @@ use std::path::Path;
 
 // CAS writes compete with package materialization for filesystem metadata
 // operations. Large Rayon pools can saturate that work during cold installs;
-// keep these workers bounded and separate from CPU work on macOS and Linux.
-#[cfg(any(target_os = "macos", target_os = "linux"))]
+// keep these workers bounded and separate from CPU work on every platform.
 static IMPORT_POOL: std::sync::OnceLock<Result<rayon::ThreadPool, rayon::ThreadPoolBuildError>> =
     std::sync::OnceLock::new();
 
@@ -341,28 +340,23 @@ impl Store {
                         })
                         .collect::<Vec<Result<(String, StoredFile), Error>>>()
                 };
-                #[cfg(any(target_os = "macos", target_os = "linux"))]
-                let results = {
-                    let pool = IMPORT_POOL
-                        .get_or_init(|| {
-                            rayon::ThreadPoolBuilder::new()
-                                .num_threads(2)
-                                .thread_name(|i| format!("aube-import-{i}"))
-                                .build()
-                        })
-                        .as_ref()
-                        .map_err(|err| {
-                            Error::Io(
-                                self.root.clone(),
-                                std::io::Error::other(format!(
-                                    "failed to create CAS import worker pool: {err}"
-                                )),
-                            )
-                        })?;
-                    pool.install(import)
-                };
-                #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-                let results = import();
+                let pool = IMPORT_POOL
+                    .get_or_init(|| {
+                        rayon::ThreadPoolBuilder::new()
+                            .num_threads(2)
+                            .thread_name(|i| format!("aube-import-{i}"))
+                            .build()
+                    })
+                    .as_ref()
+                    .map_err(|err| {
+                        Error::Io(
+                            self.root.clone(),
+                            std::io::Error::other(format!(
+                                "failed to create CAS import worker pool: {err}"
+                            )),
+                        )
+                    })?;
+                let results = pool.install(import);
                 for r in results {
                     let (rel_path, stored) = r?;
                     index.insert(rel_path, stored);

--- a/crates/aube-store/src/tarball.rs
+++ b/crates/aube-store/src/tarball.rs
@@ -1,6 +1,13 @@
 use crate::{Error, PackageIndex, Store, StoredFile};
 use std::path::Path;
 
+// CAS writes compete with package materialization for filesystem metadata
+// operations. Large Rayon pools can saturate that work during cold installs;
+// keep these workers bounded and separate from CPU work on macOS and Linux.
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+static IMPORT_POOL: std::sync::OnceLock<Result<rayon::ThreadPool, rayon::ThreadPoolBuildError>> =
+    std::sync::OnceLock::new();
+
 /// Deterministic fingerprint of a directory imported as a `file:` package.
 ///
 /// This deliberately mirrors [`Store::import_directory`]: `.git` and
@@ -273,9 +280,9 @@ impl Store {
         /*
          * Chunked staged pipeline. Read N entries, flush them to CAS
          * via rayon parallel writes, repeat. Keeps the existing
-         * rayon global pool warm across chunks and partially
+         * import worker pool warm across chunks and partially
          * overlaps tar parsing with file writes within a single
-         * tarball. No new threads spawned (per-call thread::scope
+         * tarball. No per-chunk threads spawned (per-call thread::scope
          * was tried and live locked at 80 s, see git history if
          * curious). Chunk size of 64 is roughly the median npm
          * package's file count, so most tarballs flush at most
@@ -324,14 +331,38 @@ impl Store {
                 // losing meaningful parallelism — 8 × 50µs = 400µs,
                 // well under a typical OS scheduling slice.
                 const RAYON_TASK_MIN_LEN: usize = 8;
-                let results: Vec<Result<(String, StoredFile), Error>> = chunk
-                    .into_par_iter()
-                    .with_min_len(RAYON_TASK_MIN_LEN)
-                    .map(|(rel_path, content, executable)| {
-                        self.import_bytes_gated(&rel_path, &content, executable)
-                            .map(|stored| (rel_path, stored))
-                    })
-                    .collect();
+                let import = || {
+                    chunk
+                        .into_par_iter()
+                        .with_min_len(RAYON_TASK_MIN_LEN)
+                        .map(|(rel_path, content, executable)| {
+                            self.import_bytes_gated(&rel_path, &content, executable)
+                                .map(|stored| (rel_path, stored))
+                        })
+                        .collect::<Vec<Result<(String, StoredFile), Error>>>()
+                };
+                #[cfg(any(target_os = "macos", target_os = "linux"))]
+                let results = {
+                    let pool = IMPORT_POOL
+                        .get_or_init(|| {
+                            rayon::ThreadPoolBuilder::new()
+                                .num_threads(2)
+                                .thread_name(|i| format!("aube-import-{i}"))
+                                .build()
+                        })
+                        .as_ref()
+                        .map_err(|err| {
+                            Error::Io(
+                                self.root.clone(),
+                                std::io::Error::other(format!(
+                                    "failed to create CAS import worker pool: {err}"
+                                )),
+                            )
+                        })?;
+                    pool.install(import)
+                };
+                #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+                let results = import();
                 for r in results {
                     let (rel_path, stored) = r?;
                     index.insert(rel_path, stored);


### PR DESCRIPTION
Cold installs send parallel tarball-to-CAS writes through the global Rayon pool, creating filesystem contention alongside package materialization on high-core machines. On the M5 Max fixture, file opens and clone syscalls dominated the profile.

Use a lazily initialized, process-wide two-worker pool for parallel CAS import batches on every platform, including Windows. Other Rayon work retains its existing pool. Add concurrent archive-import coverage for shared CAS contents, hashes, and executable bits.

### Benchmarks

Median wall time, three interleaved runs of the baseline at `a17a06e8` and this change, built with the same release profile and Rust toolchain on each host:

| Host / scenario | Baseline | This change |
|---|---:|---:|
| macOS, cold | 12.69s | **6.03s (-52%)** |
| macOS, warm | 0.24s | 0.25s |
| Linux, cold | 2.03s | 2.03s |
| Linux, warm | 0.27s | 0.26s |

Same `benchmarks/fixture.package.json` and frozen lockfile per host; remove `node_modules` each run, and also clear isolated cache/store/data for cold runs. Scripts disabled, global virtual store enabled, no environment concurrency overrides. Local Verdaccio runs without an uplink during timing, behind the existing 500 Mbit/s / 50 ms proxy. macOS: M5 Max, 18 logical CPUs, APFS. Linux: dev.coder, 32 CPUs, overlayfs. Toolchains: Rust 1.97.0 / 1.98.0 respectively.

The patch is roughly neutral on Linux in this comparison. Four additional cold samples with the default 32-thread global pool gave medians of 1.99s baseline and 1.93s patched, but concurrent unrelated builds introduced outliers; this does not establish a reliable Linux speedup.

<details>
<summary>Raw cold timings (seconds)</summary>

- macOS baseline: 12.872, 12.684, 12.693; patched: 6.661, 5.987, 6.031.
- Linux baseline: 3.121, 2.014, 2.028; patched: 2.071, 2.034, 1.989.
- Linux follow-up baseline: 2.570, 1.953, 1.893, 2.030; patched: 2.051, 1.779, 1.816, 3.006.

</details>

### Validation

Windows performance has not been benchmarked; the existing Windows CI job covers compatibility.

- `cargo test -p aube-store`: 117 passed on macOS and Linux.
- `cargo clippy --all-targets -- -D warnings`: passed on macOS.
- `cargo clippy -p aube-store --all-targets -- -D warnings`: passed on Linux.
- `cargo fmt --check` and the cold/warm install runs passed.

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

