### PR TITLE
ci: keep API check caches outside the checkout

### DIFF
--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -116,9 +116,11 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2 # zizmor: ignore[cache-poisoning] only main saves
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
-          # Cleanup of the normal target removes rustdoc JSON and generated
-          # manifests. Keep semver-checks' artifacts outside that directory.
-          cache-directories: target-api
+          # Older archives contain baseline checkouts inside the repository.
+          prefix-key: v1-rust-api-external
+          # Keep duplicate crate manifests outside repository discovery and
+          # preserve semver artifacts from the normal target cleanup.
+          cache-directories: ${{ runner.temp }}/aube-target-api
       - name: Select semver baseline
         env:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -131,7 +133,7 @@ jobs:
         id: rust
         continue-on-error: true
         env:
-          CARGO_TARGET_DIR: target-api
+          CARGO_TARGET_DIR: ${{ runner.temp }}/aube-target-api
         run: |
           /usr/bin/time -v ./bin/cargo-semver-checks semver-checks \
             --baseline-rev "$SEMVER_BASELINE" \


### PR DESCRIPTION
Restoring the API-check cache can bring an old baseline checkout back under the repository's `target-api` directory. `cargo-semver-checks` then discovers two manifests for `aube` and exits with `package aube is ambiguous` before comparing APIs, as seen in [the API job on PR #1503](https://github.com/aubepkg/aube/actions/runs/34012435179/job/101430439283).

Move both the semver target directory and its cache path to `${{ runner.temp }}/aube-target-api`, outside repository discovery and the normal target cleanup. Give this job a new cache prefix so neither exact nor fallback restores can select an older archive containing an in-repository baseline checkout. Keep the C ABI target and main-only cache saves as configured.

Validation:

- `actionlint .github/workflows/ci-impl.yml` and `git diff --check` pass.
- With `cargo-semver-checks` 0.49.0 and a temporary Rust workspace, the original location passes cold but reproduces the ambiguity failure after a baseline change with a warm cache.
- The external location passes cold, with a new baseline on a warm cache, and with the same baseline on a warm cache. Removing a public function still fails with `function_missing`.

This PR contains only the CI workflow fix and is based directly on `main`.

*AI-assisted — Tool: Codex; model: OpenAI/unavailable; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API stability checks by isolating generated artifacts in temporary build storage.
  * Preserved semantic versioning artifacts while ensuring consistency across stability-check steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->