### PR TITLE
fix(add): distinguish unavailable embedded confirmations

### DIFF
--- a/crates/aube/src/commands/add_supply_chain.rs
+++ b/crates/aube/src/commands/add_supply_chain.rs
@@ -209,8 +209,8 @@ async fn package_age_gate(
         if !confirm_new_package(prompt, name, &created, minimum_age_minutes).await? {
             return Err(miette!(
                 code = ERR_AUBE_NEW_PACKAGE_NAME,
-                "user aborted `{} {name}`",
-                aube_util::cmd("add")
+                "{}",
+                user_declined_to_add(name)
             ));
         }
     }
@@ -828,8 +828,8 @@ async fn similar_name_gate(names: &[String], prompt: &LowDownloadPrompt) -> miet
         if !confirm_similar_package(prompt, name, &suggestion).await? {
             return Err(miette!(
                 code = ERR_AUBE_SIMILAR_PACKAGE_NAME,
-                "user aborted `{} {name}`",
-                aube_util::cmd("add")
+                "{}",
+                user_declined_to_add(name)
             ));
         }
     }
@@ -942,7 +942,8 @@ async fn confirm_similar_package(
     let refusal = || {
         miette!(
             code = ERR_AUBE_SIMILAR_PACKAGE_NAME,
-            "refusing to add {name}: did you mean {} (top-100,000 rank #{}, edit distance {})? Pass --allow-low-downloads after verifying the package name.",
+            help = "pass --allow-low-downloads after verifying the package name",
+            "refusing to add {name}: did you mean {} (top-100,000 rank #{}, edit distance {})?",
             suggestion.name,
             suggestion.rank,
             suggestion.distance
@@ -955,7 +956,7 @@ async fn confirm_similar_package(
             prompt_similar_package(name, suggestion)
         }
         LowDownloadPrompt::Terminal => Err(refusal()),
-        LowDownloadPrompt::Host(control) => control
+        LowDownloadPrompt::Host(control) => match control
             .confirm(
                 crate::commands::install::InstallPrompt::SimilarPackageName {
                     package: name.to_string(),
@@ -965,7 +966,12 @@ async fn confirm_similar_package(
                 },
             )
             .await
-            .unwrap_or_else(|| Err(refusal())),
+            .unwrap_or_else(|| Err(refusal()))?
+        {
+            crate::commands::install::InstallPromptDecision::Accept => Ok(true),
+            crate::commands::install::InstallPromptDecision::Decline => Ok(false),
+            crate::commands::install::InstallPromptDecision::Unavailable => Err(refusal()),
+        },
     }
 }
 
@@ -1057,8 +1063,8 @@ async fn downloads_gate(
         if !confirm_low_download(prompt, name, weekly, threshold).await? {
             return Err(miette!(
                 code = ERR_AUBE_LOW_DOWNLOAD_PACKAGE,
-                "user aborted `{} {name}`",
-                aube_util::cmd("add")
+                "{}",
+                user_declined_to_add(name)
             ));
         }
     }
@@ -1074,7 +1080,8 @@ async fn confirm_low_download(
     let refusal = || {
         miette!(
             code = ERR_AUBE_LOW_DOWNLOAD_PACKAGE,
-            "refusing to add {name}: only {weekly} weekly downloads (threshold: {threshold}). Pass --allow-low-downloads to bypass, or set `lowDownloadThreshold = 0`."
+            help = "pass --allow-low-downloads to bypass, or set `lowDownloadThreshold = 0`",
+            "refusing to add {name}: only {weekly} weekly downloads (threshold: {threshold})"
         )
     };
     match prompt {
@@ -1084,7 +1091,7 @@ async fn confirm_low_download(
             prompt_continue(name, weekly, threshold)
         }
         LowDownloadPrompt::Terminal => Err(refusal()),
-        LowDownloadPrompt::Host(control) => control
+        LowDownloadPrompt::Host(control) => match control
             .confirm(
                 crate::commands::install::InstallPrompt::LowDownloadPackage {
                     package: name.to_string(),
@@ -1093,8 +1100,17 @@ async fn confirm_low_download(
                 },
             )
             .await
-            .unwrap_or_else(|| Err(refusal())),
+            .unwrap_or_else(|| Err(refusal()))?
+        {
+            crate::commands::install::InstallPromptDecision::Accept => Ok(true),
+            crate::commands::install::InstallPromptDecision::Decline => Ok(false),
+            crate::commands::install::InstallPromptDecision::Unavailable => Err(refusal()),
+        },
     }
+}
+
+fn user_declined_to_add(name: &str) -> String {
+    format!("user declined to add {name}")
 }
 
 fn prompt_continue(name: &str, weekly: u64, threshold: u64) -> miette::Result<bool> {
@@ -1129,7 +1145,8 @@ async fn confirm_new_package(
     let refusal = || {
         miette!(
             code = ERR_AUBE_NEW_PACKAGE_NAME,
-            "refusing to add {name}: the package name was first published at {created}, within the configured `minimumPackageAge` of {minimum_age_minutes} minutes. Pass --allow-low-downloads to approve this new name explicitly."
+            help = "pass --allow-low-downloads to approve this new name explicitly",
+            "refusing to add {name}: the package name was first published at {created}, within the configured `minimumPackageAge` of {minimum_age_minutes} minutes"
         )
     };
     match prompt {
@@ -1139,14 +1156,19 @@ async fn confirm_new_package(
             prompt_new_package(name, created, minimum_age_minutes)
         }
         LowDownloadPrompt::Terminal => Err(refusal()),
-        LowDownloadPrompt::Host(control) => control
+        LowDownloadPrompt::Host(control) => match control
             .confirm(crate::commands::install::InstallPrompt::NewPackageName {
                 package: name.to_string(),
                 created_at: created.to_string(),
                 minimum_age_minutes,
             })
             .await
-            .unwrap_or_else(|| Err(refusal())),
+            .unwrap_or_else(|| Err(refusal()))?
+        {
+            crate::commands::install::InstallPromptDecision::Accept => Ok(true),
+            crate::commands::install::InstallPromptDecision::Decline => Ok(false),
+            crate::commands::install::InstallPromptDecision::Unavailable => Err(refusal()),
+        },
     }
 }
 
@@ -1174,7 +1196,8 @@ fn prompt_new_package(name: &str, created: &str, minimum_age_minutes: u64) -> mi
 mod tests {
     use super::*;
     use crate::commands::install::{
-        InstallControl, InstallPrompt, InstallPromptFuture, InstallPromptHandler,
+        InstallControl, InstallPrompt, InstallPromptDecision, InstallPromptDecisionFuture,
+        InstallPromptDecisionHandler, InstallPromptFuture, InstallPromptHandler,
     };
     use std::sync::{Arc, Mutex};
 
@@ -1187,6 +1210,16 @@ mod tests {
         fn confirm(&self, prompt: InstallPrompt) -> InstallPromptFuture<'_> {
             self.prompts.lock().unwrap().push(prompt);
             Box::pin(async move { Ok(self.answer) })
+        }
+    }
+
+    struct DecisionPromptHandler {
+        decision: InstallPromptDecision,
+    }
+
+    impl InstallPromptDecisionHandler for DecisionPromptHandler {
+        fn decide(&self, _prompt: InstallPrompt) -> InstallPromptDecisionFuture<'_> {
+            Box::pin(async move { Ok(self.decision) })
         }
     }
 
@@ -1265,6 +1298,50 @@ mod tests {
             error.code().map(|code| code.to_string()).as_deref(),
             Some(ERR_AUBE_LOW_DOWNLOAD_PACKAGE)
         );
+        assert!(error.to_string().contains("only 12 weekly downloads"));
+        assert!(!error.to_string().contains("user"));
+    }
+
+    #[tokio::test]
+    async fn unavailable_embedded_confirmation_returns_the_gate_refusal() {
+        let handler = Arc::new(DecisionPromptHandler {
+            decision: InstallPromptDecision::Unavailable,
+        });
+        let prompt =
+            LowDownloadPrompt::Host(InstallControl::silent().with_prompt_decision_handler(handler));
+
+        let error = confirm_low_download(&prompt, "tiny", 12, 1000)
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error.code().map(|code| code.to_string()).as_deref(),
+            Some(ERR_AUBE_LOW_DOWNLOAD_PACKAGE)
+        );
+        assert!(error.to_string().contains("only 12 weekly downloads"));
+        assert_eq!(
+            error.help().map(|help| help.to_string()).as_deref(),
+            Some("pass --allow-low-downloads to bypass, or set `lowDownloadThreshold = 0`")
+        );
+        assert!(!error.to_string().contains("user"));
+    }
+
+    #[tokio::test]
+    async fn declined_embedded_confirmation_does_not_invent_a_host_command() {
+        let handler = Arc::new(DecisionPromptHandler {
+            decision: InstallPromptDecision::Decline,
+        });
+        let prompt =
+            LowDownloadPrompt::Host(InstallControl::silent().with_prompt_decision_handler(handler));
+
+        let decision = confirm_low_download(&prompt, "tiny", 12, 1000)
+            .await
+            .unwrap();
+
+        assert!(!decision);
+        let message = user_declined_to_add("tiny");
+        assert_eq!(message, "user declined to add tiny");
+        assert!(!message.contains("mise add"));
     }
 
     #[tokio::test]

--- a/crates/aube/src/commands/install/control.rs
+++ b/crates/aube/src/commands/install/control.rs
@@ -89,6 +89,24 @@ pub enum InstallPrompt {
 /// Future returned by an [`InstallPromptHandler`].
 pub type InstallPromptFuture<'a> = Pin<Box<dyn Future<Output = miette::Result<bool>> + Send + 'a>>;
 
+/// The outcome of a confirmation requested from an embedding host.
+///
+/// Unlike a boolean, this preserves the distinction between a user explicitly
+/// declining and a prompt that the host could not present or answer. Aube uses
+/// [`InstallPromptDecision::Unavailable`] to return the gate's normal
+/// structured refusal instead of attributing a decision to the user.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum InstallPromptDecision {
+    Accept,
+    Decline,
+    Unavailable,
+}
+
+/// Future returned by an [`InstallPromptDecisionHandler`].
+pub type InstallPromptDecisionFuture<'a> =
+    Pin<Box<dyn Future<Output = miette::Result<InstallPromptDecision>> + Send + 'a>>;
+
 /// Host-provided destination for interactive confirmation requests.
 ///
 /// Embedded aube operations never read process stdin themselves. When no
@@ -98,11 +116,27 @@ pub trait InstallPromptHandler: Send + Sync + 'static {
     fn confirm(&self, prompt: InstallPrompt) -> InstallPromptFuture<'_>;
 }
 
