### PR TITLE
fix(registry): tolerate malformed bundled dependency arrays

### DIFF
--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -306,7 +306,7 @@ jobs:
           persist-credentials: false
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
-          install: false
+          install_args: mr-boxington
           cache: false
           add_shims_to_path: false
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2 # zizmor: ignore[cache-poisoning]

--- a/.github/workflows/ffi-impl.yml
+++ b/.github/workflows/ffi-impl.yml
@@ -75,7 +75,7 @@ jobs:
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         if: github.event_name != 'release' && inputs.tag == '' && !inputs.draft_phase
         with:
-          install: false
+          install_args: mr-boxington
           cache: false
           add_shims_to_path: false
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2 # zizmor: ignore[cache-poisoning]

--- a/.github/workflows/node-addon-impl.yml
+++ b/.github/workflows/node-addon-impl.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         if: github.event_name != 'release' && inputs.tag == ''
         with:
-          install: false
+          install_args: mr-boxington
           cache: false
           add_shims_to_path: false
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2 # zizmor: ignore[cache-poisoning]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,7 @@ dependencies = [
  "aube-codes",
  "aube-util",
  "miette",
+ "proptest",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/aube-manifest/Cargo.toml
+++ b/crates/aube-manifest/Cargo.toml
@@ -31,4 +31,5 @@ default = ["workspace-yaml-preserve"]
 workspace-yaml-preserve = ["dep:serde_yaml", "dep:yamlpatch", "dep:yamlpath"]
 
 [dev-dependencies]
+proptest = "1"
 tempfile = "3"

