### PR TITLE
fix(completion): preserve the published argument struct

### DIFF
--- a/aube.usage.kdl
+++ b/aube.usage.kdl
@@ -83,6 +83,16 @@ Overrides CI's default per-project materialization and the `disableGlobalVirtual
 """#
     }
 }
+flagset completion-args {
+    flag --force help="Replace a file at a target path that aube did not write" effect=write requires=--install
+    flag --install help="Install the scripts where this shell looks for them, instead of printing them" effect=write {
+        long_help #"""
+Install the scripts where this shell looks for them, instead of printing them
+
+Writes one script per program — aube, aubr and aubx — and nothing else: no shell rc file and no PowerShell profile is edited. Where a shell needs a one-time line of its own, it is printed for you to add.
+"""#
+    }
+}
 flagset script-args {
     flag --no-install help="Skip auto-install check"
     use lockfile-args
@@ -654,16 +664,9 @@ Targets `aube-lock.yaml`, `pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap
     flag "-h --help" help="Print help" action=help builtin=#true
 }
 cmd completion help="Generate shell completions (bash, zsh, fish, powershell)" effect=read {
+    use completion-args
     flag --bin help="Generate a script for just one executable: aube, aubr, or aubx" conflicts=--install {
         arg <BIN>
-    }
-    flag --force help="Replace a file at a target path that aube did not write" effect=write requires=--install
-    flag --install help="Install the scripts where this shell looks for them, instead of printing them" effect=write {
-        long_help #"""
-Install the scripts where this shell looks for them, instead of printing them
-
-Writes one script per program — aube, aubr and aubx — and nothing else: no shell rc file and no PowerShell profile is edited. Where a shell needs a one-time line of its own, it is printed for you to add.
-"""#
     }
     flag "-h --help" help="Print help" action=help builtin=#true
     arg <SHELL> help="The shell to generate completions for (bash, zsh, fish, powershell)"

--- a/crates/aube/src/commands/completion.rs
+++ b/crates/aube/src/commands/completion.rs
@@ -12,10 +12,6 @@ pub struct CompletionArgs {
     #[usage(arg, name = "SHELL")]
     pub shell: String,
 
-    /// Generate a script for just one executable: aube, aubr, or aubx
-    #[usage(long, conflicts = "--install")]
-    pub bin: Option<String>,
-
     /// Replace a file at a target path that aube did not write
     #[usage(long, requires = "--install", effect = "write")]
     pub force: bool,
@@ -29,13 +25,29 @@ pub struct CompletionArgs {
     pub install: bool,
 }
 
+/// CLI-only options are separate from the published, constructible argument struct.
+#[derive(usage_rs::Args)]
+pub(crate) struct CompletionCliArgs {
+    #[usage(flatten)]
+    pub args: CompletionArgs,
+
+    /// Generate a script for just one executable: aube, aubr, or aubx
+    #[usage(long, conflicts = "--install")]
+    pub bin: Option<String>,
+}
+
+/// Generate or install completions for all three programs through the library API.
 pub async fn run(args: CompletionArgs) -> Result<()> {
+    run_selected(args, None).await
+}
+
+pub(crate) async fn run_selected(args: CompletionArgs, bin: Option<String>) -> Result<()> {
     let shell = usage_rs::complete::Shell::from_name(&args.shell)
         .ok_or_else(|| miette!("unsupported shell {:?}", args.shell))?;
     if args.install {
         return install(shell, args.force);
     }
-    if let Some(program) = &args.bin
+    if let Some(program) = &bin
         && !PROGRAMS.contains(&program.as_str())
     {
         return Err(miette!(
@@ -44,7 +56,7 @@ pub async fn run(args: CompletionArgs) -> Result<()> {
     }
     for program in PROGRAMS
         .into_iter()
-        .filter(|program| args.bin.as_deref().is_none_or(|bin| bin == *program))
+        .filter(|program| bin.as_deref().is_none_or(|bin| bin == *program))
     {
         print!(
             "{}",

--- a/crates/aube/src/lib.rs
+++ b/crates/aube/src/lib.rs
@@ -399,7 +399,7 @@ enum Commands {
     /// the root `package.json` overrides the built-in.
     Clean(commands::clean::CleanArgs),
     /// Generate shell completions (bash, zsh, fish, powershell)
-    Completion(commands::completion::CompletionArgs),
+    Completion(commands::completion::CompletionCliArgs),
     /// Read and write settings in `.npmrc`
     #[usage(alias = "c")]
     Config(commands::config::ConfigArgs),
@@ -1066,7 +1066,9 @@ async fn async_main(cli: Cli, invoked_as_aubr: bool) -> miette::Result<Option<i3
                 return Ok(Some(code));
             }
         }
-        Some(Commands::Completion(args)) => commands::completion::run(args).await?,
+        Some(Commands::Completion(args)) => {
+            commands::completion::run_selected(args.args, args.bin).await?
+        }
         Some(Commands::Config(args)) => commands::config::run(args).await?,
         Some(Commands::Create(args)) => {
             if let Some(code) = commands::create::run(args).await? {

--- a/crates/aube/tests/e2e.rs
+++ b/crates/aube/tests/e2e.rs
@@ -388,3 +388,13 @@ fn completion_bin_selects_one_program_and_rejects_install() {
             .exists()
     );
 }
+
+#[test]
+fn completion_library_arguments_remain_constructible() {
+    let args = aube::commands::completion::CompletionArgs {
+        shell: "bash".to_string(),
+        force: false,
+        install: false,
+    };
+    assert_eq!(args.shell, "bash");
+}

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2848,28 +2848,6 @@
         ],
         "flags": [
           {
-            "name": "bin",
-            "usage": "--bin <BIN>",
-            "help": "Generate a script for just one executable: aube, aubr, or aubx",
-            "help_first_line": "Generate a script for just one executable: aube, aubr, or aubx",
-            "short": [],
-            "long": [
-              "bin"
-            ],
-            "hide": false,
-            "global": false,
-            "arg": {
-              "name": "BIN",
-              "usage": "<BIN>",
-              "required": true,
-              "double_dash": "Optional",
-              "hide": false
-            },
-            "conflicts": [
-              "--install"
-            ]
-          },
-          {
             "name": "force",
             "usage": "--force",
             "help": "Replace a file at a target path that aube did not write",
@@ -2898,6 +2876,28 @@
             "hide": false,
             "global": false,
             "effect": "write"
+          },
+          {
+            "name": "bin",
+            "usage": "--bin <BIN>",
+            "help": "Generate a script for just one executable: aube, aubr, or aubx",
+            "help_first_line": "Generate a script for just one executable: aube, aubr, or aubx",
+            "short": [],
+            "long": [
+              "bin"
+            ],
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "BIN",
+              "usage": "<BIN>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false
+            },
+            "conflicts": [
+              "--install"
+            ]
           },
           {
             "name": "help",

--- a/docs/cli/completion.md
+++ b/docs/cli/completion.md
@@ -10,7 +10,6 @@ Generate shell completions (bash, zsh, fish, powershell)
 - **`<SHELL>`** — The shell to generate completions for (bash, zsh, fish, powershell)
 
 ## Flags
-- **`--bin <BIN>`** — Generate a script for just one executable: aube, aubr, or aubx
 - **`--force`** — Replace a file at a target path that aube did not write
 
   **Effect:** modifies state
@@ -19,4 +18,5 @@ Generate shell completions (bash, zsh, fish, powershell)
   Writes one script per program — aube, aubr and aubx — and nothing else: no shell rc file and no PowerShell profile is edited. Where a shell needs a one-time line of its own, it is printed for you to add.
 
   **Effect:** modifies state
+- **`--bin <BIN>`** — Generate a script for just one executable: aube, aubr, or aubx
 - **`-h --help`** — Print help


### PR DESCRIPTION
The late API check on #1496 caught an accidental Rust API break: adding `CompletionArgs.bin` prevents existing callers from constructing the public struct with its original fields.

Move executable selection into a crate-private `CompletionCliArgs`, keep the public `CompletionArgs` and `completion::run` interface compatible with v2.2.11, and preserve `aube completion SHELL --bin PROGRAM` behavior. Regenerate the CLI metadata and documentation.

Validation:
- `cargo-semver-checks --baseline-rev v2.2.11 --package aube`: all 223 checks pass, no semver update required.
- Four focused integration tests pass, including construction with the original public fields.
- All 12 native scripts pass shell syntax and actual completion callback checks.
- Strict Clippy for all aube targets, formatting, and documentation generation pass.

The advisory CI comparison against current `main` may report removal of the field introduced in #1496. That removal is intentional: this restores the v2.2.11 API, as verified above, while retaining the CLI feature in a private type.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-6; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Reordered the completion command options in the CLI reference for consistency.
  - Clarified the documented ordering of `--bin`, `--force`, and `--install`.

- **Tests**
  - Added end-to-end coverage for constructing completion command arguments, including shell, force, and install options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->