### PR TITLE
chore(deps): ignore yamlpath dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       default-days: 7
     exclude-paths:
       - "fixtures/**"
+    ignore:
+      - dependency-name: "yamlpath"
 
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
## Summary

- stop Dependabot from proposing `yamlpath` updates like #1509
- preserve the deliberate `<1.28` constraint for the project MSRV
- leave the existing Renovate `allowedVersions` protection unchanged

## Validation

- parsed `.github/dependabot.yml` and asserted the Cargo ignore rule
- ran `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Dependabot will no longer propose version updates for the `yamlpath` dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->