### PR TITLE
fix(audit): match GHSA IDs in URLs

### DIFF
--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -414,11 +414,11 @@ fn build_client(cwd: &std::path::Path, registry_override: Option<&str>) -> Regis
 }
 
 /// Drop advisories whose ID matches any `ignore` value. Matches
-/// against the npm numeric `id`, the `github_advisory_id`, and each
-/// entry in `cves[]`. IDs are compared case-insensitively as strings
-/// so users can pass either `GHSA-abcd-...` or the same in uppercase
-/// / lowercase, or the CVE form. Packages whose advisories all get
-/// filtered out drop from the response entirely.
+/// against the npm numeric `id`, the `github_advisory_id`, the advisory ID
+/// in `url`, and each entry in `cves[]`. IDs are compared case-insensitively
+/// as strings so users can pass either `GHSA-abcd-...` or the same in
+/// uppercase / lowercase, or the CVE form. Packages whose advisories all
+/// get filtered out drop from the response entirely.
 fn configured_audit_ignores(
     cwd: &std::path::Path,
     manifest: &aube_manifest::PackageJson,
@@ -535,6 +535,12 @@ fn advisory_matches_ignore(adv: &serde_json::Value, needles: &BTreeSet<String>) 
                 return true;
             }
         }
+    }
+    if let Some(url) = adv.get("url").and_then(|v| v.as_str())
+        && let Some(advisory_id) = url.trim_end_matches('/').rsplit('/').next()
+        && needles.contains(&advisory_id.to_ascii_lowercase())
+    {
+        return true;
     }
     false
 }
@@ -1442,6 +1448,43 @@ mod tests {
         );
         assert!(out.get("pkg-a").is_none());
         assert!(out.get("pkg-b").is_some());
+    }
+
+    #[test]
+    fn filter_ignored_matches_advisory_id_in_url() {
+        let raw = serde_json::json!({
+            "image-size": [
+                {
+                    "id": 1,
+                    "severity": "high",
+                    "title": "ICNS parser denial of service",
+                    "url": "https://github.com/advisories/GHSA-w3rx-r6r6-pgpr"
+                },
+                {
+                    "id": 2,
+                    "severity": "high",
+                    "title": "JXL and HEIF parser denial of service",
+                    "url": "https://github.com/advisories/GHSA-5p2g-fcmc-qvqq/"
+                },
+                {
+                    "id": 3,
+                    "severity": "high",
+                    "title": "Unrelated advisory",
+                    "url": "https://github.com/advisories/GHSA-unrelated"
+                }
+            ]
+        });
+
+        let out = filter_ignored_ids(
+            &raw,
+            &[
+                "ghsa-w3rx-r6r6-pgpr".to_string(),
+                "GHSA-5P2G-FCMC-QVQQ".to_string(),
+            ],
+        );
+        let advisories = out.get("image-size").unwrap().as_array().unwrap();
+        assert_eq!(advisories.len(), 1);
+        assert_eq!(advisories[0]["id"], 3);
     }
 
     #[test]

--- a/crates/aube/src/commands/audit.rs
+++ b/crates/aube/src/commands/audit.rs
@@ -537,7 +537,10 @@ fn advisory_matches_ignore(adv: &serde_json::Value, needles: &BTreeSet<String>) 
         }
     }
     if let Some(url) = adv.get("url").and_then(|v| v.as_str())
-        && let Some(advisory_id) = url.trim_end_matches('/').rsplit('/').next()
+        && let Some(advisory_id) = url
+            .split(['?', '#'])
+            .next()
+            .and_then(|path| path.trim_end_matches('/').rsplit('/').next())
         && needles.contains(&advisory_id.to_ascii_lowercase())
     {
         return true;
@@ -1458,13 +1461,13 @@ mod tests {
                     "id": 1,
                     "severity": "high",
                     "title": "ICNS parser denial of service",
-                    "url": "https://github.com/advisories/GHSA-w3rx-r6r6-pgpr"
+                    "url": "https://github.com/advisories/GHSA-w3rx-r6r6-pgpr?source=npm"
                 },
                 {
                     "id": 2,
                     "severity": "high",
                     "title": "JXL and HEIF parser denial of service",
-                    "url": "https://github.com/advisories/GHSA-5p2g-fcmc-qvqq/"
+                    "url": "https://github.com/advisories/GHSA-5p2g-fcmc-qvqq/#references"
                 },
                 {
                     "id": 3,


### PR DESCRIPTION
match GHSA identifiers exposed only in npm bulk advisory URLs when applying CLI `--ignore` or YAML workspace `audit.ignore`.

## Problem

The npm audit pipeline reported `GHSA-w3rx-r6r6-pgpr` and `GHSA-5p2g-fcmc-qvqq` despite both IDs being passed to `--ignore`.

This was attested in aube versions `2.2.12 macos-arm64 (2026-09-05)` and `2.2.13 macos-arm64 (2026-09-09)`.

## Cause

The npm bulk advisory response exposes these identifiers in its `url` field, for example `https://github.com/advisories/GHSA-w3rx-r6r6-pgpr`. The matcher checked `id`, `github_advisory_id`, and `cves[]`, but not `url`.

## Fix

Extract the final advisory ID from the URL and apply the existing case-insensitive exact match. Trailing slashes, URL queries, and fragments are handled.

## Validation
- `MBX_DISABLE=1 cargo test -p aube --lib` (844/844 passed)
- `MBX_DISABLE=1 cargo clippy -p aube --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
- Added regression coverage for URL-only GHSA IDs, case-insensitivity, trailing slash handling, and unrelated advisories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Audit ignore rules now correctly recognize advisory IDs at the end of URLs containing query strings or fragments.
  * URL matching remains case-insensitive and consistently handles trailing slashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->