### PR TITLE
fix(release): declare all aube executables in packslip

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -159,7 +159,7 @@ jobs:
       CERTIFICATES_P12_PASS: ${{ secrets.CERTIFICATES_P12_PASS }}
 
   # The packslip is this release's signed inventory: every CLI archive's
-  # digest, the executable inside it, and the workflow identity that signed
+  # digest, the executables inside it, and the workflow identity that signed
   # for all of it, so an installer can check a download against
   # github.com/jdx/aube's identity rather than a key this project would have
   # to hold. `upload-assets` already attests each archive's build provenance
@@ -180,7 +180,7 @@ jobs:
         with:
           tag: ${{ needs.release-plz-release.outputs.tag }}
           download: aube-*.tar.gz aube-*.zip
-          bin: aube
+          bin: aube aubr aubx
           attest: link
           token: ${{ secrets.AUBE_GH_TOKEN }}
 


### PR DESCRIPTION
## Summary

- declare `aube`, `aubr`, and `aubx` in every generated packslip
- keep the release workflow documentation aligned with the three shipped executables

This fixes the missing `aubr` and `aubx` commands reported in https://github.com/aubepkg/aube/discussions/1518. The release archives already contain all three binaries, but the signed packslip currently exposes only `aube` to installers such as mise.

## Testing

- `mise exec -- actionlint .github/workflows/release-plz.yml`
- generated a packslip from the v2.2.13 macOS and Windows archives with packslip 1.1.1 and verified all three binaries are declared, including automatic `.exe` resolution on Windows
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Release archives now sign all included CLI executables, improving verification coverage across packaged tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->