+/// Host-provided destination for confirmation requests that can distinguish an
+/// explicit decline from a prompt that was unavailable or unanswered.
+///
+/// Prefer this over [`InstallPromptHandler`] for new embedders. The boolean
+/// handler remains supported for compatibility and treats `false` as an
+/// explicit decline.
+pub trait InstallPromptDecisionHandler: Send + Sync + 'static {
+    fn decide(&self, prompt: InstallPrompt) -> InstallPromptDecisionFuture<'_>;
+}
+
+#[derive(Clone)]
+enum PromptHandler {
+    Boolean(Arc<dyn InstallPromptHandler>),
+    Decision(Arc<dyn InstallPromptDecisionHandler>),
+}
+
 #[derive(Clone)]
 pub struct InstallControl {
     output: InstallOutputMode,
     reporter: Option<Arc<dyn InstallReporter>>,
-    prompt_handler: Option<Arc<dyn InstallPromptHandler>>,
+    prompt_handler: Option<PromptHandler>,
     cancellation: tokio_util::sync::CancellationToken,
 }
 
@@ -150,7 +184,15 @@ impl InstallControl {
     }
 
     pub fn with_prompt_handler(mut self, handler: Arc<dyn InstallPromptHandler>) -> Self {
-        self.prompt_handler = Some(handler);
+        self.prompt_handler = Some(PromptHandler::Boolean(handler));
+        self
+    }
+
+    pub fn with_prompt_decision_handler(
+        mut self,
+        handler: Arc<dyn InstallPromptDecisionHandler>,
+    ) -> Self {
+        self.prompt_handler = Some(PromptHandler::Decision(handler));
         self
     }
 