--- a/crates/aube-manifest/src/lib.rs
+++ b/crates/aube-manifest/src/lib.rs
@@ -284,11 +284,32 @@ impl From<PackageJsonRaw> for PackageJson {
 /// either an array of dep names or a boolean (`true` meaning "bundle
 /// everything in `dependencies`"). We preserve both so the resolver
 /// can compute the exact name set.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum BundledDependencies {
     List(Vec<String>),
     All(bool),
+}
+
+impl<'de> Deserialize<'de> for BundledDependencies {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        match value {
+            serde_json::Value::Array(values) => Ok(Self::List(
+                values
+                    .into_iter()
+                    .filter_map(|value| value.as_str().map(str::to_owned))
+                    .collect(),
+            )),
+            serde_json::Value::Bool(value) => Ok(Self::All(value)),
+            _ => Err(serde::de::Error::custom(
+                "expected a boolean or an array of dependency names",
+            )),
+        }
+    }
 }
 
 impl BundledDependencies {
@@ -1328,6 +1349,7 @@ pub fn serialize_json_with_indent<T: serde::Serialize>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
 
     #[test]
     fn test_detect_json_indent() {
@@ -1853,6 +1875,55 @@ mod tests {
             p.bundled_dependencies,
             Some(BundledDependencies::List(_))
         ));
+    }
+
+    /// Regression: `@lightdash/cli@0.103.0-alpha.9` published the
+    /// legacy field as `[true]`. npm left the malformed entry in the
+    /// registry even though bundle arrays contain dependency names.
+    /// Ignore non-string entries so one old version cannot make the
+    /// package's complete version history impossible to deserialize.
+    #[test]
+    fn bundle_dependencies_array_ignores_non_string_entries() {
+        let p = parse(r#"{"name":"x","bundleDependencies":[true,"foo",null,42,{"bar":"1"}]}"#);
+        let deps = BTreeMap::new();
+        let names = p.bundled_dependencies.as_ref().unwrap().names(&deps);
+        assert_eq!(names, vec!["foo"]);
+    }
+
+    proptest! {
+        #[test]
+        fn bundled_dependency_arrays_keep_only_names(
+            entries in proptest::collection::vec(
+                prop_oneof![
+                    "[a-z][a-z0-9-]{0,15}".prop_map(serde_json::Value::String),
+                    any::<bool>().prop_map(serde_json::Value::Bool),
+                    any::<i64>().prop_map(|value| serde_json::Value::Number(value.into())),
+                    Just(serde_json::Value::Null),
+                ],
+                0..32,
+            ),
+        ) {
+            let expected = entries
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .map(str::to_owned)
+                .collect::<Vec<_>>();
+            let p: PackageJson = serde_json::from_value(serde_json::json!({
+                "name": "x",
+                "bundledDependencies": entries,
+            }))
+            .unwrap();
+            let deps = BTreeMap::new();
+            let names = p
+                .bundled_dependencies
+                .as_ref()
+                .unwrap()
+                .names(&deps)
+                .into_iter()
+                .map(str::to_owned)
+                .collect::<Vec<_>>();
+            prop_assert_eq!(names, expected);
+        }
     }
 
     /// Regression: some publishes (e.g. `@lingui/message-utils@5.2.0`+)

--- a/crates/aube-registry/src/lib.rs
+++ b/crates/aube-registry/src/lib.rs
@@ -1421,4 +1421,41 @@ mod tests {
         let names = v.bundled_dependencies.as_ref().unwrap().names(&deps);
         assert_eq!(names, vec!["legacy"]);
     }
+
+    /// Regression: `@lightdash/cli@0.103.0-alpha.9` has
+    /// `bundleDependencies: [true]` in the npm registry. Full packuments
+    /// include that historical version when resolving today's `latest`,
+    /// so its malformed entry must not abort the entire version list.
+    #[test]
+    fn packument_ignores_non_string_bundle_dependency_entries() {
+        let json = r#"{
+                "name":"@lightdash/cli",
+                "versions":{
+                    "0.103.0-alpha.9":{
+                        "name":"@lightdash/cli",
+                        "version":"0.103.0-alpha.9",
+                        "bundleDependencies":[true]
+                    },
+                    "2.176.1":{
+                        "name":"@lightdash/cli",
+                        "version":"2.176.1"
+                    }
+                },
+                "dist-tags":{"latest":"2.176.1"}
+            }"#;
+        let p: Packument = sonic_rs::from_slice(json.as_bytes()).unwrap();
+        assert_eq!(p.versions.len(), 2);
+        assert_eq!(
+            p.dist_tags.get("latest").map(String::as_str),
+            Some("2.176.1")
+        );
+        let old = &p.versions["0.103.0-alpha.9"];
+        assert!(
+            old.bundled_dependencies
+                .as_ref()
+                .unwrap()
+                .names(&old.dependencies)
+                .is_empty()
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- ignore non-string entries in bundled dependency arrays while preserving valid names
- keep boolean bundle-all behavior unchanged
- cover the historical Lightdash payload through both manifest and production packument decoding
- install only mr-boxington in native matrix jobs so wrapped Cargo works with mise 2026.9.3

## Context

The npm registry metadata for @lightdash/cli@0.103.0-alpha.9 contains bundleDependencies: [true]. Full packuments include that historical version when resolving the current latest release, so strict Vec<String> deserialization aborts the entire package lookup. This surfaced in https://github.com/jdx/mise/discussions/13007.

The published tarball contains no bundled node_modules entries, so treating the invalid boolean array member as absent matches the artifact npm produced.

The first CI run also exposed a workflow incompatibility with mise 2026.9.3. Native matrix jobs disabled tool installation but invoked Cargo through mise exec, which now activates the configured mbx wrapper. Those jobs now install only the locked mr-boxington tool, retaining mbx without installing the full development toolset.

## Test plan

- cargo test -p aube-manifest -p aube-registry
- cargo test -p aube-manifest bundled_dependency_arrays_keep_only_names
- cargo test -p aube-registry packument_ignores_non_string_bundle_dependency_entries
- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- actionlint on the three changed workflows
- isolated mise install --locked mr-boxington followed by MISE_EXEC_AUTO_INSTALL=false MBX_DISABLE=1 mise exec -- cargo --version
- target/debug/aube view @lightdash/cli version

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Manifest parsing now ignores non-string entries in bundled dependency lists instead of rejecting the entire manifest.
  - Package registry data remains available when historical versions contain malformed bundled dependency entries.
  - Valid dependency names continue to be preserved while invalid values are safely skipped.

- **Tests**
  - Added regression and property-based coverage for filtering invalid dependency entries.
  - Added coverage for registry packages containing malformed historical metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->