### PR TITLE
fix: point coderabbit configuration at aubepkg repository

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,8 +1,5 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
-inheritance: true
-reviews:
-  auto_review:
-    drafts: true
-    ignore_title_keywords:
-      - "chore: release"
-      - "chore(main): release"
+remote_config:
+  repository: "aubepkg/coderabbit"
+  ref: "main"
+  path: ".coderabbit.yaml"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,5 +1,8 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
-remote_config:
-  repository: "jdx/coderabbit"
-  ref: "main"
-  path: ".coderabbit.yaml"
+inheritance: true
+reviews:
+  auto_review:
+    drafts: true
+    ignore_title_keywords:
+      - "chore: release"
+      - "chore(main): release"


### PR DESCRIPTION
CodeRabbit rejects the reference to `jdx/coderabbit` because this repository is owned by `aubepkg`, causing reviews to fall back to default settings.

Point the remote configuration at the newly created `aubepkg/coderabbit` repository. Its `.coderabbit.yaml` on `main` preserves the existing shared settings: inheritance, draft reviews, and release-title exclusions.

Validation: local YAML parses, the same-owner remote file exists on `main`, the shared configuration passes the current CodeRabbit JSON schema, and `git diff --check` passes. The published schema does not include `remote_config`, so it cannot validate the local reference; CodeRabbit's review must confirm remote resolution.