@@ -179,12 +221,27 @@ impl InstallControl {
         })
     }
 
-    pub(crate) async fn confirm(&self, prompt: InstallPrompt) -> Option<miette::Result<bool>> {
+    pub(crate) async fn confirm(
+        &self,
+        prompt: InstallPrompt,
+    ) -> Option<miette::Result<InstallPromptDecision>> {
         let handler = self.prompt_handler.clone()?;
         Some(tokio::select! {
             biased;
-            _ = self.cancelled() => self.check_cancelled().map(|()| false),
-            result = handler.confirm(prompt) => result,
+            _ = self.cancelled() => self.check_cancelled().map(|()| InstallPromptDecision::Unavailable),
+            result = async move {
+                match handler {
+                    PromptHandler::Boolean(handler) => handler
+                        .confirm(prompt)
+                        .await
+                        .map(|accepted| if accepted {
+                            InstallPromptDecision::Accept
+                        } else {
+                            InstallPromptDecision::Decline
+                        }),
+                    PromptHandler::Decision(handler) => handler.decide(prompt).await,
+                }
+            } => result,
         })
     }
 

--- a/crates/aube/src/commands/install/mod.rs
+++ b/crates/aube/src/commands/install/mod.rs
@@ -42,7 +42,8 @@ pub(crate) use bin_linking::{
 };
 pub use control::{
     INSTALL_OUTPUT_CODE_LIFECYCLE_SCRIPT, InstallControl, InstallEvent, InstallOutputLevel,
-    InstallOutputMode, InstallPhase, InstallProgressSnapshot, InstallPrompt, InstallPromptFuture,
+    InstallOutputMode, InstallPhase, InstallProgressSnapshot, InstallPrompt, InstallPromptDecision,
+    InstallPromptDecisionFuture, InstallPromptDecisionHandler, InstallPromptFuture,
     InstallPromptHandler, InstallReporter,
 };
 pub use dep_selection::DepSelection;

--- a/crates/aube/src/embed.rs
+++ b/crates/aube/src/embed.rs
@@ -13,8 +13,8 @@ pub use crate::commands::install::node_gyp_bootstrap::bootstrap_node_gyp;
 pub use crate::commands::install::{
     DepSelection, EmbedderInstallOverrides, FrozenMode, INSTALL_OUTPUT_CODE_LIFECYCLE_SCRIPT,
     InstallControl, InstallEvent, InstallOutputLevel, InstallOutputMode, InstallPhase,
-    InstallProgressSnapshot, InstallPrompt, InstallPromptFuture, InstallPromptHandler,
-    InstallReporter,
+    InstallProgressSnapshot, InstallPrompt, InstallPromptDecision, InstallPromptDecisionFuture,
+    InstallPromptDecisionHandler, InstallPromptFuture, InstallPromptHandler, InstallReporter,
 };
 pub use crate::runtime::{EmbedderRuntime, set_embedder_runtime};
 pub use aube_manifest::{Error as ManifestError, PackageJson, Workspaces};


### PR DESCRIPTION
Embedded hosts previously answered install confirmations through a boolean API. A host that could not present a prompt had to return `false` or an error; returning `false` made aube report an explicit user abort and could invent a host command such as `mise add` in the diagnostic.

Aube now offers a backward-compatible tri-state embedding API:

```rust
InstallPromptDecision::Accept
InstallPromptDecision::Decline
InstallPromptDecision::Unavailable
```

New embedders can register `InstallPromptDecisionHandler` with `InstallControl::with_prompt_decision_handler`. `Unavailable` returns the safety gate normal structured refusal, preserving its stable error code and remediation. `Decline` remains an explicit refusal but no longer constructs a command from the embedding process name. Existing `InstallPromptHandler` implementations continue to work and retain their boolean semantics.

The three reputation gates now keep CLI remediation in structured diagnostic help. Embedders can therefore replace that help with host-native configuration while retaining the measured reason and stable aube code.

This covers low-download, newly published, and similar-name confirmations. The focused 38-test supply-chain suite and formatting pass.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*